### PR TITLE
refactor(monomorphize): tidy the monomorphization phase

### DIFF
--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -187,6 +187,34 @@ fn module_source_for_trait_impl(type_table: &TypeTable, type_id: TypeId) -> Opti
 }
 
 impl Monomorphizer {
+    /// Drain `self.structs.pending` to fixpoint, instantiating each queued
+    /// struct plus any structs its fields transitively queue. Returns the
+    /// concrete structs produced (the caller appends them to the module).
+    fn drain_pending_structs(
+        &mut self,
+        type_table: &RefCell<TypeTable>,
+        generic_structs: &IndexMap<(String, ModuleSource), TirStruct>,
+        valid_struct_names: &IndexSet<String>,
+    ) -> Vec<TirStruct> {
+        let mut new_structs = Vec::new();
+        loop {
+            self.collect_instantiation_sites(&type_table.borrow(), valid_struct_names);
+            if self.structs.pending.is_empty() {
+                break;
+            }
+            while let Some(key) = self.structs.pending.pop() {
+                let struct_key = (key.name.clone(), key.module_source.clone());
+                if let Some(generic_struct) = generic_structs.get(&struct_key)
+                    && let Some(concrete) =
+                        self.instantiate_struct(generic_struct, &key, &mut type_table.borrow_mut())
+                {
+                    new_structs.push(concrete);
+                }
+            }
+        }
+        new_structs
+    }
+
     /// Perform monomorphization on a module, optionally with access to external generic
     /// functions and structs from other modules (e.g., List methods from prelude).
     ///
@@ -224,30 +252,8 @@ impl Monomorphizer {
         // This is done in a loop because instantiating a struct (like TreeMap<String,i32>)
         // may create new GenericInstance types in its fields (like BTreeNode<String,i32>)
         // that also need to be instantiated.
-        let mut new_structs = Vec::new();
-        loop {
-            // Collect instantiation sites from current type table
-            self.collect_instantiation_sites(&module.type_table.borrow(), &valid_struct_names);
-
-            // If no new structs to instantiate, we're done
-            if self.structs.pending.is_empty() {
-                break;
-            }
-
-            // Process all pending struct instantiations
-            while let Some(key) = self.structs.pending.pop() {
-                let struct_key = (key.name.clone(), key.module_source.clone());
-                if let Some(generic_struct) = generic_structs.get(&struct_key)
-                    && let Some(concrete) = self.instantiate_struct(
-                        generic_struct,
-                        &key,
-                        &mut module.type_table.borrow_mut(),
-                    )
-                {
-                    new_structs.push(concrete);
-                }
-            }
-        }
+        let new_structs =
+            self.drain_pending_structs(&module.type_table, &generic_structs, &valid_struct_names);
 
         // Add monomorphized structs to module
         module.structs.extend(new_structs);
@@ -414,25 +420,15 @@ impl Monomorphizer {
             // batch. `collect_instantiation_sites` scans the type table —
             // doing it per-function would be `O(N · |type_table|)` and is
             // the source of the historical compiler-time regression.
-            loop {
-                self.collect_instantiation_sites(&module.type_table.borrow(), &valid_struct_names);
-                if self.structs.pending.is_empty() {
-                    break;
-                }
-                while let Some(struct_key) = self.structs.pending.pop() {
-                    let key_pair = (struct_key.name.clone(), struct_key.module_source.clone());
-                    if let Some(generic_struct) = generic_structs.get(&key_pair)
-                        && let Some(s) = self.instantiate_struct(
-                            generic_struct,
-                            &struct_key,
-                            &mut module.type_table.borrow_mut(),
-                        )
-                    {
-                        module.structs.push(s);
-                        made_progress = true;
-                    }
-                }
+            let new_structs = self.drain_pending_structs(
+                &module.type_table,
+                &generic_structs,
+                &valid_struct_names,
+            );
+            if !new_structs.is_empty() {
+                made_progress = true;
             }
+            module.structs.extend(new_structs);
 
             // Steps 3 + 4: rewrite each new body, then collect its call sites.
             for mut concrete in batch {

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -242,7 +242,6 @@ impl Monomorphizer {
         // Store in module for later phases
         module.generic_structs.clone_from(&generic_structs);
 
-        // Build set of valid struct names for collection
         let valid_struct_names: IndexSet<String> = generic_structs
             .keys()
             .map(|(name, _)| name.clone())
@@ -254,8 +253,6 @@ impl Monomorphizer {
         // that also need to be instantiated.
         let new_structs =
             self.drain_pending_structs(&module.type_table, &generic_structs, &valid_struct_names);
-
-        // Add monomorphized structs to module
         module.structs.extend(new_structs);
 
         // Phase 5: Remove generic structs from the concrete struct list

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -285,7 +285,7 @@ impl Monomorphizer {
         // Phase 8: Collect function instantiation sites from Call expressions
         self.collect_function_instantiation_sites(&module, &generic_functions);
 
-        // Phase 9: Process function instantiations and generate concrete functions
+        // Phase 9: Process function instantiations and generate concrete functions.
         // Use iterative approach: each newly instantiated function may have method calls
         // that need to be instantiated too (e.g., a generic method calling another generic
         // method on self, like sort() -> sort_by())
@@ -299,11 +299,12 @@ impl Monomorphizer {
                 .map(|(k, v)| (k.clone(), Rc::clone(v)))
                 .collect();
 
-        // Phase 9: Unified instantiation loop
+        // Unified instantiation loop.
         // Process functions and structs together until fixpoint. Function instantiation
         // may create new GenericInstance types that require struct instantiation, which
         // in turn may create new function instantiation sites. Processing them in a
-        // single loop eliminates the need for the separate "Phase 13" second pass.
+        // single loop removes the second function-instantiation pass the pipeline
+        // previously needed.
         let mut new_functions: Vec<Rc<RefCell<TirFunction>>> = Vec::new();
         loop {
             let mut made_progress = false;

--- a/wado-compiler/src/monomorphize/call_rewrite.rs
+++ b/wado-compiler/src/monomorphize/call_rewrite.rs
@@ -33,8 +33,8 @@ fn receiver_module_hint(tt: &TypeTable, tid: TypeId) -> Option<ModuleSource> {
 /// preserving the call's `method_info`. The new `monomorph_info` records the
 /// pre-mono `generic_name` and the type args the instance was keyed with.
 ///
-/// `func.method_info` is unchanged until the reassignment, so cloning it here
-/// matches the previous per-site `let original_method_info = …` capture.
+/// `func` is overwritten in full here, so move `method_info` out instead of
+/// cloning it.
 fn apply_instantiation(
     func: &mut FunctionRef,
     module_source: ModuleSource,
@@ -44,7 +44,7 @@ fn apply_instantiation(
     method_type_args: Vec<TypeId>,
     is_blanket: bool,
 ) {
-    let method_info = func.method_info.clone();
+    let method_info = std::mem::take(&mut func.method_info);
     *func = FunctionRef {
         module_source,
         name: mangled,

--- a/wado-compiler/src/monomorphize/call_rewrite.rs
+++ b/wado-compiler/src/monomorphize/call_rewrite.rs
@@ -240,7 +240,6 @@ impl Monomorphizer {
         } = &mut expr.kind
         {
             let original_func_name = func.name.clone();
-            let original_method_info = func.method_info.clone();
             let qualified_func_key =
                 generic_function_key(func.is_method(), &func.module_source, &func.name);
             let qualified_func_name = qualified_func_key.1;
@@ -253,7 +252,7 @@ impl Monomorphizer {
             } else if func.method_info.is_none() && func.monomorph_info.is_none() {
                 self.infer_instantiated_type_args(
                     &qualified_func_name,
-                    &original_method_info,
+                    &func.method_info,
                     args,
                     type_table,
                 )
@@ -267,7 +266,7 @@ impl Monomorphizer {
                     module_source: func.module_source.clone(),
                     impl_type_args: vec![],
                     method_type_args: inferred_args,
-                    method_info: original_method_info.clone(),
+                    method_info: func.method_info.clone(),
                 };
                 if let Some(mangled) = self.lookup_function_instantiation(&key) {
                     let mangled = mangled.clone();
@@ -352,8 +351,8 @@ impl Monomorphizer {
         // Extract method name from method_info or fall back to function name
         let method_name = method_func
             .method_info
-            .clone()
-            .map(|info| info.method_name)
+            .as_ref()
+            .map(|info| info.method_name.clone())
             .unwrap_or_else(|| method_func.name.clone());
         // If this is a generic method call, rewrite to monomorphized name
         if !type_args.is_empty()
@@ -365,8 +364,8 @@ impl Monomorphizer {
             // base (`List<u8>^…`). Mirrors the collect path in `func_inst.rs`.
             let trait_name_opt = method_func
                 .method_info
-                .clone()
-                .and_then(|info| info.trait_name);
+                .as_ref()
+                .and_then(|info| info.trait_name.clone());
             let (own_name, names_to_try) = self.newtype_aware_method_names(
                 receiver.type_id,
                 type_table,
@@ -514,7 +513,7 @@ impl Monomorphizer {
         {
             // Try trait method name format first (e.g., Triple^IndexValue::index_value)
             let mut possible_keys = Vec::new();
-            if let Some(ref info) = method_func.method_info.clone()
+            if let Some(info) = method_func.method_info.as_ref()
                 && let Some(ref trait_name) = info.trait_name
             {
                 // For ref-type impls, try the ref struct name first (e.g., "&^IntoIterator::into_iter")

--- a/wado-compiler/src/monomorphize/call_rewrite.rs
+++ b/wado-compiler/src/monomorphize/call_rewrite.rs
@@ -29,6 +29,35 @@ fn receiver_module_hint(tt: &TypeTable, tid: TypeId) -> Option<ModuleSource> {
     }
 }
 
+/// Rebuild `func` to point at the monomorphized instance named `mangled`,
+/// preserving the call's `method_info`. The new `monomorph_info` records the
+/// pre-mono `generic_name` and the type args the instance was keyed with.
+///
+/// `func.method_info` is unchanged until the reassignment, so cloning it here
+/// matches the previous per-site `let original_method_info = …` capture.
+fn apply_instantiation(
+    func: &mut FunctionRef,
+    module_source: ModuleSource,
+    mangled: String,
+    generic_name: String,
+    impl_type_args: Vec<TypeId>,
+    method_type_args: Vec<TypeId>,
+    is_blanket: bool,
+) {
+    let method_info = func.method_info.clone();
+    *func = FunctionRef {
+        module_source,
+        name: mangled,
+        monomorph_info: Some(MonomorphInfo {
+            generic_name,
+            impl_type_args,
+            method_type_args,
+            is_blanket,
+        }),
+        method_info,
+    };
+}
+
 impl Monomorphizer {
     /// Try to find a queued instantiation, allowing `key.module_source` to be
     /// an approximate hint. Mirrors `lookup_template_with_trait_fallback` in
@@ -241,17 +270,16 @@ impl Monomorphizer {
                     method_info: original_method_info.clone(),
                 };
                 if let Some(mangled) = self.lookup_function_instantiation(&key) {
-                    *func = FunctionRef {
-                        module_source: key.module_source.clone(),
-                        name: mangled.clone(),
-                        monomorph_info: Some(MonomorphInfo {
-                            generic_name: original_func_name,
-                            impl_type_args: key.impl_type_args.clone(),
-                            method_type_args: key.method_type_args.clone(),
-                            is_blanket: false,
-                        }),
-                        method_info: original_method_info,
-                    };
+                    let mangled = mangled.clone();
+                    apply_instantiation(
+                        func,
+                        key.module_source.clone(),
+                        mangled,
+                        original_func_name,
+                        key.impl_type_args.clone(),
+                        key.method_type_args.clone(),
+                        false,
+                    );
 
                     if let ResolvedType::TypeParam { index, .. } = type_table.get(expr.type_id)
                         && let Some(&concrete) = key.method_type_args.get(*index as usize)
@@ -294,18 +322,15 @@ impl Monomorphizer {
                     if let Some((key, mangled)) =
                         self.lookup_instantiation_with_trait_fallback(key, &candidates, None)
                     {
-                        let original_method_info = func.method_info.clone();
-                        *func = FunctionRef {
-                            module_source: key.module_source.clone(),
-                            name: mangled,
-                            monomorph_info: Some(MonomorphInfo {
-                                generic_name: generic_method_name,
-                                impl_type_args: key.impl_type_args.clone(),
-                                method_type_args: key.method_type_args,
-                                is_blanket: false,
-                            }),
-                            method_info: original_method_info,
-                        };
+                        apply_instantiation(
+                            func,
+                            key.module_source.clone(),
+                            mangled,
+                            generic_method_name,
+                            key.impl_type_args.clone(),
+                            key.method_type_args,
+                            false,
+                        );
                         break;
                     }
                 }
@@ -368,18 +393,15 @@ impl Monomorphizer {
                     &candidates,
                     receiver_module.as_ref(),
                 ) {
-                    let original_method_info = method_func.method_info.clone();
-                    *method_func = FunctionRef {
-                        module_source: key.module_source.clone(),
-                        name: mangled,
-                        monomorph_info: Some(MonomorphInfo {
-                            generic_name: full_method_name.clone(),
-                            impl_type_args: key.impl_type_args.clone(),
-                            method_type_args: key.method_type_args,
-                            is_blanket: false,
-                        }),
-                        method_info: original_method_info,
-                    };
+                    apply_instantiation(
+                        method_func,
+                        key.module_source.clone(),
+                        mangled,
+                        full_method_name.clone(),
+                        key.impl_type_args.clone(),
+                        key.method_type_args,
+                        false,
+                    );
                     type_args.clear();
                     rewritten = true;
                     break;
@@ -433,18 +455,15 @@ impl Monomorphizer {
                                 dg_receiver_module.as_ref(),
                             )
                         {
-                            let original_method_info = method_func.method_info.clone();
-                            *method_func = FunctionRef {
-                                module_source: combined_key.module_source.clone(),
-                                name: mangled,
-                                monomorph_info: Some(MonomorphInfo {
-                                    generic_name: generic_method_name.clone(),
-                                    impl_type_args: combined_key.impl_type_args.clone(),
-                                    method_type_args: combined_key.method_type_args.clone(),
-                                    is_blanket: false,
-                                }),
-                                method_info: original_method_info,
-                            };
+                            apply_instantiation(
+                                method_func,
+                                combined_key.module_source.clone(),
+                                mangled,
+                                generic_method_name.clone(),
+                                combined_key.impl_type_args.clone(),
+                                combined_key.method_type_args.clone(),
+                                false,
+                            );
                             type_args.clear();
 
                             if let ResolvedType::TypeParam { index, .. } =
@@ -551,19 +570,15 @@ impl Monomorphizer {
                     &pk_candidates,
                     pk_receiver_module.as_ref(),
                 ) {
-                    // Preserve original method_info
-                    let original_method_info = method_func.method_info.clone();
-                    *method_func = FunctionRef {
-                        module_source: key.module_source.clone(),
-                        name: mangled,
-                        monomorph_info: Some(MonomorphInfo {
-                            generic_name: key.name.clone(),
-                            impl_type_args: key.impl_type_args.clone(),
-                            method_type_args: key.method_type_args,
-                            is_blanket: false,
-                        }),
-                        method_info: original_method_info,
-                    };
+                    apply_instantiation(
+                        method_func,
+                        key.module_source.clone(),
+                        mangled,
+                        key.name.clone(),
+                        key.impl_type_args.clone(),
+                        key.method_type_args,
+                        false,
+                    );
                     break;
                 }
             }
@@ -608,18 +623,15 @@ impl Monomorphizer {
                 None
             };
             if let Some((mangled, generic_name, impl_ta, method_ta, ms)) = blanket_lookup {
-                let original_method_info = method_func.method_info.clone();
-                *method_func = FunctionRef {
-                    module_source: ms,
-                    name: mangled,
-                    monomorph_info: Some(MonomorphInfo {
-                        generic_name,
-                        impl_type_args: impl_ta,
-                        method_type_args: method_ta,
-                        is_blanket: true,
-                    }),
-                    method_info: original_method_info,
-                };
+                apply_instantiation(
+                    method_func,
+                    ms,
+                    mangled,
+                    generic_name,
+                    impl_ta,
+                    method_ta,
+                    true,
+                );
             }
         }
         // Tuple variadic impl: rewrite Tuple^Eq::eq → Tuple<i32,i32,i32>^Eq::eq
@@ -657,18 +669,15 @@ impl Monomorphizer {
                     &candidates,
                     tuple_receiver_module.as_ref(),
                 ) {
-                    let original_method_info = method_func.method_info.clone();
-                    *method_func = FunctionRef {
-                        module_source: key.module_source,
-                        name: mangled,
-                        monomorph_info: Some(MonomorphInfo {
-                            generic_name,
-                            impl_type_args,
-                            method_type_args: vec![],
-                            is_blanket: false,
-                        }),
-                        method_info: original_method_info,
-                    };
+                    apply_instantiation(
+                        method_func,
+                        key.module_source,
+                        mangled,
+                        generic_name,
+                        impl_type_args,
+                        vec![],
+                        false,
+                    );
                 }
             }
         }

--- a/wado-compiler/src/monomorphize/call_rewrite.rs
+++ b/wado-compiler/src/monomorphize/call_rewrite.rs
@@ -638,12 +638,7 @@ impl Monomorphizer {
                 )
             });
             let impl_type_args = mono.map(|m| m.impl_type_args.clone()).unwrap_or_else(|| {
-                let mut receiver_type = receiver.type_id;
-                while let ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) =
-                    type_table.get(receiver_type).clone()
-                {
-                    receiver_type = inner;
-                }
+                let receiver_type = type_table.peel_refs(receiver.type_id);
                 type_table.as_tuple(receiver_type).unwrap_or_default()
             });
             {

--- a/wado-compiler/src/monomorphize/call_rewrite.rs
+++ b/wado-compiler/src/monomorphize/call_rewrite.rs
@@ -289,7 +289,7 @@ impl Monomorphizer {
                     type_args.clear();
                 }
             }
-            // Also handle static method calls (formerly StaticCall) that need rewriting
+            // Also handle static method calls that need rewriting
             if let FunctionRef {
                 monomorph_info: Some(monomorph),
                 method_info: Some(info),

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -1583,8 +1583,8 @@ impl Monomorphizer {
                             // Apply the callee's own substituted type args.
                             // Type args feeding into MethodInfo names use the
                             // qualified mangle so call sites match the
-                            // function-definition naming
-                            // (`func_inst.rs:840+`).
+                            // function-definition naming produced by the
+                            // `method_instantiation_name*` helpers.
                             let impl_names: Vec<String> = sub_impl_type_args
                                 .iter()
                                 .map(|&tid| type_table.mangle_type_arg_for_generic(tid))
@@ -2255,8 +2255,8 @@ impl Monomorphizer {
                 // Then substitute struct_type
                 *struct_type = self.substitute_type(*struct_type, substitution, type_table);
 
-                // Important: expr.type_id has already been substituted (line 1605 above)
-                // Use it to get the correct struct type and name
+                // Important: expr.type_id has already been substituted at the top
+                // of this function. Use it to get the correct struct type and name
                 // This handles the case where struct_type is a plain Struct but expr.type_id
                 // has been properly substituted to the monomorphized version
                 if expr.type_id != *struct_type {
@@ -3794,8 +3794,8 @@ fn try_lower_comparison(
             // synthesised here (Eq / Ord operator lowering) name
             // their target methods with the same struct-name form
             // the monomorphizer's `method_instantiation_name_inner`
-            // and `func_inst.rs:840` use to set the function
-            // definition's `MethodInfo.struct_name`. Falling back to
+            // uses to set the function definition's
+            // `MethodInfo.struct_name`. Falling back to
             // `mangle_type_name` here used to emit `Foo<String>::eq`
             // call sites against `Foo<core:prelude/string.wado/String>::eq`
             // function definitions and broke the inliner's

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -454,8 +454,8 @@ impl Monomorphizer {
                     let mangled = self.function_instantiation_name(&key, type_table);
                     self.try_queue_function(key, mangled);
                 }
-                // Also check if this is a static method call on a monomorphized struct
-                // (formerly StaticCall). Use method_info metadata to get struct/method name.
+                // Also check if this is a static method call on a monomorphized struct.
+                // Use method_info metadata to get struct/method name.
                 if let FunctionRef {
                     method_info: Some(info),
                     monomorph_info: Some(monomorph),
@@ -1496,7 +1496,6 @@ impl Monomorphizer {
         // Substitute the expression's own type
         expr.type_id = self.substitute_type(expr.type_id, substitution, type_table);
 
-        // Recurse into sub-expressions
         match &mut expr.kind {
             TirExprKind::Call {
                 func: call_func,
@@ -1504,15 +1503,13 @@ impl Monomorphizer {
                 args,
                 ..
             } => {
-                // Substitute type args themselves
                 for type_arg in type_args.iter_mut() {
                     *type_arg = self.substitute_type(*type_arg, substitution, type_table);
                 }
-                // For static method calls (formerly StaticCall), also update the func name
-                // by delegating to the StaticCall substitution logic below via a flag.
+                // A static method call carries method_info; substitute the type
+                // args embedded in its mangled name too.
                 let is_static_method = call_func.method_info.is_some();
                 if is_static_method {
-                    // Inline the StaticCall substitution logic
                     if !substitution.is_empty()
                         && let Some(info) = call_func.method_info.clone()
                     {

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -522,11 +522,7 @@ impl Monomorphizer {
                                     method_type_args,
                                     method_info,
                                 };
-                                let mangled = self.method_instantiation_name(
-                                    &key,
-                                    type_table,
-                                    impl_type_args.len(),
-                                );
+                                let mangled = self.method_instantiation_name(&key, type_table);
                                 self.try_queue_function(key, mangled);
                             }
                             break;
@@ -611,10 +607,7 @@ impl Monomorphizer {
                                     method_type_args: type_args.clone(),
                                     method_info: Some(method_info),
                                 };
-                                let mangled = self.method_instantiation_name(
-                                    &key, type_table,
-                                    0, // non-generic struct: no impl type params
-                                );
+                                let mangled = self.method_instantiation_name(&key, type_table);
                                 self.try_queue_function(key, mangled);
                                 found = true;
                                 break;
@@ -705,11 +698,8 @@ impl Monomorphizer {
                                                 method_type_args: type_args.clone(),
                                                 method_info: Some(method_info),
                                             };
-                                            let mangled = self.method_instantiation_name(
-                                                &key,
-                                                type_table,
-                                                impl_type_args.len(),
-                                            );
+                                            let mangled =
+                                                self.method_instantiation_name(&key, type_table);
                                             self.try_queue_function(key, mangled);
                                             break;
                                         }
@@ -857,11 +847,7 @@ impl Monomorphizer {
                                     method_type_args: method_type_args_for_key,
                                     method_info,
                                 };
-                                let mangled = self.method_instantiation_name(
-                                    &key,
-                                    type_table,
-                                    effective_impl_type_args.len(),
-                                );
+                                let mangled = self.method_instantiation_name(&key, type_table);
                                 self.try_queue_function(key, mangled);
                                 break;
                             }
@@ -940,11 +926,7 @@ impl Monomorphizer {
                                     method_type_args: method_type_args_for_key,
                                     method_info,
                                 };
-                                let mangled = self.method_instantiation_name(
-                                    &key,
-                                    type_table,
-                                    impl_type_args.len(),
-                                );
+                                let mangled = self.method_instantiation_name(&key, type_table);
                                 self.try_queue_function(key, mangled);
                                 break;
                             }
@@ -1054,11 +1036,9 @@ impl Monomorphizer {
                         method_type_args: method_ta,
                         method_info,
                     };
-                    let impl_type_params_count = generic_func.impl_type_params.len();
                     let mangled = self.method_instantiation_name_inner(
                         &key,
                         type_table,
-                        impl_type_params_count,
                         &generic_func.impl_type_params,
                     );
                     self.try_queue_function(key, mangled);
@@ -1137,7 +1117,6 @@ impl Monomorphizer {
                         ) {
                             let generic_func = generic_func_rc.borrow();
                             let method_info = generic_func.method_info.clone();
-                            let impl_type_params_count = generic_func.impl_type_params.len();
                             let impl_type_params: Vec<crate::tir::TirTypeParam> =
                                 generic_func.impl_type_params.clone();
                             let template_module = generic_func.module_source.clone();
@@ -1152,7 +1131,6 @@ impl Monomorphizer {
                             let mangled = self.method_instantiation_name_inner(
                                 &key,
                                 type_table,
-                                impl_type_params_count,
                                 &impl_type_params,
                             );
                             self.try_queue_function(key, mangled);

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -508,7 +508,7 @@ impl Monomorphizer {
                                 let key = InstantiationKey {
                                     name: generic_method_name,
                                     module_source: template_module,
-                                    impl_type_args: impl_type_args.clone(),
+                                    impl_type_args,
                                     method_type_args,
                                     method_info,
                                 };
@@ -684,7 +684,7 @@ impl Monomorphizer {
                                             let key = InstantiationKey {
                                                 name: generic_method_name.clone(),
                                                 module_source: template_module,
-                                                impl_type_args: impl_type_args.clone(),
+                                                impl_type_args,
                                                 method_type_args: type_args.clone(),
                                                 method_info: Some(method_info),
                                             };
@@ -833,7 +833,7 @@ impl Monomorphizer {
                                 let key = InstantiationKey {
                                     name: generic_method_name.clone(),
                                     module_source: template_module,
-                                    impl_type_args: effective_impl_type_args.clone(),
+                                    impl_type_args: effective_impl_type_args,
                                     method_type_args: method_type_args_for_key,
                                     method_info,
                                 };
@@ -912,7 +912,7 @@ impl Monomorphizer {
                                 let key = InstantiationKey {
                                     name: generic_method_name.clone(),
                                     module_source: template_module,
-                                    impl_type_args: impl_type_args.clone(),
+                                    impl_type_args,
                                     method_type_args: method_type_args_for_key,
                                     method_info,
                                 };
@@ -1509,270 +1509,264 @@ impl Monomorphizer {
                 // A static method call carries method_info; substitute the type
                 // args embedded in its mangled name too.
                 let is_static_method = call_func.method_info.is_some();
-                if is_static_method {
-                    if !substitution.is_empty()
-                        && let Some(info) = call_func.method_info.clone()
-                    {
-                        let old_func_name = call_func.name.clone();
-                        let module_source = call_func.module_source.clone();
+                if is_static_method
+                    && !substitution.is_empty()
+                    && let Some(info) = call_func.method_info.clone()
+                {
+                    let old_func_name = call_func.name.clone();
+                    let module_source = call_func.module_source.clone();
 
-                        // Derive substituted type args from the callee's own monomorph_info.
-                        // The callee's monomorph_info records which type params the callee
-                        // uses (impl-level and method-level). We substitute through the
-                        // outer function's substitution map to resolve any type params.
-                        //
-                        // This is the single source of truth for the callee's type args.
-                        // We must NOT use the outer substitution map's entries directly
-                        // as type args — those are the outer function's type params, not
-                        // the callee's.
-                        let (sub_impl_type_args, sub_method_type_args) = if let FunctionRef {
+                    // Derive substituted type args from the callee's own monomorph_info.
+                    // The callee's monomorph_info records which type params the callee
+                    // uses (impl-level and method-level). We substitute through the
+                    // outer function's substitution map to resolve any type params.
+                    //
+                    // This is the single source of truth for the callee's type args.
+                    // We must NOT use the outer substitution map's entries directly
+                    // as type args — those are the outer function's type params, not
+                    // the callee's.
+                    let (sub_impl_type_args, sub_method_type_args) = if let FunctionRef {
+                        monomorph_info: Some(mi),
+                        ..
+                    } = &*call_func
+                    {
+                        (
+                            mi.impl_type_args
+                                .iter()
+                                .map(|&tid| self.substitute_type(tid, substitution, type_table))
+                                .collect::<Vec<_>>(),
+                            mi.method_type_args
+                                .iter()
+                                .map(|&tid| self.substitute_type(tid, substitution, type_table))
+                                .collect::<Vec<_>>(),
+                        )
+                    } else if self.current_impl_type_param_count > 0
+                        && info.struct_name == info.base_struct_name
+                        && self.current_impl_struct_name.as_deref()
+                            == Some(info.base_struct_name.as_str())
+                    {
+                        // The callee has no monomorph_info, but the outer function
+                        // has impl-level type params AND the callee's struct matches
+                        // the outer impl's struct (e.g., we're inside
+                        // `impl<K,V> TreeMap<K,V>` and calling `TreeMap::new()`).
+                        // The elaborator didn't annotate the bare struct reference with
+                        // type args, so we derive them from the outer substitution's
+                        // impl-level entries.
+                        let mut sorted_entries: Vec<_> = substitution.iter().collect();
+                        sorted_entries.sort_by_key(|(idx, _)| **idx);
+                        let impl_args: Vec<TypeId> = sorted_entries
+                            .iter()
+                            .take(self.current_impl_type_param_count)
+                            .map(|(_, tid)| **tid)
+                            .collect();
+                        (impl_args, vec![])
+                    } else {
+                        (vec![], vec![])
+                    };
+
+                    // Build the new method info with substituted type names.
+                    let mut new_info = if info.is_type_param_receiver {
+                        // The struct name is a type parameter (e.g., T^Ord::cmp);
+                        // resolve the concrete receiver by the param's name.
+                        match self.receiver_substitution_tid(&info, substitution) {
+                            Some(concrete_tid) => {
+                                let type_name = type_table.mangle_type_name(concrete_tid);
+                                let base = type_table.base_type_name(concrete_tid);
+                                info.with_substituted_struct_name(&type_name, &base)
+                            }
+                            None => info.clone(),
+                        }
+                    } else {
+                        // Apply the callee's own substituted type args.
+                        // Type args feeding into MethodInfo names use the
+                        // qualified mangle so call sites match the
+                        // function-definition naming produced by the
+                        // `method_instantiation_name*` helpers.
+                        let impl_names: Vec<String> = sub_impl_type_args
+                            .iter()
+                            .map(|&tid| type_table.mangle_type_arg_for_generic(tid))
+                            .collect();
+                        let method_names: Vec<String> = sub_method_type_args
+                            .iter()
+                            .map(|&tid| type_table.mangle_type_arg_for_generic(tid))
+                            .collect();
+                        if impl_names.is_empty() && method_names.is_empty() {
+                            info.clone()
+                        } else {
+                            info.with_type_args(&impl_names, &method_names)
+                        }
+                    };
+                    // For type param receivers, also update method type args if they
+                    // contain type params that need substitution (e.g., R → FixedReader
+                    // in a default trait method body calling Self::read::<R>(r)).
+                    // The with_substituted_struct_name above only replaces the struct
+                    // name, not the method type args.
+                    if info.is_type_param_receiver
+                        && let FunctionRef {
                             monomorph_info: Some(mi),
                             ..
                         } = &*call_func
-                        {
-                            (
-                                mi.impl_type_args
-                                    .iter()
-                                    .map(|&tid| self.substitute_type(tid, substitution, type_table))
-                                    .collect::<Vec<_>>(),
-                                mi.method_type_args
-                                    .iter()
-                                    .map(|&tid| self.substitute_type(tid, substitution, type_table))
-                                    .collect::<Vec<_>>(),
-                            )
-                        } else if self.current_impl_type_param_count > 0
-                            && info.struct_name == info.base_struct_name
-                            && self.current_impl_struct_name.as_deref()
-                                == Some(info.base_struct_name.as_str())
-                        {
-                            // The callee has no monomorph_info, but the outer function
-                            // has impl-level type params AND the callee's struct matches
-                            // the outer impl's struct (e.g., we're inside
-                            // `impl<K,V> TreeMap<K,V>` and calling `TreeMap::new()`).
-                            // The elaborator didn't annotate the bare struct reference with
-                            // type args, so we derive them from the outer substitution's
-                            // impl-level entries.
-                            let mut sorted_entries: Vec<_> = substitution.iter().collect();
-                            sorted_entries.sort_by_key(|(idx, _)| **idx);
-                            let impl_args: Vec<TypeId> = sorted_entries
+                    {
+                        let substituted_method_args: Vec<TypeId> = mi
+                            .method_type_args
+                            .iter()
+                            .map(|&tid| self.substitute_type(tid, substitution, type_table))
+                            .collect();
+                        let any_changed = substituted_method_args
+                            .iter()
+                            .zip(mi.method_type_args.iter())
+                            .any(|(a, b)| a != b);
+                        if any_changed {
+                            new_info.method_type_args = substituted_method_args
                                 .iter()
-                                .take(self.current_impl_type_param_count)
-                                .map(|(_, tid)| **tid)
+                                .map(|&tid| type_table.mangle_type_arg_for_generic(tid))
                                 .collect();
-                            (impl_args, vec![])
-                        } else {
-                            (vec![], vec![])
-                        };
+                        }
+                    }
+                    let new_func_name = new_info.to_mangled_name();
 
-                        // Build the new method info with substituted type names.
-                        let mut new_info = if info.is_type_param_receiver {
-                            // The struct name is a type parameter (e.g., T^Ord::cmp);
-                            // resolve the concrete receiver by the param's name.
-                            match self.receiver_substitution_tid(&info, substitution) {
-                                Some(concrete_tid) => {
-                                    let type_name = type_table.mangle_type_name(concrete_tid);
-                                    let base = type_table.base_type_name(concrete_tid);
-                                    info.with_substituted_struct_name(&type_name, &base)
-                                }
-                                None => info.clone(),
-                            }
-                        } else {
-                            // Apply the callee's own substituted type args.
-                            // Type args feeding into MethodInfo names use the
-                            // qualified mangle so call sites match the
-                            // function-definition naming produced by the
-                            // `method_instantiation_name*` helpers.
-                            let impl_names: Vec<String> = sub_impl_type_args
-                                .iter()
-                                .map(|&tid| type_table.mangle_type_arg_for_generic(tid))
-                                .collect();
-                            let method_names: Vec<String> = sub_method_type_args
-                                .iter()
-                                .map(|&tid| type_table.mangle_type_arg_for_generic(tid))
-                                .collect();
-                            if impl_names.is_empty() && method_names.is_empty() {
-                                info.clone()
+                    // The work each branch performs is gated on its own real
+                    // precondition, not on whether the mangled name changed:
+                    //
+                    //  - A type-param receiver (`S^Trait::method`) needs its
+                    //    home module resolved and its concrete instance queued
+                    //    exactly when the receiver resolved to a concrete type.
+                    //    The mangled name is incidental — it stays `S^…` when a
+                    //    user struct is literally named `S` (so it equals the
+                    //    type-param spelling), yet the instance must still be
+                    //    queued or it is left unresolved at WIR build.
+                    //  - A non-type-param call encodes all of its type args in
+                    //    its name, so an unchanged name means nothing to rewrite.
+                    let receiver_tid = self.receiver_substitution_tid(&info, substitution);
+                    let receiver_is_concrete = receiver_tid.is_some_and(|tid| {
+                        !matches!(
+                            type_table.get(tid),
+                            ResolvedType::TypeParam { .. } | ResolvedType::TypePack { .. }
+                        )
+                    });
+
+                    if info.is_type_param_receiver {
+                        if receiver_is_concrete {
+                            let concrete_type_id = receiver_tid
+                                .expect("receiver_is_concrete implies a resolved receiver");
+                            let receiver_module =
+                                module_source_for_trait_impl(type_table, concrete_type_id);
+                            // Per the inspect_ref_array_field.wado contract, this
+                            // path must consult `concrete_impl_module_for` only —
+                            // letting a generic `impl<T> Trait for Foo<T>` leak in
+                            // would route `&List<i32>^Inspect` to List's impl in
+                            // format.wado instead of the ref blanket's, and the
+                            // leading `&` would disappear at codegen.
+                            //
+                            // If no concrete impl exists, a generic impl
+                            // on the receiver type lives in that type's
+                            // own module by convention — fall through to
+                            // `receiver_module`. Only when no per-type
+                            // impl exists at all does dispatch run
+                            // through a blanket impl
+                            // (`impl<I: Bound> Trait for I`); those live
+                            // in the blanket's own module.
+                            let trait_name_for_blanket = new_info
+                                .base_trait_name
+                                .as_deref()
+                                .or(new_info.trait_name.as_deref());
+                            let generic_or_concrete =
+                                self.functions.generic_or_concrete_impl_module(
+                                    &new_info,
+                                    receiver_module.as_ref(),
+                                );
+                            let blanket_module = if generic_or_concrete.is_none() {
+                                trait_name_for_blanket.and_then(|tn| {
+                                    self.functions
+                                        .trait_env
+                                        .blanket_impl_module_for_trait(tn, receiver_module.as_ref())
+                                        .cloned()
+                                })
                             } else {
-                                info.with_type_args(&impl_names, &method_names)
-                            }
-                        };
-                        // For type param receivers, also update method type args if they
-                        // contain type params that need substitution (e.g., R → FixedReader
-                        // in a default trait method body calling Self::read::<R>(r)).
-                        // The with_substituted_struct_name above only replaces the struct
-                        // name, not the method type args.
-                        if info.is_type_param_receiver
-                            && let FunctionRef {
+                                None
+                            };
+                            let concrete_impl_module = self
+                                .functions
+                                .impl_module(&new_info, receiver_module.as_ref());
+                            let concrete_module =
+                                concrete_impl_module.or(blanket_module).or(receiver_module);
+                            let method_type_arg_tids: Vec<TypeId> = if let FunctionRef {
                                 monomorph_info: Some(mi),
                                 ..
                             } = &*call_func
-                        {
-                            let substituted_method_args: Vec<TypeId> = mi
-                                .method_type_args
-                                .iter()
-                                .map(|&tid| self.substitute_type(tid, substitution, type_table))
-                                .collect();
-                            let any_changed = substituted_method_args
-                                .iter()
-                                .zip(mi.method_type_args.iter())
-                                .any(|(a, b)| a != b);
-                            if any_changed {
-                                new_info.method_type_args = substituted_method_args
+                            {
+                                mi.method_type_args
                                     .iter()
-                                    .map(|&tid| type_table.mangle_type_arg_for_generic(tid))
-                                    .collect();
-                            }
-                        }
-                        let new_func_name = new_info.to_mangled_name();
-
-                        // The work each branch performs is gated on its own real
-                        // precondition, not on whether the mangled name changed:
-                        //
-                        //  - A type-param receiver (`S^Trait::method`) needs its
-                        //    home module resolved and its concrete instance queued
-                        //    exactly when the receiver resolved to a concrete type.
-                        //    The mangled name is incidental — it stays `S^…` when a
-                        //    user struct is literally named `S` (so it equals the
-                        //    type-param spelling), yet the instance must still be
-                        //    queued or it is left unresolved at WIR build.
-                        //  - A non-type-param call encodes all of its type args in
-                        //    its name, so an unchanged name means nothing to rewrite.
-                        let receiver_tid = self.receiver_substitution_tid(&info, substitution);
-                        let receiver_is_concrete = receiver_tid.is_some_and(|tid| {
-                            !matches!(
-                                type_table.get(tid),
-                                ResolvedType::TypeParam { .. } | ResolvedType::TypePack { .. }
-                            )
-                        });
-
-                        if info.is_type_param_receiver {
-                            if receiver_is_concrete {
-                                let concrete_type_id = receiver_tid
-                                    .expect("receiver_is_concrete implies a resolved receiver");
-                                let receiver_module =
-                                    module_source_for_trait_impl(type_table, concrete_type_id);
-                                // Per the inspect_ref_array_field.wado contract, this
-                                // path must consult `concrete_impl_module_for` only —
-                                // letting a generic `impl<T> Trait for Foo<T>` leak in
-                                // would route `&List<i32>^Inspect` to List's impl in
-                                // format.wado instead of the ref blanket's, and the
-                                // leading `&` would disappear at codegen.
-                                //
-                                // If no concrete impl exists, a generic impl
-                                // on the receiver type lives in that type's
-                                // own module by convention — fall through to
-                                // `receiver_module`. Only when no per-type
-                                // impl exists at all does dispatch run
-                                // through a blanket impl
-                                // (`impl<I: Bound> Trait for I`); those live
-                                // in the blanket's own module.
-                                let trait_name_for_blanket = new_info
-                                    .base_trait_name
-                                    .as_deref()
-                                    .or(new_info.trait_name.as_deref());
-                                let generic_or_concrete =
-                                    self.functions.generic_or_concrete_impl_module(
-                                        &new_info,
-                                        receiver_module.as_ref(),
-                                    );
-                                let blanket_module = if generic_or_concrete.is_none() {
-                                    trait_name_for_blanket.and_then(|tn| {
-                                        self.functions
-                                            .trait_env
-                                            .blanket_impl_module_for_trait(
-                                                tn,
-                                                receiver_module.as_ref(),
-                                            )
-                                            .cloned()
-                                    })
-                                } else {
-                                    None
-                                };
-                                let concrete_impl_module = self
-                                    .functions
-                                    .impl_module(&new_info, receiver_module.as_ref());
-                                let concrete_module =
-                                    concrete_impl_module.or(blanket_module).or(receiver_module);
-                                let method_type_arg_tids: Vec<TypeId> = if let FunctionRef {
-                                    monomorph_info: Some(mi),
-                                    ..
-                                } = &*call_func
-                                {
-                                    mi.method_type_args
-                                        .iter()
-                                        .map(|&tid| {
-                                            self.substitute_type(tid, substitution, type_table)
-                                        })
-                                        .collect()
-                                } else {
-                                    Vec::new()
-                                };
-                                let impl_type_arg_tids: Vec<TypeId> = type_table
-                                    .generic_type_args(concrete_type_id)
-                                    .unwrap_or_default();
-                                // A generic-instance receiver
-                                // (`List<i32>^Default::default`) must queue its impl
-                                // instantiation even with no method type args of its
-                                // own — they are impl-level. A non-generic receiver
-                                // (`i32^Default::default`) is a direct function.
-                                let new_monomorph = if method_type_arg_tids.is_empty()
-                                    && impl_type_arg_tids.is_empty()
-                                {
-                                    None
-                                } else {
-                                    let base_info = LocalMethodName::new(
-                                        new_info.base_struct_name.clone(),
-                                        new_info.trait_name.clone(),
-                                        new_info.method_name.clone(),
-                                    )
-                                    .with_base_trait_module(new_info.base_trait_module.clone());
-                                    let generic_name = base_info.to_mangled_name();
-                                    Some(MonomorphInfo {
-                                        generic_name,
-                                        impl_type_args: impl_type_arg_tids,
-                                        method_type_args: method_type_arg_tids,
-                                        is_blanket: false,
-                                    })
-                                };
-                                // Generics have a defined home module by construction:
-                                // either the trait-impl block's module, or — for
-                                // auto-derived impls — the receiver type's module
-                                // (`module_source_for_trait_impl`). Crash here rather
-                                // than fall back to the call-site module; a failure
-                                // means a missing prelude definition or an unhandled
-                                // `ResolvedType` arm in `module_source_for_trait_impl`.
-                                let resolved_module = concrete_module.unwrap_or_else(|| {
-                                    panic!(
-                                        "no home module for generic dispatch `{}` \
+                                    .map(|&tid| self.substitute_type(tid, substitution, type_table))
+                                    .collect()
+                            } else {
+                                Vec::new()
+                            };
+                            let impl_type_arg_tids: Vec<TypeId> = type_table
+                                .generic_type_args(concrete_type_id)
+                                .unwrap_or_default();
+                            // A generic-instance receiver
+                            // (`List<i32>^Default::default`) must queue its impl
+                            // instantiation even with no method type args of its
+                            // own — they are impl-level. A non-generic receiver
+                            // (`i32^Default::default`) is a direct function.
+                            let new_monomorph = if method_type_arg_tids.is_empty()
+                                && impl_type_arg_tids.is_empty()
+                            {
+                                None
+                            } else {
+                                let base_info = LocalMethodName::new(
+                                    new_info.base_struct_name.clone(),
+                                    new_info.trait_name.clone(),
+                                    new_info.method_name.clone(),
+                                )
+                                .with_base_trait_module(new_info.base_trait_module.clone());
+                                let generic_name = base_info.to_mangled_name();
+                                Some(MonomorphInfo {
+                                    generic_name,
+                                    impl_type_args: impl_type_arg_tids,
+                                    method_type_args: method_type_arg_tids,
+                                    is_blanket: false,
+                                })
+                            };
+                            // Generics have a defined home module by construction:
+                            // either the trait-impl block's module, or — for
+                            // auto-derived impls — the receiver type's module
+                            // (`module_source_for_trait_impl`). Crash here rather
+                            // than fall back to the call-site module; a failure
+                            // means a missing prelude definition or an unhandled
+                            // `ResolvedType` arm in `module_source_for_trait_impl`.
+                            let resolved_module = concrete_module.unwrap_or_else(|| {
+                                panic!(
+                                    "no home module for generic dispatch `{}` \
                                          (concrete type id {:?}); add the missing impl \
                                          to the prelude, or extend \
                                          `module_source_for_trait_impl` for the receiver's \
                                          `ResolvedType` arm",
-                                        new_info.to_mangled_name(),
-                                        concrete_type_id,
-                                    )
-                                });
-                                *call_func = FunctionRef {
-                                    module_source: resolved_module,
-                                    name: new_func_name,
-                                    monomorph_info: new_monomorph,
-                                    method_info: Some(new_info),
-                                };
-                            }
-                        } else if new_func_name != old_func_name {
-                            let monomorph_info = Some(MonomorphInfo {
-                                generic_name: old_func_name,
-                                impl_type_args: sub_impl_type_args,
-                                method_type_args: sub_method_type_args,
-                                is_blanket: false,
+                                    new_info.to_mangled_name(),
+                                    concrete_type_id,
+                                )
                             });
                             *call_func = FunctionRef {
-                                module_source,
+                                module_source: resolved_module,
                                 name: new_func_name,
-                                monomorph_info,
+                                monomorph_info: new_monomorph,
                                 method_info: Some(new_info),
                             };
                         }
+                    } else if new_func_name != old_func_name {
+                        let monomorph_info = Some(MonomorphInfo {
+                            generic_name: old_func_name,
+                            impl_type_args: sub_impl_type_args,
+                            method_type_args: sub_method_type_args,
+                            is_blanket: false,
+                        });
+                        *call_func = FunctionRef {
+                            module_source,
+                            name: new_func_name,
+                            monomorph_info,
+                            method_info: Some(new_info),
+                        };
                     }
                 }
                 for arg in args {

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -1263,8 +1263,7 @@ impl Monomorphizer {
         self.current_impl_struct_name = generic
             .method_info
             .as_ref()
-            .map(|info| info.base_struct_name.clone())
-            .unwrap_or_default();
+            .map(|info| info.base_struct_name.clone());
         let body = generic.body.as_ref().map(|b| {
             let mut new_body = b.clone();
             self.substitute_types_in_block(
@@ -1546,7 +1545,8 @@ impl Monomorphizer {
                             )
                         } else if self.current_impl_type_param_count > 0
                             && info.struct_name == info.base_struct_name
-                            && info.base_struct_name == self.current_impl_struct_name
+                            && self.current_impl_struct_name.as_deref()
+                                == Some(info.base_struct_name.as_str())
                         {
                             // The callee has no monomorph_info, but the outer function
                             // has impl-level type params AND the callee's struct matches

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -3537,37 +3537,40 @@ impl Monomorphizer {
                 }
             }
             TirExprKind::Block(block) => {
-                for stmt in &block.stmts {
-                    match &stmt.kind {
-                        TirStmtKind::Return { value: Some(v) } => {
-                            Self::collect_return_value_type_ids(v, types);
-                        }
-                        TirStmtKind::Expr(e) => {
-                            Self::collect_return_value_types_in_expr(e, types);
-                        }
-                        TirStmtKind::If {
-                            then_block,
-                            else_block,
-                            ..
-                        } => {
-                            for s in &then_block.stmts {
-                                if let TirStmtKind::Return { value: Some(v) } = &s.kind {
-                                    Self::collect_return_value_type_ids(v, types);
-                                }
-                            }
-                            if let Some(eb) = else_block {
-                                for s in &eb.stmts {
-                                    if let TirStmtKind::Return { value: Some(v) } = &s.kind {
-                                        Self::collect_return_value_type_ids(v, types);
-                                    }
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
+                Self::collect_return_value_types_in_block(block, types);
             }
             _ => {}
+        }
+    }
+
+    /// Collect return-value types reachable in `block`. Mirrors the traversal
+    /// of [`Self::fixup_return_types_in_block`] exactly so the wrong/correct
+    /// pairs computed here cover every Return the fixup can touch — including
+    /// those nested in `If`/`Loop`/`LabeledBlock`.
+    fn collect_return_value_types_in_block(block: &TirBlock, types: &mut IndexSet<TypeId>) {
+        for stmt in &block.stmts {
+            match &stmt.kind {
+                TirStmtKind::Return { value: Some(v) } => {
+                    Self::collect_return_value_type_ids(v, types);
+                }
+                TirStmtKind::Expr(e) => {
+                    Self::collect_return_value_types_in_expr(e, types);
+                }
+                TirStmtKind::If {
+                    then_block,
+                    else_block,
+                    ..
+                } => {
+                    Self::collect_return_value_types_in_block(then_block, types);
+                    if let Some(eb) = else_block {
+                        Self::collect_return_value_types_in_block(eb, types);
+                    }
+                }
+                TirStmtKind::LabeledBlock { block, .. } | TirStmtKind::Loop { body: block } => {
+                    Self::collect_return_value_types_in_block(block, types);
+                }
+                _ => {}
+            }
         }
     }
 

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -360,12 +360,7 @@ impl TirMutVisitor for MethodTypeArgInferer<'_> {
         // Infer T from the first non-self argument's inner type. For
         // `element<T: Serialize>(&mut self, value: &T)` the first arg is `&T`,
         // so unwrap references (and an auto-boxed `Box<T>`) to reach T.
-        let mut arg_type = first_arg.expr.type_id;
-        while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-            self.type_table.get(arg_type).clone()
-        {
-            arg_type = t;
-        }
+        let mut arg_type = self.type_table.peel_refs(first_arg.expr.type_id);
         if let ResolvedType::GenericInstance {
             name,
             type_args: ta,
@@ -384,12 +379,7 @@ impl TirMutVisitor for MethodTypeArgInferer<'_> {
             ResolvedType::TypeParam { .. } | ResolvedType::TypePack { .. } | ResolvedType::Unknown
         );
         let receiver_impl_type_args = {
-            let mut base = receiver.type_id;
-            while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                self.type_table.get(base).clone()
-            {
-                base = t;
-            }
+            let base = self.type_table.peel_refs(receiver.type_id);
             match self.type_table.get(base) {
                 ResolvedType::GenericInstance { type_args: ta, .. } => ta.clone(),
                 ResolvedType::BuiltinArray(elem) => vec![*elem],
@@ -999,12 +989,7 @@ impl Monomorphizer {
                                 {
                                     let arg_idx = pi - 1;
                                     if let Some(arg) = args.get(arg_idx) {
-                                        let mut arg_type = arg.expr.type_id;
-                                        while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                                            type_table.get(arg_type).clone()
-                                        {
-                                            arg_type = t;
-                                        }
+                                        let mut arg_type = type_table.peel_refs(arg.expr.type_id);
                                         if let ResolvedType::GenericInstance {
                                             name,
                                             type_args: ta,
@@ -1061,12 +1046,7 @@ impl Monomorphizer {
                 // auto-derived impl. `is_tuple_type` checks the receiver's
                 // `ResolvedType` + defining module, which disambiguates.
                 let receiver_is_builtin_tuple = {
-                    let mut inner = receiver.type_id;
-                    while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                        type_table.get(inner).clone()
-                    {
-                        inner = t;
-                    }
+                    let inner = type_table.peel_refs(receiver.type_id);
                     match type_table.get(inner) {
                         ResolvedType::GenericInstance {
                             name,
@@ -1090,12 +1070,7 @@ impl Monomorphizer {
                     });
                     let impl_type_args =
                         mono.map(|m| m.impl_type_args.clone()).unwrap_or_else(|| {
-                            let mut receiver_type = receiver.type_id;
-                            while let ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) =
-                                type_table.get(receiver_type).clone()
-                            {
-                                receiver_type = inner;
-                            }
+                            let receiver_type = type_table.peel_refs(receiver.type_id);
                             type_table.as_tuple(receiver_type).unwrap_or_default()
                         });
                     {
@@ -1859,12 +1834,7 @@ impl Monomorphizer {
                 // Primitives use direct Wasm instructions, not trait methods.
                 // Convert back to a binary op when monomorphization concretized to a primitive.
                 if let Some((trait_name_before, method_name_before)) = type_param_trait_info {
-                    let mut recv_inner = receiver.type_id;
-                    while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                        type_table.get(recv_inner).clone()
-                    {
-                        recv_inner = t;
-                    }
+                    let recv_inner = type_table.peel_refs(receiver.type_id);
                     if type_table.is_primitive_like(recv_inner)
                         && let Some(binary_op) = trait_method_to_binary_op(
                             trait_name_before.as_deref(),
@@ -2489,12 +2459,7 @@ impl Monomorphizer {
         // that happen to appear inside a generic impl block.
         let has_explicit_type_params = info.struct_name != info.base_struct_name;
         let receiver_is_generic = {
-            let mut base = receiver_type_id;
-            while let ResolvedType::Ref(inner) | ResolvedType::MutRef(inner) =
-                type_table.get(base).clone()
-            {
-                base = inner;
-            }
+            let base = type_table.peel_refs(receiver_type_id);
             // Unwrap Newtype to check if the underlying base type is generic
             let effective = match type_table.get(base) {
                 ResolvedType::Newtype { base_type, .. } => *base_type,
@@ -2553,11 +2518,7 @@ impl Monomorphizer {
         // name directly instead of adding type args.
         let new_info = if info.is_type_param_receiver && !type_names.is_empty() {
             // Use the (already-substituted) receiver type to find the concrete name.
-            let mut inner = receiver_type_id;
-            while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) = type_table.get(inner).clone()
-            {
-                inner = t;
-            }
+            let inner = type_table.peel_refs(receiver_type_id);
             // For newtypes/flags: first try the newtype's own name (e.g., "Meters"),
             // then fall back to the base type name (e.g., "f64") if no direct impl exists.
             let own_mangled = type_table.mangle_type_name(inner);
@@ -2580,12 +2541,7 @@ impl Monomorphizer {
         } else if needs_struct_type_args {
             // Derive the struct name from the already-substituted receiver type.
             // Resolve through newtypes so that e.g. MyArray<i32>::len → List<i32>::len.
-            let mut recv_inner = receiver_type_id;
-            while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                type_table.get(recv_inner).clone()
-            {
-                recv_inner = t;
-            }
+            let recv_inner = type_table.peel_refs(receiver_type_id);
             let recv_mangled = type_table.mangle_type_name_resolving_newtypes(recv_inner);
             // `base_type_name(Newtype)` returns the newtype's own name (e.g.
             // "MyBytes"), but the post-substitution body actually targets the
@@ -2616,12 +2572,7 @@ impl Monomorphizer {
         if info.is_type_param_receiver {
             // Type param receiver: redirect to a concrete method (e.g., T^Ord::cmp → i32^Ord::cmp)
             let receiver_module = {
-                let mut inner = receiver_type_id;
-                while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                    type_table.get(inner).clone()
-                {
-                    inner = t;
-                }
+                let inner = type_table.peel_refs(receiver_type_id);
                 module_source_for_trait_impl(type_table, inner)
             };
             // Per the inspect_ref_array_field.wado contract, this path must
@@ -2666,12 +2617,7 @@ impl Monomorphizer {
             // - Generic impl method: receiver has type_args (peeling newtypes) → handled by receiver scan → None
             // - Blanket impl method: neither → is_blanket = true
             let receiver_has_type_args = {
-                let mut inner = receiver_type_id;
-                while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                    type_table.get(inner).clone()
-                {
-                    inner = t;
-                }
+                let inner = type_table.peel_refs(receiver_type_id);
                 // Peel newtypes: `type FieldValue = List<u8>` inherits
                 // List's generic-impl dispatch, so the call must not be
                 // marked blanket even though FieldValue itself has no impl.
@@ -2768,12 +2714,7 @@ impl Monomorphizer {
             // under "&"), routing a `&List<i32>` call to `&Array`'s template.
             // The receiver's module disambiguates them.
             let receiver_hint = {
-                let mut inner = receiver_type_id;
-                while let ResolvedType::Ref(t) | ResolvedType::MutRef(t) =
-                    type_table.get(inner).clone()
-                {
-                    inner = t;
-                }
+                let inner = type_table.peel_refs(receiver_type_id);
                 super::module_source_for_trait_impl(type_table, inner)
             };
             let resolved_module = self

--- a/wado-compiler/src/monomorphize/state.rs
+++ b/wado-compiler/src/monomorphize/state.rs
@@ -148,10 +148,11 @@ pub(super) struct Monomorphizer {
     /// in the substitution map when rewriting static method calls.
     pub current_impl_type_param_count: usize,
     /// Base struct name of the impl block being instantiated (e.g., `TreeMap` for
-    /// `impl<K,V> TreeMap<K,V>`). Used to restrict impl type arg propagation to
-    /// calls on the same struct — calls to other structs within the same impl block
-    /// must not receive these type args.
-    pub current_impl_struct_name: String,
+    /// `impl<K,V> TreeMap<K,V>`), or `None` when the current function is not an
+    /// impl method. Used to restrict impl type arg propagation to calls on the
+    /// same struct — calls to other structs within the same impl block must not
+    /// receive these type args.
+    pub current_impl_struct_name: Option<String>,
     /// Maps each type-parameter *name* of the function currently being
     /// instantiated to its key in the substitution map (impl-level params use
     /// their own index; method-level params are offset past the impl params).
@@ -178,7 +179,7 @@ impl Monomorphizer {
                 trait_env,
             },
             current_impl_type_param_count: 0,
-            current_impl_struct_name: String::new(),
+            current_impl_struct_name: None,
             current_param_substitution_key: IndexMap::default(),
         }
     }

--- a/wado-compiler/src/monomorphize/state.rs
+++ b/wado-compiler/src/monomorphize/state.rs
@@ -274,21 +274,19 @@ impl Monomorphizer {
 
     /// Generate instantiated method name
     /// Format: `StructWithImplArgs::methodWithMethodArgs`
-    /// e.g., `Container::transform` with `[i32, i64]` and `impl_type_params_count=1` -> `"Container<i32>::transform<i64>"`
+    /// e.g., `Container::transform` with `[i32, i64]` -> `"Container<i32>::transform<i64>"`
     pub fn method_instantiation_name(
         &self,
         key: &InstantiationKey,
         type_table: &TypeTable,
-        impl_type_params_count: usize,
     ) -> String {
-        self.method_instantiation_name_inner(key, type_table, impl_type_params_count, &[])
+        self.method_instantiation_name_inner(key, type_table, &[])
     }
 
     pub fn method_instantiation_name_inner(
         &self,
         key: &InstantiationKey,
         type_table: &TypeTable,
-        impl_type_params_count: usize,
         impl_type_params: &[crate::tir::TirTypeParam],
     ) -> String {
         // Use method_info metadata instead of parsing key.name
@@ -296,9 +294,6 @@ impl Monomorphizer {
             // Fallback to regular function naming if no method_info
             return self.function_instantiation_name(key, type_table);
         };
-
-        // impl_type_args and method_type_args are now separate in InstantiationKey
-        let _ = impl_type_params_count; // no longer needed for split
 
         let impl_arg_names: Vec<String> = key
             .impl_type_args

--- a/wado-compiler/src/monomorphize/struct_inst.rs
+++ b/wado-compiler/src/monomorphize/struct_inst.rs
@@ -85,7 +85,6 @@ impl Monomorphizer {
             })
             .collect();
 
-        // Create the monomorphized struct
         let concrete = TirStruct {
             name: mangled_name,
             module_source: key.module_source.clone(),

--- a/wado-compiler/src/monomorphize/struct_inst.rs
+++ b/wado-compiler/src/monomorphize/struct_inst.rs
@@ -45,14 +45,9 @@ impl Monomorphizer {
                 && type_args == &key.impl_type_args
             {
                 self.structs.type_substitutions.insert(id, concrete_type_id);
-                self.structs.type_to_mangled_name.insert(
-                    id,
-                    self.structs
-                        .instantiated
-                        .get(key)
-                        .cloned()
-                        .unwrap_or_default(),
-                );
+                self.structs
+                    .type_to_mangled_name
+                    .insert(id, mangled_name.clone());
             }
         }
 


### PR DESCRIPTION
## Summary

A cleanup pass over the monomorphization phase (`wado-compiler/src/monomorphize/`), removing duplication and dead code, fixing one latent bug, and tightening comments. No intended behavior change except the bug fix; the full E2E suite stays green at every step.

## Bug fix

- **Pack-expansion return-type collection.** `collect_return_value_types_in_expr` scanned only direct `Return`s and shallow `If` branches, ignoring `Loop`/`LabeledBlock` and nested statements — while its counterpart `fixup_return_types_in_block` descends into all of them. A `return` nested in a loop/labeled block within a variadic pack-expansion element therefore had its generic type missed, so the wrong/correct type pair was never computed and the pack-type fixup silently skipped it. The collector now mirrors the fixer's traversal exactly via a shared block helper.

## Refactors (behavior-preserving)

- Extract `apply_instantiation`, collapsing seven duplicated `FunctionRef` rebuild blocks in `call_rewrite.rs` into one helper; it moves `method_info` into the rebuilt ref instead of cloning.
- Extract `drain_pending_structs`, deduplicating the two identical struct-instantiation drain loops.
- Replace 13 hand-rolled `while let Ref(t) | MutRef(t)` loops with the existing `TypeTable::peel_refs`.
- Drop the vestigial `impl_type_params_count` parameter from `method_instantiation_name`/`_inner` (it was discarded via `let _ =`).
- Remove a redundant re-lookup with `unwrap_or_default()` in `struct_inst.rs` (reuse the already-fetched mangled name; the fallback could have inserted an empty name).
- Avoid cloning `LocalMethodName` for read-only field access (`as_ref()` instead of `clone()`), and drop one redundant intermediate clone.
- Model `current_impl_struct_name` as `Option<String>` instead of an empty-string sentinel, so an absent impl context no longer aliases a struct literally named `""`.

## Docs

- Fix the confusing phase numbering (`Phase 9` labelled two blocks; a comment claimed a non-existent "Phase 13 second pass" was eliminated).
- Replace stale line/file references in comments with stable symbol references.
- Drop comments that only restated the next line, and fix a self-contradictory static-call comment.

## Deferred (noted, intentionally out of scope)

A few smells need data-model or infrastructure changes too large for a tidy pass and warrant their own tasks:

- Recovering monomorphized struct type args by reverse-looking-up a mangled string (`mangled_to_key` / `find_type_args_by_mangled_name`) — needs type args stored on the monomorphized `Struct` variant or a `TypeId` on `MethodInfo`.
- The `O(structs × type_table)` scan in `instantiate_struct` — needs a redirect-aware reverse index in `TypeTable` (a naive canonical lookup would miss redirected ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DYk7uxXt8rhbYa3yTc8jQ

---
_Generated by [Claude Code](https://claude.ai/code/session_017DYk7uxXt8rhbYa3yTc8jQ)_