### PR TITLE
fix(cli): share Kiln generator AOT cache across a `wado test` run

### DIFF
--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write as _;
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 
 use wado_manifest::DependencySource;
 
@@ -9,7 +10,7 @@ use lexopt::Parser;
 use wado_compiler::LogLevel;
 
 use crate::args::{self, CliExit};
-use crate::compiler_host::FilesystemCompilerHost;
+use crate::compiler_host::{FilesystemCompilerHost, KilnComponentCache};
 use crate::kiln_driver::{PipelineError, PipelineOutcome};
 use crate::kiln_provider::CliGeneratorProvider;
 use crate::manifest;
@@ -362,6 +363,17 @@ pub async fn try_compile(
     filename: &str,
     flags: &CompileFlags,
 ) -> Result<wado_compiler::CompileResult, wado_compiler::CompileFailure> {
+    try_compile_with_kiln_cache(filename, flags, None).await
+}
+
+/// `try_compile` with an optional [`KilnComponentCache`]. `wado test`
+/// passes one shared across every fixture so a generator is AOT-compiled
+/// once per run; `None` keeps the per-host cache for single-file builds.
+pub async fn try_compile_with_kiln_cache(
+    filename: &str,
+    flags: &CompileFlags,
+    kiln_cache: Option<Arc<KilnComponentCache>>,
+) -> Result<wado_compiler::CompileResult, wado_compiler::CompileFailure> {
     let path = Path::new(filename);
 
     let source = match fs::read_to_string(path) {
@@ -381,11 +393,12 @@ pub async fn try_compile(
     // Load the nearest manifest once: it seeds both the host's `[dependencies]`
     // index and the Kiln pipeline's `[build-dependencies]` resolution.
     let manifest_pair = load_nearest_manifest(path);
-    let host = attach_manifest_deps(
-        FilesystemCompilerHost::with_log_level(base_path.clone(), flags.log_level),
-        manifest_pair.as_ref(),
-        &base_path,
-    );
+    let base_host = FilesystemCompilerHost::with_log_level(base_path.clone(), flags.log_level);
+    let base_host = match kiln_cache {
+        Some(cache) => base_host.with_shared_kiln_cache(cache),
+        None => base_host,
+    };
+    let host = attach_manifest_deps(base_host, manifest_pair.as_ref(), &base_path);
 
     let pipeline_outcome =
         match maybe_run_pipeline(path, &host, flags.no_cache, manifest_pair).await {

--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -15,22 +15,88 @@ use wado_compiler::{
 use crate::kiln_runtime::{self, KilnRunPolicy};
 use crate::runtime::create_kiln_engine;
 
+/// AOT-compiled generator [`Component`]s, keyed by wasm SHA-256.
+///
+/// AOT dominates generator execution (~7s for a 432KB generator; see
+/// [`kiln_runtime::compile_component`]), so a generator must be compiled
+/// once, not once per fixture. A `wado test` run shares one cache across
+/// every per-fixture host via
+/// [`FilesystemCompilerHost::with_shared_kiln_cache`]; standalone hosts get
+/// their own. In-memory only — a disk `.cwasm` cache would be a
+/// trust-the-disk code-injection vector. Every `Component` comes from `engine`.
+#[derive(Default)]
+pub struct KilnComponentCache {
+    engine: OnceLock<wasmtime::Engine>,
+    components: Mutex<Vec<([u8; 32], wasmtime::component::Component)>>,
+    /// AOT count (misses); asserted by tests instead of wall-clock timing.
+    compile_count: AtomicUsize,
+}
+
+impl KilnComponentCache {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Lazily-created shared engine; run components on the engine that
+    /// [`Self::get_or_compile`] returns alongside them.
+    fn engine(&self) -> Result<wasmtime::Engine, GeneratorRunnerError> {
+        if let Some(engine) = self.engine.get() {
+            return Ok(engine.clone());
+        }
+        let engine = create_kiln_engine(wasmtime::OptLevel::Speed).map_err(|error| {
+            GeneratorRunnerError::Host(format!("failed to create kiln wasmtime engine: {error}"))
+        })?;
+        // First `set` wins; always clone from the stored value.
+        let _ = self.engine.set(engine);
+        Ok(self
+            .engine
+            .get()
+            .expect("kiln engine was set above or by a racing caller")
+            .clone())
+    }
+
+    /// AOT-compiled component for `wasm` (plus its engine), compiling on a
+    /// miss. Racing callers may each compile and overwrite — wasted but
+    /// correct; holding the lock across the multi-second compile would
+    /// serialize unrelated generators.
+    fn get_or_compile(
+        &self,
+        wasm: &[u8],
+    ) -> Result<(wasmtime::Engine, wasmtime::component::Component), GeneratorRunnerError> {
+        let engine = self.engine()?;
+        let key = wado_compiler::kiln::content_hash(wasm);
+        if let Ok(guard) = self.components.lock()
+            && let Some((_, component)) = guard.iter().find(|(k, _)| k == &key)
+        {
+            return Ok((engine, component.clone()));
+        }
+        let component = kiln_runtime::compile_component(&engine, wasm)?;
+        self.compile_count.fetch_add(1, Ordering::SeqCst);
+        if let Ok(mut guard) = self.components.lock() {
+            if let Some(slot) = guard.iter_mut().find(|(k, _)| k == &key) {
+                slot.1 = component.clone();
+            } else {
+                guard.push((key, component.clone()));
+            }
+        }
+        Ok((engine, component))
+    }
+
+    #[must_use]
+    pub fn compile_count(&self) -> usize {
+        self.compile_count.load(Ordering::SeqCst)
+    }
+}
+
 pub struct FilesystemCompilerHost {
     inner: Arc<wado_lsp::FilesystemCompilerHost>,
     print_diagnostics: bool,
     log_level: LogLevel,
     start_time: Instant,
-    kiln_engine: OnceLock<wasmtime::Engine>,
-    /// In-memory only: when N invocations in one pipeline run share a
-    /// generator they share the same wasm bytes, so caching the
-    /// `Component` (which is internally `Arc`) turns N×cranelift-AOT
-    /// into 1×AOT + (N-1) cheap clones. Not persisted to disk —
-    /// caching a serialized `.cwasm` would expose a trust-the-disk
-    /// code-injection vector that this in-memory cache does not.
-    kiln_components: Mutex<Vec<([u8; 32], wasmtime::component::Component)>>,
-    /// Cache misses on `kiln_components`. Tests assert against this
-    /// rather than wall-clock timing.
-    kiln_component_compile_count: AtomicUsize,
+    /// Per-host by default; a `wado test` run shares one across all
+    /// fixtures via [`Self::with_shared_kiln_cache`].
+    kiln_cache: Arc<KilnComponentCache>,
     /// Precomputed `[dependencies]` index. When set, `dependency_index`
     /// returns it instead of having the inner host re-read the manifest —
     /// the caller already parsed it for the Kiln pipeline.
@@ -45,9 +111,7 @@ impl FilesystemCompilerHost {
             print_diagnostics: true,
             log_level: crate::args::DEFAULT_LOG_LEVEL,
             start_time: Instant::now(),
-            kiln_engine: OnceLock::new(),
-            kiln_components: Mutex::new(Vec::new()),
-            kiln_component_compile_count: AtomicUsize::new(0),
+            kiln_cache: Arc::new(KilnComponentCache::new()),
             dep_index: None,
         }
     }
@@ -59,9 +123,7 @@ impl FilesystemCompilerHost {
             print_diagnostics: false,
             log_level: LogLevel::Off,
             start_time: Instant::now(),
-            kiln_engine: OnceLock::new(),
-            kiln_components: Mutex::new(Vec::new()),
-            kiln_component_compile_count: AtomicUsize::new(0),
+            kiln_cache: Arc::new(KilnComponentCache::new()),
             dep_index: None,
         }
     }
@@ -73,9 +135,7 @@ impl FilesystemCompilerHost {
             print_diagnostics: true,
             log_level,
             start_time: Instant::now(),
-            kiln_engine: OnceLock::new(),
-            kiln_components: Mutex::new(Vec::new()),
-            kiln_component_compile_count: AtomicUsize::new(0),
+            kiln_cache: Arc::new(KilnComponentCache::new()),
             dep_index: None,
         }
     }
@@ -88,38 +148,17 @@ impl FilesystemCompilerHost {
         self
     }
 
+    /// Share one [`KilnComponentCache`] across hosts so a generator is
+    /// AOT-compiled once per `wado test` run instead of once per fixture.
     #[must_use]
-    pub fn kiln_component_compile_count(&self) -> usize {
-        self.kiln_component_compile_count.load(Ordering::SeqCst)
+    pub fn with_shared_kiln_cache(mut self, cache: Arc<KilnComponentCache>) -> Self {
+        self.kiln_cache = cache;
+        self
     }
 
-    /// Concurrent callers with the same key may each compile once and
-    /// overwrite each other in the map — that's wasted but correct
-    /// (the resulting `Component`s are equivalent). Holding the Mutex
-    /// across the multi-second cranelift call would serialize unrelated
-    /// generators, which is the worse tradeoff.
-    fn get_or_compile_kiln_component(
-        &self,
-        engine: &wasmtime::Engine,
-        wasm: &[u8],
-    ) -> Result<wasmtime::component::Component, GeneratorRunnerError> {
-        let key = wado_compiler::kiln::content_hash(wasm);
-        if let Ok(guard) = self.kiln_components.lock()
-            && let Some((_, component)) = guard.iter().find(|(k, _)| k == &key)
-        {
-            return Ok(component.clone());
-        }
-        let component = kiln_runtime::compile_component(engine, wasm)?;
-        self.kiln_component_compile_count
-            .fetch_add(1, Ordering::SeqCst);
-        if let Ok(mut guard) = self.kiln_components.lock() {
-            if let Some(slot) = guard.iter_mut().find(|(k, _)| k == &key) {
-                slot.1 = component.clone();
-            } else {
-                guard.push((key, component.clone()));
-            }
-        }
-        Ok(component)
+    #[must_use]
+    pub fn kiln_component_compile_count(&self) -> usize {
+        self.kiln_cache.compile_count()
     }
 
     pub fn diagnostics(&self) -> Vec<Diagnostic> {
@@ -212,22 +251,7 @@ impl CompilerHost for FilesystemCompilerHost {
         component_wasm: &[u8],
         request: GeneratorRequest,
     ) -> Result<GeneratorResponse, GeneratorRunnerError> {
-        let engine = if let Some(engine) = self.kiln_engine.get() {
-            engine.clone()
-        } else {
-            let engine = create_kiln_engine(wasmtime::OptLevel::Speed).map_err(|error| {
-                GeneratorRunnerError::Host(format!(
-                    "failed to create kiln wasmtime engine: {error}"
-                ))
-            })?;
-            // Racing callers: first `set` wins; we always clone from the stored value.
-            let _ = self.kiln_engine.set(engine);
-            self.kiln_engine
-                .get()
-                .expect("kiln_engine was set above or by a racing caller")
-                .clone()
-        };
-        let component = self.get_or_compile_kiln_component(&engine, component_wasm)?;
+        let (engine, component) = self.kiln_cache.get_or_compile(component_wasm)?;
         let (outcome, diagnostics) = kiln_runtime::run_generator(
             &engine,
             self.inner.clone(),

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -21,6 +21,7 @@ use wasmtime::component::{Component, Linker};
 
 use crate::args::{self, CliExit};
 use crate::compile::{self, CompileFlags, OptLevel};
+use crate::compiler_host::KilnComponentCache;
 use crate::discover;
 use crate::manifest as project_manifest;
 use crate::runtime::{self, WasiState};
@@ -762,11 +763,16 @@ async fn compile_artifact(
     flags: Arc<CompileFlags>,
     overall_start: Instant,
     observer: Arc<StageObserver>,
+    kiln_cache: Arc<KilnComponentCache>,
 ) -> CompileOutcome {
     let compile_start = Instant::now();
-    let panic_or_result = AssertUnwindSafe(compile::try_compile(&path, &flags))
-        .catch_unwind()
-        .await;
+    let panic_or_result = AssertUnwindSafe(compile::try_compile_with_kiln_cache(
+        &path,
+        &flags,
+        Some(kiln_cache),
+    ))
+    .catch_unwind()
+    .await;
     let compile_duration = compile_start.elapsed();
     observer.add_work(compile_duration);
     let elapsed = format_duration(overall_start.elapsed());
@@ -940,6 +946,7 @@ async fn run_compile_stage(
     artifact_tx: mpsc::Sender<CompiledArtifact>,
     todo_tx: mpsc::Sender<TodoCompileError>,
     cfail_tx: mpsc::Sender<CompileFailure>,
+    kiln_cache: Arc<KilnComponentCache>,
 ) -> usize {
     let mut compiled_count = 0_usize;
 
@@ -949,6 +956,7 @@ async fn run_compile_stage(
             let flags = Arc::clone(&flags);
             let observer_inner = Arc::clone(&observer);
             let cpu_budget = Arc::clone(&cpu_budget);
+            let kiln_cache = Arc::clone(&kiln_cache);
             // Spawn each per-fixture worker as an independent task so
             // its progress is not gated by `buffer_unordered`'s outer
             // polling state. If the outer loop is briefly parked on
@@ -976,6 +984,7 @@ async fn run_compile_stage(
                             flags,
                             overall_start,
                             observer_inner,
+                            kiln_cache,
                         )),
                         Ok(Err(e)) => {
                             let elapsed = format_duration(overall_start.elapsed());
@@ -1375,6 +1384,8 @@ async fn run_pipeline(
     let epoch_ticker = (!no_run).then(|| Arc::new(EpochTicker::start()));
 
     let paths_owned: Vec<String> = paths.to_vec();
+    // Shared across fixtures so each generator is AOT-compiled once per run.
+    let kiln_cache = Arc::new(KilnComponentCache::new());
     let compile_future = run_compile_stage(
         paths_owned,
         flags.clone(),
@@ -1385,6 +1396,7 @@ async fn run_pipeline(
         artifact_tx,
         todo_tx,
         cfail_tx,
+        kiln_cache,
     );
 
     let load_future: Pin<Box<dyn Future<Output = usize> + Send>> =

--- a/wado-cli/tests/kiln_compile.rs
+++ b/wado-cli/tests/kiln_compile.rs
@@ -16,7 +16,7 @@
 
 use std::path::PathBuf;
 
-use wado_cli::compiler_host::FilesystemCompilerHost;
+use wado_cli::compiler_host::{FilesystemCompilerHost, KilnComponentCache};
 use wado_cli::kiln_driver::{GeneratorProvider, ProviderError};
 use wado_cli::kiln_provider::{CACHE_DIR, CliGeneratorProvider};
 use wado_compiler::kiln::{GeneratorModule, InvocationPath};
@@ -667,6 +667,58 @@ fn host_caches_compiled_component_across_run_generator_calls() {
         2,
         "distinct wasm bytes must trigger a fresh component compile"
     );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// A shared [`KilnComponentCache`] must AOT-compile a generator once even
+/// across the separate hosts a `wado test` run builds per fixture.
+#[test]
+fn shared_kiln_cache_compiles_generator_once_across_hosts() {
+    let tmp = unique_tmp("kiln-shared-component-cache");
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir_all(&tmp).unwrap();
+
+    let gen_path = tmp.join("my_generator.wado");
+    std::fs::write(&gen_path, MINIMAL_GENERATOR).unwrap();
+
+    let provider = CliGeneratorProvider::new(tmp.clone());
+    let module = GeneratorModule::LocalPath(InvocationPath::normalize("./my_generator.wado"));
+    let resolved = runtime()
+        .block_on(async { provider.resolve(&module).await })
+        .expect("generator compiles");
+
+    let request = || GeneratorRequest {
+        primary: GeneratorInputFile {
+            path: "schema.proto".to_string(),
+            content: "syntax = \"proto3\";".to_string(),
+        },
+        inputs: vec![],
+        options: r#"{"verbose": false}"#.to_string(),
+    };
+
+    let cache = std::sync::Arc::new(KilnComponentCache::new());
+
+    // Two separate hosts, as the per-fixture pipeline builds them.
+    let host_a = FilesystemCompilerHost::with_log_level(tmp.clone(), LogLevel::Off)
+        .with_shared_kiln_cache(cache.clone());
+    let host_b = FilesystemCompilerHost::with_log_level(tmp.clone(), LogLevel::Off)
+        .with_shared_kiln_cache(cache.clone());
+
+    runtime()
+        .block_on(async { host_a.run_generator(&resolved.wasm, request()).await })
+        .expect("first host generator run");
+    runtime()
+        .block_on(async { host_b.run_generator(&resolved.wasm, request()).await })
+        .expect("second host generator run");
+
+    assert_eq!(
+        cache.compile_count(),
+        1,
+        "shared cache must AOT-compile the generator once across hosts"
+    );
+    assert_eq!(host_a.kiln_component_compile_count(), 1);
+    assert_eq!(host_b.kiln_component_compile_count(), 1);
 
     let _ = std::fs::remove_dir_all(&tmp);
 }

--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -141,8 +141,10 @@ impl DeserializeError {
 #[compiler_item("serialize_seq")]
 pub trait SerializeSeq {
 
+
     #[compiler_item("serialize_seq_element")]
     fn element<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
+
 
     #[compiler_item("serialize_seq_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
@@ -157,8 +159,10 @@ pub trait SerializeMap {
 #[compiler_item("serialize_struct")]
 pub trait SerializeStruct {
 
+
     #[compiler_item("serialize_struct_field")]
     fn field<T: Serialize>(&mut self, name: &String, value: &T) -> Result<(), SerializeError>;
+
 
     #[compiler_item("serialize_struct_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
@@ -167,8 +171,10 @@ pub trait SerializeStruct {
 #[compiler_item("serialize_variant")]
 pub trait SerializeVariant {
 
+
     #[compiler_item("serialize_variant_payload")]
     fn payload<T: Serialize>(&mut self, value: &T) -> Result<(), SerializeError>;
+
 
     #[compiler_item("serialize_variant_end")]
     fn end(&mut self) -> Result<(), SerializeError>;
@@ -215,9 +221,11 @@ pub trait Serializer {
     }
     fn serialize_null(&mut self) -> Result<(), SerializeError>;
 
+
     #[compiler_item("serializer_begin_seq")]
     fn begin_seq(&mut self, len: i32) -> Result<Self::SeqSerializer, SerializeError> with stores[self];
     fn begin_map(&mut self, len: i32) -> Result<Self::MapSerializer, SerializeError> with stores[self];
+
 
     #[compiler_item("serializer_begin_struct")]
     fn begin_struct(
@@ -226,6 +234,7 @@ pub trait Serializer {
         fields: i32,
     ) -> Result<Self::StructSerializer, SerializeError> with stores[self];
 
+
     #[compiler_item("serializer_serialize_unit_variant")]
     fn serialize_unit_variant(
         &mut self,
@@ -233,6 +242,7 @@ pub trait Serializer {
         variant_name: &String,
         disc: i32,
     ) -> Result<(), SerializeError>;
+
 
     #[compiler_item("serializer_begin_variant")]
     fn begin_variant(
@@ -253,8 +263,10 @@ pub trait Serialize {
 #[compiler_item("deserialize_seq")]
 pub trait DeserializeSeq {
 
+
     #[compiler_item("deserialize_seq_next_element")]
     fn next_element<T: Deserialize>(&mut self) -> Result<Option<T>, DeserializeError>;
+
 
     #[compiler_item("deserialize_seq_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
@@ -289,14 +301,18 @@ pub trait FieldSchema {
 #[compiler_item("deserialize_struct")]
 pub trait DeserializeStruct {
 
+
     #[compiler_item("deserialize_struct_next_field")]
     fn next_field<S: FieldSchema>(&mut self) -> Result<Option<i32>, DeserializeError>;
+
 
     #[compiler_item("deserialize_struct_value")]
     fn value<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
 
+
     #[compiler_item("deserialize_struct_skip")]
     fn skip(&mut self) -> Result<(), DeserializeError>;
+
 
     #[compiler_item("deserialize_struct_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
@@ -305,15 +321,19 @@ pub trait DeserializeStruct {
 #[compiler_item("deserialize_variant")]
 pub trait DeserializeVariant {
 
+
     #[compiler_item("deserialize_variant_variant_name")]
     fn variant_name(&mut self) -> Result<String, DeserializeError>;
+
 
     #[compiler_item("deserialize_variant_disc")]
     fn disc(&mut self) -> Result<i32, DeserializeError>;
 
+
     #[compiler_item("deserialize_variant_payload")]
     fn payload<T: Deserialize>(&mut self) -> Result<T, DeserializeError>;
     fn is_unit(&mut self) -> Result<bool, DeserializeError>;
+
 
     #[compiler_item("deserialize_variant_end")]
     fn end(&mut self) -> Result<(), DeserializeError>;
@@ -399,9 +419,11 @@ pub trait Deserializer {
     }
     fn is_null(&mut self) -> Result<bool, DeserializeError>;
 
+
     #[compiler_item("deserializer_begin_seq")]
     fn begin_seq(&mut self) -> Result<Self::SeqAccess, DeserializeError> with stores[self];
     fn begin_map(&mut self) -> Result<Self::MapAccess, DeserializeError> with stores[self];
+
 
     #[compiler_item("deserializer_begin_struct")]
     fn begin_struct(
@@ -409,6 +431,7 @@ pub trait Deserializer {
         name: &String,
         num_fields: i32,
     ) -> Result<Self::StructAccess, DeserializeError> with stores[self];
+
 
     #[compiler_item("deserializer_begin_variant")]
     fn begin_variant(


### PR DESCRIPTION
## Problem

The tidy CI's `wado test --no-run package-gale` step takes ~40 min on a cold Kiln cache (any gale change, or a `kiln.json` delete) — an order of magnitude over a warm run (~4 min).

Root cause: `wado test` rebuilds the `CompilerHost` per fixture, and the cranelift-AOT-compiled generator `Component` was cached on that **per-fixture** host. On a cold cache every fixture re-runs the generator, so the *same* generator was AOT-compiled once per fixture — 9 s each for package-gale's 744 KB generator, ×~1085 fixtures. That AOT is the bulk of the step (CI reported `compile cpu: 9463s`).

`compile_component` already documents this: *"Cranelift-AOT dominates here (~7s on a 432KB generator), so the host caches the result across invocations"* — but the cache's lifetime (per-fixture host) defeated it.

## Fix

Lift the generator-component cache (engine + AOT'd `Component`s, keyed by wasm SHA-256) into a `KilnComponentCache` shared across every fixture's host for the whole run, so a generator is AOT-compiled **once**, not once per fixture. Standalone `compile`/`run`/`serve` keep a per-host cache, so single-file builds are unchanged.

## Results

97-fixture `LeftRecursion` subset, all `kiln.json` deleted (true miss), debug build:

| | compile cpu | wall |
| --- | ---: | ---: |
| before | 1519 s | 384 s |
| **after** | **171 s** | **44 s** |

≈ **8.9×**. Extrapolated, the CI step drops from ~40 min to ~4–5 min (≈ a warm run). Profile-independent, so the local dev loop benefits too.

## Correctness & tests

- Full `wado test --no-run package-gale` regenerates **byte-identical** output (0 changed generated/`kiln.json` files).
- New TDD test `shared_kiln_cache_compiles_generator_once_across_hosts` (red→green); existing per-host cache test still passes.
- Full `wado-cli` suite green (kiln_compile, kiln_pipeline, kiln_build_dep, gale_cli, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012omVLJoyv614CgPdp3edmc

---
_Generated by [Claude Code](https://claude.ai/code/session_012omVLJoyv614CgPdp3edmc)_