### PR TITLE
refactor(synthesis): replace name-format heuristics with metadata, and dedup serde deserialize

### DIFF
--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -140,7 +140,9 @@ impl DeserializeError {
 
 #[compiler_item("serialize_seq")]
 pub trait SerializeSeq {
+    #[compiler_item("serialize_seq_element")]
     fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
+    #[compiler_item("serialize_seq_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
 }
 
@@ -152,13 +154,17 @@ pub trait SerializeMap {
 
 #[compiler_item("serialize_struct")]
 pub trait SerializeStruct {
+    #[compiler_item("serialize_struct_field")]
     fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerializeError>;
+    #[compiler_item("serialize_struct_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
 }
 
 #[compiler_item("serialize_variant")]
 pub trait SerializeVariant {
+    #[compiler_item("serialize_variant_payload")]
     fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
+    #[compiler_item("serialize_variant_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
 }
 
@@ -202,19 +208,23 @@ pub trait Serializer {
         return seq.end();
     }
     fn serialize_null(&mut self) -> Result<(), SerializeError>;
+    #[compiler_item("serializer_begin_seq")]
     fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, SerializeError> with stores[self];
     fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, SerializeError> with stores[self];
+    #[compiler_item("serializer_begin_struct")]
     fn begin_struct(
         &mut self,
         name: &String,
         fields: i32,
     ) -> Result<Self::StructSerializer, SerializeError> with stores[self];
+    #[compiler_item("serializer_serialize_unit_variant")]
     fn serialize_unit_variant(
         &mut self,
         type_name: &String,
         variant_name: &String,
         disc: i32,
     ) -> Result<(), SerializeError>;
+    #[compiler_item("serializer_begin_variant")]
     fn begin_variant(
         &mut self,
         type_name: &String,
@@ -232,7 +242,9 @@ pub trait Serialize {
 
 #[compiler_item("deserialize_seq")]
 pub trait DeserializeSeq {
+    #[compiler_item("deserialize_seq_next_element")]
     fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeserializeError>;
+    #[compiler_item("deserialize_seq_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
@@ -264,18 +276,26 @@ pub trait FieldSchema {
 
 #[compiler_item("deserialize_struct")]
 pub trait DeserializeStruct {
+    #[compiler_item("deserialize_struct_next_field")]
     fn next_field<S: FieldSchema>(&mut self) -> Result<Option<i32>, DeserializeError>;
+    #[compiler_item("deserialize_struct_value")]
     fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
+    #[compiler_item("deserialize_struct_skip")]
     fn skip(&mut self) -> Result<(), DeserializeError>;
+    #[compiler_item("deserialize_struct_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
 #[compiler_item("deserialize_variant")]
 pub trait DeserializeVariant {
+    #[compiler_item("deserialize_variant_variant_name")]
     fn variant_name(&mut self) -> Result<String, DeserializeError>;
+    #[compiler_item("deserialize_variant_disc")]
     fn disc(&mut self) -> Result<i32, DeserializeError>;
+    #[compiler_item("deserialize_variant_payload")]
     fn payload<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
     fn is_unit(&mut self) -> Result<bool, DeserializeError>;
+    #[compiler_item("deserialize_variant_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
@@ -358,13 +378,16 @@ pub trait Deserializer {
         }
     }
     fn is_null(&mut self) -> Result<bool, DeserializeError>;
+    #[compiler_item("deserializer_begin_seq")]
     fn begin_seq(&mut self) -> Result<Self::SeqAccess, DeserializeError> with stores[self];
     fn begin_map(&mut self) -> Result<Self::MapAccess, DeserializeError> with stores[self];
+    #[compiler_item("deserializer_begin_struct")]
     fn begin_struct(
         &mut self,
         name: &String,
         num_fields: i32,
     ) -> Result<Self::StructAccess, DeserializeError> with stores[self];
+    #[compiler_item("deserializer_begin_variant")]
     fn begin_variant(
         &mut self,
         type_name: &String,

--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -140,8 +140,10 @@ impl DeserializeError {
 
 #[compiler_item("serialize_seq")]
 pub trait SerializeSeq {
+
     #[compiler_item("serialize_seq_element")]
     fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
+
     #[compiler_item("serialize_seq_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
 }
@@ -154,16 +156,20 @@ pub trait SerializeMap {
 
 #[compiler_item("serialize_struct")]
 pub trait SerializeStruct {
+
     #[compiler_item("serialize_struct_field")]
     fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerializeError>;
+
     #[compiler_item("serialize_struct_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
 }
 
 #[compiler_item("serialize_variant")]
 pub trait SerializeVariant {
+
     #[compiler_item("serialize_variant_payload")]
     fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
+
     #[compiler_item("serialize_variant_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
 }
@@ -208,15 +214,18 @@ pub trait Serializer {
         return seq.end();
     }
     fn serialize_null(&mut self) -> Result<(), SerializeError>;
+
     #[compiler_item("serializer_begin_seq")]
     fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, SerializeError> with stores[self];
     fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, SerializeError> with stores[self];
+
     #[compiler_item("serializer_begin_struct")]
     fn begin_struct(
         &mut self,
         name: &String,
         fields: i32,
     ) -> Result<Self::StructSerializer, SerializeError> with stores[self];
+
     #[compiler_item("serializer_serialize_unit_variant")]
     fn serialize_unit_variant(
         &mut self,
@@ -224,6 +233,7 @@ pub trait Serializer {
         variant_name: &String,
         disc: i32,
     ) -> Result<(), SerializeError>;
+
     #[compiler_item("serializer_begin_variant")]
     fn begin_variant(
         &mut self,
@@ -242,8 +252,10 @@ pub trait Serialize {
 
 #[compiler_item("deserialize_seq")]
 pub trait DeserializeSeq {
+
     #[compiler_item("deserialize_seq_next_element")]
     fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeserializeError>;
+
     #[compiler_item("deserialize_seq_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
 }
@@ -276,25 +288,33 @@ pub trait FieldSchema {
 
 #[compiler_item("deserialize_struct")]
 pub trait DeserializeStruct {
+
     #[compiler_item("deserialize_struct_next_field")]
     fn next_field<S: FieldSchema>(&mut self) -> Result<Option<i32>, DeserializeError>;
+
     #[compiler_item("deserialize_struct_value")]
     fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
+
     #[compiler_item("deserialize_struct_skip")]
     fn skip(&mut self) -> Result<(), DeserializeError>;
+
     #[compiler_item("deserialize_struct_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
 }
 
 #[compiler_item("deserialize_variant")]
 pub trait DeserializeVariant {
+
     #[compiler_item("deserialize_variant_variant_name")]
     fn variant_name(&mut self) -> Result<String, DeserializeError>;
+
     #[compiler_item("deserialize_variant_disc")]
     fn disc(&mut self) -> Result<i32, DeserializeError>;
+
     #[compiler_item("deserialize_variant_payload")]
     fn payload<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
     fn is_unit(&mut self) -> Result<bool, DeserializeError>;
+
     #[compiler_item("deserialize_variant_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
 }
@@ -378,15 +398,18 @@ pub trait Deserializer {
         }
     }
     fn is_null(&mut self) -> Result<bool, DeserializeError>;
+
     #[compiler_item("deserializer_begin_seq")]
     fn begin_seq(&mut self) -> Result<Self::SeqAccess, DeserializeError> with stores[self];
     fn begin_map(&mut self) -> Result<Self::MapAccess, DeserializeError> with stores[self];
+
     #[compiler_item("deserializer_begin_struct")]
     fn begin_struct(
         &mut self,
         name: &String,
         num_fields: i32,
     ) -> Result<Self::StructAccess, DeserializeError> with stores[self];
+
     #[compiler_item("deserializer_begin_variant")]
     fn begin_variant(
         &mut self,

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -319,6 +319,57 @@ pub enum CompilerItem {
     /// `u128 as f32` casts.
     U128AsF32,
 
+    // ── Serde protocol methods ────────────────────────────────────────
+    // Methods on the `core:serde` (de)serializer traits that `serde_synth`
+    // emits calls to. Registered per `(trait, method)` so a stdlib rename of
+    // any one method flows through the synthesiser without a hardcoded literal.
+    /// `Serializer::begin_seq`.
+    SerializerBeginSeq,
+    /// `Serializer::begin_struct`.
+    SerializerBeginStruct,
+    /// `Serializer::serialize_unit_variant`.
+    SerializerSerializeUnitVariant,
+    /// `Serializer::begin_variant`.
+    SerializerBeginVariant,
+    /// `SerializeSeq::element`.
+    SerializeSeqElement,
+    /// `SerializeSeq::end`.
+    SerializeSeqEnd,
+    /// `SerializeStruct::field`.
+    SerializeStructField,
+    /// `SerializeStruct::end`.
+    SerializeStructEnd,
+    /// `SerializeVariant::payload`.
+    SerializeVariantPayload,
+    /// `SerializeVariant::end`.
+    SerializeVariantEnd,
+    /// `Deserializer::begin_seq`.
+    DeserializerBeginSeq,
+    /// `Deserializer::begin_struct`.
+    DeserializerBeginStruct,
+    /// `Deserializer::begin_variant`.
+    DeserializerBeginVariant,
+    /// `DeserializeSeq::next_element`.
+    DeserializeSeqNextElement,
+    /// `DeserializeSeq::end`.
+    DeserializeSeqEnd,
+    /// `DeserializeStruct::next_field`.
+    DeserializeStructNextField,
+    /// `DeserializeStruct::value`.
+    DeserializeStructValue,
+    /// `DeserializeStruct::skip`.
+    DeserializeStructSkip,
+    /// `DeserializeStruct::end`.
+    DeserializeStructEnd,
+    /// `DeserializeVariant::variant_name`.
+    DeserializeVariantVariantName,
+    /// `DeserializeVariant::disc`.
+    DeserializeVariantDisc,
+    /// `DeserializeVariant::payload`.
+    DeserializeVariantPayload,
+    /// `DeserializeVariant::end`.
+    DeserializeVariantEnd,
+
     // ── Type families ─────────────────────────────────────────────────
     /// The tuple type family (`pub type [..T];`). The owning module is
     /// recorded so the compiler can synthesise tuple types under the
@@ -413,6 +464,29 @@ impl CompilerItem {
         Self::I128AsF32,
         Self::U128AsF64,
         Self::U128AsF32,
+        Self::SerializerBeginSeq,
+        Self::SerializerBeginStruct,
+        Self::SerializerSerializeUnitVariant,
+        Self::SerializerBeginVariant,
+        Self::SerializeSeqElement,
+        Self::SerializeSeqEnd,
+        Self::SerializeStructField,
+        Self::SerializeStructEnd,
+        Self::SerializeVariantPayload,
+        Self::SerializeVariantEnd,
+        Self::DeserializerBeginSeq,
+        Self::DeserializerBeginStruct,
+        Self::DeserializerBeginVariant,
+        Self::DeserializeSeqNextElement,
+        Self::DeserializeSeqEnd,
+        Self::DeserializeStructNextField,
+        Self::DeserializeStructValue,
+        Self::DeserializeStructSkip,
+        Self::DeserializeStructEnd,
+        Self::DeserializeVariantVariantName,
+        Self::DeserializeVariantDisc,
+        Self::DeserializeVariantPayload,
+        Self::DeserializeVariantEnd,
         Self::Tuple,
         Self::Array,
     ];
@@ -506,6 +580,29 @@ impl CompilerItem {
             Self::I128AsF32 => "i128_as_f32",
             Self::U128AsF64 => "u128_as_f64",
             Self::U128AsF32 => "u128_as_f32",
+            Self::SerializerBeginSeq => "serializer_begin_seq",
+            Self::SerializerBeginStruct => "serializer_begin_struct",
+            Self::SerializerSerializeUnitVariant => "serializer_serialize_unit_variant",
+            Self::SerializerBeginVariant => "serializer_begin_variant",
+            Self::SerializeSeqElement => "serialize_seq_element",
+            Self::SerializeSeqEnd => "serialize_seq_end",
+            Self::SerializeStructField => "serialize_struct_field",
+            Self::SerializeStructEnd => "serialize_struct_end",
+            Self::SerializeVariantPayload => "serialize_variant_payload",
+            Self::SerializeVariantEnd => "serialize_variant_end",
+            Self::DeserializerBeginSeq => "deserializer_begin_seq",
+            Self::DeserializerBeginStruct => "deserializer_begin_struct",
+            Self::DeserializerBeginVariant => "deserializer_begin_variant",
+            Self::DeserializeSeqNextElement => "deserialize_seq_next_element",
+            Self::DeserializeSeqEnd => "deserialize_seq_end",
+            Self::DeserializeStructNextField => "deserialize_struct_next_field",
+            Self::DeserializeStructValue => "deserialize_struct_value",
+            Self::DeserializeStructSkip => "deserialize_struct_skip",
+            Self::DeserializeStructEnd => "deserialize_struct_end",
+            Self::DeserializeVariantVariantName => "deserialize_variant_variant_name",
+            Self::DeserializeVariantDisc => "deserialize_variant_disc",
+            Self::DeserializeVariantPayload => "deserialize_variant_payload",
+            Self::DeserializeVariantEnd => "deserialize_variant_end",
             Self::Tuple => "tuple",
             Self::Array => "array",
         }
@@ -630,7 +727,30 @@ impl CompilerItem {
             | Self::SerializeErrorKindCustom
             | Self::DeserializeErrorKindMissingField
             | Self::DeserializeErrorKindUnknownVariant
-            | Self::DeserializeErrorKindInvalidValue => false,
+            | Self::DeserializeErrorKindInvalidValue
+            | Self::SerializerBeginSeq
+            | Self::SerializerBeginStruct
+            | Self::SerializerSerializeUnitVariant
+            | Self::SerializerBeginVariant
+            | Self::SerializeSeqElement
+            | Self::SerializeSeqEnd
+            | Self::SerializeStructField
+            | Self::SerializeStructEnd
+            | Self::SerializeVariantPayload
+            | Self::SerializeVariantEnd
+            | Self::DeserializerBeginSeq
+            | Self::DeserializerBeginStruct
+            | Self::DeserializerBeginVariant
+            | Self::DeserializeSeqNextElement
+            | Self::DeserializeSeqEnd
+            | Self::DeserializeStructNextField
+            | Self::DeserializeStructValue
+            | Self::DeserializeStructSkip
+            | Self::DeserializeStructEnd
+            | Self::DeserializeVariantVariantName
+            | Self::DeserializeVariantDisc
+            | Self::DeserializeVariantPayload
+            | Self::DeserializeVariantEnd => false,
         }
     }
 
@@ -698,7 +818,30 @@ impl CompilerItem {
             | Self::I128AsF64
             | Self::I128AsF32
             | Self::U128AsF64
-            | Self::U128AsF32 => CompilerItemKind::Method,
+            | Self::U128AsF32
+            | Self::SerializerBeginSeq
+            | Self::SerializerBeginStruct
+            | Self::SerializerSerializeUnitVariant
+            | Self::SerializerBeginVariant
+            | Self::SerializeSeqElement
+            | Self::SerializeSeqEnd
+            | Self::SerializeStructField
+            | Self::SerializeStructEnd
+            | Self::SerializeVariantPayload
+            | Self::SerializeVariantEnd
+            | Self::DeserializerBeginSeq
+            | Self::DeserializerBeginStruct
+            | Self::DeserializerBeginVariant
+            | Self::DeserializeSeqNextElement
+            | Self::DeserializeSeqEnd
+            | Self::DeserializeStructNextField
+            | Self::DeserializeStructValue
+            | Self::DeserializeStructSkip
+            | Self::DeserializeStructEnd
+            | Self::DeserializeVariantVariantName
+            | Self::DeserializeVariantDisc
+            | Self::DeserializeVariantPayload
+            | Self::DeserializeVariantEnd => CompilerItemKind::Method,
             Self::Tuple => CompilerItemKind::TupleFamily,
             Self::Array => CompilerItemKind::BuiltinType,
             Self::OptionSome | Self::OptionNone | Self::ResultOk | Self::ResultErr => {

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -1095,6 +1095,17 @@ impl CompilerItems {
         self.require_trait(item).1
     }
 
+    /// Non-panicking [`Self::trait_name`]: `None` when the item is not
+    /// registered. Used to classify a trait reference against optional
+    /// anchors (e.g. serde traits, absent unless the program imports serde)
+    /// without forcing every caller to import them.
+    pub fn trait_name_opt(&self, item: CompilerItem) -> Option<&str> {
+        match self.get(item)? {
+            Resolved::Trait { name, .. } => Some(name.as_str()),
+            _ => None,
+        }
+    }
+
     /// Resolved method name of a **single-method** trait — `"fmt"` for
     /// `Display`, `"inspect"` for `Inspect`, and so on across the
     /// format-family traits. Panics for multi-method traits where

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -786,6 +786,54 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         self.sem.decls.pending_synthesis_requests.push(req);
     }
 
+    /// Classify the trait named by an `impl Trait for Type;` request into a
+    /// [`tir::SynthTrait`]. Returns `None` for any trait the compiler cannot
+    /// synthesize, letting the caller emit a diagnostic. `From<Source>`
+    /// resolves its argument to a [`TypeId`] here so no downstream pass has to
+    /// re-parse the mangled trait name.
+    fn classify_synth_trait(&mut self, trait_type: &ast::Type) -> Option<tir::SynthTrait> {
+        use crate::compiler_item::CompilerItem;
+        let base = trait_type.head_base_name()?;
+        // `trait_name_opt` keeps the serde anchors optional: a program that
+        // never imports serde has them unregistered, and a `From<…>` request
+        // must still classify there without tripping a registry panic.
+        enum Kind {
+            From,
+            Serialize,
+            Deserialize,
+        }
+        let kind = {
+            let tt = self.tysys.type_table.borrow();
+            let items = tt.compiler_items();
+            let is = |item| items.trait_name_opt(item) == Some(base);
+            if is(CompilerItem::Serialize) {
+                Kind::Serialize
+            } else if is(CompilerItem::Deserialize) {
+                Kind::Deserialize
+            } else if is(CompilerItem::From) {
+                Kind::From
+            } else {
+                return None;
+            }
+        };
+        match kind {
+            Kind::Serialize => Some(tir::SynthTrait::Serialize),
+            Kind::Deserialize => Some(tir::SynthTrait::Deserialize),
+            // `From<Source>` resolves its single argument to a `TypeId` so no
+            // downstream pass re-parses the mangled trait name.
+            Kind::From => {
+                if let ast::Type::Generic(generic) = trait_type
+                    && generic.args.len() == 1
+                {
+                    let source = self.resolve_type(&generic.args[0]);
+                    Some(tir::SynthTrait::From { source })
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
     /// Record a coercion decision for the expression at `ast_id`. Called
     /// from each successful `try_coerce_*` sub-helper so every caller of
     /// those helpers (`try_coerce`, `resolve_cast`, the deferred-coercion
@@ -1499,23 +1547,37 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     // `tir_module.synthesis_requests`.
                     if impl_block.is_synthesize_request {
                         if let Some(ref trait_type) = impl_block.trait_type {
-                            let synth_trait_name = self.get_type_name_full(trait_type);
-                            let target_type_id = self.resolve_type(&impl_block.ty);
-                            let type_params: Vec<_> = self
-                                .annotate_ctx
-                                .trait_ctx
-                                .type_params
-                                .iter()
-                                .map(|(name, &(index, type_id))| (name.clone(), index, type_id))
-                                .collect();
-                            let req = crate::tir::SynthesisRequest {
-                                trait_name: synth_trait_name,
-                                target_type_name: struct_name.clone(),
-                                target_type_id,
-                                type_params,
-                                span: impl_block.span,
-                            };
-                            self.record_pending_synthesis_request(req);
+                            match self.classify_synth_trait(trait_type) {
+                                Some(trait_ref) => {
+                                    let target_type_id = self.resolve_type(&impl_block.ty);
+                                    let type_params: Vec<_> = self
+                                        .annotate_ctx
+                                        .trait_ctx
+                                        .type_params
+                                        .iter()
+                                        .map(|(name, &(index, type_id))| {
+                                            (name.clone(), index, type_id)
+                                        })
+                                        .collect();
+                                    let req = crate::tir::SynthesisRequest {
+                                        trait_ref,
+                                        target_type_name: struct_name.clone(),
+                                        target_type_id,
+                                        type_params,
+                                        span: impl_block.span,
+                                    };
+                                    self.record_pending_synthesis_request(req);
+                                }
+                                None => {
+                                    let _ = self.logger.error(
+                                        types::TypeError::UnsupportedSynthesisTrait {
+                                            trait_name: self.get_type_name_full(trait_type),
+                                            type_name: struct_name.clone(),
+                                            span: impl_block.span,
+                                        },
+                                    );
+                                }
+                            }
                         }
                         self.annotate_ctx.trait_ctx = saved_trait_ctx;
                         continue;

--- a/wado-compiler/src/elaborator/module.rs
+++ b/wado-compiler/src/elaborator/module.rs
@@ -340,6 +340,21 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         trait_decl.span,
                         self.logger,
                     );
+                    // Register `#[compiler_item("...")]` on individual trait
+                    // method declarations against the trait as their owner type
+                    // — the trait body is the only place a serde protocol
+                    // method and its owning trait are both in scope.
+                    for method in &trait_decl.methods {
+                        super::item::register_method_compiler_item(
+                            &self.tysys.type_table,
+                            &method.attrs,
+                            &method.name,
+                            &trait_decl.name,
+                            &self.current_module_source,
+                            method.span,
+                            self.logger,
+                        );
+                    }
                 }
                 _ => {}
             }

--- a/wado-compiler/src/elaborator/types.rs
+++ b/wado-compiler/src/elaborator/types.rs
@@ -282,6 +282,15 @@ pub enum TypeError {
         span: Span,
     },
 
+    /// `impl Trait for Type;` requested synthesis of a trait the compiler
+    /// cannot generate. Only `From`, `Serialize`, and `Deserialize` are
+    /// synthesizable through the bodyless-impl form.
+    UnsupportedSynthesisTrait {
+        trait_name: String,
+        type_name: String,
+        span: Span,
+    },
+
     /// Trait impl cannot re-specify a parameter default (defaults belong to
     /// the trait declaration).
     DefaultInTraitImpl {
@@ -638,6 +647,17 @@ impl TypeError {
             } => (
                 Code::TypeMismatch,
                 format!("pattern mismatch: expected '{expected}', found '{found}'"),
+                *span,
+            ),
+            TypeError::UnsupportedSynthesisTrait {
+                trait_name,
+                type_name,
+                span,
+            } => (
+                Code::TypeMismatch,
+                format!(
+                    "cannot synthesize trait `{trait_name}` for `{type_name}`: only `From`, `Serialize`, and `Deserialize` support `impl Trait for Type;`"
+                ),
                 *span,
             ),
             TypeError::DefaultInTraitImpl {

--- a/wado-compiler/src/lower/plan/globals.rs
+++ b/wado-compiler/src/lower/plan/globals.rs
@@ -253,7 +253,7 @@ fn build_module_init_function(
     TirFunction {
         module_source,
         is_async: false,
-        name: "__initialize_module".to_string(),
+        name: crate::name::MODULE_INIT_FUNCTION.to_string(),
         is_pub: true,
         is_export: false,
         type_params: Vec::new(),
@@ -670,7 +670,8 @@ pub fn build_initialize_modules(flat: &mut FlatPackage) {
     let mut seen = IndexSet::default();
     for func_rc in &flat.functions {
         let func = func_rc.borrow();
-        if func.name == "__initialize_module" && seen.insert(func.module_source.clone()) {
+        if func.name == crate::name::MODULE_INIT_FUNCTION && seen.insert(func.module_source.clone())
+        {
             modules_with_init.push(func.module_source.clone());
         }
     }
@@ -746,7 +747,7 @@ pub fn build_initialize_modules(flat: &mut FlatPackage) {
             TirExprKind::Call {
                 func: FunctionRef {
                     module_source: module_source.clone(),
-                    name: "__initialize_module".to_string(),
+                    name: crate::name::MODULE_INIT_FUNCTION.to_string(),
                     monomorph_info: None,
                     method_info: None,
                 },
@@ -783,7 +784,7 @@ pub fn build_initialize_modules(flat: &mut FlatPackage) {
     let init_modules_func = TirFunction {
         module_source: entry_source.clone(),
         is_async: false,
-        name: "__initialize_modules".to_string(),
+        name: crate::name::MODULES_INIT_FUNCTION.to_string(),
         is_pub: false,
         is_export: false,
         type_params: Vec::new(),
@@ -823,7 +824,7 @@ pub fn build_initialize_modules(flat: &mut FlatPackage) {
         TirExprKind::Call {
             func: FunctionRef {
                 module_source: entry_source.clone(),
-                name: "__initialize_modules".to_string(),
+                name: crate::name::MODULES_INIT_FUNCTION.to_string(),
                 monomorph_info: None,
                 method_info: None,
             },

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1178,6 +1178,18 @@ pub fn mangle_fn_type(param_count: usize, ret_type: &str) -> String {
     format!("Fn<{param_count},{ret_type}>")
 }
 
+/// Canonical struct-type-argument names for a closure / [`CLOSURE_FN_TRAIT`]
+/// receiver: `[arity, return-type]`. Feeding these to
+/// [`mangle_generic_name`] with `CLOSURE_FN_TRAIT` reproduces the
+/// [`mangle_fn_type`] head, so the two spellings cannot drift. Trait synthesis
+/// (`Fn<N,Ret>^Inspect`) and template expansion both build them here.
+///
+/// Examples:
+/// - `fn_type_arg_names(2, "i32")` → `["2", "i32"]`
+pub fn fn_type_arg_names(arity: usize, return_type_name: &str) -> Vec<String> {
+    vec![arity.to_string(), return_type_name.to_string()]
+}
+
 /// Build an Option type name from inner type name.
 ///
 /// Examples:

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -72,6 +72,37 @@ pub const CLOSURE_STRUCT_PREFIX: &str = "__Closure_";
 /// anchor shape.
 pub const CLOSURE_FN_TRAIT: &str = "Fn";
 
+/// Label the template-string synthesiser stamps on the block wrapping an
+/// expanded `` `...` `` literal. The template-hoist and const-branch-prune
+/// optimizers key on it to recognise template expansions, so the producer
+/// (`synthesis::template`) and those consumers share this one definition
+/// instead of re-hardcoding the literal — compiler-internal, hence a `const`.
+pub const TEMPLATE_BLOCK_LABEL: &str = "__tmpl";
+
+/// Name of the result accumulator local in an expanded template block.
+/// Recognised by the template-hoist optimizer; single-sourced here.
+pub const TEMPLATE_RESULT_LOCAL: &str = "__r";
+
+/// Name of the `Formatter` local in an expanded template block. Producer-only
+/// today, kept beside its siblings so the template-local convention lives in
+/// one place.
+pub const TEMPLATE_FORMATTER_LOCAL: &str = "__f";
+
+/// Per-module initializer function the lowering phase synthesises to run a
+/// module's global initializers. The optimizer's liveness / const-object
+/// passes treat it as a root, so producer and consumers share this name.
+pub const MODULE_INIT_FUNCTION: &str = "__initialize_module";
+
+/// Aggregate initializer that calls every module's [`MODULE_INIT_FUNCTION`].
+/// Shares the [`MODULE_INIT_FUNCTION`] prefix, so a `starts_with`
+/// over the latter still covers both.
+pub const MODULES_INIT_FUNCTION: &str = "__initialize_modules";
+
+/// Prefix the const-object globalization pass stamps on the globals it hoists
+/// constant aggregates into (`__const_obj_0`, …). It both mints and rescans
+/// these names, so the prefix lives here rather than as a repeated literal.
+pub const CONST_OBJ_GLOBAL_PREFIX: &str = "__const_obj_";
+
 /// A free function name (not a method on a struct).
 ///
 /// Format: `{module_source}/{name}`

--- a/wado-compiler/src/optimize/const_branch_prune.rs
+++ b/wado-compiler/src/optimize/const_branch_prune.rs
@@ -130,7 +130,7 @@ fn prune_expr_local(engine: &mut Engine, id: ExprId, mode: PruneMode) -> bool {
     if let ExprKind::LabeledBlock { label, block, .. } = &engine.body.exprs[id].kind {
         let label = label.clone();
         let block = *block;
-        let go = (mode == PruneMode::PostFixpoint || label != "__tmpl")
+        let go = (mode == PruneMode::PostFixpoint || label != crate::name::TEMPLATE_BLOCK_LABEL)
             && engine.body.blocks[block].stmts.last().is_some_and(|&last| {
                 matches!(
                     &engine.body.stmts[last].kind,
@@ -174,7 +174,8 @@ fn prune_expr_local(engine: &mut Engine, id: ExprId, mode: PruneMode) -> bool {
     if let ExprKind::LabeledBlock { label, block, .. } = &engine.body.exprs[id].kind {
         let label = label.clone();
         let block = *block;
-        let single_break = (mode == PruneMode::PostFixpoint || label != "__tmpl")
+        let single_break = (mode == PruneMode::PostFixpoint
+            || label != crate::name::TEMPLATE_BLOCK_LABEL)
             && engine.body.blocks[block].stmts.len() == 1
             && matches!(
                 &engine.body.stmts[engine.body.blocks[block].stmts[0]].kind,
@@ -225,7 +226,7 @@ fn is_tail_break_only_labeled_block(body: &Body, stmt: StmtId, mode: PruneMode) 
         return false;
     };
     let inner = *inner;
-    if mode == PruneMode::Fixpoint && label == "__tmpl" {
+    if mode == PruneMode::Fixpoint && label == crate::name::TEMPLATE_BLOCK_LABEL {
         return false;
     }
     let Some(&last) = body.blocks[inner].stmts.last() else {
@@ -256,7 +257,7 @@ fn ends_with_terminator_stmt(body: &Body, stmts: &[StmtId]) -> bool {
 }
 
 fn unused_label_flattenable(body: &Body, label: &str, inner: BlockId, mode: PruneMode) -> bool {
-    (mode == PruneMode::PostFixpoint || label != "__tmpl")
+    (mode == PruneMode::PostFixpoint || label != crate::name::TEMPLATE_BLOCK_LABEL)
         && (body.blocks[inner].stmts.is_empty() || !block_has_break_to(body, inner, label))
 }
 

--- a/wado-compiler/src/optimize/const_object_globalization.rs
+++ b/wado-compiler/src/optimize/const_object_globalization.rs
@@ -100,10 +100,10 @@ pub fn globalize_const_objects(project: &mut NirPackage) -> bool {
     let base = project
         .globals
         .iter()
-        .filter(|g| g.name.starts_with("__const_obj_"))
+        .filter(|g| g.name.starts_with(crate::name::CONST_OBJ_GLOBAL_PREFIX))
         .count();
     for (n, cand) in (base..).zip(candidates) {
-        let name = format!("__const_obj_{n}");
+        let name = format!("{}{n}", crate::name::CONST_OBJ_GLOBAL_PREFIX);
 
         let mut func = project.functions[cand.func_idx].borrow_mut();
         let body = func.body.as_mut().expect("candidate function has a body");
@@ -144,7 +144,8 @@ pub fn globalize_const_objects(project: &mut NirPackage) -> bool {
 fn skip_function(f: &NirFunction) -> bool {
     f.is_cm_binding
         || f.is_dispatch_wrapper
-        || f.name.starts_with("__initialize")
+        || f.name == crate::name::MODULE_INIT_FUNCTION
+        || f.name == crate::name::MODULES_INIT_FUNCTION
         || f.value_copy_type().is_some()
 }
 

--- a/wado-compiler/src/optimize/tmpl_hoist.rs
+++ b/wado-compiler/src/optimize/tmpl_hoist.rs
@@ -505,7 +505,11 @@ fn transform_stmt(
     };
     if let Some((local_index, value)) = let_info {
         let tmpl_block = match &engine.body.exprs[value].kind {
-            ExprKind::LabeledBlock { label, block, .. } if label == "__tmpl" => Some(*block),
+            ExprKind::LabeledBlock { label, block, .. }
+                if label == crate::name::TEMPLATE_BLOCK_LABEL =>
+            {
+                Some(*block)
+            }
             _ => None,
         };
         if let Some(tb) = tmpl_block
@@ -642,7 +646,7 @@ fn extract_tmpl_candidate(body: &Body, block: BlockId) -> Option<TmplCandidate> 
             value,
             type_id,
             ..
-        } if name == "__r" => {
+        } if name == crate::name::TEMPLATE_RESULT_LOCAL => {
             let local_index = *local_index;
             let value = *value;
             let type_id = *type_id;
@@ -701,7 +705,7 @@ fn extract_tmpl_candidate(body: &Body, block: BlockId) -> Option<TmplCandidate> 
         StmtKind::Break {
             label: Some(label),
             value: Some(val),
-        } if label == "__tmpl" => match &body.exprs[*val].kind {
+        } if label == crate::name::TEMPLATE_BLOCK_LABEL => match &body.exprs[*val].kind {
             ExprKind::Local { index, .. } if *index == buf_local_index => {}
             _ => return None,
         },

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -5458,9 +5458,10 @@ impl Parser {
                 });
             } else {
                 // Trait methods are not pub (visibility comes from trait itself)
-                // Trait methods cannot be exported at the CM boundary
-                let _ = attrs; // attrs currently unused for trait methods
-                methods.push(self.parse_function(false, false, false, Vec::new())?);
+                // Trait methods cannot be exported at the CM boundary.
+                // Attributes (e.g. `#[compiler_item("...")]`) carry through so
+                // the elaborator can register per-method compiler items.
+                methods.push(self.parse_function(false, false, false, attrs)?);
             }
         }
 

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -145,6 +145,8 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
         // `with E` clauses (which the elaborator also canonicalises to the
         // defining module).
         let owner_sources = effect_owner_module_sources(&project.tir_modules);
+        // Keyed by the qualified `interface::method` effect name — the same key
+        // call sites are rewritten against.
         let mut adapters: IndexMap<String, Rc<RefCell<TirFunction>>> = IndexMap::default();
         // Auxiliary functions returned alongside an adapter (e.g. the
         // per-import `__cm_lift__*` for async imports). Not used for
@@ -154,8 +156,6 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
         for qualified_name in &seen_effects {
             if let Some(func_info) = project.cm_interface_registry.get_function(qualified_name) {
                 let func_info = func_info.clone();
-                let binding_name =
-                    binding_func_name(&func_info.interface_name, &func_info.method_name);
                 let owner_module = lookup_effect_owner(
                     &owner_sources,
                     &func_info.interface_name,
@@ -171,40 +171,30 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                     &entry_source,
                 );
                 auxiliary_functions.extend(produced.auxiliary);
-                let adapter = produced.adapter;
-                adapters.insert(qualified_name.clone(), adapter.clone());
-                // Also index by binding function name for lookup
-                adapters.insert(binding_name, adapter);
+                adapters.insert(qualified_name.clone(), produced.adapter);
             }
         }
 
         // Step 3: Add binding functions (and their auxiliaries) to the entry module
         if let Some(entry_module) = project.tir_modules.get_mut(&entry_source) {
-            for (key, adapter_rc) in &adapters {
-                // Only add each adapter once (skip the duplicate keyed by binding_name)
-                if key.contains("::") {
-                    entry_module.functions.push(adapter_rc.clone());
-                }
+            for adapter_rc in adapters.values() {
+                entry_module.functions.push(adapter_rc.clone());
             }
             for aux in auxiliary_functions {
                 entry_module.functions.push(aux);
             }
         }
 
-        // Step 4: Rewrite effect-like call nodes to target adapters
-        let adapter_map: IndexMap<String, Rc<RefCell<TirFunction>>> = adapters
-            .iter()
-            .filter(|(k, _)| k.contains("::"))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-
+        // Step 4: Rewrite effect-like call nodes to target adapters. Call sites
+        // are keyed by qualified `interface::method` name, exactly how
+        // `adapters` is keyed.
         for module in project.tir_modules.values() {
             for func_rc in &module.functions {
                 let mut func = func_rc.borrow_mut();
                 if let Some(body) = &mut func.body {
                     rewrite_calls_in_block(
                         body,
-                        &adapter_map,
+                        &adapters,
                         &entry_source,
                         project.cm_interface_registry,
                         &entry_type_table,

--- a/wado-compiler/src/synthesis/from_synth.rs
+++ b/wado-compiler/src/synthesis/from_synth.rs
@@ -8,30 +8,30 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::compiler_item::CompilerItem;
-use crate::name::{LocalMethodName, MethodName};
+use crate::name::{LocalMethodName, MethodName, mangle_generic_name};
 use crate::synthesis::common::{
     block, local_ref, make_synthetic_method, param_local, return_stmt, synth_span,
 };
 use crate::tir::{
-    SynthesisRequest, TirExpr, TirExprKind, TirFunction, TirModule, TirParam, TypeTable,
+    SynthTrait, SynthesisRequest, TirExpr, TirExprKind, TirFunction, TirModule, TirParam, TypeId,
+    TypeTable,
 };
 
 pub fn synthesize_from(module: &mut TirModule) {
-    // Resolve the canonical `From` trait name via the compiler-item
-    // registry so a stdlib rename of the trait still routes synthesis
-    // through the same anchor. The `From<T>` mangled form keeps the
-    // registered name as its prefix; build the prefix from the
-    // registry-driven name and drain matching requests in one pass.
+    // Resolve the canonical `From` trait name via the compiler-item registry
+    // so a stdlib rename of the trait still routes synthesis through the same
+    // anchor. The request carries its source type as a resolved `TypeId`
+    // (`SynthTrait::From`), so draining is a structural match — no `From<…>`
+    // string parsing.
     let from_trait_name = module
         .type_table
         .borrow()
         .compiler_items()
         .trait_name(CompilerItem::From)
         .to_string();
-    let from_prefix = format!("{from_trait_name}<");
     let requests: Vec<SynthesisRequest> = module
         .synthesis_requests
-        .extract_if(.., |r| r.trait_name.starts_with(from_prefix.as_str()))
+        .extract_if(.., |r| matches!(r.trait_ref, SynthTrait::From { .. }))
         .collect();
     if requests.is_empty() {
         return;
@@ -41,26 +41,24 @@ pub fn synthesize_from(module: &mut TirModule) {
     let mut generated = Vec::new();
 
     for req in &requests {
-        let from_type_name = extract_from_type_name(&req.trait_name, &from_prefix);
-        let from_trait = format!("{from_trait_name}<{from_type_name}>");
+        let SynthTrait::From { source } = req.trait_ref else {
+            continue;
+        };
+        // Build the `From<Source>` trait spelling from the source type via the
+        // type table — the canonical naming authority — rather than echoing a
+        // pre-mangled request string.
+        let source_name = module.type_table.borrow().type_name(source);
+        let from_trait = mangle_generic_name(&from_trait_name, &[source_name]);
         let key = MethodName::format_local(&req.target_type_name, Some(&from_trait), "from");
         if existing.contains(&key) {
             continue;
         }
-        if let Some(func) = generate_variant_from(module, req, &from_type_name) {
+        if let Some(func) = generate_variant_from(module, req, source, &from_trait) {
             generated.push(Rc::new(RefCell::new(func)));
         }
     }
 
     module.functions.extend(generated);
-}
-
-fn extract_from_type_name(trait_name: &str, from_prefix: &str) -> String {
-    trait_name
-        .strip_prefix(from_prefix)
-        .and_then(|s| s.strip_suffix('>'))
-        .unwrap_or(trait_name)
-        .to_string()
 }
 
 fn collect_existing_from_methods(
@@ -94,24 +92,24 @@ fn collect_existing_from_methods(
 fn generate_variant_from(
     module: &TirModule,
     req: &SynthesisRequest,
-    from_type_name: &str,
+    source: TypeId,
+    from_trait: &str,
 ) -> Option<TirFunction> {
     let variant_def = module
         .variants
         .iter()
         .find(|v| v.name == req.target_type_name)?;
 
-    let tt = module.type_table.borrow();
-
+    // Match the case by resolved type identity, not by type-name string, so two
+    // distinct same-named payload types never collide.
     let matching_case = variant_def
         .cases
         .iter()
-        .find(|c| c.payload != TypeTable::UNIT && tt.type_name(c.payload) == from_type_name)?;
+        .find(|c| c.payload != TypeTable::UNIT && c.payload == source)?;
 
     let case_name = matching_case.name.clone();
     let case_index = matching_case.index;
     let from_type = matching_case.payload;
-    drop(tt);
 
     let span = synth_span();
     let variant_type = req.target_type_id;
@@ -130,14 +128,12 @@ fn generate_variant_from(
     let body = block(vec![return_stmt(Some(variant_construct))]);
     let locals = vec![param_local("value", from_type, false)];
 
-    let from_trait_with_arg = format!("From<{from_type_name}>");
     let method_info = LocalMethodName::new(
         req.target_type_name.clone(),
-        Some(from_trait_with_arg.clone()),
+        Some(from_trait.to_string()),
         "from".to_string(),
     );
-    let qualified_name =
-        MethodName::format_local(&req.target_type_name, Some(&from_trait_with_arg), "from");
+    let qualified_name = MethodName::format_local(&req.target_type_name, Some(from_trait), "from");
 
     Some(make_synthetic_method(
         qualified_name,

--- a/wado-compiler/src/synthesis/kiln_synth.rs
+++ b/wado-compiler/src/synthesis/kiln_synth.rs
@@ -12,9 +12,8 @@
 //!
 //! See WEP 2026-04-12 (Kiln) §"Options schema".
 
-use crate::compiler_item::CompilerItem;
 use crate::package::Package;
-use crate::tir::SynthesisRequest;
+use crate::tir::{SynthTrait, SynthesisRequest};
 
 /// Target world that identifies a Kiln generator package.
 pub const KILN_GENERATOR_WORLD: &str = "core:kiln/generator";
@@ -41,16 +40,9 @@ pub fn prepare_kiln(project: &mut Package) {
         return;
     };
 
-    let deserialize_trait_name = entry_module
-        .type_table
-        .borrow()
-        .compiler_items()
-        .trait_name(CompilerItem::Deserialize)
-        .to_string();
-    let already_requested = entry_module
-        .synthesis_requests
-        .iter()
-        .any(|req| req.trait_name == deserialize_trait_name && req.target_type_name == "Options");
+    let already_requested = entry_module.synthesis_requests.iter().any(|req| {
+        matches!(req.trait_ref, SynthTrait::Deserialize) && req.target_type_name == "Options"
+    });
     if already_requested {
         return;
     }
@@ -62,7 +54,7 @@ pub fn prepare_kiln(project: &mut Package) {
         .unwrap_or(crate::tir::TypeTable::UNIT);
 
     entry_module.synthesis_requests.push(SynthesisRequest {
-        trait_name: deserialize_trait_name,
+        trait_ref: SynthTrait::Deserialize,
         target_type_name: "Options".to_string(),
         target_type_id,
         type_params: Vec::new(),

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -2128,7 +2128,10 @@ fn generate_variant_family_deserialize(
                 .iter()
                 .map(|(_, _, payload)| tt.make_result(*payload, deser_error_type))
                 .collect(),
-            cases.iter().map(|(_, _, payload)| tt.type_name(*payload)).collect(),
+            cases
+                .iter()
+                .map(|(_, _, payload)| tt.type_name(*payload))
+                .collect(),
         ),
     };
 

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -90,6 +90,32 @@ pub(super) struct SerdeStdlibNames {
     pub d_struct_access_proj: String,
     pub d_seq_access_proj: String,
     pub d_variant_access_proj: String,
+    /// Method names on the (de)serializer traits, resolved per
+    /// `(trait, method)` compiler item so `serde_synth` emits the call
+    /// without a hardcoded literal.
+    pub m_serializer_begin_seq: String,
+    pub m_serializer_begin_struct: String,
+    pub m_serializer_serialize_unit_variant: String,
+    pub m_serializer_begin_variant: String,
+    pub m_serialize_seq_element: String,
+    pub m_serialize_seq_end: String,
+    pub m_serialize_struct_field: String,
+    pub m_serialize_struct_end: String,
+    pub m_serialize_variant_payload: String,
+    pub m_serialize_variant_end: String,
+    pub m_deserializer_begin_seq: String,
+    pub m_deserializer_begin_struct: String,
+    pub m_deserializer_begin_variant: String,
+    pub m_deserialize_seq_next_element: String,
+    pub m_deserialize_seq_end: String,
+    pub m_deserialize_struct_next_field: String,
+    pub m_deserialize_struct_value: String,
+    pub m_deserialize_struct_skip: String,
+    pub m_deserialize_struct_end: String,
+    pub m_deserialize_variant_variant_name: String,
+    pub m_deserialize_variant_disc: String,
+    pub m_deserialize_variant_payload: String,
+    pub m_deserialize_variant_end: String,
 }
 
 impl SerdeStdlibNames {
@@ -224,6 +250,73 @@ impl SerdeStdlibNames {
                     items.trait_name(CompilerItem::DeserializeVariant),
                 )
             ),
+            m_serializer_begin_seq: items
+                .method_name(CompilerItem::SerializerBeginSeq)
+                .to_string(),
+            m_serializer_begin_struct: items
+                .method_name(CompilerItem::SerializerBeginStruct)
+                .to_string(),
+            m_serializer_serialize_unit_variant: items
+                .method_name(CompilerItem::SerializerSerializeUnitVariant)
+                .to_string(),
+            m_serializer_begin_variant: items
+                .method_name(CompilerItem::SerializerBeginVariant)
+                .to_string(),
+            m_serialize_seq_element: items
+                .method_name(CompilerItem::SerializeSeqElement)
+                .to_string(),
+            m_serialize_seq_end: items.method_name(CompilerItem::SerializeSeqEnd).to_string(),
+            m_serialize_struct_field: items
+                .method_name(CompilerItem::SerializeStructField)
+                .to_string(),
+            m_serialize_struct_end: items
+                .method_name(CompilerItem::SerializeStructEnd)
+                .to_string(),
+            m_serialize_variant_payload: items
+                .method_name(CompilerItem::SerializeVariantPayload)
+                .to_string(),
+            m_serialize_variant_end: items
+                .method_name(CompilerItem::SerializeVariantEnd)
+                .to_string(),
+            m_deserializer_begin_seq: items
+                .method_name(CompilerItem::DeserializerBeginSeq)
+                .to_string(),
+            m_deserializer_begin_struct: items
+                .method_name(CompilerItem::DeserializerBeginStruct)
+                .to_string(),
+            m_deserializer_begin_variant: items
+                .method_name(CompilerItem::DeserializerBeginVariant)
+                .to_string(),
+            m_deserialize_seq_next_element: items
+                .method_name(CompilerItem::DeserializeSeqNextElement)
+                .to_string(),
+            m_deserialize_seq_end: items
+                .method_name(CompilerItem::DeserializeSeqEnd)
+                .to_string(),
+            m_deserialize_struct_next_field: items
+                .method_name(CompilerItem::DeserializeStructNextField)
+                .to_string(),
+            m_deserialize_struct_value: items
+                .method_name(CompilerItem::DeserializeStructValue)
+                .to_string(),
+            m_deserialize_struct_skip: items
+                .method_name(CompilerItem::DeserializeStructSkip)
+                .to_string(),
+            m_deserialize_struct_end: items
+                .method_name(CompilerItem::DeserializeStructEnd)
+                .to_string(),
+            m_deserialize_variant_variant_name: items
+                .method_name(CompilerItem::DeserializeVariantVariantName)
+                .to_string(),
+            m_deserialize_variant_disc: items
+                .method_name(CompilerItem::DeserializeVariantDisc)
+                .to_string(),
+            m_deserialize_variant_payload: items
+                .method_name(CompilerItem::DeserializeVariantPayload)
+                .to_string(),
+            m_deserialize_variant_end: items
+                .method_name(CompilerItem::DeserializeVariantEnd)
+                .to_string(),
         }
     }
 }
@@ -882,7 +975,7 @@ fn generate_struct_serialize(
         local_ref(1, "s", mut_ref_s),
         "S",
         &names.serializer,
-        "begin_struct",
+        &names.m_serializer_begin_struct,
         serde_module.clone(),
         vec![],
         vec![],
@@ -915,7 +1008,7 @@ fn generate_struct_serialize(
             local_ref(st_local, "st", mut_ref_ss),
             &names.s_struct_serializer_proj,
             &names.serialize_struct,
-            "field",
+            &names.m_serialize_struct_field,
             serde_module.clone(),
             vec![field_type_names[i].clone()],
             vec![*field_type],
@@ -937,7 +1030,7 @@ fn generate_struct_serialize(
         local_ref(st_local, "st", mut_ref_ss),
         &names.s_struct_serializer_proj,
         &names.serialize_struct,
-        "end",
+        &names.m_serialize_struct_end,
         serde_module,
         vec![],
         vec![],
@@ -1147,7 +1240,7 @@ fn generate_struct_deserialize(
         local_ref(0, "d", mut_ref_d),
         "D",
         &names.deserializer,
-        "begin_struct",
+        &names.m_deserializer_begin_struct,
         serde_module.clone(),
         vec![],
         vec![],
@@ -1212,7 +1305,7 @@ fn generate_struct_deserialize(
         local_ref(sd_local, "sd", mut_ref_sa),
         &names.d_struct_access_proj,
         &names.deserialize_struct,
-        "next_field",
+        &names.m_deserialize_struct_next_field,
         serde_module.clone(),
         vec![struct_type_name],
         vec![struct_type],
@@ -1234,7 +1327,7 @@ fn generate_struct_deserialize(
             local_ref(sd_local, "sd", mut_ref_sa),
             &names.d_struct_access_proj,
             &names.deserialize_struct,
-            "value",
+            &names.m_deserialize_struct_value,
             serde_module.clone(),
             vec![field_type_names[i].clone()],
             vec![*type_id],
@@ -1297,7 +1390,7 @@ fn generate_struct_deserialize(
         local_ref(sd_local, "sd", mut_ref_sa),
         &names.d_struct_access_proj,
         &names.deserialize_struct,
-        "skip",
+        &names.m_deserialize_struct_skip,
         serde_module.clone(),
         vec![],
         vec![],
@@ -1403,7 +1496,7 @@ fn generate_struct_deserialize(
         local_ref(sd_local, "sd", mut_ref_sa),
         &names.d_struct_access_proj,
         &names.deserialize_struct,
-        "end",
+        &names.m_deserialize_struct_end,
         serde_module,
         vec![],
         vec![],
@@ -1809,7 +1902,7 @@ fn generate_enum_serialize(
             local_ref(1, "s", mut_ref_s),
             "S",
             &names.serializer,
-            "serialize_unit_variant",
+            &names.m_serializer_serialize_unit_variant,
             serde_module.clone(),
             vec![],
             vec![],
@@ -1993,7 +2086,7 @@ fn generate_enum_deserialize(
         local_ref(0, "d", mut_ref_d),
         "D",
         &names.deserializer,
-        "begin_variant",
+        &names.m_deserializer_begin_variant,
         serde_module.clone(),
         vec![],
         vec![],
@@ -2024,7 +2117,7 @@ fn generate_enum_deserialize(
         local_ref(va_local, "va", mut_ref_va),
         &names.d_variant_access_proj,
         &names.deserialize_variant,
-        "disc",
+        &names.m_deserialize_variant_disc,
         serde_module.clone(),
         vec![],
         vec![],
@@ -2056,7 +2149,7 @@ fn generate_enum_deserialize(
             local_ref(va_local, "va", mut_ref_va),
             &names.d_variant_access_proj,
             &names.deserialize_variant,
-            "end",
+            &names.m_deserialize_variant_end,
             serde_module.clone(),
             vec![],
             vec![],
@@ -2122,7 +2215,7 @@ fn generate_enum_deserialize(
         local_ref(va_local, "va", mut_ref_va),
         &names.d_variant_access_proj,
         &names.deserialize_variant,
-        "variant_name",
+        &names.m_deserialize_variant_variant_name,
         serde_module.clone(),
         vec![],
         vec![],
@@ -2176,7 +2269,7 @@ fn generate_enum_deserialize(
             local_ref(va_local, "va", mut_ref_va),
             &names.d_variant_access_proj,
             &names.deserialize_variant,
-            "end",
+            &names.m_deserialize_variant_end,
             serde_module.clone(),
             vec![],
             vec![],
@@ -2410,7 +2503,7 @@ fn generate_variant_serialize(
                 local_ref(1, "s", mut_ref_s),
                 "S",
                 &names.serializer,
-                "serialize_unit_variant",
+                &names.m_serializer_serialize_unit_variant,
                 serde_module.clone(),
                 vec![],
                 vec![],
@@ -2456,7 +2549,7 @@ fn generate_variant_serialize(
                 local_ref(1, "s", mut_ref_s),
                 "S",
                 &names.serializer,
-                "begin_variant",
+                &names.m_serializer_begin_variant,
                 serde_module.clone(),
                 vec![],
                 vec![],
@@ -2486,7 +2579,7 @@ fn generate_variant_serialize(
                 local_ref(vs_local, "__vs", mut_ref_vs),
                 &names.s_variant_serializer_proj,
                 &names.serialize_variant,
-                "payload",
+                &names.m_serialize_variant_payload,
                 serde_module.clone(),
                 vec![payload_type_names[i].clone()],
                 vec![*payload_type],
@@ -2499,7 +2592,7 @@ fn generate_variant_serialize(
                 local_ref(vs_local, "__vs", mut_ref_vs),
                 &names.s_variant_serializer_proj,
                 &names.serialize_variant,
-                "end",
+                &names.m_serialize_variant_end,
                 serde_module.clone(),
                 vec![],
                 vec![],
@@ -2715,7 +2808,7 @@ fn generate_variant_deserialize(
         local_ref(0, "d", mut_ref_d),
         "D",
         &names.deserializer,
-        "begin_variant",
+        &names.m_deserializer_begin_variant,
         serde_module.clone(),
         vec![],
         vec![],
@@ -2744,7 +2837,7 @@ fn generate_variant_deserialize(
         local_ref(va_local, "va", mut_ref_va),
         &names.d_variant_access_proj,
         &names.deserialize_variant,
-        "disc",
+        &names.m_deserialize_variant_disc,
         serde_module.clone(),
         vec![],
         vec![],
@@ -2778,7 +2871,7 @@ fn generate_variant_deserialize(
                 local_ref(va_local, "va", mut_ref_va),
                 &names.d_variant_access_proj,
                 &names.deserialize_variant,
-                "end",
+                &names.m_deserialize_variant_end,
                 serde_module.clone(),
                 vec![],
                 vec![],
@@ -2823,7 +2916,7 @@ fn generate_variant_deserialize(
                 local_ref(va_local, "va", mut_ref_va),
                 &names.d_variant_access_proj,
                 &names.deserialize_variant,
-                "payload",
+                &names.m_deserialize_variant_payload,
                 serde_module.clone(),
                 vec![payload_type_names[i].clone()],
                 vec![*payload_type],
@@ -2836,7 +2929,7 @@ fn generate_variant_deserialize(
                 local_ref(va_local, "va", mut_ref_va),
                 &names.d_variant_access_proj,
                 &names.deserialize_variant,
-                "end",
+                &names.m_deserialize_variant_end,
                 serde_module.clone(),
                 vec![],
                 vec![],
@@ -2933,7 +3026,7 @@ fn generate_variant_deserialize(
         local_ref(va_local, "va", mut_ref_va),
         &names.d_variant_access_proj,
         &names.deserialize_variant,
-        "variant_name",
+        &names.m_deserialize_variant_variant_name,
         serde_module.clone(),
         vec![],
         vec![],
@@ -2989,7 +3082,7 @@ fn generate_variant_deserialize(
                 local_ref(va_local, "va", mut_ref_va),
                 &names.d_variant_access_proj,
                 &names.deserialize_variant,
-                "end",
+                &names.m_deserialize_variant_end,
                 serde_module.clone(),
                 vec![],
                 vec![],
@@ -3034,7 +3127,7 @@ fn generate_variant_deserialize(
                 local_ref(va_local, "va", mut_ref_va),
                 &names.d_variant_access_proj,
                 &names.deserialize_variant,
-                "payload",
+                &names.m_deserialize_variant_payload,
                 serde_module.clone(),
                 vec![payload_type_names[i].clone()],
                 vec![*payload_type],
@@ -3047,7 +3140,7 @@ fn generate_variant_deserialize(
                 local_ref(va_local, "va", mut_ref_va),
                 &names.d_variant_access_proj,
                 &names.deserialize_variant,
-                "end",
+                &names.m_deserialize_variant_end,
                 serde_module.clone(),
                 vec![],
                 vec![],
@@ -3386,7 +3479,7 @@ fn generate_flags_serialize(
         local_ref(1, "s", mut_ref_s),
         "S",
         &names.serializer,
-        "begin_seq",
+        &names.m_serializer_begin_seq,
         serde_module.clone(),
         vec![],
         vec![],
@@ -3409,7 +3502,7 @@ fn generate_flags_serialize(
             local_ref(seq_local, "seq", mut_ref_seq),
             &names.s_seq_serializer_proj,
             &names.serialize_seq,
-            "element",
+            &names.m_serialize_seq_element,
             serde_module.clone(),
             vec![string_struct_name.clone()],
             vec![string_type],
@@ -3433,7 +3526,7 @@ fn generate_flags_serialize(
         local_ref(seq_local, "seq", mut_ref_seq),
         &names.s_seq_serializer_proj,
         &names.serialize_seq,
-        "end",
+        &names.m_serialize_seq_end,
         serde_module,
         vec![],
         vec![],
@@ -3607,7 +3700,7 @@ fn generate_flags_deserialize(
         local_ref(0, "d", mut_ref_d),
         "D",
         &names.deserializer,
-        "begin_seq",
+        &names.m_deserializer_begin_seq,
         serde_module.clone(),
         vec![],
         vec![],
@@ -3645,7 +3738,7 @@ fn generate_flags_deserialize(
         local_ref(seq_local, "seq", mut_ref_seq),
         &names.d_seq_access_proj,
         &names.deserialize_seq,
-        "next_element",
+        &names.m_deserialize_seq_next_element,
         serde_module.clone(),
         vec![string_struct_name.clone()],
         vec![string_type],
@@ -3809,7 +3902,7 @@ fn generate_flags_deserialize(
         local_ref(seq_local, "seq", mut_ref_seq),
         &names.d_seq_access_proj,
         &names.deserialize_seq,
-        "end",
+        &names.m_deserialize_seq_end,
         serde_module,
         vec![],
         vec![],

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -13,9 +13,9 @@ use crate::module_source::ModuleSource;
 use crate::name::{LocalMethodName, MethodName, mangle_local_trait_method};
 use crate::package::Package;
 use crate::tir::{
-    CallArg, FunctionKind, FunctionRef, InlineHint, TirBinaryOp, TirBlock, TirExpr, TirExprKind,
-    TirFunction, TirLocal, TirMatchArm, TirModule, TirParam, TirPattern, TirStmt, TirStmtKind,
-    TirStructField, TirTemplatePart, TirTypeParam, TypeId, TypeTable,
+    CallArg, FunctionKind, FunctionRef, InlineHint, SynthTrait, TirBinaryOp, TirBlock, TirExpr,
+    TirExprKind, TirFunction, TirLocal, TirMatchArm, TirModule, TirParam, TirPattern, TirStmt,
+    TirStmtKind, TirStructField, TirTemplatePart, TirTypeParam, TypeId, TypeTable,
 };
 use crate::token::Span;
 
@@ -314,50 +314,52 @@ pub fn synthesize_serde(project: &mut Package) {
         let mut generated = Vec::new();
 
         for req in &requests {
-            let trait_name = req.trait_name.as_str();
-            if trait_name == names.serialize {
-                let key = MethodName::format_local(
-                    &req.target_type_name,
-                    Some(&names.serialize),
-                    "serialize",
-                );
-                if existing.contains(&key) {
-                    continue;
-                }
-                let func = generate_struct_serialize(module, req, &names)
-                    .or_else(|| generate_enum_serialize(module, req, &names))
-                    .or_else(|| generate_variant_serialize(module, req, &names))
-                    .or_else(|| generate_flags_serialize(module, req, &names));
-                if let Some(f) = func {
-                    generated.push(Rc::new(RefCell::new(f)));
-                }
-            } else if trait_name == names.deserialize {
-                let key = MethodName::format_local(
-                    &req.target_type_name,
-                    Some(&names.deserialize),
-                    "deserialize",
-                );
-                if existing.contains(&key) {
-                    continue;
-                }
-                if let Some((lookup_func, deser_func)) =
-                    generate_struct_deserialize(module, req, &names)
-                {
-                    generated.push(Rc::new(RefCell::new(lookup_func)));
-                    generated.push(Rc::new(RefCell::new(deser_func)));
-                } else {
-                    let func = generate_enum_deserialize(module, req, &names)
-                        .or_else(|| generate_variant_deserialize(module, req, &names))
-                        .or_else(|| generate_flags_deserialize(module, req, &names));
+            match req.trait_ref {
+                SynthTrait::Serialize => {
+                    let key = MethodName::format_local(
+                        &req.target_type_name,
+                        Some(&names.serialize),
+                        "serialize",
+                    );
+                    if existing.contains(&key) {
+                        continue;
+                    }
+                    let func = generate_struct_serialize(module, req, &names)
+                        .or_else(|| generate_enum_serialize(module, req, &names))
+                        .or_else(|| generate_variant_serialize(module, req, &names))
+                        .or_else(|| generate_flags_serialize(module, req, &names));
                     if let Some(f) = func {
                         generated.push(Rc::new(RefCell::new(f)));
                     }
                 }
-            } else {
-                panic!(
-                    "unsupported synthesis trait `{trait_name}` for `{}`",
-                    req.target_type_name
-                );
+                SynthTrait::Deserialize => {
+                    let key = MethodName::format_local(
+                        &req.target_type_name,
+                        Some(&names.deserialize),
+                        "deserialize",
+                    );
+                    if existing.contains(&key) {
+                        continue;
+                    }
+                    if let Some((lookup_func, deser_func)) =
+                        generate_struct_deserialize(module, req, &names)
+                    {
+                        generated.push(Rc::new(RefCell::new(lookup_func)));
+                        generated.push(Rc::new(RefCell::new(deser_func)));
+                    } else {
+                        let func = generate_enum_deserialize(module, req, &names)
+                            .or_else(|| generate_variant_deserialize(module, req, &names))
+                            .or_else(|| generate_flags_deserialize(module, req, &names));
+                        if let Some(f) = func {
+                            generated.push(Rc::new(RefCell::new(f)));
+                        }
+                    }
+                }
+                // `From` requests are drained by `from_synth`, which runs
+                // before this pass, so none reach the serde drain.
+                SynthTrait::From { .. } => unreachable!(
+                    "From synthesis requests must be drained by from_synth before serde_synth"
+                ),
             }
         }
 

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -2012,12 +2012,73 @@ fn generate_enum_serialize(
     })
 }
 
+/// Which TIR construct a deserialized case materializes: a payload-less
+/// `enum` discriminant or a `variant` case (which may carry a payload).
+#[derive(Clone, Copy)]
+enum DeserConstruct {
+    Enum,
+    Variant,
+}
+
+/// Build the success value for a matched case — an `EnumConstruct` for enums,
+/// a `VariantConstruct` (with optional payload) for variants.
+fn build_deser_construct(
+    kind: DeserConstruct,
+    target_type: TypeId,
+    case_index: u32,
+    case_name: &str,
+    payload: Option<(u32, TypeId)>,
+    span: Span,
+) -> TirExpr {
+    let node = match kind {
+        DeserConstruct::Enum => TirExprKind::EnumConstruct {
+            enum_type: target_type,
+            case_index,
+            case_name: case_name.to_string(),
+        },
+        DeserConstruct::Variant => TirExprKind::VariantConstruct {
+            variant_type: target_type,
+            case_index,
+            case_name: case_name.to_string(),
+            payload: payload.map(|(idx, ty)| Box::new(local_ref(idx, "__payload", ty))),
+        },
+    };
+    TirExpr::new(node, target_type, span)
+}
+
 fn generate_enum_deserialize(
     module: &TirModule,
     req: &crate::tir::SynthesisRequest,
     names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let enum_def = find_enum(module, &req.target_type_name)?;
+    let cases = enum_def
+        .cases
+        .iter()
+        .map(|c| (c.name.clone(), c.index, TypeTable::UNIT))
+        .collect();
+    Some(generate_variant_family_deserialize(
+        module,
+        req,
+        names,
+        cases,
+        DeserConstruct::Enum,
+    ))
+}
+
+/// Shared `deserialize` synthesiser for `enum` and `variant` types. Both decode
+/// a `begin_variant` access, try a discriminant match first, then fall back to
+/// matching the variant name; the only difference is how a matched case
+/// materializes (see [`DeserConstruct`]) and whether it carries a payload —
+/// captured per case as `(name, index, payload_type)`, with `payload_type ==
+/// UNIT` for payload-less cases.
+fn generate_variant_family_deserialize(
+    module: &TirModule,
+    req: &crate::tir::SynthesisRequest,
+    names: &SerdeStdlibNames,
+    cases: Vec<(String, u32, TypeId)>,
+    kind: DeserConstruct,
+) -> TirFunction {
     let span = synth_span();
     let serde_module = ModuleSource::serde();
 
@@ -2035,14 +2096,14 @@ fn generate_enum_deserialize(
     };
     let mut tt = module.type_table.borrow_mut();
 
-    let enum_type = req.target_type_id;
+    let target_type = req.target_type_id;
     let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
     let ref_string_type = tt.make_ref(string_type);
     let deser_error_type = tt.make_struct(names.deserialize_error.clone(), serde_module.clone());
     let deser_error_kind_type = tt
         .find_enum_type(&names.deserialize_error_kind, &serde_module)
         .unwrap_or(TypeTable::I32);
-    let result_enum_err = tt.make_result(enum_type, deser_error_type);
+    let result_target_err = tt.make_result(target_type, deser_error_type);
     let d_type_param = tt.make_type_param("D".to_string(), 0);
     let mut_ref_d = tt.make_mut_ref(d_type_param);
     let variant_access_type = tt.make_assoc_type_projection(
@@ -2055,20 +2116,23 @@ fn generate_enum_deserialize(
     let mut_ref_va = tt.make_mut_ref(variant_access_type);
     let result_string_err = tt.make_result(string_type, deser_error_type);
     let result_unit_err = tt.make_result(TypeTable::UNIT, deser_error_type);
+    let result_i32_err = tt.make_result(TypeTable::I32, deser_error_type);
 
-    let cases: Vec<(String, u32)> = enum_def
-        .cases
-        .iter()
-        .map(|c| (c.name.clone(), c.index))
-        .collect();
     let num_cases = cases.len();
+    // Only variant cases carry payloads; enum cases are all UNIT and never
+    // reach the payload arm of `build_case_arm`, so skip the per-case work.
+    let (payload_result_types, payload_type_names): (Vec<TypeId>, Vec<String>) = match kind {
+        DeserConstruct::Enum => (Vec::new(), Vec::new()),
+        DeserConstruct::Variant => (
+            cases
+                .iter()
+                .map(|(_, _, payload)| tt.make_result(*payload, deser_error_type))
+                .collect(),
+            cases.iter().map(|(_, _, payload)| tt.type_name(*payload)).collect(),
+        ),
+    };
 
     drop(tt);
-
-    let result_i32_err = {
-        let mut tt = module.type_table.borrow_mut();
-        tt.make_result(TypeTable::I32, deser_error_type)
-    };
 
     let mut locals = vec![param_local("d", mut_ref_d, false)];
     let mut next_local: u32 = 1;
@@ -2078,6 +2142,117 @@ fn generate_enum_deserialize(
     let disc_local = alloc_local(&mut next_local, &mut locals, TypeTable::I32);
     let name_result_local = alloc_local(&mut next_local, &mut locals, result_string_err);
     let name_local = alloc_local(&mut next_local, &mut locals, string_type);
+
+    // Per-case arm shared by the disc-match and name-match loops: `end()` the
+    // access and return `Ok(construct)`, deserializing a payload first for
+    // non-unit variant cases. Only `condition` differs between the loops.
+    let build_case_arm = |i: usize,
+                          condition: TirExpr,
+                          next_local: &mut u32,
+                          locals: &mut Vec<crate::tir::TirLocal>|
+     -> crate::tir::TirStmt {
+        let (case_name, case_index, payload_type) = &cases[i];
+        let end_call = type_param_method_call(
+            local_ref(va_local, "va", mut_ref_va),
+            &names.d_variant_access_proj,
+            &names.deserialize_variant,
+            &names.m_deserialize_variant_end,
+            serde_module.clone(),
+            vec![],
+            vec![],
+            vec![],
+            result_unit_err,
+            span,
+        );
+        if *payload_type == TypeTable::UNIT {
+            let construct =
+                build_deser_construct(kind, target_type, *case_index, case_name, None, span);
+            let mut if_body = propagate_unit_result_stmts(
+                end_call,
+                result_unit_err,
+                deser_error_type,
+                result_target_err,
+                next_local,
+                locals,
+                span,
+                names,
+            );
+            if_body.push(return_stmt(Some(variant_ok(
+                construct,
+                result_target_err,
+                span,
+                names,
+            ))));
+            if_stmt(condition, block(if_body), None)
+        } else {
+            let payload_local = alloc_local(next_local, locals, *payload_type);
+            let p_result_local = alloc_local(next_local, locals, payload_result_types[i]);
+            let payload_call = type_param_method_call(
+                local_ref(va_local, "va", mut_ref_va),
+                &names.d_variant_access_proj,
+                &names.deserialize_variant,
+                &names.m_deserialize_variant_payload,
+                serde_module.clone(),
+                vec![payload_type_names[i].clone()],
+                vec![*payload_type],
+                vec![],
+                payload_result_types[i],
+                span,
+            );
+            let construct = build_deser_construct(
+                kind,
+                target_type,
+                *case_index,
+                case_name,
+                Some((payload_local, *payload_type)),
+                span,
+            );
+            let mut ok_stmts = propagate_unit_result_stmts(
+                end_call,
+                result_unit_err,
+                deser_error_type,
+                result_target_err,
+                next_local,
+                locals,
+                span,
+                names,
+            );
+            ok_stmts.push(return_stmt(Some(variant_ok(
+                construct,
+                result_target_err,
+                span,
+                names,
+            ))));
+            let if_body = block(vec![
+                let_mut_stmt(
+                    "__p_r",
+                    p_result_local,
+                    payload_result_types[i],
+                    payload_call,
+                ),
+                if_let_ok(
+                    local_ref(p_result_local, "__p_r", payload_result_types[i]),
+                    payload_result_types[i],
+                    *payload_type,
+                    payload_local,
+                    "__payload",
+                    block(ok_stmts),
+                    propagate_err_block(
+                        p_result_local,
+                        "__p_r",
+                        payload_result_types[i],
+                        deser_error_type,
+                        result_target_err,
+                        span,
+                        names,
+                    ),
+                    span,
+                    names,
+                ),
+            ]);
+            if_stmt(condition, if_body, None)
+        }
+    };
 
     let mut stmts = Vec::new();
 
@@ -2108,11 +2283,9 @@ fn generate_enum_deserialize(
         begin_call,
     ));
 
-    // if let Ok(mut va) = __va_r { ... }
     let mut then_stmts = Vec::new();
 
     // --- disc-based path (tried first) ---
-    // let __disc_r = va.disc()
     let disc_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
         &names.d_variant_access_proj,
@@ -2132,62 +2305,19 @@ fn generate_enum_deserialize(
         disc_call,
     ));
 
-    // Build disc-based matching: if __disc == 0 { ... } if __disc == 1 { ... } ...
     let mut disc_then_stmts = Vec::new();
-    for (case_name, case_index) in &cases {
+    for (i, &(_, case_index, _)) in cases.iter().enumerate() {
         let condition = TirExpr::new(
             TirExprKind::Binary {
                 op: crate::tir::TirBinaryOp::Eq,
                 left: Box::new(local_ref(disc_local, "__disc", TypeTable::I32)),
-                right: Box::new(i32_const(*case_index as i32)),
+                right: Box::new(i32_const(case_index as i32)),
             },
             TypeTable::BOOL,
             span,
         );
-
-        let end_call = type_param_method_call(
-            local_ref(va_local, "va", mut_ref_va),
-            &names.d_variant_access_proj,
-            &names.deserialize_variant,
-            &names.m_deserialize_variant_end,
-            serde_module.clone(),
-            vec![],
-            vec![],
-            vec![],
-            result_unit_err,
-            span,
-        );
-
-        let enum_construct = TirExpr::new(
-            TirExprKind::EnumConstruct {
-                enum_type,
-                case_index: *case_index,
-                case_name: case_name.clone(),
-            },
-            enum_type,
-            span,
-        );
-
-        let mut if_body_stmts = propagate_unit_result_stmts(
-            end_call,
-            result_unit_err,
-            deser_error_type,
-            result_enum_err,
-            &mut next_local,
-            &mut locals,
-            span,
-            names,
-        );
-        if_body_stmts.push(return_stmt(Some(variant_ok(
-            enum_construct,
-            result_enum_err,
-            span,
-            names,
-        ))));
-        disc_then_stmts.push(if_stmt(condition, block(if_body_stmts), None));
+        disc_then_stmts.push(build_case_arm(i, condition, &mut next_local, &mut locals));
     }
-
-    // Unknown disc error
     let disc_unknown_err = deserialize_error_literal(
         deser_error_type,
         deser_error_kind_type,
@@ -2200,17 +2330,13 @@ fn generate_enum_deserialize(
     );
     disc_then_stmts.push(return_stmt(Some(variant_err(
         disc_unknown_err,
-        result_enum_err,
+        result_target_err,
         span,
         names,
     ))));
 
-    // if let Ok(__disc) = __disc_r { disc_matching } else { name fallback }
-
-    // --- name-based fallback (existing logic) ---
+    // --- name-based fallback ---
     let mut name_fallback_stmts = Vec::new();
-
-    // let __name_r = va.variant_name()
     let name_call = type_param_method_call(
         local_ref(va_local, "va", mut_ref_va),
         &names.d_variant_access_proj,
@@ -2231,9 +2357,7 @@ fn generate_enum_deserialize(
     ));
 
     let mut name_then_stmts = Vec::new();
-
-    // For each case: if name == "CaseName" { ... end(); return Ok(EnumConstruct) }
-    for (case_name, case_index) in &cases {
+    for (i, (case_name, _, _)) in cases.iter().enumerate() {
         let key_ref = ref_expr(
             local_ref(name_local, "__name", string_type),
             ref_string_type,
@@ -2264,50 +2388,8 @@ fn generate_enum_deserialize(
             TypeTable::BOOL,
             span,
         );
-
-        let end_call = type_param_method_call(
-            local_ref(va_local, "va", mut_ref_va),
-            &names.d_variant_access_proj,
-            &names.deserialize_variant,
-            &names.m_deserialize_variant_end,
-            serde_module.clone(),
-            vec![],
-            vec![],
-            vec![],
-            result_unit_err,
-            span,
-        );
-
-        let enum_construct = TirExpr::new(
-            TirExprKind::EnumConstruct {
-                enum_type,
-                case_index: *case_index,
-                case_name: case_name.clone(),
-            },
-            enum_type,
-            span,
-        );
-
-        let mut if_body_stmts = propagate_unit_result_stmts(
-            end_call,
-            result_unit_err,
-            deser_error_type,
-            result_enum_err,
-            &mut next_local,
-            &mut locals,
-            span,
-            names,
-        );
-        if_body_stmts.push(return_stmt(Some(variant_ok(
-            enum_construct,
-            result_enum_err,
-            span,
-            names,
-        ))));
-        name_then_stmts.push(if_stmt(condition, block(if_body_stmts), None));
+        name_then_stmts.push(build_case_arm(i, condition, &mut next_local, &mut locals));
     }
-
-    // Unknown variant error
     let unknown_err = deserialize_error_literal(
         deser_error_type,
         deser_error_kind_type,
@@ -2320,7 +2402,7 @@ fn generate_enum_deserialize(
     );
     name_then_stmts.push(return_stmt(Some(variant_err(
         unknown_err,
-        result_enum_err,
+        result_target_err,
         span,
         names,
     ))));
@@ -2337,7 +2419,7 @@ fn generate_enum_deserialize(
             "__name_r",
             result_string_err,
             deser_error_type,
-            result_enum_err,
+            result_target_err,
             span,
             names,
         ),
@@ -2345,7 +2427,6 @@ fn generate_enum_deserialize(
         names,
     ));
 
-    // Wire up disc path with name fallback in else
     then_stmts.push(if_let_ok(
         local_ref(disc_result_local, "__disc_r", result_i32_err),
         result_i32_err,
@@ -2358,7 +2439,6 @@ fn generate_enum_deserialize(
         names,
     ));
 
-    // Wire up: if let Ok(mut va) = __va_r { then_stmts } else { propagate err }
     stmts.push(if_let_ok(
         local_ref(va_result_local, "__va_r", result_va_err),
         result_va_err,
@@ -2371,7 +2451,7 @@ fn generate_enum_deserialize(
             "__va_r",
             result_va_err,
             deser_error_type,
-            result_enum_err,
+            result_target_err,
             span,
             names,
         ),
@@ -2390,7 +2470,7 @@ fn generate_enum_deserialize(
         "deserialize",
     );
 
-    Some(TirFunction {
+    TirFunction {
         module_source: ModuleSource::default(),
         name: qualified_name,
         is_pub: true,
@@ -2417,7 +2497,7 @@ fn generate_enum_deserialize(
             is_mut: false,
             span,
         }],
-        return_type: result_enum_err,
+        return_type: result_target_err,
         task_return_type: None,
         effects: Vec::new(),
         stores: vec![],
@@ -2436,7 +2516,7 @@ fn generate_enum_deserialize(
         kind: FunctionKind::Regular,
 
         return_abi: crate::tir::ReturnAbi::default(),
-    })
+    }
 }
 
 fn generate_variant_serialize(
@@ -2735,613 +2815,18 @@ fn generate_variant_deserialize(
     names: &SerdeStdlibNames,
 ) -> Option<TirFunction> {
     let variant_def = find_variant(module, &req.target_type_name)?;
-    let span = synth_span();
-    let serde_module = ModuleSource::serde();
-
-    let (eq_trait_name, string_struct_name) = {
-        let tt = module.type_table.borrow();
-        let items = tt.compiler_items();
-        (
-            items
-                .trait_name(crate::compiler_item::CompilerItem::Eq)
-                .to_string(),
-            items
-                .struct_name(crate::compiler_item::CompilerItem::String)
-                .to_string(),
-        )
-    };
-    let mut tt = module.type_table.borrow_mut();
-
-    let variant_type = req.target_type_id;
-    let string_type = tt.make_compiler_struct(crate::compiler_item::CompilerItem::String);
-    let ref_string_type = tt.make_ref(string_type);
-    let deser_error_type = tt.make_struct(names.deserialize_error.clone(), serde_module.clone());
-    let deser_error_kind_type = tt
-        .find_enum_type(&names.deserialize_error_kind, &serde_module)
-        .unwrap_or(TypeTable::I32);
-    let result_variant_err = tt.make_result(variant_type, deser_error_type);
-    let d_type_param = tt.make_type_param("D".to_string(), 0);
-    let mut_ref_d = tt.make_mut_ref(d_type_param);
-    let variant_access_type = tt.make_assoc_type_projection(
-        d_type_param,
-        names.variant_access_assoc.clone(),
-        vec![names.deserialize_variant.clone()],
-        vec![],
-    );
-    let result_va_err = tt.make_result(variant_access_type, deser_error_type);
-    let mut_ref_va = tt.make_mut_ref(variant_access_type);
-    let result_string_err = tt.make_result(string_type, deser_error_type);
-    let result_unit_err = tt.make_result(TypeTable::UNIT, deser_error_type);
-
-    let cases: Vec<(String, u32, TypeId)> = variant_def
+    let cases = variant_def
         .cases
         .iter()
         .map(|c| (c.name.clone(), c.index, c.payload))
         .collect();
-    let num_cases = cases.len();
-    let payload_result_types: Vec<TypeId> = cases
-        .iter()
-        .map(|(_, _, payload)| tt.make_result(*payload, deser_error_type))
-        .collect();
-    let payload_type_names: Vec<String> = cases
-        .iter()
-        .map(|(_, _, payload)| tt.type_name(*payload))
-        .collect();
-
-    let result_i32_err = tt.make_result(TypeTable::I32, deser_error_type);
-
-    drop(tt);
-
-    let mut locals = vec![param_local("d", mut_ref_d, false)];
-    let mut next_local: u32 = 1;
-    let va_result_local = alloc_local(&mut next_local, &mut locals, result_va_err);
-    let va_local = alloc_local(&mut next_local, &mut locals, variant_access_type);
-    let disc_result_local = alloc_local(&mut next_local, &mut locals, result_i32_err);
-    let disc_local = alloc_local(&mut next_local, &mut locals, TypeTable::I32);
-    let name_result_local = alloc_local(&mut next_local, &mut locals, result_string_err);
-    let name_local = alloc_local(&mut next_local, &mut locals, string_type);
-
-    let mut stmts = Vec::new();
-
-    // let __va_r = d.begin_variant(&"TypeName", num_cases)
-    let begin_call = type_param_method_call(
-        local_ref(0, "d", mut_ref_d),
-        "D",
-        &names.deserializer,
-        &names.m_deserializer_begin_variant,
-        serde_module.clone(),
-        vec![],
-        vec![],
-        vec![
-            ref_expr(
-                string_lit(&req.target_type_name, string_type, span),
-                ref_string_type,
-                span,
-            ),
-            i32_const(num_cases as i32),
-        ],
-        result_va_err,
-        span,
-    );
-    stmts.push(let_mut_stmt(
-        "__va_r",
-        va_result_local,
-        result_va_err,
-        begin_call,
-    ));
-
-    let mut then_stmts = Vec::new();
-
-    // --- disc-based path (tried first) ---
-    let disc_call = type_param_method_call(
-        local_ref(va_local, "va", mut_ref_va),
-        &names.d_variant_access_proj,
-        &names.deserialize_variant,
-        &names.m_deserialize_variant_disc,
-        serde_module.clone(),
-        vec![],
-        vec![],
-        vec![],
-        result_i32_err,
-        span,
-    );
-    then_stmts.push(let_mut_stmt(
-        "__disc_r",
-        disc_result_local,
-        result_i32_err,
-        disc_call,
-    ));
-
-    let mut disc_then_stmts = Vec::new();
-    for (i, (case_name, case_index, payload_type)) in cases.iter().enumerate() {
-        let is_unit = *payload_type == TypeTable::UNIT;
-
-        let condition = TirExpr::new(
-            TirExprKind::Binary {
-                op: crate::tir::TirBinaryOp::Eq,
-                left: Box::new(local_ref(disc_local, "__disc", TypeTable::I32)),
-                right: Box::new(i32_const(*case_index as i32)),
-            },
-            TypeTable::BOOL,
-            span,
-        );
-
-        if is_unit {
-            let end_call = type_param_method_call(
-                local_ref(va_local, "va", mut_ref_va),
-                &names.d_variant_access_proj,
-                &names.deserialize_variant,
-                &names.m_deserialize_variant_end,
-                serde_module.clone(),
-                vec![],
-                vec![],
-                vec![],
-                result_unit_err,
-                span,
-            );
-
-            let construct = TirExpr::new(
-                TirExprKind::VariantConstruct {
-                    variant_type,
-                    case_index: *case_index,
-                    case_name: case_name.clone(),
-                    payload: None,
-                },
-                variant_type,
-                span,
-            );
-
-            let mut if_body_stmts = propagate_unit_result_stmts(
-                end_call,
-                result_unit_err,
-                deser_error_type,
-                result_variant_err,
-                &mut next_local,
-                &mut locals,
-                span,
-                names,
-            );
-            if_body_stmts.push(return_stmt(Some(variant_ok(
-                construct,
-                result_variant_err,
-                span,
-                names,
-            ))));
-            disc_then_stmts.push(if_stmt(condition, block(if_body_stmts), None));
-        } else {
-            let payload_local = alloc_local(&mut next_local, &mut locals, *payload_type);
-            let p_result_local = alloc_local(&mut next_local, &mut locals, payload_result_types[i]);
-
-            let payload_call = type_param_method_call(
-                local_ref(va_local, "va", mut_ref_va),
-                &names.d_variant_access_proj,
-                &names.deserialize_variant,
-                &names.m_deserialize_variant_payload,
-                serde_module.clone(),
-                vec![payload_type_names[i].clone()],
-                vec![*payload_type],
-                vec![],
-                payload_result_types[i],
-                span,
-            );
-
-            let end_call = type_param_method_call(
-                local_ref(va_local, "va", mut_ref_va),
-                &names.d_variant_access_proj,
-                &names.deserialize_variant,
-                &names.m_deserialize_variant_end,
-                serde_module.clone(),
-                vec![],
-                vec![],
-                vec![],
-                result_unit_err,
-                span,
-            );
-
-            let construct = TirExpr::new(
-                TirExprKind::VariantConstruct {
-                    variant_type,
-                    case_index: *case_index,
-                    case_name: case_name.clone(),
-                    payload: Some(Box::new(local_ref(
-                        payload_local,
-                        "__payload",
-                        *payload_type,
-                    ))),
-                },
-                variant_type,
-                span,
-            );
-
-            let mut ok_stmts = propagate_unit_result_stmts(
-                end_call,
-                result_unit_err,
-                deser_error_type,
-                result_variant_err,
-                &mut next_local,
-                &mut locals,
-                span,
-                names,
-            );
-            ok_stmts.push(return_stmt(Some(variant_ok(
-                construct,
-                result_variant_err,
-                span,
-                names,
-            ))));
-            let ok_block = block(ok_stmts);
-
-            let if_body = block(vec![
-                let_mut_stmt(
-                    "__p_r",
-                    p_result_local,
-                    payload_result_types[i],
-                    payload_call,
-                ),
-                if_let_ok(
-                    local_ref(p_result_local, "__p_r", payload_result_types[i]),
-                    payload_result_types[i],
-                    *payload_type,
-                    payload_local,
-                    "__payload",
-                    ok_block,
-                    propagate_err_block(
-                        p_result_local,
-                        "__p_r",
-                        payload_result_types[i],
-                        deser_error_type,
-                        result_variant_err,
-                        span,
-                        names,
-                    ),
-                    span,
-                    names,
-                ),
-            ]);
-            disc_then_stmts.push(if_stmt(condition, if_body, None));
-        }
-    }
-
-    let disc_unknown_err = deserialize_error_literal(
-        deser_error_type,
-        deser_error_kind_type,
-        &names.deser_err_unknown_variant_name,
-        names.deser_err_unknown_variant_index,
-        "unknown variant discriminant",
-        string_type,
-        span,
+    Some(generate_variant_family_deserialize(
+        module,
+        req,
         names,
-    );
-    disc_then_stmts.push(return_stmt(Some(variant_err(
-        disc_unknown_err,
-        result_variant_err,
-        span,
-        names,
-    ))));
-
-    // --- name-based fallback ---
-    let mut name_fallback_stmts = Vec::new();
-
-    let name_call = type_param_method_call(
-        local_ref(va_local, "va", mut_ref_va),
-        &names.d_variant_access_proj,
-        &names.deserialize_variant,
-        &names.m_deserialize_variant_variant_name,
-        serde_module.clone(),
-        vec![],
-        vec![],
-        vec![],
-        result_string_err,
-        span,
-    );
-    name_fallback_stmts.push(let_mut_stmt(
-        "__name_r",
-        name_result_local,
-        result_string_err,
-        name_call,
-    ));
-
-    let mut name_then_stmts = Vec::new();
-
-    for (i, (case_name, case_index, payload_type)) in cases.iter().enumerate() {
-        let is_unit = *payload_type == TypeTable::UNIT;
-
-        let key_ref = ref_expr(
-            local_ref(name_local, "__name", string_type),
-            ref_string_type,
-            span,
-        );
-        let lit_ref = ref_expr(
-            string_lit(case_name, string_type, span),
-            ref_string_type,
-            span,
-        );
-        let eq_method = LocalMethodName::new(
-            string_struct_name.clone(),
-            Some(eq_trait_name.clone()),
-            "eq".to_string(),
-        );
-        let condition = TirExpr::new(
-            TirExprKind::method_call(
-                Box::new(key_ref),
-                FunctionRef {
-                    module_source: ModuleSource::string(),
-                    name: eq_method.to_mangled_name(),
-                    monomorph_info: None,
-                    method_info: Some(eq_method),
-                },
-                vec![],
-                vec![CallArg::new(lit_ref, false)],
-            ),
-            TypeTable::BOOL,
-            span,
-        );
-
-        if is_unit {
-            let end_call = type_param_method_call(
-                local_ref(va_local, "va", mut_ref_va),
-                &names.d_variant_access_proj,
-                &names.deserialize_variant,
-                &names.m_deserialize_variant_end,
-                serde_module.clone(),
-                vec![],
-                vec![],
-                vec![],
-                result_unit_err,
-                span,
-            );
-
-            let construct = TirExpr::new(
-                TirExprKind::VariantConstruct {
-                    variant_type,
-                    case_index: *case_index,
-                    case_name: case_name.clone(),
-                    payload: None,
-                },
-                variant_type,
-                span,
-            );
-
-            let mut if_body_stmts = propagate_unit_result_stmts(
-                end_call,
-                result_unit_err,
-                deser_error_type,
-                result_variant_err,
-                &mut next_local,
-                &mut locals,
-                span,
-                names,
-            );
-            if_body_stmts.push(return_stmt(Some(variant_ok(
-                construct,
-                result_variant_err,
-                span,
-                names,
-            ))));
-            name_then_stmts.push(if_stmt(condition, block(if_body_stmts), None));
-        } else {
-            let payload_local = alloc_local(&mut next_local, &mut locals, *payload_type);
-            let p_result_local = alloc_local(&mut next_local, &mut locals, payload_result_types[i]);
-
-            let payload_call = type_param_method_call(
-                local_ref(va_local, "va", mut_ref_va),
-                &names.d_variant_access_proj,
-                &names.deserialize_variant,
-                &names.m_deserialize_variant_payload,
-                serde_module.clone(),
-                vec![payload_type_names[i].clone()],
-                vec![*payload_type],
-                vec![],
-                payload_result_types[i],
-                span,
-            );
-
-            let end_call = type_param_method_call(
-                local_ref(va_local, "va", mut_ref_va),
-                &names.d_variant_access_proj,
-                &names.deserialize_variant,
-                &names.m_deserialize_variant_end,
-                serde_module.clone(),
-                vec![],
-                vec![],
-                vec![],
-                result_unit_err,
-                span,
-            );
-
-            let construct = TirExpr::new(
-                TirExprKind::VariantConstruct {
-                    variant_type,
-                    case_index: *case_index,
-                    case_name: case_name.clone(),
-                    payload: Some(Box::new(local_ref(
-                        payload_local,
-                        "__payload",
-                        *payload_type,
-                    ))),
-                },
-                variant_type,
-                span,
-            );
-
-            let mut ok_stmts = propagate_unit_result_stmts(
-                end_call,
-                result_unit_err,
-                deser_error_type,
-                result_variant_err,
-                &mut next_local,
-                &mut locals,
-                span,
-                names,
-            );
-            ok_stmts.push(return_stmt(Some(variant_ok(
-                construct,
-                result_variant_err,
-                span,
-                names,
-            ))));
-            let ok_block = block(ok_stmts);
-
-            let if_body = block(vec![
-                let_mut_stmt(
-                    "__p_r",
-                    p_result_local,
-                    payload_result_types[i],
-                    payload_call,
-                ),
-                if_let_ok(
-                    local_ref(p_result_local, "__p_r", payload_result_types[i]),
-                    payload_result_types[i],
-                    *payload_type,
-                    payload_local,
-                    "__payload",
-                    ok_block,
-                    propagate_err_block(
-                        p_result_local,
-                        "__p_r",
-                        payload_result_types[i],
-                        deser_error_type,
-                        result_variant_err,
-                        span,
-                        names,
-                    ),
-                    span,
-                    names,
-                ),
-            ]);
-            name_then_stmts.push(if_stmt(condition, if_body, None));
-        }
-    }
-
-    // Unknown variant error
-    let unknown_err = deserialize_error_literal(
-        deser_error_type,
-        deser_error_kind_type,
-        &names.deser_err_unknown_variant_name,
-        names.deser_err_unknown_variant_index,
-        "unknown variant",
-        string_type,
-        span,
-        names,
-    );
-    name_then_stmts.push(return_stmt(Some(variant_err(
-        unknown_err,
-        result_variant_err,
-        span,
-        names,
-    ))));
-
-    name_fallback_stmts.push(if_let_ok(
-        local_ref(name_result_local, "__name_r", result_string_err),
-        result_string_err,
-        string_type,
-        name_local,
-        "__name",
-        block(name_then_stmts),
-        propagate_err_block(
-            name_result_local,
-            "__name_r",
-            result_string_err,
-            deser_error_type,
-            result_variant_err,
-            span,
-            names,
-        ),
-        span,
-        names,
-    ));
-
-    // Wire up disc path with name fallback
-    then_stmts.push(if_let_ok(
-        local_ref(disc_result_local, "__disc_r", result_i32_err),
-        result_i32_err,
-        TypeTable::I32,
-        disc_local,
-        "__disc",
-        block(disc_then_stmts),
-        block(name_fallback_stmts),
-        span,
-        names,
-    ));
-
-    stmts.push(if_let_ok(
-        local_ref(va_result_local, "__va_r", result_va_err),
-        result_va_err,
-        variant_access_type,
-        va_local,
-        "va",
-        block(then_stmts),
-        propagate_err_block(
-            va_result_local,
-            "__va_r",
-            result_va_err,
-            deser_error_type,
-            result_variant_err,
-            span,
-            names,
-        ),
-        span,
-        names,
-    ));
-
-    let method_info = LocalMethodName::new(
-        req.target_type_name.clone(),
-        Some(names.deserialize.clone()),
-        "deserialize".to_string(),
-    );
-    let qualified_name = MethodName::format_local(
-        &req.target_type_name,
-        Some(&names.deserialize),
-        "deserialize",
-    );
-
-    Some(TirFunction {
-        module_source: ModuleSource::default(),
-        name: qualified_name,
-        is_pub: true,
-        is_export: false,
-        is_cm_export: false,
-        is_ambient: false,
-        benign_effects: Vec::new(),
-        is_async: false,
-        type_params: vec![TirTypeParam {
-            name: "D".to_string(),
-            is_effect: false,
-            is_pack: false,
-            bounds: vec![names.deserializer.clone()],
-            default: None,
-            index: 0,
-        }],
-        impl_type_params: Vec::new(),
-        monomorph_info: None,
-        method_info: Some(method_info),
-        params: vec![TirParam {
-            name: "d".to_string(),
-            type_id: mut_ref_d,
-            local_index: 0,
-            is_mut: false,
-            span,
-        }],
-        return_type: result_variant_err,
-        task_return_type: None,
-        effects: Vec::new(),
-        stores: vec![],
-        body: Some(block(stmts)),
-        span,
-        local_count: next_local,
-        locals,
-        address_taken_locals: IndexSet::default(),
-        stores_aliased_locals: IndexSet::default(),
-        is_cm_binding: false,
-        is_dispatch_wrapper: false,
-        inline_hint: InlineHint::Auto,
-        compiler_item: None,
-        export_name: None,
-        allocator_tag: None,
-        kind: FunctionKind::Regular,
-
-        return_abi: crate::tir::ReturnAbi::default(),
-    })
+        cases,
+        DeserConstruct::Variant,
+    ))
 }
 
 fn find_flags<'a>(module: &'a TirModule, name: &str) -> Option<&'a crate::tir::TirFlags> {

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -1135,19 +1135,19 @@ fn method_name_for_type(
             return_type,
             ..
         } => {
-            // Match the mangling used by `synthesis/traits::generate_fn_inspect_fn`:
-            // base struct is `Fn`, type args are `[<arity>, <return-type-mangled>]`.
-            // Without this arm, the `_` fallback below would call
-            // `LocalMethodName::new("Fn<N,Ret>", ...)` whose debug_assert
-            // rejects struct names containing `<`.
-            let arity = params.len().to_string();
-            let ret_name = tt_ref.mangle_type_name(return_type);
+            // A `Fn` receiver mangles as base struct `Fn` with the canonical
+            // `[arity, return-type]` args (shared with trait synthesis through
+            // `name::fn_type_arg_names`). Without this arm the `_` fallback
+            // would call `LocalMethodName::new("Fn<N,Ret>", ...)` whose
+            // debug_assert rejects struct names containing `<`.
+            let type_args =
+                crate::name::fn_type_arg_names(params.len(), &tt_ref.mangle_type_name(return_type));
             LocalMethodName::new(
                 crate::name::CLOSURE_FN_TRAIT.to_string(),
                 Some(trait_name.to_string()),
                 method_name.to_string(),
             )
-            .with_struct_type_args(&[arity, ret_name])
+            .with_struct_type_args(&type_args)
         }
         _ => {
             let name = tt_ref.mangle_type_name(type_id);

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -435,7 +435,7 @@ fn build_template_block(
         .to_string();
     let with_capacity_qualified =
         crate::name::MethodName::format_local(&string_struct_name, None, "with_capacity");
-    let label = "__tmpl".to_string();
+    let label = crate::name::TEMPLATE_BLOCK_LABEL.to_string();
 
     // Estimate capacity: sum of literal lengths + 16 per interpolation
     let capacity_estimate: i64 = parts
@@ -479,7 +479,7 @@ fn build_template_block(
     );
     let mut stmts = vec![TirStmt::new(
         TirStmtKind::Let {
-            name: "__r".to_string(),
+            name: crate::name::TEMPLATE_RESULT_LOCAL.to_string(),
             local_index: buf_index,
             is_mut: true,
             is_reactive: false,
@@ -503,7 +503,7 @@ fn build_template_block(
                 let buf_ref = TirExpr::new(
                     TirExprKind::Local {
                         index: buf_index,
-                        name: "__r".to_string(),
+                        name: crate::name::TEMPLATE_RESULT_LOCAL.to_string(),
                     },
                     string_type,
                     span,
@@ -555,7 +555,7 @@ fn build_template_block(
                     let buf_ref = TirExpr::new(
                         TirExprKind::Local {
                             index: buf_index,
-                            name: "__r".to_string(),
+                            name: crate::name::TEMPLATE_RESULT_LOCAL.to_string(),
                         },
                         string_type,
                         span,
@@ -674,7 +674,7 @@ fn build_template_block(
                             target: Box::new(TirExpr::new(
                                 TirExprKind::Local {
                                     index: idx,
-                                    name: "__f".to_string(),
+                                    name: crate::name::TEMPLATE_FORMATTER_LOCAL.to_string(),
                                 },
                                 formatter_type,
                                 span,
@@ -700,7 +700,7 @@ fn build_template_block(
                     );
                     stmts.push(TirStmt::new(
                         TirStmtKind::Let {
-                            name: "__f".to_string(),
+                            name: crate::name::TEMPLATE_FORMATTER_LOCAL.to_string(),
                             local_index: idx,
                             is_mut: true,
                             is_reactive: false,
@@ -719,7 +719,7 @@ fn build_template_block(
                         expr: Box::new(TirExpr::new(
                             TirExprKind::Local {
                                 index: fmt_index,
-                                name: "__f".to_string(),
+                                name: crate::name::TEMPLATE_FORMATTER_LOCAL.to_string(),
                             },
                             formatter_type,
                             span,
@@ -772,7 +772,7 @@ fn build_template_block(
     let buf_final = TirExpr::new(
         TirExprKind::Local {
             index: buf_index,
-            name: "__r".to_string(),
+            name: crate::name::TEMPLATE_RESULT_LOCAL.to_string(),
         },
         string_type,
         span,
@@ -813,7 +813,7 @@ fn build_formatter_expr(
             expr: Box::new(TirExpr::new(
                 TirExprKind::Local {
                     index: buf_index,
-                    name: "__r".to_string(),
+                    name: crate::name::TEMPLATE_RESULT_LOCAL.to_string(),
                 },
                 string_type,
                 span,

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -1158,7 +1158,7 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
     // their dispatch stubs are keyed by `(arity, return_type)`, not `TypeId`.
     let span = synth_span();
     for (type_id, base_name, type_arg_names) in collect_parameterized_types(&tt) {
-        let mangled = format_parameterized_name(&base_name, &type_arg_names);
+        let mangled = crate::name::mangle_generic_name(&base_name, &type_arg_names);
         if ctx.has_impl(&mangled, &inspect_name) {
             continue;
         }
@@ -1197,7 +1197,8 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_>
 
     // `Fn` dispatch stubs — one per canonical `(arity, return_type)`.
     for sig in collect_canonical_fn_signatures(&tt) {
-        let mangled = format_parameterized_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
+        let mangled =
+            crate::name::mangle_generic_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
         if ctx.has_impl(&mangled, &inspect_name) {
             continue;
         }
@@ -2253,7 +2254,7 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     // in `core:prelude/tuple.wado`. Opaque resource types delegate to their
     // `Inspect` counterpart. `Fn` signatures are handled separately below.
     for (type_id, base_name, type_arg_names) in collect_parameterized_types(&tt) {
-        let mangled = format_parameterized_name(&base_name, &type_arg_names);
+        let mangled = crate::name::mangle_generic_name(&base_name, &type_arg_names);
         if ctx.has_impl(&mangled, &inspect_alt_name) || !has_inspect(&mangled, ctx) {
             continue;
         }
@@ -2290,7 +2291,8 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     // delegate would let the optimizer collapse InspectAlt to Inspect
     // before WIR build runs, defeating the per-literal source dispatch.
     for sig in collect_canonical_fn_signatures(&tt) {
-        let mangled = format_parameterized_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
+        let mangled =
+            crate::name::mangle_generic_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
         if ctx.has_impl(&mangled, &inspect_alt_name) || !has_inspect(&mangled, ctx) {
             continue;
         }
@@ -3085,7 +3087,7 @@ fn generate_fallback_impls(
         if base_name == TypeTable::TUPLE_TYPE_NAME {
             continue;
         }
-        let mangled = format_parameterized_name(&base_name, &type_arg_names);
+        let mangled = crate::name::mangle_generic_name(&base_name, &type_arg_names);
         if ctx.has_impl(&mangled, &pair.target_trait) {
             continue;
         }
@@ -3122,7 +3124,8 @@ fn generate_fallback_impls(
 
     // `Fn` dispatch-stub fallbacks — one per canonical `(arity, return_type)`.
     for sig in collect_canonical_fn_signatures(&tt) {
-        let mangled = format_parameterized_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
+        let mangled =
+            crate::name::mangle_generic_name(crate::name::CLOSURE_FN_TRAIT, &sig.type_arg_names);
         if ctx.has_impl(&mangled, &pair.target_trait) {
             continue;
         }
@@ -3223,8 +3226,9 @@ fn decompose_type_for_method_name(
             return_type,
             ..
         } => {
-            let args = vec![params.len().to_string(), tt.mangle_type_name(*return_type)];
-            ("Fn".to_string(), false, args)
+            let args =
+                crate::name::fn_type_arg_names(params.len(), &tt.mangle_type_name(*return_type));
+            (crate::name::CLOSURE_FN_TRAIT.to_string(), false, args)
         }
         ResolvedType::GenericResource {
             name, type_args, ..
@@ -3387,9 +3391,9 @@ struct FnSignature {
     repr_type_id: TypeId,
     arity: usize,
     return_type: TypeId,
-    /// `[arity.to_string(), mangle_type_name(return_type)]` — the form
-    /// consumed by `format_parameterized_name` and the dispatch-stub
-    /// emitters.
+    /// `[arity, mangle_type_name(return_type)]` (see
+    /// [`crate::name::fn_type_arg_names`]) — the form consumed by
+    /// [`crate::name::mangle_generic_name`] and the dispatch-stub emitters.
     type_arg_names: Vec<String>,
 }
 
@@ -3418,19 +3422,13 @@ fn collect_canonical_fn_signatures(tt: &TypeTable) -> Vec<FnSignature> {
             repr_type_id: id,
             arity,
             return_type: *return_type,
-            type_arg_names: vec![arity.to_string(), tt.mangle_type_name(*return_type)],
+            type_arg_names: crate::name::fn_type_arg_names(
+                arity,
+                &tt.mangle_type_name(*return_type),
+            ),
         });
     }
     result
-}
-
-/// Format a parameterized type's mangled name from base name and type arg names.
-fn format_parameterized_name(base_name: &str, type_arg_names: &[String]) -> String {
-    if type_arg_names.is_empty() {
-        base_name.to_string()
-    } else {
-        format!("{}<{}>", base_name, type_arg_names.join(","))
-    }
 }
 
 /// Generate `EnumName^Eq::eq(&self, &Self) -> bool`

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -4051,10 +4051,23 @@ pub struct TirImpl {
     pub span: Span,
 }
 
+/// Which compiler-synthesizable trait an `impl Trait for Type;` request names.
+///
+/// The set is closed: the elaborator classifies the requested trait at the
+/// syntax boundary and rejects anything else with a diagnostic, so downstream
+/// synthesis never needs to re-parse a trait-name string. `From` carries its
+/// source type as a resolved [`TypeId`] rather than a mangled `From<…>` name.
+#[derive(Debug, Clone)]
+pub enum SynthTrait {
+    From { source: TypeId },
+    Serialize,
+    Deserialize,
+}
+
 /// `impl Trait for Type;` — request the compiler to synthesize the trait implementation.
 #[derive(Debug, Clone)]
 pub struct SynthesisRequest {
-    pub trait_name: String,
+    pub trait_ref: SynthTrait,
     pub target_type_name: String,
     pub target_type_id: TypeId,
     /// Type parameters: `(name, index, type_id)`

--- a/wado-compiler/tests/fixtures/synth_error_unsupported_trait.wado
+++ b/wado-compiler/tests/fixtures/synth_error_unsupported_trait.wado
@@ -1,0 +1,17 @@
+// `impl Trait for Type;` (a synthesis request) is only valid for the
+// compiler-synthesizable traits From / Serialize / Deserialize. Requesting it
+// for any other trait must be a clean compile error, not a panic.
+trait Greet {
+    fn greet(&self) -> i32;
+}
+
+struct Widget {
+    size: i32,
+}
+
+impl Greet for Widget;
+
+export fn run() {}
+
+__DATA__
+{"compile_error": "cannot synthesize trait `Greet`"}


### PR DESCRIPTION
Cleans up several smells in the TIR synthesis phase, replacing string round-trips with structured metadata, single-sourcing cross-pass names, and collapsing the largest duplication. Each change is behavior-preserving (verified by the e2e suite and zero-diff WIR golden regeneration) except where it converts a user-triggerable panic into a proper diagnostic.

## Synthesis requests carry structured trait references

`SynthesisRequest` flattened the requested trait into a `trait_name` string (e.g. `From<i32>`) that `from_synth` then re-parsed with `strip_prefix`/`strip_suffix` to recover the source type. Replaced it with a closed `SynthTrait` enum (`From { source: TypeId }`, `Serialize`, `Deserialize`). The elaborator classifies the trait once at the syntax boundary:

- `from_synth` matches the variant case by `TypeId` identity instead of a type-name string (also fixing same-name-different-module collisions) and builds the `From<…>` method name via `name.rs` mangling.
- `serde_synth` dispatches on an exhaustive `match`, removing the `panic!("unsupported synthesis trait")`.
- A bodyless `impl Trait for Type;` naming a non-synthesizable trait now reports a clean `UnsupportedSynthesisTrait` diagnostic instead of panicking.

## CM adapter map keyed solely by qualified name

`generate_adapters` inserted each import adapter twice — once under its qualified `interface::method` name, once under its `__cm_binding__` function name — then used `key.contains("::")` to skip the duplicate. The binding-name entry was never looked up; both the redundant insertion and the two `contains("::")` filters are gone.

## Centralized `Fn` type-name mangling in `name.rs`

The closure/`Fn` receiver convention (base `Fn`, struct-type args `[arity, return-type]`) was open-coded in three places. Added `name::fn_type_arg_names` and routed all of them through it, and removed `traits::format_parameterized_name`, a byte-for-byte duplicate of `name::mangle_generic_name`.

## Single-sourced cross-pass synthetic names

The template synthesiser and the lowering phase stamp fixed internal names (`__tmpl`, `__r`, `__initialize_module`, `__const_obj_`, …) that later optimizer passes recognise by string-matching the same literals in another file. Lifted them to `name.rs` consts (matching the existing `CLOSURE_*` convention) and referenced the const at every producer and consumer. Purely cosmetic synthetic locals that no pass re-matches are left alone.

## Serde protocol method names routed through compiler items

`serde_synth` hardcoded ~33 serde method-name literals (`disc`, `payload`, `begin_variant`, `end`, …) scattered across the file. Registered each as a per-`(trait, method)` compiler item (23 items), snapshotted them on `SerdeStdlibNames`, and emit every call through the snapshot — the same rename-safety the trait names and associated types already had. This required teaching the parser to keep `#[compiler_item("...")]` attributes on trait method declarations (previously discarded) and the elaborator to register them against their owning trait.

## Unified enum/variant deserialize synthesis

`generate_enum_deserialize` and `generate_variant_deserialize` were near-identical (same `begin_variant` decode, disc-match-then-name-fallback skeleton, error handling, function wrapper), differing only in how a matched case materializes. Extracted the shared body into `generate_variant_family_deserialize`, parameterized by the case list and a `DeserConstruct` discriminant; the two entry points are now thin wrappers. Net −518 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtgKJ485TgHm12Sd6BACZi

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtgKJ485TgHm12Sd6BACZi)_