### PR TITLE
docs(gale): rewrite perf.md from a fresh profile

### DIFF
--- a/package-gale/perf.md
+++ b/package-gale/perf.md
@@ -220,10 +220,14 @@ reduction is real and host-independent.)
 ### 3. `Parser` token reads — `last_end` 5.7%, `expect`, `advance` (~8%)
 
 `Parser::last_end` is a 4-step `Parser→List→Token→Span→end` load chain.
-**Inlining / per-method micro-opt does not help** (see below): the cost
-is the actual loads, which the SoA decomposition in (1) removes by making
-the end offset a direct `array.get i32`. This is the same lever as §1 —
-SoA pays off in two places at once.
+It ranks high **purely because of call frequency** — it is invoked an
+enormous number of times — not because any single call is expensive.
+That is why **inlining and precomputation both measured zero improvement**
+(see below): there is no call overhead or redundant work to remove; the
+only thing that moves the needle is making each load cheaper. The SoA
+decomposition in (1) does exactly that, turning the end offset into a
+direct `array.get i32`. This is the same lever as §1 — SoA pays off in two
+places at once.
 
 ### 4. Kind-set membership — `_gale_kind_set_*` (~9%)
 
@@ -262,12 +266,15 @@ incorrectly). Candidates:
 
 ## What does not work
 
-- **Inlining hot `Parser` methods / any per-method micro-opt.** Caching
-  `Parser::last_end` as a field or forcing inlining removes the named
-  function from the profile but does not move wall time — the cost is the
-  loads (`Parser→List→Token→Span→end`), not call overhead. wasmtime +
-  Cranelift handle small Wasm calls cheaply enough that inlinability is
-  not the lever. The real fix is removing the loads (SoA, §1).
+- **Inlining hot `Parser` methods / any per-method micro-opt.**
+  `Parser::last_end` is high only because of its huge call count, not
+  per-call expense. Precomputing it (caching the value in a field) or
+  forcing inlining removes the named function from the profile but
+  measured **no wall-time change** — there is no call overhead or
+  redundant work to remove; the cost is performing the loads
+  (`Parser→List→Token→Span→end`) that many times. wasmtime + Cranelift
+  handle small Wasm calls cheaply enough that inlinability is not the
+  lever. The real fix is making each load cheaper (SoA, §1).
 - **Data-driven / bytecode-VM scan** (see below).
 
 ## Failed approaches (do not repeat)

--- a/package-gale/perf.md
+++ b/package-gale/perf.md
@@ -113,14 +113,28 @@ multiply rather than add.
 The dominant _category_, and now **allocation-bound** (`push`) rather
 than reallocation-bound — the pre-size (`List::with_capacity` in
 `tokenize`) already collapsed `grow` from 15.3% to ~1%, so that earlier
-"cheapest win" is **done**. What remains is the Wasm GC
-`(array (ref Token))` indirection plus a per-token `struct.new Token` on
-every `push` (each `Token` carries a `LexerSlice`, a `Span`, and a
-`leading_trivia: List<Token>`, so the struct is not trivial). The lever is
-**SoA decomposition of `List<Token>`**: parallel primitive arrays
-(`kinds` / `starts` / `ends` as `List<i32>`) so `peek_kind` becomes a
-single `array.get i32` (not `array.get (ref Token)` + `struct.get`) and
-per-token allocation disappears in the lex loop. Two ways to get there:
+"cheapest win" is **done**.
+
+`push` is **not a copy** (checked, like `_gale_rule` §2): the WIR body is
+just a length check + `array.set<ref Token>` + increment, and the token
+array holds **refs** (`(array (ref Token))`), so `push` stores a pointer —
+there is no `$value_copy$Token` anywhere. Two genuine costs remain, both
+removed by the same lever:
+
+1. The per-token **`struct.new Token`** (with its `LexerSlice`, `Span`,
+   and `leading_trivia: List<Token>` sub-allocations) — this lands in
+   `tokenize`, not `push`.
+2. Inside `push`, the **`array.set` into a `(array (ref Token))`** — a GC
+   reference store / write barrier executed once per token; combined with
+   the sheer call frequency (one `push` per token) this is what puts the
+   trivial body at the top, the same call-frequency effect as `last_end`
+   (§3), not per-call expense.
+
+The lever is **SoA decomposition of `List<Token>`**: parallel primitive
+arrays (`kinds` / `starts` / `ends` as `List<i32>`) so `peek_kind` becomes
+a single `array.get i32` (not `array.get (ref Token)` + `struct.get`),
+per-token allocation disappears in the lex loop, and the ref-array store
+becomes a barrier-free `array.set i32`. Two ways to get there:
 
 - **Gale-side:** redesign `Token` so hot fields are flat primitives,
   with an opaque sidecar (or removal) for `text` / `leading_trivia`;

--- a/package-gale/perf.md
+++ b/package-gale/perf.md
@@ -39,7 +39,7 @@ not the historical one.
 > dev host is ~10× slower per iter than the release headline, and that
 > slack is concentrated in **allocation/GC host work**. So the profile
 > **over-weights allocation-heavy guest frames** (`List<Token>::push`,
-> the `_gale_rule` result copy) relative to pure-compute frames
+> the `_gale_rule` per-call rule-name allocation) relative to pure-compute frames
 > (`scan_*`, `follow_yields`, the kind-set tests), which it
 > **under-weights**. Read the table as relative self-time with that
 > directional skew in mind; the _ordering within_ the compute frames and
@@ -63,26 +63,29 @@ per-run noise of a ~3.5 ms-of-guest-work-per-iter workload.)
 
 ## Live profile (guest sampler, 7 runs merged, 1620 samples @1 ms)
 
