### PR TITLE
chore: raise testFloats timeout to 10s to fix CI flakiness

### DIFF
--- a/wado-compiler/lib/core/prelude/fpfmt_comprehensive_test.wado
+++ b/wado-compiler/lib/core/prelude/fpfmt_comprehensive_test.wado
@@ -119,6 +119,7 @@ fn run_batch(bits: &List<i64>, expected: &List<String>, batch_name: String) -> i
 }
 
 
+#[timeout_ms(10000)]
 test "comprehensive testFloats" {
     let bits = test_floats_bits();
     let expected = test_floats_expected();


### PR DESCRIPTION
## Summary

The `comprehensive testFloats` test in `wado-compiler/lib/core/prelude/fpfmt_comprehensive_test.wado` occasionally exceeds the default 5000ms timeout in CI, causing flaky failures:

```
comprehensive testFloats (wado-compiler/lib/core/prelude/fpfmt_comprehensive_test.wado)
test timed out after 5000ms
→ test: 1681 passed, 1 failed
```

This bumps its per-test timeout to 10000ms via `#[timeout_ms(10000)]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZDe6gZWb5SA6GzmBnDQ3)_