### PR TITLE
refactor(elaborator): close out the annotate→reify boundary smells (Stage 7)

### DIFF
--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -305,18 +305,29 @@ alone_ — literal kinds, the syntactic shape of a node (`Index` vs
 mangling-sensitive. Anything that depends on resolution is a recorded
 decision, not a re-computation.
 
-Implementation note (the Stage 7 gap): the _current_ reify violates
-this rule in two places — it re-runs `resolve_type` /
-`resolve_type_with_self` for type annotations, `Self`, and impl type
-args, and it re-computes mangled method / struct names. Both are
-decisions (they depend on the impl's positional type-param indexing and
-on name mangling), and both have drifted from `annotate` and been fixed
-one bug at a time (`TreeMap<String, V>` self-type indexing, the
-`&T`-blanket `&^Inspect` name). Stage 7 closes the gap structurally:
-`annotate` records the resolved types and the impl identity / mangled
-name, and reify reads them. Once reify re-derives nothing
-decision-bearing it cannot drift — the parity-bug class disappears by
-construction.
+Implementation note (the Stage 7 gap — closed): the gap reify once had —
+re-running `resolve_type` / `resolve_type_with_self` for type
+annotations, `Self`, and impl type args, and re-computing mangled
+method / struct names — drifted from `annotate` and was fixed one bug at
+a time (`TreeMap<String, V>` self-type indexing, the `&T`-blanket
+`&^Inspect` name). Stage 7 closed it structurally: `annotate` records the
+resolved types and the impl identity / mangled name (`ann_fn_param_types`,
+`ann_fn_return_type`, `ann_decl_type_params`, `ImplFacts::self_type` /
+`struct_name`, `ann_method_names`, `GenericInstantiation::mangled_name`),
+and reify reads them via `.expect(...)` — a missing fact is a loud panic,
+not a silent recompute. Two boundary invariants keep the gap closed by
+construction:
+
+- Fail-loud, not fail-safe. Reify does not fall back to recomputation when
+  a fact is absent; every decision-bearing read is an `.expect`. The sole
+  surviving `resolve_type` call is the global read for a snapshot-rehydrated
+  callee module, whose `ModuleSemantics` legitimately carries no
+  `current_module_globals` — a documented exception, not a fallback.
+- Single source for the projection rule. The "dense, real type params"
+  predicate (`!effect && !fn-bound`) that fixes positional monomorph slots
+  lives once, as `ast::GenericParam::is_real_type_param`; the annotate walk
+  and reify both call it instead of re-spelling the filter (it was inlined
+  at ~15 sites, the original drift vector for index-shift bugs).
 
 ### DCE / Liveness
 

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -447,8 +447,9 @@ analysis layer alongside `liveness`, reading the same facts
 (`function_effects`, `effect_ops`, `method_dispatch`, …). This is the
 same TIR→AST+facts move Stage 7 made for control-flow / missing-return,
 and it lets the LSP surface effect and stores diagnostics too (it builds
-no TIR). Until that move lands, reify passes `None` as its live set
-(gating off); `liveness` is still computed and feeds the
+no TIR). That move has landed (the effect / stores / purity checks read
+`Semantics`, not the emitted TIR), so reify now passes `Some(live_items)`
+and gates dead free-function emission; `liveness` also feeds the
 `DeadFunction` / `DeadGlobal` diagnostics. The policy is owned by
 [`wep-2026-05-16-unused-diagnostics.md`](./wep-2026-05-16-unused-diagnostics.md)
 (Phase 3b).
@@ -463,25 +464,26 @@ The change touches every file under `elaborator/` and lands incrementally,
 with the suite (E2E, WIR golden, LSP query) green at every step, in
 dependency order. Stages are guidelines, not PR boundaries.
 
-Phase 1 (Stages 1–5, 7a, 7-A, 7-B) is DONE: `TypeSystem` / `ModuleSemantics` /
+Phase 1 (Stages 1–6, 7a, 7-A, 7-B) is DONE: `TypeSystem` / `ModuleSemantics` /
 per-`AstId` `TypeAnnotations` extracted from the God Object; `reify` split out
 as the sole TIR producer reading recorded facts; the combined `annotate` walk
 builds no TIR (every `resolve_*` returns a `TypeId`), so LSP runs `annotate`
 alone. The premise the WEP existed to fix — LSP building and discarding TIR —
 is resolved. Detail in the Status section below and in git.
 
-Remaining in Phase 1:
+Stage 6 — the piece that landed last — closes Phase 1:
 
-**Stage 6 — Liveness and DCE.** `liveness::compute(&Semantics)` and the
+Stage 6 — Liveness and DCE. `liveness::compute(&Semantics)` and the
 `Liveness` field on `Semantics` have landed (computed in WEP phase order; the
-`DeadFunction` / `DeadGlobal` diagnostics consume `dead_items`). The reify
-gate on `live_items` is wired but **disabled** (`None` live set) pending two
-prerequisites: (1) every semantic diagnostic that can fire on dead code is
-produced from `Semantics` rather than the emitted TIR (the "diagnostics from
-`Semantics`" move — see the Prerequisite section above and
-`wep-2026-05-16-unused-diagnostics.md` Phase 3b), and (2) cross-module graph
-completeness. Until both land, reify passes `None` (gating off) while
-`liveness` still feeds the dead-code diagnostics. Independent of Phase 2.
+`DeadFunction` / `DeadGlobal` diagnostics consume `dead_items`). The reify gate
+is now enabled: `build_tir_from_state` passes `Some(&liveness.live_items)` and
+`reify_module` skips dead user free functions (globals stay ungated — an
+initializer can trap or have effects; `optimize/dce.rs` removes genuinely pure
+dead ones). Both prerequisites landed: (1) the semantic diagnostics that can
+fire on dead code (effect / stores / purity) are produced from `Semantics`
+rather than the emitted TIR, so dropping a dead function suppresses no
+diagnostic; (2) the cross-module graph resolves the dispatch facts that leave
+no `references` edge. Independent of Phase 2.
 
 Each stage keeps `mise run test`, the WIR golden fixtures, and the LSP query
 tests green. Performance is not tracked during migration; see Trade-offs.