-|   Pct | Symbol                       | role                                          |
-| ----: | ---------------------------- | --------------------------------------------- |
-| 24.0% | `List<Token>::push`          | per-token `struct.new Token` + array store    |
-| 18.1% | `_gale_rule<ResultColumn..>` | rule-result subtree copy (result wrapper)     |
-|  5.7% | `Parser::last_end`           | `Parser→List→Token→Span→end` load chain       |
-|  4.3% | `_gale_kind_set_8`           | membership test over the big keyword set      |
-|  4.1% | `follow_yields`              | runtime FOLLOW gate (LL repair), parse + scan |
-|  3.9% | `scan_any_name`              | scan (prediction)                             |
-|  3.2% | `char::to_ascii_lowercase`   | case-insensitive keyword matching             |
-|  2.7% | `scan_expr`                  | scan (LR precedence climb)                    |
-|  2.5% | `StrCharIter::collect`       | `input.chars().collect()` into `List<char>`   |
-|  1.7% | `Parser::expect`             | token read                                    |
-|  1.7% | `tokenize`                   | lexer driver (was 27.9% historically)         |
-|  1.5% | `List<char>::push`           | lexer char-buffer fill                        |
-|  1.0% | `List<Token>::grow`          | token-array reallocation (now pre-sized away) |
-|  0.9% | `classify_keyword`           | keyword vs identifier disambiguation          |
+|   Pct | Symbol                       | role                                             |
+| ----: | ---------------------------- | ------------------------------------------------ |
+| 24.0% | `List<Token>::push`          | per-token `struct.new Token` + array store       |
+| 18.1% | `_gale_rule<ResultColumn..>` | per-call rule-name `String` alloc at the wrapper |
+|  5.7% | `Parser::last_end`           | `Parser→List→Token→Span→end` load chain          |
+|  4.3% | `_gale_kind_set_8`           | membership test over the big keyword set         |
+|  4.1% | `follow_yields`              | runtime FOLLOW gate (LL repair), parse + scan    |
+|  3.9% | `scan_any_name`              | scan (prediction)                                |
+|  3.2% | `char::to_ascii_lowercase`   | case-insensitive keyword matching                |
+|  2.7% | `scan_expr`                  | scan (LR precedence climb)                       |
+|  2.5% | `StrCharIter::collect`       | `input.chars().collect()` into `List<char>`      |
+|  1.7% | `Parser::expect`             | token read                                       |
+|  1.7% | `tokenize`                   | lexer driver (was 27.9% historically)            |
+|  1.5% | `List<char>::push`           | lexer char-buffer fill                           |
+|  1.0% | `List<Token>::grow`          | token-array reallocation (now pre-sized away)    |
+|  0.9% | `classify_keyword`           | keyword vs identifier disambiguation             |
 
 Rough buckets (self-time): token-stream construction (`push`+`grow`) ≈
-**25%**; the rule-result copy (`_gale_rule<*>`, all variants) ≈ **21%**;
-lexer char-level work (`to_ascii_lowercase` + `List<char>` +
+**25%**; the per-call rule-name `String` allocation at the `_gale_rule`
+boundary (`_gale_rule<*>`, all variants) ≈ **21%** — but see §2: a spike
+that removes only that allocation cuts ~40% of dev-host wall time, so the
+profile **under**-attributes it; lexer char-level work
+(`to_ascii_lowercase` + `List<char>` +
 `classify_keyword` + `collect` + `try_*`) ≈ **13%**; `scan_*` ≈ **11%**;
 kind-set membership ≈ **9%**; `Parser` token reads
 (`last_end`/`expect`/`advance`) ≈ **8%**; the FOLLOW gate ≈ **4%**.
@@ -90,13 +93,15 @@ kind-set membership ≈ **9%**; `Parser` token reads
 This is a different shape from the previous revision, where `follow_yields`
 led at 18.6% and `List<Token>::grow` at 15.3%. The pre-size killed `grow`,
 the per-loop FOLLOW prune dropped the gate to ~4%, and two
-allocation-bound costs rose to the top: per-token construction and a
-result-subtree copy in the generic rule wrapper (the latter not present
-in the old profile at all). Per the measurement note, the two leaders are
-exactly the frames the dev host inflates, so treat their _absolute_
-percentages as upper bounds — but both are real (the rule-copy is a
-genuine deep copy, §2, and per-token allocation is genuine `struct.new`,
-§1), so the _ordering_ holds.
+allocation-bound costs rose to the top: per-token construction and the
+per-call rule-name `String` allocation at the generic rule wrapper
+(neither present in the old profile at the same weight). Per the
+measurement note, the two leaders are exactly the frames the dev host
+inflates, but both are real allocations (per-token `struct.new`, §1, and
+per-rule `struct.new String`, §2 — the latter confirmed by a spike, not
+just the sampler), so the _ordering_ holds. Note §2 is **not** a subtree
+copy (a WIR-level fact an earlier draft got wrong): the wrapper returns a
+`ref`; the cost is the rule-name allocation at the call site.
 
 ## What would move the needle
 
@@ -128,45 +133,89 @@ per-token allocation disappears in the lex loop. Two ways to get there:
   escaping). Today the pass fires on zero candidates in
   Gale-generated parsers.
 
-### 2. Rule-result subtree copy — `_gale_rule<*>` (~21%)
+### 2. Per-call rule-name `String` allocation — the `_gale_rule` boundary (~40% dev-host)
 
