### PR TITLE
docs(example): add hello_cm.wado using raw wasi:cli

### DIFF
--- a/example/hello_cm.wado
+++ b/example/hello_cm.wado
@@ -7,11 +7,7 @@
 use { Stdout } from "wasi:cli";
 
 export fn run() with Stdout {
-    // "Hello, world!\n" as raw UTF-8 bytes.
-    let message: List<u8> = [
-        72, 101, 108, 108, 111, 44, 32, // "Hello, "
-        119, 111, 114, 108, 100, 33, 10, // "world!\n"
-    ];
+    let message: List<u8> = "Hello, world!\n".bytes().collect();
 
     // wasi:cli/stdout writes through a CM stream. Create a [readable, writable]
     // pair, hand the readable end to write_via_stream, push the bytes into the

--- a/example/hello_cm.wado
+++ b/example/hello_cm.wado
@@ -1,0 +1,24 @@
+// Hello World using the raw wasi:cli interface.
+//
+// Unlike `hello.wado`, this bypasses `core:cli` (println) and the internal
+// stream helpers, talking to the `wasi:cli/stdout` Component Model interface
+// directly.
+
+use { Stdout } from "wasi:cli";
+
+export fn run() with Stdout {
+    // "Hello, world!\n" as raw UTF-8 bytes.
+    let message: List<u8> = [
+        72, 101, 108, 108, 111, 44, 32, // "Hello, "
+        119, 111, 114, 108, 100, 33, 10, // "world!\n"
+    ];
+
+    // wasi:cli/stdout writes through a CM stream. Create a [readable, writable]
+    // pair, hand the readable end to write_via_stream, push the bytes into the
+    // writable end, then drop both ends to signal completion.
+    let [rx, tx] = Stream::<u8>::new();
+    let pending = Stdout::write_via_stream(rx);
+    tx.write(message);
+    tx.drop();
+    pending.drop();
+}


### PR DESCRIPTION
Adds `example/hello_cm.wado`, a Hello World that writes directly to the `wasi:cli/stdout` Component Model interface — no `core:cli` (`println`) and no internal stream helpers.

```wado
use { Stdout } from "wasi:cli";

export fn run() with Stdout {
    let message: List<u8> = "Hello, world!\n".bytes().collect();

    let [rx, tx] = Stream::<u8>::new();
    let pending = Stdout::write_via_stream(rx);
    tx.write(message);
    tx.drop();
    pending.drop();
}
```

It demonstrates the raw WASI P3 `write_via_stream` protocol: create a stream pair, hand the readable end to `write_via_stream`, push bytes into the writable end, then drop both ends to signal completion. Complements `example/hello.wado`, which uses the higher-level `core:cli` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9Cf3qn1cmBmBBZrtCAkNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9Cf3qn1cmBmBBZrtCAkNx)_