@@ -508,8 +510,10 @@ null/unknown reader had to be ported before the block-result-type reader.
       `default_method_semantics`).
 - [x] **Stage 7a** — routing removed; the combined walk survives only as the
       `annotate` fact-recorder.
-- [~] **Stage 6** — Liveness / DCE: landed but the reify gate is disabled (see
-  the Migration Plan "Remaining in Phase 1" above for the two prerequisites).
+- [x] **Stage 6** — Liveness / DCE: landed and the reify gate is enabled
+      (`reify_module` skips dead user free functions; globals stay ungated). Both
+      prerequisites — diagnostics from `Semantics`, cross-module graph
+      completeness — are in place.
 - [x] **Stage 7-A — reify is mechanical.** Every decision-bearing read goes
       through a recorded fact (signatures, effect/resource ops, decl type-param
       defaults, struct field types, method-call/free-call type args, const and

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1020,6 +1020,34 @@ pub struct TestDecl {
     pub span: Span,
 }
 
+/// Test attributes resolved from a `TestDecl`'s `#[...]` annotations (plus the
+/// enclosing module's `#[TODO]`). Shared by the annotate and reify walks so the
+/// attribute semantics live in one place.
+#[derive(Debug, Clone, Copy)]
+pub struct TestMetadata {
+    pub expect_trap: bool,
+    pub is_todo: bool,
+    pub timeout_ms: Option<u64>,
+}
+
+impl TestDecl {
+    /// Resolve this test's `#[expect_trap]` / `#[TODO]` / `#[timeout_ms(..)]`
+    /// attributes. `module_is_todo` folds in a module-level `#[TODO]`.
+    pub fn metadata(&self, module_is_todo: bool) -> TestMetadata {
+        TestMetadata {
+            expect_trap: self.attributes.iter().any(|a| a.name == "expect_trap"),
+            is_todo: module_is_todo || self.attributes.iter().any(|a| a.name == "TODO"),
+            timeout_ms: self.attributes.iter().find_map(|a| {
+                if a.name == "timeout_ms" {
+                    a.args.first().and_then(|arg| arg.as_str().parse::<u64>().ok())
+                } else {
+                    None
+                }
+            }),
+        }
+    }
+}
+
 /// Global variable declaration: `global name: Type = expr;`
 /// or `pub global mut name: Type = expr;`
 #[derive(Debug, Clone)]

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -2923,6 +2923,23 @@ pub struct GenericParam {
     pub span: Span,
 }
 
+impl GenericParam {
+    /// Whether this param carries an `fn`-signature bound (`<F: fn(...)>`).
+    /// Such params are erased before codegen, so they occupy no positional
+    /// monomorphization slot.
+    pub fn has_fn_bound(&self) -> bool {
+        self.bounds.iter().any(|b| b.fn_signature.is_some())
+    }
+
+    /// Whether this param occupies a dense, positional slot — the "real" type
+    /// params monomorphization substitutes by index. Excludes effect params
+    /// (`effect E`) and `fn`-bound params (`<F: fn(...)>`). Single source for
+    /// the projection rule shared by the annotate walk and reify.
+    pub fn is_real_type_param(&self) -> bool {
+        !self.is_effect && !self.has_fn_bound()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StructDecl {
     pub id: AstId,

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -1039,7 +1039,9 @@ impl TestDecl {
             is_todo: module_is_todo || self.attributes.iter().any(|a| a.name == "TODO"),
             timeout_ms: self.attributes.iter().find_map(|a| {
                 if a.name == "timeout_ms" {
-                    a.args.first().and_then(|arg| arg.as_str().parse::<u64>().ok())
+                    a.args
+                        .first()
+                        .and_then(|arg| arg.as_str().parse::<u64>().ok())
                 } else {
                     None
                 }

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -1907,11 +1907,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let params = self.lookup_function_type_params(callee);
         let inferable: Vec<&ast::GenericParam> = params
             .iter()
-            .filter(|p| {
-                !p.is_effect
-                    && p.default.is_none()
-                    && !p.bounds.iter().any(|b| b.fn_signature.is_some())
-            })
+            .filter(|p| !p.is_effect && p.default.is_none() && !p.has_fn_bound())
             .collect();
         if inferable.is_empty() {
             return;
@@ -1936,7 +1932,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .filter(|&(p, &tid)| {
                     !p.is_effect
                         && p.default.is_none()
-                        && !p.bounds.iter().any(|b| b.fn_signature.is_some())
+                        && !p.has_fn_bound()
                         && self.is_unbound_type_param(tid)
                         && !scope_params.contains(&tid)
                 })
@@ -1981,10 +1977,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let params = self.lookup_function_type_params(callee);
         // Dense type-argument index space (matches `populate_generic_function_cache`):
         // non-effect, non-`fn`-bound params in declaration order.
-        let space: Vec<&ast::GenericParam> = params
-            .iter()
-            .filter(|p| !p.is_effect && !p.bounds.iter().any(|b| b.fn_signature.is_some()))
-            .collect();
+        let space: Vec<&ast::GenericParam> =
+            params.iter().filter(|p| p.is_real_type_param()).collect();
         let n = space.len();
         if n == 0 || space.iter().any(|p| p.default.is_some()) {
             self.report_uninferred_fn_type_args(callee, type_args, span);

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -677,8 +677,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let real_type_param_count = func
             .type_params
             .iter()
-            .filter(|p| !p.is_effect)
-            .filter(|p| !p.bounds.iter().any(|b| b.fn_signature.is_some()))
+            .filter(|p| p.is_real_type_param())
             .count();
         if type_args.is_empty() && real_type_param_count != 0 {
             return None;
@@ -775,8 +774,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let real_type_param_count = func_ast
             .type_params
             .iter()
-            .filter(|p| !p.is_effect)
-            .filter(|p| !p.bounds.iter().any(|b| b.fn_signature.is_some()))
+            .filter(|p| p.is_real_type_param())
             .count();
 
         // (a) Turbofish on the identifier: `name::<T, ...>`.

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -906,7 +906,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // fn-bound params are realised eagerly and do not need
         // monomorphisation, so a function whose only non-effect params are
         // fn-bound has nothing to cache.
-        let has_real_type_params = func.type_params.iter().any(|p| p.is_real_type_param());
+        let has_real_type_params = func
+            .type_params
+            .iter()
+            .any(super::super::ast::GenericParam::is_real_type_param);
         if !has_real_type_params {
             return;
         }
@@ -1026,7 +1029,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `<F: fn(...)>` bounds are eagerly realised to the bound's function
         // type and do not consume a `TypeParam` slot — they're not generic
         // parameters that need monomorphisation.
-        let has_real_type_params = func.type_params.iter().any(|p| p.is_real_type_param());
+        let has_real_type_params = func
+            .type_params
+            .iter()
+            .any(super::super::ast::GenericParam::is_real_type_param);
         let declared_return_type = if has_real_type_params {
             scope.populate_generic_function_cache(func)
         } else {

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -906,10 +906,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // fn-bound params are realised eagerly and do not need
         // monomorphisation, so a function whose only non-effect params are
         // fn-bound has nothing to cache.
-        let has_real_type_params = func
-            .type_params
-            .iter()
-            .any(|p| !p.is_effect && !p.bounds.iter().any(|b| b.fn_signature.is_some()));
+        let has_real_type_params = func.type_params.iter().any(|p| p.is_real_type_param());
         if !has_real_type_params {
             return;
         }
@@ -952,8 +949,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let type_param_list: Vec<(String, TypeId)> = func
             .type_params
             .iter()
-            .filter(|p| !p.is_effect)
-            .filter(|p| !p.bounds.iter().any(|b| b.fn_signature.is_some()))
+            .filter(|p| p.is_real_type_param())
             .filter_map(|p| {
                 self.annotate_ctx
                     .trait_ctx
@@ -1030,10 +1026,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // `<F: fn(...)>` bounds are eagerly realised to the bound's function
         // type and do not consume a `TypeParam` slot — they're not generic
         // parameters that need monomorphisation.
-        let has_real_type_params = func
-            .type_params
-            .iter()
-            .any(|p| !p.is_effect && !p.bounds.iter().any(|b| b.fn_signature.is_some()));
+        let has_real_type_params = func.type_params.iter().any(|p| p.is_real_type_param());
         let declared_return_type = if has_real_type_params {
             scope.populate_generic_function_cache(func)
         } else {
@@ -1163,7 +1156,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if p.is_effect {
                     return None;
                 }
-                if p.bounds.iter().any(|b| b.fn_signature.is_some()) {
+                if p.has_fn_bound() {
                     return None;
                 }
                 let idx = non_effect_non_fn_idx;
@@ -1769,7 +1762,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if p.is_effect {
                     return None;
                 }
-                if p.bounds.iter().any(|b| b.fn_signature.is_some()) {
+                if p.has_fn_bound() {
                     return None;
                 }
                 let idx = non_effect_non_fn_idx;

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -1232,41 +1232,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         test_index: usize,
         module_is_todo: bool,
     ) -> Option<(TirFunction, TirTest)> {
-        let expect_trap = test_decl.attributes.iter().any(|a| a.name == "expect_trap");
-        let is_todo = module_is_todo || test_decl.attributes.iter().any(|a| a.name == "TODO");
-        let timeout_ms = test_decl.attributes.iter().find_map(|a| {
-            if a.name == "timeout_ms" {
-                a.args
-                    .first()
-                    .and_then(|arg| arg.as_str().parse::<u64>().ok())
-            } else {
-                None
-            }
-        });
-
-        // Generate function name: __test_{index} or __test_{name_snake_case}
-        // For expect_trap tests: __test_trap_{index} or __test_trap_{index}_{name_snake_case}
-        // For TODO tests:        __test_todo_{index} or __test_todo_{index}_{name_snake_case}
-        // For custom timeout:    __test_tm{ms}_{index} or __test_trap_tm{ms}_{index}_{name}
-        let prefix = match (is_todo, expect_trap, timeout_ms) {
-            (true, _, Some(ms)) => format!("__test_todo_tm{ms}"),
-            (true, _, None) => "__test_todo".to_string(),
-            (_, true, Some(ms)) => format!("__test_trap_tm{ms}"),
-            (_, true, None) => "__test_trap".to_string(),
-            (_, _, Some(ms)) => format!("__test_tm{ms}"),
-            (_, _, None) => "__test".to_string(),
-        };
-        let function_name = match &test_decl.name {
-            Some(name) => {
-                // Convert the test name to an ASCII snake_case segment. Non-ASCII
-                // characters collapse to `_` so the derived CM kebab export name
-                // stays valid; the lossless original name is preserved on
-                // `TirTest::name` for display and `--test-name` filtering.
-                let snake_name = crate::name::test_name_to_snake(name);
-                format!("{prefix}_{test_index}_{snake_name}")
-            }
-            None => format!("{prefix}_{test_index}"),
-        };
+        let meta = test_decl.metadata(module_is_todo);
+        let ast::TestMetadata {
+            expect_trap,
+            is_todo,
+            timeout_ms,
+        } = meta;
+        let function_name =
+            crate::name::test_function_name(&meta, test_index, test_decl.name.as_deref());
 
         // Create function context - tests have no parameters and return unit
         let return_type = TypeTable::UNIT;

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1211,8 +1211,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .iter()
                     .zip(inferred.iter())
                     .filter(|&(param, &tid)| {
-                        let has_fn_bound = param.bounds.iter().any(|b| b.fn_signature.is_some());
-                        !has_fn_bound
+                        !param.has_fn_bound()
                             && matches!(
                                 self.tysys.type_table.borrow().get(tid),
                                 ResolvedType::TypeParam { .. } | ResolvedType::TypePack { .. }
@@ -1248,9 +1247,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .zip(inferred.iter())
                             .enumerate()
                             .filter(|&(_, (param, &tid))| {
-                                let has_fn_bound =
-                                    param.bounds.iter().any(|b| b.fn_signature.is_some());
-                                !has_fn_bound
+                                !param.has_fn_bound()
                                     && matches!(
                                         self.tysys.type_table.borrow().get(tid),
                                         ResolvedType::TypeParam { .. }

--- a/wado-compiler/src/elaborator/reify.rs
+++ b/wado-compiler/src/elaborator/reify.rs
@@ -1478,38 +1478,14 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     ) -> Option<(TirFunction, TirTest)> {
         use crate::tir::{FunctionKind, InlineHint, ReturnAbi, TypeTable};
 
-        let expect_trap = test_decl.attributes.iter().any(|a| a.name == "expect_trap");
-        let is_todo = module_is_todo || test_decl.attributes.iter().any(|a| a.name == "TODO");
-        let timeout_ms = test_decl.attributes.iter().find_map(|a| {
-            if a.name == "timeout_ms" {
-                a.args
-                    .first()
-                    .and_then(|arg| arg.as_str().parse::<u64>().ok())
-            } else {
-                None
-            }
-        });
-
-        let prefix = match (is_todo, expect_trap, timeout_ms) {
-            (true, _, Some(ms)) => format!("__test_todo_tm{ms}"),
-            (true, _, None) => "__test_todo".to_string(),
-            (_, true, Some(ms)) => format!("__test_trap_tm{ms}"),
-            (_, true, None) => "__test_trap".to_string(),
-            (_, _, Some(ms)) => format!("__test_tm{ms}"),
-            (_, _, None) => "__test".to_string(),
-        };
-        let function_name = match &test_decl.name {
-            // Use the shared ASCII-only snake conversion: non-ASCII letters
-            // must collapse to `_` so the segment downgrades losslessly into
-            // a Component Model kebab-case export name. A Unicode-aware
-            // `is_alphanumeric` here would leak multibyte letters into the
-            // export name and crash Wasm validation (matches item.rs).
-            Some(name) => {
-                let snake_name = crate::name::test_name_to_snake(name);
-                format!("{prefix}_{test_index}_{snake_name}")
-            }
-            None => format!("{prefix}_{test_index}"),
-        };
+        let meta = test_decl.metadata(module_is_todo);
+        let ast::TestMetadata {
+            expect_trap,
+            is_todo,
+            timeout_ms,
+        } = meta;
+        let function_name =
+            crate::name::test_function_name(&meta, test_index, test_decl.name.as_deref());
 
         let return_type = TypeTable::UNIT;
         let mut ctx = FunctionContext::new(return_type, function_name.clone());

--- a/wado-compiler/src/elaborator/reify.rs
+++ b/wado-compiler/src/elaborator/reify.rs
@@ -910,7 +910,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         let type_param_names: Vec<String> = func
             .type_params
             .iter()
-            .filter(|p| !p.is_effect && !p.bounds.iter().any(|b| b.fn_signature.is_some()))
+            .filter(|p| p.is_real_type_param())
             .map(|p| p.name.clone())
             .collect();
 
@@ -1008,7 +1008,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 .function_effects
                 .get(&func.id)
                 .cloned()
-                .unwrap_or_else(|| self.reify_effects(&func.effects)),
+                .expect("resolve_function/resolve_method records function_effects for every function reify emits"),
             stores: func.stores.clone(),
             body,
             span: func.span,
@@ -1258,10 +1258,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             // eagerly to the bound's function type (already baked into the
             // recorded param/return types), so they must not consume a
             // positional type-param slot or the real method params shift index.
-            if p.is_effect
-                || p.bounds.iter().any(|b| b.fn_signature.is_some())
-                || type_param_names.iter().any(|n| n == &p.name)
-            {
+            if !p.is_real_type_param() || type_param_names.iter().any(|n| n == &p.name) {
                 continue;
             }
             if type_param_names.len() <= next_idx {
@@ -1438,7 +1435,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 .function_effects
                 .get(&func.id)
                 .cloned()
-                .unwrap_or_else(|| self.reify_effects(&func.effects)),
+                .expect("resolve_function/resolve_method records function_effects for every function reify emits"),
             stores: func.stores.clone(),
             body,
             span: func.span,
@@ -7682,16 +7679,13 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 _ => None,
             })
         {
-            // 7-A: the global's declared type was resolved by `annotate_decls`
-            // and lives on `current_module_globals`; read it back (same source
-            // as `reify_global`), re-resolving only if unrecorded.
-            let ty = self
-                .sem
-                .decls
-                .current_module_globals
-                .get(&ident.name)
-                .map(|(t, _)| *t)
-                .unwrap_or_else(|| self.resolve_type(&global_decl.ty));
+            // The fact is genuinely absent here: branch 2 above already
+            // returned for any global present in `current_module_globals`, and
+            // this branch only fires for a snapshot-rehydrated callee module,
+            // which carries no `current_module_globals`. So resolve the declared
+            // type from the AST — the one documented reify type re-resolution
+            // (WEP 2026-05-26 §"Stage 7"). Everywhere else reify reads a fact.
+            let ty = self.resolve_type(&global_decl.ty);
             return TirExpr::new(
                 TirExprKind::GlobalVarGet {
                     module_source: self.current_module_source.clone(),

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -143,6 +143,68 @@ impl TypeSystem {
         mapping
     }
 
+    /// The traits the compiler auto-derives for eligible aggregate types
+    /// (`struct` / `variant` / `enum` / generic instance) and exposes through
+    /// method-call and operator dispatch, each paired with the method it
+    /// declares. The single source for the auto-derive method ↔ trait mapping:
+    /// the dispatch sites read it instead of hardcoding the `"eq"` / `"cmp"`
+    /// strings and the per-trait return type. Adding a new auto-derived trait
+    /// is one entry here (plus its synthesis in `synthesis::traits`).
+    const AUTO_DERIVED_METHODS: &'static [(CompilerItem, &'static str)] =
+        &[(CompilerItem::Eq, "eq"), (CompilerItem::Ord, "cmp")];
+
+    /// The trait name and the return type an auto-derived trait fixes,
+    /// regardless of what any user impl writes (`Eq` → `bool`, `Ord` →
+    /// `Ordering`).
+    fn auto_derive_descriptor(&self, item: CompilerItem) -> (String, TypeId) {
+        let trait_name = self
+            .type_table
+            .borrow()
+            .compiler_items()
+            .trait_name(item)
+            .to_string();
+        let return_type = match item {
+            CompilerItem::Eq => TypeTable::BOOL,
+            _ => self
+                .type_table
+                .borrow_mut()
+                .make_compiler_enum(CompilerItem::Ordering),
+        };
+        (trait_name, return_type)
+    }
+
+    /// Resolve the auto-derived trait that declares `method_name`. Returns its
+    /// compiler-item identity, trait name, and fixed return type, or `None`
+    /// when no auto-derived trait declares that method.
+    pub(super) fn auto_derive_by_method(
+        &self,
+        method_name: &str,
+    ) -> Option<(CompilerItem, String, TypeId)> {
+        let item = Self::AUTO_DERIVED_METHODS
+            .iter()
+            .find(|(_, m)| *m == method_name)
+            .map(|(it, _)| *it)?;
+        let (trait_name, return_type) = self.auto_derive_descriptor(item);
+        Some((item, trait_name, return_type))
+    }
+
+    /// Mirror of [`Self::auto_derive_by_method`] keyed by trait name, for
+    /// operator dispatch which already knows the trait. Returns the
+    /// compiler-item identity and the fixed return type.
+    pub(super) fn auto_derive_by_trait(&self, trait_name: &str) -> Option<(CompilerItem, TypeId)> {
+        let item = Self::AUTO_DERIVED_METHODS.iter().find_map(|(item, _)| {
+            let name = self
+                .type_table
+                .borrow()
+                .compiler_items()
+                .trait_name(*item)
+                .to_string();
+            (name == trait_name).then_some(*item)
+        })?;
+        let (_, return_type) = self.auto_derive_descriptor(item);
+        Some((item, return_type))
+    }
+
     /// Check that concrete type args at non-type-parameter positions match the impl type.
     /// e.g., `impl KeyValueLiteral for TreeMap<String, V>` with `TreeMap<i32, String>` should fail
     /// because position 0 expects String but got i32.
@@ -1382,33 +1444,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // respectively) regardless of what a user impl writes, so normalize
         // those here. `find_arithmetic_trait_impl` would otherwise default
         // `output_type` to the receiver type when no `type Output` is
-        // declared.
-        let (eq_name, ord_name) = {
-            let tt = self.tysys.type_table.borrow();
-            let items = tt.compiler_items();
-            (
-                items.trait_name(CompilerItem::Eq).to_string(),
-                items.trait_name(CompilerItem::Ord).to_string(),
-            )
-        };
-        let is_eq = trait_name == eq_name;
-        let is_ord = trait_name == ord_name;
+        // declared. The auto-derive set and the fixed return types come from
+        // `TypeSystem::auto_derive_by_trait` (the single source).
+        let auto_derive = self.tysys.auto_derive_by_trait(trait_name);
         let (info_trait_name, self_kind, param_types, return_type) = if let Some(info) =
             self.find_arithmetic_trait_impl(struct_name, lookup_type_id, trait_name, method_name)
         {
-            let return_type = if is_eq {
-                TypeTable::BOOL
-            } else if is_ord {
-                self.tysys
-                    .type_table
-                    .borrow_mut()
-                    .make_compiler_enum(CompilerItem::Ordering)
-            } else {
-                info.output_type
-            };
+            let return_type = auto_derive.map_or(info.output_type, |(_, rt)| rt);
             let param_types = info.rhs_type.map(|t| vec![t]).unwrap_or_default();
             (info.trait_name, info.self_kind, param_types, return_type)
-        } else if (is_eq || is_ord)
+        } else if let Some((_, return_type)) = auto_derive
             && self.type_implements_trait(&self.annotate_ctx, lookup_type_id, trait_name)
         {
             let ref_self_ty = self
@@ -1416,14 +1461,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .type_table
                 .borrow_mut()
                 .intern(ResolvedType::Ref(lookup_type_id));
-            let return_type = if is_eq {
-                TypeTable::BOOL
-            } else {
-                self.tysys
-                    .type_table
-                    .borrow_mut()
-                    .make_compiler_enum(CompilerItem::Ordering)
-            };
             (
                 trait_name.to_string(),
                 ast::SelfKind::Ref,
@@ -1458,48 +1495,24 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// because their equality/comparison lowers to Wasm instructions, not
     /// to a method body.
     ///
-    /// FIXME: this function has two places where it hard-codes knowledge
-    /// that should live on the trait declarations themselves:
+    /// The method ↔ trait mapping and the fixed return type come from
+    /// [`TypeSystem::auto_derive_by_method`] — the single source for which
+    /// traits the compiler auto-derives — so adding a new auto-derived trait
+    /// touches that table, not this arm.
     ///
-    ///   1. `method_name -> trait_name` is a closed `match` against `"eq"`
-    ///      and `"cmp"`.  Adding auto-derive method-call support for
-    ///      `Inspect::inspect` / `Display::fmt` / any new auto-derived
-    ///      trait requires extending this arm. The right design is a
-    ///      reverse-index built from `trait_env.decl_index` that answers
-    ///      "which traits declare a method named `X`?" and then filters
-    ///      by those that have an auto-derive rule.
-    ///
-    ///   2. The synthesized [`MethodInfo`] is built with a fixed shape
-    ///      (`self_kind: Ref`, single `&Self` parameter named `"other"`,
-    ///      no defaults, no method type params).  If the prelude ever
-    ///      evolves the `Eq` or `Ord` trait declaration (e.g. renames
-    ///      the parameter, adds a default arg, takes `&mut self`), this
-    ///      shape drifts silently.  The right design is to look the
-    ///      real `ast::Function` up via `find_trait_decl_methods` and
-    ///      substitute `Self` through the same path as user-written
-    ///      impls (via `trait_ctx.self_type`).
-    ///
-    /// Tracked as a post-PR cleanup; the shape is stable enough for the
-    /// current two traits that it does not cause observable bugs today.
+    /// The synthesized [`MethodInfo`] is still built with the fixed shape the
+    /// auto-derived `Eq` / `Ord` declarations have (`self_kind: Ref`, a single
+    /// `&Self` parameter named `"other"`, no defaults, no method type params).
+    /// Should a future auto-derived trait need a different shape, read it from
+    /// the trait's `ast::Function` (via `find_trait_decl_methods`) instead of
+    /// this literal; the current two traits share this shape exactly.
     pub(super) fn try_auto_derived_method_match(
         &mut self,
         struct_name: &str,
         method_name: &str,
         receiver_type_id: TypeId,
     ) -> Option<TraitMethodMatch> {
-        let (eq_name, ord_name) = {
-            let tt = self.tysys.type_table.borrow();
-            let items = tt.compiler_items();
-            (
-                items.trait_name(CompilerItem::Eq).to_string(),
-                items.trait_name(CompilerItem::Ord).to_string(),
-            )
-        };
-        let trait_name: String = match method_name {
-            "eq" => eq_name.clone(),
-            "cmp" => ord_name,
-            _ => return None,
-        };
+        let (_, trait_name, return_type) = self.tysys.auto_derive_by_method(method_name)?;
         let base_type_id = self.tysys.get_base_type(receiver_type_id);
         if !self.tysys.auto_derive_eligible_kind(base_type_id) {
             return None;
@@ -1512,15 +1525,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .type_table
             .borrow_mut()
             .intern(ResolvedType::Ref(base_type_id));
-        let is_eq_match = trait_name == eq_name;
-        let return_type = if is_eq_match {
-            TypeTable::BOOL
-        } else {
-            self.tysys
-                .type_table
-                .borrow_mut()
-                .make_compiler_enum(CompilerItem::Ordering)
-        };
         let method_info = MethodInfo {
             return_type,
             self_kind: ast::SelfKind::Ref,

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -153,45 +153,39 @@ impl TypeSystem {
     const AUTO_DERIVED_METHODS: &'static [(CompilerItem, &'static str)] =
         &[(CompilerItem::Eq, "eq"), (CompilerItem::Ord, "cmp")];
 
-    /// The trait name and the return type an auto-derived trait fixes,
-    /// regardless of what any user impl writes (`Eq` → `bool`, `Ord` →
-    /// `Ordering`).
-    fn auto_derive_descriptor(&self, item: CompilerItem) -> (String, TypeId) {
+    /// The return type an auto-derived trait fixes, regardless of what any user
+    /// impl writes (`Eq` → `bool`, `Ord` → `Ordering`).
+    fn auto_derive_return_type(&self, item: CompilerItem) -> TypeId {
+        match item {
+            CompilerItem::Eq => TypeTable::BOOL,
+            _ => self
+                .type_table
+                .borrow_mut()
+                .make_compiler_enum(CompilerItem::Ordering),
+        }
+    }
+
+    /// Resolve the auto-derived trait that declares `method_name`, returning its
+    /// trait name and fixed return type, or `None` when no auto-derived trait
+    /// declares that method.
+    pub(super) fn auto_derive_by_method(&self, method_name: &str) -> Option<(String, TypeId)> {
+        let item = Self::AUTO_DERIVED_METHODS
+            .iter()
+            .find(|(_, m)| *m == method_name)
+            .map(|(it, _)| *it)?;
         let trait_name = self
             .type_table
             .borrow()
             .compiler_items()
             .trait_name(item)
             .to_string();
-        let return_type = match item {
-            CompilerItem::Eq => TypeTable::BOOL,
-            _ => self
-                .type_table
-                .borrow_mut()
-                .make_compiler_enum(CompilerItem::Ordering),
-        };
-        (trait_name, return_type)
-    }
-
-    /// Resolve the auto-derived trait that declares `method_name`. Returns its
-    /// compiler-item identity, trait name, and fixed return type, or `None`
-    /// when no auto-derived trait declares that method.
-    pub(super) fn auto_derive_by_method(
-        &self,
-        method_name: &str,
-    ) -> Option<(CompilerItem, String, TypeId)> {
-        let item = Self::AUTO_DERIVED_METHODS
-            .iter()
-            .find(|(_, m)| *m == method_name)
-            .map(|(it, _)| *it)?;
-        let (trait_name, return_type) = self.auto_derive_descriptor(item);
-        Some((item, trait_name, return_type))
+        Some((trait_name, self.auto_derive_return_type(item)))
     }
 
     /// Mirror of [`Self::auto_derive_by_method`] keyed by trait name, for
-    /// operator dispatch which already knows the trait. Returns the
-    /// compiler-item identity and the fixed return type.
-    pub(super) fn auto_derive_by_trait(&self, trait_name: &str) -> Option<(CompilerItem, TypeId)> {
+    /// operator dispatch which already knows the trait. Returns the fixed
+    /// return type, or `None` when `trait_name` is not an auto-derived trait.
+    pub(super) fn auto_derive_by_trait(&self, trait_name: &str) -> Option<TypeId> {
         let item = Self::AUTO_DERIVED_METHODS.iter().find_map(|(item, _)| {
             let name = self
                 .type_table
@@ -201,8 +195,7 @@ impl TypeSystem {
                 .to_string();
             (name == trait_name).then_some(*item)
         })?;
-        let (_, return_type) = self.auto_derive_descriptor(item);
-        Some((item, return_type))
+        Some(self.auto_derive_return_type(item))
     }
 
     /// Check that concrete type args at non-type-parameter positions match the impl type.
@@ -1450,10 +1443,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let (info_trait_name, self_kind, param_types, return_type) = if let Some(info) =
             self.find_arithmetic_trait_impl(struct_name, lookup_type_id, trait_name, method_name)
         {
-            let return_type = auto_derive.map_or(info.output_type, |(_, rt)| rt);
+            let return_type = auto_derive.unwrap_or(info.output_type);
             let param_types = info.rhs_type.map(|t| vec![t]).unwrap_or_default();
             (info.trait_name, info.self_kind, param_types, return_type)
-        } else if let Some((_, return_type)) = auto_derive
+        } else if let Some(return_type) = auto_derive
             && self.type_implements_trait(&self.annotate_ctx, lookup_type_id, trait_name)
         {
             let ref_self_ty = self
@@ -1512,7 +1505,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         method_name: &str,
         receiver_type_id: TypeId,
     ) -> Option<TraitMethodMatch> {
-        let (_, trait_name, return_type) = self.tysys.auto_derive_by_method(method_name)?;
+        let (trait_name, return_type) = self.tysys.auto_derive_by_method(method_name)?;
         let base_type_id = self.tysys.get_base_type(receiver_type_id);
         if !self.tysys.auto_derive_eligible_kind(base_type_id) {
             return None;

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1272,6 +1272,32 @@ pub fn test_name_to_snake(name: &str) -> String {
         .to_lowercase()
 }
 
+/// Build the exported function name for a test block. The prefix encodes the
+/// test's attributes, the index disambiguates anonymous tests, and `name` (when
+/// present) is appended as an ASCII snake-case segment via [`test_name_to_snake`].
+///
+/// - `__test_{index}` / `__test_{index}_{snake}` — plain
+/// - `__test_trap_…` — `#[expect_trap]`
+/// - `__test_todo_…` — `#[TODO]` (or module-level `#[TODO]`)
+/// - `__test_tm{ms}_…` — `#[timeout_ms(ms)]` (combines: `__test_trap_tm{ms}_…`)
+///
+/// The single source of this format: both the annotate walk and reify call here
+/// so the two never drift.
+pub fn test_function_name(meta: &crate::ast::TestMetadata, test_index: usize, name: Option<&str>) -> String {
+    let prefix = match (meta.is_todo, meta.expect_trap, meta.timeout_ms) {
+        (true, _, Some(ms)) => format!("__test_todo_tm{ms}"),
+        (true, _, None) => "__test_todo".to_string(),
+        (_, true, Some(ms)) => format!("__test_trap_tm{ms}"),
+        (_, true, None) => "__test_trap".to_string(),
+        (_, _, Some(ms)) => format!("__test_tm{ms}"),
+        (_, _, None) => "__test".to_string(),
+    };
+    match name {
+        Some(name) => format!("{prefix}_{test_index}_{}", test_name_to_snake(name)),
+        None => format!("{prefix}_{test_index}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1283,7 +1283,11 @@ pub fn test_name_to_snake(name: &str) -> String {
 ///
 /// The single source of this format: both the annotate walk and reify call here
 /// so the two never drift.
-pub fn test_function_name(meta: &crate::ast::TestMetadata, test_index: usize, name: Option<&str>) -> String {
+pub fn test_function_name(
+    meta: &crate::ast::TestMetadata,
+    test_index: usize,
+    name: Option<&str>,
+) -> String {
     let prefix = match (meta.is_todo, meta.expect_trap, meta.timeout_ms) {
         (true, _, Some(ms)) => format!("__test_todo_tm{ms}"),
         (true, _, None) => "__test_todo".to_string(),


### PR DESCRIPTION
## Summary

A sweep of the `elaborator` phase for code smells, fixing the high-value ones and bringing the WEP documentation back in line with the code. No behavior change — purely structural hardening of the annotate→reify boundary, with the E2E suite green at every step.

## What changed

### Single-source the decisions reify and annotate must agree on

- **Test-name mangling** was duplicated verbatim between `item.rs:resolve_test_decl` (annotate) and `reify.rs:reify_test_decl` (reify): attribute parsing, the prefix `match`, and the snake conversion. Since the resulting name is the CM test export name, a one-sided change would silently produce mismatched / colliding exports. Extracted `ast::TestDecl::metadata()` + `ast::TestMetadata` (attribute semantics) and `name::test_function_name()` (the export-name format, beside `test_name_to_snake`); both walks call them.
- **The "real type params" projection rule** (`!is_effect && !fn-bound`, which fixes positional monomorphization slots) was inlined at ~15 sites across `call`/`expr`/`item`/`method_lookup`/`reify`. Extracted `ast::GenericParam::is_real_type_param()` / `has_fn_bound()`; every site now calls them, so reify's body-scope indices and monomorphize's substitution keys share one definition.

### Centralize auto-derive trait knowledge

The `Eq↔eq↔bool` / `Ord↔cmp↔Ordering` / `&Self`-param knowledge was hardcoded as repeated `(eq_name, ord_name)` pairs and `is_eq`/`is_ord` return-type matches in `try_auto_derived_method_match` and `resolve_trait_method_for_op`. Centralized into a single `TypeSystem::AUTO_DERIVED_METHODS` table plus `auto_derive_by_method` / `auto_derive_by_trait` / `auto_derive_return_type` helpers (pure type-system ops, per the WEP Phase 2 direction). Adding a new auto-derived trait is now one table entry. Resolves the long-standing `FIXME` in `try_auto_derived_method_match`.

### Harden the boundary fail-loud

The two `function_effects` reads in reify fell back to recomputing via `reify_effects(&func.effects)` when the fact was absent — but annotate records `function_effects` unconditionally, and that fallback is actually *wrong* for effect-param canonicalization. Converted both to `.expect(...)`, matching the sibling `ann_*` reads, so a missing fact is a loud panic rather than silent drift. The lone surviving `resolve_type` call (a snapshot-rehydrated callee global) is now clearly a documented exception, not a fallback.

### Documentation (WEP `2026-05-26-elaborator-rearchitecture`)

The WEP had drifted from the code. Corrected three stale claims to match reality:

- The liveness reify-gate is **enabled** (`Some(live_items)`), not disabled (`None`); Stage 6 is done, closing Phase 1. Updated the Prerequisite, Migration Plan, and Status sections.
- The "Stage 7 gap" implementation note claimed reify still re-runs `resolve_type` and re-computes mangled names. It doesn't — reify reads recorded facts. Rewrote the note to describe the closed state plus the two boundary invariants (fail-loud; single-source projection rule).

## Review

Ran a high-effort recall-biased self-review (line-by-line, removed-behavior, cross-file tracer, plus cleanup/altitude/conventions angles): zero correctness findings. Three API-tightening cleanups it surfaced in the new auto-derive helpers were applied in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKN5ihStENuy5ov6aeZo4q)_