-**New, and the second-largest self-time category.** Every parser rule is
-emitted as `_parse_X(p, follow) = _gale_rule(_parse_X__inner(p, follow),
-"X")`. `_gale_rule<T>` exists only to push the rule name onto the
-`ParseError.rule_stack` on the **error** path:
+**The single largest reducible cost, and not what the profile name
+suggests.** Every parser rule is emitted as
+`_parse_X(p, follow) = _gale_rule(_parse_X__inner(p, follow), "X")`.
+`_gale_rule<T>` records the rule name on the `ParseError.rule_stack` on
+the **error** path only:
 
 ```wado
 fn _gale_rule<T>(r: Result<T, ParseError>, rule: String) -> Result<T, ParseError> {
     if let Err(mut e) = r { e.rule_stack.push(rule); return Result::Err(e); }
-    return r;   // success: the whole T is passed in by value and returned by value
+    return r;
 }
 ```
 
-On the **success** path the freshly built node `T` is routed _by value_
-into the wrapper and returned _by value_. Value semantics make that a
-deep copy of the entire CST subtree — and `ResultColumnNode` is a
-`variant` whose arms embed `Token`s (each with a `LexerSlice`, a `Span`,
-and a `leading_trivia: List<Token>`), so the copy is not cheap.
-`result_column` is the single hottest rule on this fixture (SELECT lists
-dominate the corpus), so `_gale_rule<ResultColumnNode>` alone is 18.1%;
-the other `_gale_rule<*>` variants add ~3%. The frame is a pure leaf
-(inclusive == self), consistent with an inlined copy and no child calls.
-Two independent levers:
+The profile attributes ~18% self-time to `_gale_rule<ResultColumnNode>`,
+which **misled an earlier draft into calling it a "subtree copy."** It is
+not. The WIR proves the success path is free of any copy — `Result<…>` is
+a boxed `ref`, so `return r` returns a reference and the only
+`$value_copy$` is on the cold `Err` branch:
 
-- **Wado-side (copy/move elision).** A by-value parameter that is
-  returned unchanged on a path where the source is dead after the
-  `return` should **move**, not deep-copy. Teaching the optimizer to
-  elide this removes the cost grammar-wide, for every generated parser,
-  with no Gale change. This is the higher-leverage fix.
-- **Gale-side (keep the success path copy-free).** The wrapper only needs
-  to touch the value on `Err`. Restructure so the node never crosses a
-  generic by-value boundary on success — e.g. push rule context through a
-  side channel (the parser already threads `&mut Parser`), inline the
-  wrapper at the call site so the move is visible to the optimizer, or
-  carry the rule id on the error rather than wrapping the result.
+```text
+fn _gale_rule<ResultColumnNode>(r, rule) {
+    if ref.test …::Err(r) { … $value_copy … }   // cold: only on parse failure
+    return r;                                     // returns a ref — no copy
+}
+```
+
+The real cost lives at the **call site**, in the wrapper `_parse_X`: the
+rule-name `"X"` is rebuilt on **every** rule entry as
+`struct.new String { repr: array.new_data("result_column"), used: 13 }` —
+a fresh GC allocation on the hot success path, consumed only on the cold
+error path. Thousands of these per parse dominate the allocation traffic.
+
+**Measured (dev host, same host throughout — the comparison is valid even
+though absolute times are dev-inflated; spike copies the generated parser
+and drives `queries.sql`):**
+
+| variant                                     | per-iter | throughput |  vs base |
+| ------------------------------------------- | -------: | ---------: | -------: |
+| base (as generated)                         | ~39.1 ms |  ~342 KB/s |        — |
+| rule-name hoisted to a single shared global | ~22.9 ms |  ~582 KB/s | **−41%** |
+| `_gale_rule` bypassed entirely              | ~21.9 ms |  ~610 KB/s | **−44%** |
+
+The middle row is the finding: keeping the wrapper call **and** its
+`ref.test`, changing only the per-call `String` literal into one pre-built
+global, recovers ~93% of the full removal. So:
+
+- **Reducing the call count is not the lever.** Removing the wrapper call
+  and `ref.test` on top of the hoist buys only ~3% more (22.9 → 21.9 ms);
+  the wrapper itself is nearly free. (This contradicts the intuition that
+  the per-rule call overhead matters — it does not.)
+- **Reducing the per-call allocation is the whole win.** Build each
+  distinct rule name once, not on every rule entry.
+
+**Future direction.** Wado already has a const-aggregate → global hoist
+(`const_object_globalization`, see `docs/optimizer.md`), but it does not
+fire here for two reasons, both fixable: (a) its gate `is_globalizable_const`
+does not list `ExprKind::StringLiteral`, and (b) a string only takes the
+inline `array.new_fixed` const repr (vs the opaque `array.new_data` data
+segment) when its byte length is `<= string_inline_max_bytes`, which is
+**4** at `-O2` (`optimize::string_inline_max_bytes`) — far below the
+13–25-byte rule names. Even raising that threshold alone is not enough:
+the strings are inline call arguments, not `let` bindings, and the pass
+only hoists `let`-bound aggregates, so the `struct.new String` stays at
+the call site. Either path closes the gap:
+
+- **Wado-side:** teach the const-aggregate hoist to also globalize a
+  constant `String` (or any constant aggregate) appearing as an inline
+  argument, not just a `let` binding — and let the eager-const-string
+  threshold cover typical identifier-length literals. Fixes this for every
+  generated parser and any Wado program that passes string literals on a
+  hot path, with no Gale change.
+- **Gale-side:** emit each rule name as a module-level
+  `global RULE_<id>: String = "…"` once and pass that to `_gale_rule`
+  (`gen_rule_entry_wrapper` in `parser_gen.wado`), instead of inlining the
+  literal at every call. Lower-leverage but self-contained; the stronger
+  variant passes an `i32` rule-id and turns `rule_stack` into
+  `List<i32>`, eliminating hot-path string work entirely.
 
 (Per the measurement note the dev host over-weights this allocation-bound
-frame; expect a smaller — but still material — share on a release host.)
+cost; the release share is smaller, but the per-parse allocation-count
+reduction is real and host-independent.)
 
 ### 3. `Parser` token reads — `last_end` 5.7%, `expect`, `advance` (~8%)
 

--- a/package-gale/perf.md
+++ b/package-gale/perf.md
@@ -13,127 +13,190 @@ failed approaches) and [`antlr4-compatibility.md`](./antlr4-compatibility.md).
 `benchmark/sqlite_parse`, 13366-byte realistic SQL fixture, guest run at
 `-O2` under wasmtime:
 
-| Parser                        |        per-iter | throughput |
-| ----------------------------- | --------------: | ---------: |
-| **Gale (generated)**          | **~20 ms/iter** |  ~660 KB/s |
-| Rust `sqlparser-rs` (release) |   ~1.64 ms/iter |  8.15 MB/s |
+| Parser                        |          per-iter | throughput |
+| ----------------------------- | ----------------: | ---------: |
+| **Gale (generated)**          | **~3.57 ms/iter** | ~3.75 MB/s |
+| Rust `sqlparser-rs` (release) |     ~1.90 ms/iter |  7.05 MB/s |
 
-Current gap ≈ **12×** vs `sqlparser-rs` release. (The earlier "5× gap"
-figure compared against `sqlparser-rs` _debug_, ~6.7 ms/iter; ~3× on
-that axis.) The fixture now parses **~6.6× faster** than the 137 ms/iter
-recorded when this section first lived in `TODO.md` — the lexer rework
-collapsed `tokenize` self-time, so the priorities below are re-derived
-from a fresh profile, not the historical one.
+Current gap ≈ **1.9×** vs `sqlparser-rs` release — down from the **12×**
+this table recorded one revision ago. Two things closed it: the lexer
+rework collapsed `tokenize` self-time, and the token list is now
+pre-sized (`List::with_capacity(chars.len()/4 + 1)` in `tokenize`), which
+all but eliminated `List<Token>::grow`. The fixture now parses **~38×
+faster** than the 137 ms/iter recorded when this section first lived in
+`TODO.md`, and **~5.6× faster** than the ~20 ms/iter of the previous
+revision — so the priorities below are re-derived from a fresh profile,
+not the historical one.
+
+> **Measurement note (read before trusting the percentages).** The
+> headline table above is from the release benchmark (`mise run
+> sqlite-parse`, host built `--release`). The **profile below was
+> captured with the dev-profile `wado`** (`cargo run`, per the
+> inner-dev-loop guidance in the root `CLAUDE.md` — no release rebuild).
+> `Cargo.toml` raises `opt-level` on `cranelift-codegen`, so the
+> JIT-compiled **guest code is near-release quality**, but the wasmtime
+> runtime, GC, and allocator host paths run at dev speed. Net effect: the
+> dev host is ~10× slower per iter than the release headline, and that
+> slack is concentrated in **allocation/GC host work**. So the profile
+> **over-weights allocation-heavy guest frames** (`List<Token>::push`,
+> the `_gale_rule` result copy) relative to pure-compute frames
+> (`scan_*`, `follow_yields`, the kind-set tests), which it
+> **under-weights**. Read the table as relative self-time with that
+> directional skew in mind; the _ordering within_ the compute frames and
+> within the allocation frames is reliable, the alloc-vs-compute split is
+> a soft upper bound on the alloc share.
 
 Reproduce:
 
 ```sh
 cd benchmark
-# both baselines:
+# both baselines (release host — slow rebuild):
 mise run sqlite-parse
-# Gale alone, with a guest profile (self-time sampling):
+# Gale alone, dev host, with a guest profile (self-time sampling):
 wado run --no-cache --profile guest,/tmp/p.json,1 -O2 sqlite_parse/sqlite_parse.wado
 ```
 
 (`wado` = `cargo run --bin wado --`. Analyze `p.json` with the
-`profiling-wado` skill's script, or upload to profiler.firefox.com.)
+`profiling-wado` skill's script, or upload to profiler.firefox.com. The
+table below merges **7 dev-host runs @1 ms = 1620 samples** to damp the
+per-run noise of a ~3.5 ms-of-guest-work-per-iter workload.)
 
-## Live profile (guest sampler, 1177 combined samples @1–5 ms)
+## Live profile (guest sampler, 7 runs merged, 1620 samples @1 ms)
 
-|   Pct | Symbol                     | role                                          |
-| ----: | -------------------------- | --------------------------------------------- |
-| 18.6% | `follow_yields`            | runtime FOLLOW gate (LL repair), parse + scan |
-| 15.3% | `List<Token>::grow`        | token-array reallocation                      |
-|  7.1% | `Parser::last_end`         | `Parser→List→Token→Span→end` load chain       |
-|  6.1% | `_gale_kind_set_8`         | membership test over the big keyword set      |
-|  5.0% | `List<Token>::push`        | per-token `struct.new Token`                  |
-|  4.3% | `List<char>::grow`         | lexer char-buffer reallocation                |
-|  4.2% | `char::to_ascii_lowercase` | case-insensitive keyword matching             |
-|  3.6% | `scan_any_name`            | scan (prediction)                             |
-|  3.2% | `scan_expr`                | scan (LR precedence climb)                    |
-|  2.7% | `Parser::expect`           | token read                                    |
-|  1.8% | `tokenize`                 | lexer driver (was 27.9% historically)         |
+|   Pct | Symbol                       | role                                          |
+| ----: | ---------------------------- | --------------------------------------------- |
+| 24.0% | `List<Token>::push`          | per-token `struct.new Token` + array store    |
+| 18.1% | `_gale_rule<ResultColumn..>` | rule-result subtree copy (result wrapper)     |
+|  5.7% | `Parser::last_end`           | `Parser→List→Token→Span→end` load chain       |
+|  4.3% | `_gale_kind_set_8`           | membership test over the big keyword set      |
+|  4.1% | `follow_yields`              | runtime FOLLOW gate (LL repair), parse + scan |
+|  3.9% | `scan_any_name`              | scan (prediction)                             |
+|  3.2% | `char::to_ascii_lowercase`   | case-insensitive keyword matching             |
+|  2.7% | `scan_expr`                  | scan (LR precedence climb)                    |
+|  2.5% | `StrCharIter::collect`       | `input.chars().collect()` into `List<char>`   |
+|  1.7% | `Parser::expect`             | token read                                    |
+|  1.7% | `tokenize`                   | lexer driver (was 27.9% historically)         |
+|  1.5% | `List<char>::push`           | lexer char-buffer fill                        |
+|  1.0% | `List<Token>::grow`          | token-array reallocation (now pre-sized away) |
+|  0.9% | `classify_keyword`           | keyword vs identifier disambiguation          |
 
-Rough buckets: token-stream construction (`grow`+`push`) ≈ **20%**; the
-FOLLOW gate ≈ **19%**; `Parser` token reads ≈ **11%**; kind-set
-membership ≈ **9–10%**; lexer char-level work
-(`to_ascii_lowercase` + `List<char>` + `classify_keyword`) ≈ **13%**;
-`scan_*` ≈ **8–10%**.
+Rough buckets (self-time): token-stream construction (`push`+`grow`) ≈
+**25%**; the rule-result copy (`_gale_rule<*>`, all variants) ≈ **21%**;
+lexer char-level work (`to_ascii_lowercase` + `List<char>` +
+`classify_keyword` + `collect` + `try_*`) ≈ **13%**; `scan_*` ≈ **11%**;
+kind-set membership ≈ **9%**; `Parser` token reads
+(`last_end`/`expect`/`advance`) ≈ **8%**; the FOLLOW gate ≈ **4%**.
+
+This is a different shape from the previous revision, where `follow_yields`
+led at 18.6% and `List<Token>::grow` at 15.3%. The pre-size killed `grow`,
+the per-loop FOLLOW prune dropped the gate to ~4%, and two
+allocation-bound costs rose to the top: per-token construction and a
+result-subtree copy in the generic rule wrapper (the latter not present
+in the old profile at all). Per the measurement note, the two leaders are
+exactly the frames the dev host inflates, so treat their _absolute_
+percentages as upper bounds — but both are real (the rule-copy is a
+genuine deep copy, §2, and per-token allocation is genuine `struct.new`,
+§1), so the _ordering_ holds.
 
 ## What would move the needle
 
 Ordered by current self-time. None are mutually exclusive; several
 multiply rather than add.
 
-### 1. The runtime FOLLOW gate — `follow_yields` (~19%)
+### 1. Token-stream construction — `push` 24.0% + `grow` 1.0% (~25%)
 
-New top cost since the LL repair moved to a runtime-threaded
-`follow: &List<List<i32>>` argument (see _LL Prediction_ in
-`AGENTS.md`). `follow_yields` runs at every tail-greedy `Repeat`
-iteration on **both** the parse and scan sides, walking the caller
-continuation at every depth. Levers, cheapest first:
+The dominant _category_, and now **allocation-bound** (`push`) rather
+than reallocation-bound — the pre-size (`List::with_capacity` in
+`tokenize`) already collapsed `grow` from 15.3% to ~1%, so that earlier
+"cheapest win" is **done**. What remains is the Wasm GC
+`(array (ref Token))` indirection plus a per-token `struct.new Token` on
+every `push` (each `Token` carries a `LexerSlice`, a `Span`, and a
+`leading_trivia: List<Token>`, so the struct is not trivial). The lever is
+**SoA decomposition of `List<Token>`**: parallel primitive arrays
+(`kinds` / `starts` / `ends` as `List<i32>`) so `peek_kind` becomes a
+single `array.get i32` (not `array.get (ref Token)` + `struct.get`) and
+per-token allocation disappears in the lex loop. Two ways to get there:
 
-- **Narrow where it is called.** It only needs to fire on `Repeat`s that
-  actually have a caller-FOLLOW conflict; tighten the `gate_caller_follow`
-  predicate in lowering so non-conflicting loops emit no gate at all
-  (the `emit_follow` prune already removes it grammar-wide when there is
-  no gate anywhere — this is the per-loop refinement).
-- **Cheapen the check.** It compares token kinds against small per-depth
-  sets; a flat `i32` representation or a depth-0 fast path (the common
-  K=1 case) avoids the nested `List<List<i32>>` walk.
-- **Hoist invariants.** The `follow` argument and `TK_EOF` are loop
-  invariant; ensure the loop guard does not re-fetch them per iteration.
+- **Gale-side:** redesign `Token` so hot fields are flat primitives,
+  with an opaque sidecar (or removal) for `text` / `leading_trivia`;
+  keep the public `Token` API as a view handle if needed.
+- **Wado-side:** extend `container_sroa` to handle (a) struct fields
+  (currently locals only), (b) inner structs with nested
+  struct/reference fields, (c) cross-function rewrites for the
+  `scan_*(&List<Token>, ...)` parameter pattern (1100+ sites in the
+  SQLite parser pass `&p.tokens` as a bare reference, always
+  escaping). Today the pass fires on zero candidates in
+  Gale-generated parsers.
 
-### 2. Token-stream construction — `grow` 15.3% + `push` 5.0% (~20%)
+### 2. Rule-result subtree copy — `_gale_rule<*>` (~21%)
 
-The dominant _category_, now reallocation-bound (`grow`) rather than
-lexer-bound. Two non-overlapping paths (carried from the original
-analysis, still valid):
+**New, and the second-largest self-time category.** Every parser rule is
+emitted as `_parse_X(p, follow) = _gale_rule(_parse_X__inner(p, follow),
+"X")`. `_gale_rule<T>` exists only to push the rule name onto the
+`ParseError.rule_stack` on the **error** path:
 
-1. **Pre-size the token list.** `grow` at 15% means the `List<Token>`
-   reallocates repeatedly while tokenizing. Reserve capacity up front
-   (e.g. proportional to input length) so the lex loop does at most one
-   or two growths. Cheapest available win.
-2. **SoA decomposition of `List<Token>`.** The deeper cost is Wasm GC
-   `(array (ref Token))` indirection plus per-token `struct.new Token`.
-   Decompose into parallel primitive arrays (`kinds` / `starts` / `ends`
-   as `List<i32>`) so `peek_kind` becomes a single `array.get i32` (not
-   `array.get (ref Token)` + `struct.get`) and per-token allocation
-   disappears in the lex loop. Two ways to get there:
-   - **Gale-side:** redesign `Token` so hot fields are flat primitives,
-     with an opaque sidecar (or removal) for `text` / `leading_trivia`;
-     keep the public `Token` API as a view handle if needed.
-   - **Wado-side:** extend `container_sroa` to handle (a) struct fields
-     (currently locals only), (b) inner structs with nested
-     struct/reference fields, (c) cross-function rewrites for the
-     `scan_*(&List<Token>, ...)` parameter pattern (1100+ sites in the
-     SQLite parser pass `&p.tokens` as a bare reference, always
-     escaping). Today the pass fires on zero candidates in
-     Gale-generated parsers.
+```wado
+fn _gale_rule<T>(r: Result<T, ParseError>, rule: String) -> Result<T, ParseError> {
+    if let Err(mut e) = r { e.rule_stack.push(rule); return Result::Err(e); }
+    return r;   // success: the whole T is passed in by value and returned by value
+}
+```
 
-### 3. `Parser` token reads — `last_end` 7.1%, `expect`, `advance` (~11%)
+On the **success** path the freshly built node `T` is routed _by value_
+into the wrapper and returned _by value_. Value semantics make that a
+deep copy of the entire CST subtree — and `ResultColumnNode` is a
+`variant` whose arms embed `Token`s (each with a `LexerSlice`, a `Span`,
+and a `leading_trivia: List<Token>`), so the copy is not cheap.
+`result_column` is the single hottest rule on this fixture (SELECT lists
+dominate the corpus), so `_gale_rule<ResultColumnNode>` alone is 18.1%;
+the other `_gale_rule<*>` variants add ~3%. The frame is a pure leaf
+(inclusive == self), consistent with an inlined copy and no child calls.
+Two independent levers:
+
+- **Wado-side (copy/move elision).** A by-value parameter that is
+  returned unchanged on a path where the source is dead after the
+  `return` should **move**, not deep-copy. Teaching the optimizer to
+  elide this removes the cost grammar-wide, for every generated parser,
+  with no Gale change. This is the higher-leverage fix.
+- **Gale-side (keep the success path copy-free).** The wrapper only needs
+  to touch the value on `Err`. Restructure so the node never crosses a
+  generic by-value boundary on success — e.g. push rule context through a
+  side channel (the parser already threads `&mut Parser`), inline the
+  wrapper at the call site so the move is visible to the optimizer, or
+  carry the rule id on the error rather than wrapping the result.
+
+(Per the measurement note the dev host over-weights this allocation-bound
+frame; expect a smaller — but still material — share on a release host.)
+
+### 3. `Parser` token reads — `last_end` 5.7%, `expect`, `advance` (~8%)
 
 `Parser::last_end` is a 4-step `Parser→List→Token→Span→end` load chain.
 **Inlining / per-method micro-opt does not help** (see below): the cost
-is the actual loads, which the SoA decomposition in (2) removes by making
-the end offset a direct `array.get i32`.
+is the actual loads, which the SoA decomposition in (1) removes by making
+the end offset a direct `array.get i32`. This is the same lever as §1 —
+SoA pays off in two places at once.
 
-### 4. Kind-set membership — `_gale_kind_set_*` (~9–10%)
+### 4. Kind-set membership — `_gale_kind_set_*` (~9%)
 
-`_gale_kind_set_8` alone is 6.1%: a membership test over the large SQLite
-keyword set, called from scan dispatch and the parser's lookahead gates.
-Generated today as a branch/compare cascade. A compile-time **perfect
-hash** or a **bitset indexed by token kind** (`(kind >> 5)` word +
-`1 << (kind & 31)`) turns it into O(1) with no branch cascade — worth it
-because a handful of large sets dominate.
+`_gale_kind_set_8` alone is 4.3%: a `k matches { TK_… | TK_… | … }`
+membership test over the large SQLite keyword set (~125 kinds), called
+from scan dispatch and the parser's lookahead gates. Generated today as a
+branch/compare cascade (71 such helpers in the SQLite parser). A
+compile-time **perfect hash** or a **bitset indexed by token kind**
+(`(kind >> 5)` word + `1 << (kind & 31)`) turns it into O(1) with no
+branch cascade — worth it because a handful of large sets dominate. This
+is a pure-compute frame the dev host does _not_ inflate, so its release
+share is likely a touch higher than 9%.
 
-### 5. Lexer dispatch (~13%, independent secondary lever)
+### 5. Lexer char-level work (~13%, independent secondary lever)
 
 Inside lexing, work splits across `to_ascii_lowercase` (case-insensitive
-matching), `List<char>` buffer building, and `classify_keyword`. Pick by
-what profiling on the predicate-correct lexer says is hottest (after
-Stage C makes predicates real — a fast tokenizer is meaningless if it
-tokenizes incorrectly). Candidates:
+matching, 3.2%), `List<char>` buffer building, `classify_keyword` (0.9%),
+and the up-front `input.chars().collect()` into `List<char>`
+(`StrCharIter::collect`, 2.5%, in `_gale_new_parser`). Pick by what
+profiling on the predicate-correct lexer says is hottest (after Stage C
+makes predicates real — a fast tokenizer is meaningless if it tokenizes
+incorrectly). Candidates:
 
 - **Table-driven DFA** for the whole lexer (NFA → DFA → transition
   table). Replaces both per-character dispatch and `classify_keyword`;
@@ -155,7 +218,7 @@ tokenizes incorrectly). Candidates:
   function from the profile but does not move wall time — the cost is the
   loads (`Parser→List→Token→Span→end`), not call overhead. wasmtime +
   Cranelift handle small Wasm calls cheaply enough that inlinability is
-  not the lever. The real fix is removing the loads (SoA, §2).
+  not the lever. The real fix is removing the loads (SoA, §1).
 - **Data-driven / bytecode-VM scan** (see below).
 
 ## Failed approaches (do not repeat)

--- a/package-gale/perf.md
+++ b/package-gale/perf.md
@@ -29,22 +29,19 @@ revision — so the priorities below are re-derived from a fresh profile,
 not the historical one.
 
 > **Measurement note (read before trusting the percentages).** The
-> headline table above is from the release benchmark (`mise run
-> sqlite-parse`, host built `--release`). The **profile below was
-> captured with the dev-profile `wado`** (`cargo run`, per the
-> inner-dev-loop guidance in the root `CLAUDE.md` — no release rebuild).
-> `Cargo.toml` raises `opt-level` on `cranelift-codegen`, so the
-> JIT-compiled **guest code is near-release quality**, but the wasmtime
-> runtime, GC, and allocator host paths run at dev speed. Net effect: the
-> dev host is ~10× slower per iter than the release headline, and that
-> slack is concentrated in **allocation/GC host work**. So the profile
-> **over-weights allocation-heavy guest frames** (`List<Token>::push`,
-> the `_gale_rule` per-call rule-name allocation) relative to pure-compute frames
-> (`scan_*`, `follow_yields`, the kind-set tests), which it
-> **under-weights**. Read the table as relative self-time with that
-> directional skew in mind; the _ordering within_ the compute frames and
-> within the allocation frames is reliable, the alloc-vs-compute split is
-> a soft upper bound on the alloc share.
+> headline table is from the release benchmark (`mise run sqlite-parse`).
+> The **profile below was captured with the dev-profile `wado`** (`cargo
+> run`, per the inner-dev-loop guidance in the root `CLAUDE.md` — no
+> release rebuild). `Cargo.toml` raises `opt-level` on `cranelift-codegen`,
+> so the JIT-compiled **guest code is near-release quality**, but the
+> wasmtime runtime, GC, and allocator run at dev speed — making the dev
+> host ~10× slower per iter, with the slack concentrated in
+> **allocation/GC**. So the profile inflates allocation-bound frames
+> relative to pure-compute ones (`scan_*`, `follow_yields`, kind-set), and
+> its per-frame attribution within allocation is loose: §2 is a case where
+> a spike shows ~40% of wall time for a frame the sampler puts at 18%.
+> Read the percentages as relative, and the alloc-vs-compute split as
+> approximate.
 
 Reproduce:
 
@@ -58,8 +55,8 @@ wado run --no-cache --profile guest,/tmp/p.json,1 -O2 sqlite_parse/sqlite_parse.
 
 (`wado` = `cargo run --bin wado --`. Analyze `p.json` with the
 `profiling-wado` skill's script, or upload to profiler.firefox.com. The
-table below merges **7 dev-host runs @1 ms = 1620 samples** to damp the
-per-run noise of a ~3.5 ms-of-guest-work-per-iter workload.)
+table below merges **7 dev-host runs @1 ms = 1620 samples** to damp
+per-run sampling noise.)
 
 ## Live profile (guest sampler, 7 runs merged, 1620 samples @1 ms)
 
@@ -82,31 +79,25 @@ per-run noise of a ~3.5 ms-of-guest-work-per-iter workload.)
 
 Rough buckets (self-time): token-stream construction (`push`+`grow`) ≈
 **25%**; the per-call rule-name `String` allocation at the `_gale_rule`
-boundary (`_gale_rule<*>`, all variants) ≈ **21%** — but see §2: a spike
-that removes only that allocation cuts ~40% of dev-host wall time, so the
-profile **under**-attributes it; lexer char-level work
-(`to_ascii_lowercase` + `List<char>` +
+boundary (`_gale_rule<*>`, all variants) ≈ **21%** (under-attributed — see
+§2); lexer char-level work (`to_ascii_lowercase` + `List<char>` +
 `classify_keyword` + `collect` + `try_*`) ≈ **13%**; `scan_*` ≈ **11%**;
 kind-set membership ≈ **9%**; `Parser` token reads
 (`last_end`/`expect`/`advance`) ≈ **8%**; the FOLLOW gate ≈ **4%**.
 
-This is a different shape from the previous revision, where `follow_yields`
-led at 18.6% and `List<Token>::grow` at 15.3%. The pre-size killed `grow`,
-the per-loop FOLLOW prune dropped the gate to ~4%, and two
-allocation-bound costs rose to the top: per-token construction and the
-per-call rule-name `String` allocation at the generic rule wrapper
-(neither present in the old profile at the same weight). Per the
-measurement note, the two leaders are exactly the frames the dev host
-inflates, but both are real allocations (per-token `struct.new`, §1, and
-per-rule `struct.new String`, §2 — the latter confirmed by a spike, not
-just the sampler), so the _ordering_ holds. Note §2 is **not** a subtree
-copy (a WIR-level fact an earlier draft got wrong): the wrapper returns a
-`ref`; the cost is the rule-name allocation at the call site.
+A different shape from the previous revision, where `follow_yields` led
+at 18.6% and `List<Token>::grow` at 15.3%: the pre-size killed `grow` and
+the per-loop FOLLOW prune dropped the gate to ~4%, leaving two real
+allocations on top — per-token `struct.new` (§1) and the per-call
+rule-name `struct.new String` (§2, confirmed by a spike). Both are
+allocation-bound, so the dev host inflates them (measurement note); the
+ordering holds.
 
 ## What would move the needle
 
-Ordered by current self-time. None are mutually exclusive; several
-multiply rather than add.
+Ordered by profile self-time (but §2 is the largest once the sampler's
+under-attribution is corrected — see its spike). None are mutually
+exclusive; several multiply rather than add.
 
 ### 1. Token-stream construction — `push` 24.0% + `grow` 1.0% (~25%)
 
@@ -162,11 +153,10 @@ fn _gale_rule<T>(r: Result<T, ParseError>, rule: String) -> Result<T, ParseError
 }
 ```
 
-The profile attributes ~18% self-time to `_gale_rule<ResultColumnNode>`,
-which **misled an earlier draft into calling it a "subtree copy."** It is
-not. The WIR proves the success path is free of any copy — `Result<…>` is
-a boxed `ref`, so `return r` returns a reference and the only
-`$value_copy$` is on the cold `Err` branch:
+The profile puts ~18% self-time on `_gale_rule<ResultColumnNode>`, but it
+is **not a copy**. The WIR shows the success path is copy-free —
+`Result<…>` is a boxed `ref`, so `return r` returns a reference, and the
+only `$value_copy$` is on the cold `Err` branch:
 
 ```text
 fn _gale_rule<ResultColumnNode>(r, rule) {
@@ -227,9 +217,8 @@ the call site. Either path closes the gap:
   variant passes an `i32` rule-id and turns `rule_stack` into
   `List<i32>`, eliminating hot-path string work entirely.
 
-(Per the measurement note the dev host over-weights this allocation-bound
-cost; the release share is smaller, but the per-parse allocation-count
-reduction is real and host-independent.)
+(The ~40% is dev-host; release allocates faster so the share is smaller,
+but the per-parse allocation-count drop is real and host-independent.)
 
 ### 3. `Parser` token reads — `last_end` 5.7%, `expect`, `advance` (~8%)
 


### PR DESCRIPTION
## Summary

Rewrites `package-gale/perf.md` from current measurements (the old revision was badly stale) and records three investigations of the top profile frames, each of which turned out **not** to be the cost it looked like.

### Benchmark state refresh
- Gale now parses `sqlite_parse` at **~3.57 ms/iter (3.75 MB/s)** vs `sqlparser-rs` **~1.90 ms/iter** — the gap is **~1.9×**, not the ~12× the file claimed. Pre-sizing the token list and the per-loop FOLLOW prune landed since the last revision.
- New profile from **7 dev-host guest-profiler runs merged (1620 samples @1 ms)**, with an explicit measurement note: the profile was taken with the dev-profile `wado` (guest near-release via raised `cranelift-codegen` opt, but host GC/allocator at dev speed), so it inflates allocation-bound frames and its per-frame attribution within allocation is loose.

### Investigations (WIR + same-host A/B spikes)
- **`_gale_rule` (sampled 18%)** — not a subtree copy. The wrapper returns a boxed `ref`; the real cost is the rule-name `String` rebuilt at every rule entry (`struct.new String`) on the hot path, used only on the cold error path. A spike that hoists it to a global recovers ~41% of dev-host wall time; bypassing the wrapper entirely ~44% — so call count is not the lever, the per-call allocation is. Future direction noted (Wado-side const-string globalization or Gale-side rule-name globals / i32 ids); **no compiler change made**.
- **`List<Token>::push` (24%)** — not a copy. The token array holds refs; `push` stores a pointer. The cost is the per-token `struct.new Token` (in `tokenize`) plus the ref-array write barrier, amplified by call frequency. SoA (i32 arrays) removes both.
- **`Parser::last_end` (5.7%)** — high purely from call frequency, not per-call expense; inlining and precomputation both measured zero change. Only making each load cheaper (SoA) helps.

### Priorities re-derived
SoA token decomposition (#1, also removes the `last_end` load chain), the `_gale_rule` rule-name allocation (#2), lexer char work, `scan_*`, kind-set membership. The still-valid "What does not work" / "Failed approaches" / "Correctness" sections are preserved.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019s6btHK1utFMGk2QUB2B2E)_