### PR TITLE
perf(gale): cache per-state ATN continuation FIRST/nullability

### DIFF
--- a/package-gale/src/runtime/atn.wado
+++ b/package-gale/src/runtime/atn.wado
@@ -111,6 +111,13 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability: the per-state analogue of
+    /// `rule_*`, cached at decode so the LR loop-entry decision is array
+    /// lookups, not a DFS per call. Empty unless the ATN has precedence edges.
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -399,6 +406,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -420,8 +431,29 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache `state_cont_*` after the rule fixpoint converges (it reads
+/// `rule_first` / `rule_nullable`). Per-state analogue of
+/// `atn_compute_first_nullable`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -1002,11 +1034,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -1026,16 +1061,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe209873265cdeca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "741538d9d6c17ba04aef378568b4ab2abdfbffd161000d9ab169b2a4d9abf5d0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d8570cc6d156bd91",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_1.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7f5fbf1bbfbb8bcd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_2.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-06005b69386bbcb5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_3.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6b1d2bbaf12eb95",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_4.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5f54fecb605bbbb9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_5.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ecf481963e0cdc79",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f6f731f2db602556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c7333c46ee1e2ae3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-903cadfd5f466fd3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-86c47cc59e39c88f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-69e6d41676a958ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da24a0de62028c37",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e19f84c31bb1ba1d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-968aab64fde5c720",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7c9628ebde9b1092",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3feeacc5bb7c0e2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e336cd99cabce3d1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-75aee7aa9bd1c5e6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2103099bbe8c6685",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b230e9d9b9e7a116",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4cd3c5efda6e6f68",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3d11b7a0de9bdfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e83472c3c8d59131",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-936ca045e8760afb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fabce5812b80e12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e60cefc96dbfbbfe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b39e4e6d0638fb0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0cb1bfe7b9b61662",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8ce620c4d041bf4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8a748c4b1072dc5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7517e433ec88ae11",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-30b6d0915e1f0a7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d835a9bcc70209d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-adcdf24e70551231",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-948fa494f8c39e9d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fd667898473386a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-168d84bfffd30ffc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16d2a937059aa781",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-591b970bacca2c10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4733ce0433551c40",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28a5608b944daeba",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a624ec57ce05fcc6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8f00b8e71dfed758",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2486b1d4d30844f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8d0cdbdd515a30d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3f0e08ebba8a9cc9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6b0034f6018d25eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3474970db58e7330",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-42f8d57fbb23a068",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19a60490c6262e02",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0ca22bd1314e7218",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4f103577715c8db1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0858b0f2d3b7c4c7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-db6337cca451074c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5af4cc46d8f644ac",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-67a53975d13d7ce7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e99183eec619f224",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4",
     "hash": "277dfd7e556da18b06db5bf0fccd85fe10f7a2e1f0229f7a11d5580da4f5fc38"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-65bf707c5ba0786e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a108c538b000f929",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-13b53d6471caafad",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c3d8d8e6f2084845",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b04e1a8213a36b6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0fc821cebb8739b9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5b1293e53cbeb9bb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-519b6ed9e8bcfed9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-733afd8e981f5ae2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4cbc959a0677270c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fbf1b14e07366be8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1c9a22fe77a307d0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c447bd0f1e3cfb69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_1.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-65bfc0bca1a8281d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_2.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c96ea7cd6ff29fe7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_3.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-59da71624671b64e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_4.g4",
     "hash": "b75cc6b1b5387a38b7faf0c7f28b2278e632d380687b5cfbd93d691d753d4dfc"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-321bb4a887aeed4a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0be243caf6fa7899",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0a0e80b115ce1b00",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7e29f3b4c52a634",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7328289d4b21bbf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-71680d2235544569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9b9906af711e224",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9f755a2bcab50c9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-47145b4638541e1c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-754daf97c5b4efbb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3acd8c540ac647a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-04125904502f125a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d8261611e9a89d09",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da61cc30a860cd7c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5a5bb5c5af282292",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f87b05ab4a39bca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56f734d0f6b9deff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8496a4404edac6de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a687b33884dd47c6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bb13da02739a232a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d7cb3561c793879a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ae687c4a1d9f02d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_1/WhitespaceInfluence_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_1/WhitespaceInfluence_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c388e02f87dfc0a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/WhitespaceInfluence_1.g4",
     "hash": "eb2ee832bbd5bc64766c64a697b83e430bc397e5e3c51480f276099243202a4c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_2/WhitespaceInfluence_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_2/WhitespaceInfluence_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1ab77744f9ca15db",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/WhitespaceInfluence_2.g4",
     "hash": "eb2ee832bbd5bc64766c64a697b83e430bc397e5e3c51480f276099243202a4c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-09d1c200974978a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/DFAToATNThatFailsBackToDFA.g4",
     "hash": "48db67da6df9caa67f3e56b39408023058c363703e5eac58a74bea22a92f0066"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bb7d7e78cfe384f0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/DFAToATNThatMatchesThenFailsInATN.g4",
     "hash": "ce03131129eb8147280be2cb5319ce363f7a4184ab6b871b761128c49ce4edb3"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc047b298adbd6ff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/EnforcedGreedyNestedBraces_1.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-33a1b9e191706298",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/EnforcedGreedyNestedBraces_2.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7e9dbd2dcc8c7f1f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/ErrorInMiddle.g4",
     "hash": "ca5afb8c050f2d8b96fd19595dc603645d812846f62c9d767d56f7d0a0c5a0d9"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-09a68458b925b66f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharAtStart.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8d28678e27119289",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharAtStartAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0a75febf6dce6ee7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharInToken.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0d1d417e56e97c5d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharInTokenAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6a2ee85d80fbc724",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/LexerExecDFA.g4",
     "hash": "9082786e9c7fc41aaf4fdfc2878c546039534e8b4ce83af668f95a9189b005d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e2f1f8bcb19d0f20",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/StringsEmbeddedInActions_1.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6a04ad223e68e94",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/StringsEmbeddedInActions_2.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-20c969840991a3f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ActionPlacement.g4",
     "hash": "d2e2766e7a6e95053b231cd43aca1fe4f764aee1d333e2302d278b5b067e209c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-83016601a9b99d5e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSet.g4",
     "hash": "8e650ba32b5a406d9b26183b2d8bedcce9c1db181bdb411ad7c5839dcf4b228d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3fa288c086e09b6b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetInSet.g4",
     "hash": "b5e383c044a1563de26a51b2d6b7cb2248fd55be0e3964e1d14b3610562eec1b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-29c547f5ad34451b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetNot.g4",
     "hash": "69cca11dfc28d919af7dc2ee9fe3723a7cd21d664d0be3beac4731d55c756c1c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b212d9c3f7a0aaba",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetPlus.g4",
     "hash": "0cbc99fa0bac4ead651732b006ec8eb8eeca91cf996b2f879d7b0169d1ea3d1d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d80f8c3e310bb24",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetRange.g4",
     "hash": "3e05d18b49d5c8c36a07be0bfad40393aad4dbfd51a4236754351f81326709b1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4df1bb08a6aa71b7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithEscapedChar.g4",
     "hash": "5223c3ae6c31d174c32451245dd1b500378e5db8269d2436d6c3e13348c843a1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3175b424871ce827",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithMissingEscapeChar.g4",
     "hash": "50af99ded636823b3572ef557e472106e875b6a577bfce40a5a9f136e02a5425"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3f9872321402cf65",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithQuote1.g4",
     "hash": "be53ac24d9dde8c37359d79d1cc412859db4f7c36ea7d8994a7e41abb529735e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1679daf06413d935",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithQuote2.g4",
     "hash": "9abf142b50b105db8ba755c0a77ed4d38d3f00173bf0b86e12df3eb7f3d9f869"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f01c3a503e28942c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/EOFSuffixInFirstRule_2.g4",
     "hash": "441bbb7e472213eb37da15d9b0992d1c4d399644b0fa057762e0b579ae06e531"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f95f1e6e5f68f882",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/EscapedCharacters.g4",
     "hash": "88a4f34355fb87e7adbc718fcfe030c51f5c362d158b4cce6a5796189ba1cd4a"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b515465e8b02e1f9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyClosure.g4",
     "hash": "d1458a9fc1db2a1bc64866ee5b621bdea6b8aca8fd321a6053f7b64c496bf279"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-02a351cdd460574e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyConfigs.g4",
     "hash": "bdd0480bbe82e2296561739001674c10fb887a4867707fe2de4f1c1eb323655b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-95fc1ab83dba482e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyOptional.g4",
     "hash": "0e2acf0a59884a4de77f9b74b30c2dc30770c78b1a11db4db50b1cea97df2d4d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a524032860837b91",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyPositiveClosure.g4",
     "hash": "5d96b0c62fad69596130c0cfe142462b2dffa59bcc399e1decfd28cd0ad2ac03"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e201f35f0906d78",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/HexVsID.g4",
     "hash": "a1aa12f4fe19f66adc2b83628e3806eb535b11a974c9e7173202674b57eb3bf2"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a591bb6db372c0e6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/KeywordID.g4",
     "hash": "5eec334a6818219de3e310c919f6fa92ee282ea3d98561d1e53fa586df4b7645"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0ff248d14dc88725",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyClosure.g4",
     "hash": "919895cc80becbaa85e86b313156de11fb8cc30e641612bb47a295326f546a2c"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/l.wado",
-      "hash": "23337acdf550ed4a41033d5b671b45bede6a3ea99c2574970fe4585762d96291",
+      "hash": "ad293c73a68504e71d8e116923514be63b4301578e64a5022a431a7add2c6d47",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/l.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/l.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bae57e916d1ffb3d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyConfigs.g4",
     "hash": "ccf5c3efabd0e9fb90790d1eecb50a96b56642cb5f696121dbebe686a03d9c66"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-de78f2284a4fc7c7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyOptional.g4",
     "hash": "611a3d559cf19bd50743e764270d813639b924662b03e7075f24f3ac3520ac9d"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/l.wado",
-      "hash": "f833e7cd00c5cde88f570668c2470d9091b62a24208c196d59df551ec15c35dc",
+      "hash": "9fa9f9e1373f0964ceedae2177f24c846e10eb13d1220705b8995695e93fa989",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/l.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/l.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c4e715bcb502910b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyPositiveClosure.g4",
     "hash": "a19bcb18c02be6721bf1028a7c1335d28291e3e247dbd8e5fa2fcbc88d716fe4"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-50828f11ff4f0950",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyTermination1.g4",
     "hash": "5841fcdcd5adf818f59bf6e0f6a29db4d1027ce77dcc476160b96079fcf35a8b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6a85f20bce148fa6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyTermination2.g4",
     "hash": "9ea5e3f0fd959bb4a51b464e3c49d7f20e95f5189bab762287847163d70a5960"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9819ff37cf490a94",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/Parentheses.g4",
     "hash": "10a47eed1b802ff2274c0d7ffffc1a145b6142f25340091ecdb1176446429acc"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-87da43b39fac31e6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/QuoteTranslation.g4",
     "hash": "fd454e5ff551c86e4eab1e50e2375a62b8246aae8b700f386202c3fbc795225f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-453eff130b58499c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1.g4",
     "hash": "ccf3affeed08d41932ee1b94716d414b1bae3d229b6c7f3f4d17e62300e91492"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/l.wado",
-      "hash": "c2615c078eef959b4fae4383be804f795c5392c510678886ada736c1eb7246ec",
+      "hash": "637732f9e18b55e67147cc4529fb3f2c52e1d737da3a5d1e8a28093376caa219",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/l.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/l.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e976ea990a9b384c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1.g4",
     "hash": "7b6ed71096a57f601b91ad9c0bee2e6b2fc376dcf23c80eb7430b84c165be764"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/l.wado",
-      "hash": "dc50ccf166455c6feb907ae4b7d0d97a3bf6941b5af1f9c12b5978614741b91e",
+      "hash": "642a2e304479120a6224181939788136cc4746f17f16fb0ce0f0d750bbbd6ed6",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/l.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/l.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e5247cad2dab1cee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother.g4",
     "hash": "95a088465b495a7bfbf61a77ce9bb6ae79caa9288236175927e10273cca715f1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-31eb36b9151f6251",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ReservedWordsEscaping.g4",
     "hash": "66600b7a97e9750d7527d65b8f6799e6e8f39806bf1a1bc70f349d2d79549d04"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-af19525b552e215c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ReservedWordsEscaping_NULL.g4",
     "hash": "c0512ddd17eb85b03ec5ee0bdfbd91e04bf5186ea196a43c6699b55bf350e582"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-29c28d333d3b6ac7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/Slashes.g4",
     "hash": "8542b8d313ce35cd690e1408d548786844016931b7659852bbcb1af80919f7df"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e0cd8559492f780b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/StackoverflowDueToNotEscapedHyphen.g4",
     "hash": "8ac36d903f20ad5d1c01d8de6e7555e7095b62f80282b91c7309cb119f6e0e81"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/TokenType0xFFFF/TokenType0xFFFF.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/TokenType0xFFFF/TokenType0xFFFF.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b8a429f4a4f89db4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/TokenType0xFFFF.g4",
     "hash": "510dfbf59b57e04442706e8d5ae998b7daa9bfb6e4ab2347959fcaf010e4793c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9f1c51764ee8e0aa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/UnicodeCharSet.g4",
     "hash": "be6380e8ca1f1838a7908f37fc269bbfe32d7522dff990274bfc144c90d5a73f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8751b66f0e110739",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ZeroLengthToken.g4",
     "hash": "602fefbd71118c707ee514a7eb2d6eeac92032b2009e51b705b154429bffd5ea"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9b0691d83b7c26f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/RuleRef.g4",
     "hash": "94e77d3cf0e835f48dfd591d6b9b625e723dc68af632bce754d64e7a83682e5f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-09fbe00d3bc38c84",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Token2.g4",
     "hash": "7f89f3118adb112f187ec9a91475c3230eb8d3e0f11d5f98649b5ca5cd018210"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e99a1057f66caf20",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "01ee51d71cecc10fa33d0b88dd68d026e6e3e811ceaa04d124aaf32b943836ef"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5ca43ba2c46316e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAlts.g4",
     "hash": "18ff657616b51f930ed3ce29a3df32d447b93f1ff9f857f30f3eb53458857f94"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cbcf1aab05830c30",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ConjuringUpToken.g4",
     "hash": "cec24d194020155bc5c53585d2a955c7d39e697e652fa11acaf3efc1a7589fb7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ba1a39b00df7ed03",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ConjuringUpTokenFromSet.g4",
     "hash": "b56e1ba56f51bf544a254459dcc27c19e3f719f8eafae34e005aef07581e6517"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-969eb11a43ed2b8c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ContextListGetters.g4",
     "hash": "b7f98ec81bd992592439948185bb23c69116c968bf6f2529cf779cfa9801366f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1ad21b2d6d06e4c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_1.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d4d5ce55d20d8c99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_2.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dac7e5406c83f78e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_3.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ab6558c0c36be6e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_4.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d4d8675a3d0ccdaf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ExtraneousInput.g4",
     "hash": "d65f706ca2451405802574364ae8d3d7abf995b07027e8a4625c575ee48c919b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ecf1cbc4cfe469b5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/InvalidATNStateRemoval.g4",
     "hash": "264f98bcea9cc9d12c0c89782381318f9404f87e10f26da3a6762a42f6738109"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3d790ace4e4cae9b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "894561cdd0b332fdb9c86599422d88ee6f45086a452209a385b14df01e56f8aa"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9a9e5ae2b3c77489",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL2.g4",
     "hash": "2aaa2b6a34f4a4348b34477ca85e32d712d0090ea04767439f00a52c9e369525"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e2a951ea27a3f6e5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL3.g4",
     "hash": "c71f82724eba5c68a8618a7e086bdd6d4945e4a769695822a02a3e560fc12d76"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a48393b52e013a27",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LLStar.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-46cbefb268ae277c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionBeforeLoop.g4",
     "hash": "e85e3274b80d9927fac0d6f6fd84f36c85e3495b5c8288e0dcb1117c16f07173"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b3c2586de28786e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionBeforeLoop2.g4",
     "hash": "51530a0ee95353c6b0fb35a295e36225ea546f7677798f9ce2d4671ba35b7edd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c9fea4ebbe23f1da",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a3750df5a8803f59",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionDuringLoop2.g4",
     "hash": "e425f4fea0c6671792c777df6308de1546711741603dfcde04e0cf3ebebf6b9f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-63cecfcb5cedc740",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/NoViableAltAvoidance.g4",
     "hash": "b28914eab8290e79724e3e1b2ac223e8b6c5021ac6ca3c564ee873762146bbfc"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c0a9e83725b58cfa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleSetInsertion.g4",
     "hash": "5c5213e807e10eac992c2dd076d8f12a8df33bb71c1803ee039588b15da2782b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9e3665c322270c1a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletion.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b28fc5c7b51faa07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeAlt.g4",
     "hash": "8620c2090497e410ec32e4c6556c760c41ffe1a00ca410ee8a598dfdd77baf3c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e60ecbcf0d996b9e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeLoop.g4",
     "hash": "981912e9f61c0e8e34da6607456532112011597125c30dcbddf0125401041f85"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a1be999d15c082cd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeLoop2.g4",
     "hash": "959f4e3f298f227e7e5c734f8325acfb023db1858bc5f3c11f1236c771316b55"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0fce13055579b613",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforePredict.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-98ed602a8cd4be62",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-84b763e2874c2d22",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionDuringLoop2.g4",
     "hash": "e425f4fea0c6671792c777df6308de1546711741603dfcde04e0cf3ebebf6b9f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5045f663e7dc4a80",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionExpectingSet.g4",
     "hash": "82fab2ac95de6f83693cfada43a42fb29c81c33276e86a92c9ffe512e0619240"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7caf65b1310140ab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenInsertion.g4",
     "hash": "4153af41f9ffb8e3498f2f8624598a75ecb726bce94b85532bc26a2f9a553a93"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5f12680add0982f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/TokenMismatch.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7edada74454e038f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/TokenMismatch2.g4",
     "hash": "4bd0badd70e068efac023f2f42dff67c8439fb46b31ad4ecffa908f2eb619d18"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b8fabc02665e372",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/APlus.g4",
     "hash": "2b0dbbd74f199abf2352f0d10d69380a3efa3415df6e4766c0ec28607af19cda"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7c282d1165854819",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AStar_2.g4",
     "hash": "a92a7a73eaf0898b23dda4615fc26ca13df1545ef078fde29cdf8c3bc9cbb95e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ca3c42476effe3a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAPlus.g4",
     "hash": "d4aee965be5cd3da519492b2a33a77762e9b3679da9f616bc2e85a73f2202fae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bf6d86c42643f34a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAStar_2.g4",
     "hash": "6d4d8fd0f1b4d3dc3e2e8faf8ea35103229eb6c35779eaccc5d82b1628327b23"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fd0987522e3c3d04",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorB.g4",
     "hash": "a5be6ae4578376bc6ce8bc8244b8547a686c023b8288b7ee1b788e3109641aef"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ca0a9d2b381f627",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBPlus.g4",
     "hash": "513f4bbe3648eb8ee7cda9846f4decf54510992284d1f855c91d3ff63f4eb561"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1152d091e08d881c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBStar_2.g4",
     "hash": "30bd8a0630f5fee2c9cdd84358bb4330bdbbef41ce747fb918a5317b26d72094"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3a26a14dae7b4e0a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Basic.g4",
     "hash": "12d9ef272c7c1189094b1667f57d2434ee01e7390bde72fef40bbd2c39c655ad"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aa50827c29e482a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0c4881b44435d2c0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-855c6a6f9c847f68",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "87cddc954cc58d91bcee872b5e1136ec8db7cdba27d288e3158f1263465e1c68"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-44d7757f10ad787e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "9961fd76deec1ff3f156b53cae19057402f659774e286b5109f317f9099548bf"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eedbc49242ab35e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding1.g4",
     "hash": "17ad7d25ee1aed14f17ea5029f7488a334ac41dae14112578dd467489ca814cd"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/t.wado",
-      "hash": "643759c078e7227b5b58fb5650adbc16bf7abf1ee6ca82a93340735e059bff2f",
+      "hash": "25cd83894b6cc8e216a0811c6721bef0bce1e6d792f5758673efd47b11be0dd3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/t.wado
@@ -1233,6 +1233,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1521,6 +1535,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1542,8 +1560,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2124,11 +2166,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2148,16 +2193,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b080b7b9a48eb684",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "82b13e026c76cbd8d6e148ff6b07a4afcaff767d281341b009acb47f2177fa99"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/t.wado",
-      "hash": "edd593f7699393b4e1ea7afcbccf6fc30432add8c274e4a6e909f5ca885d60dd",
+      "hash": "064f7d0e42fe01f280599c92e1000aa5bfb9d5a53ed1f88ff6438086f9b41a81",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/t.wado
@@ -1233,6 +1233,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1521,6 +1535,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1542,8 +1560,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2124,11 +2166,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2148,16 +2193,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe37baada5f5ab17",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_1.g4",
     "hash": "ce8b6e86f90fd838f389c969f26848a74f12cedfc2269000d54013aefc9d7cfd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-779de95f8ee98331",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_2.g4",
     "hash": "4901211c2a6d24bc31faad4232c52b1076c788c30ca1626ee8189f377298edb3"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fc452d9f90e47c1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_3.g4",
     "hash": "be54343e5d0af2db673e19012a397a002684ea46cbfae40b2d7283c34d120aaf"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ba8d8f5a1a9cd3e8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_4.g4",
     "hash": "f093c2f32b839973701e676ff0a7ac42b07bde81fe26d0dd62242d5bddea35df"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8a3fb073ddef8302",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_5.g4",
     "hash": "288f969b08c50c65a8fe90dca09e2900316e61a1e643ed8dffe19f0baf33caeb"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1649510774c10ce4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_6.g4",
     "hash": "f1f23150782692a30fca3499f09edc2d8b32615fe4158fdd496ca236f257abfd"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9f9256112977bfa6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "a2b9873d31df6aa521f495b2f4f63cbcb01917154e56af08ec8162e66ec4b375"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-430ff774fe3ccc56",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "10da0f9ef1418b4e7996ee9ca537b6eb00e24cd75a5e9cadcf6a0f2cd05403d8"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Labels/Labels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Labels/Labels.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4cd701463810458a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Labels.g4",
     "hash": "6263c0c263ff2e359d5ffe29f5156e36760ebc32acbd8fcae5cb2b94eea08fae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da67aaa4d4e7d1dc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelForClosureContext.g4",
     "hash": "b74922c349f6fd54727a73a9292ac1aa7379006a6b5858b2120f09137b8f5220"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6a945f81d6250b39",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelsOnRuleRefStartOfAlt.g4",
     "hash": "936dbddefbedcc17fb63d1cebd59dba273f24001d8510aa9e4584026b3a77a47"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnSet/ListLabelsOnSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnSet/ListLabelsOnSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4149c91165003e23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelsOnSet.g4",
     "hash": "3e061c74b0839caf5d204be5aa58fad88f4a12eacb1a4b5987312548a5e87351"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c1965b1ad3551636",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/MultipleEOFHandling.g4",
     "hash": "f1cb5bab46a024203403073ff94ae02fed6987c2e63b627edf697a7d299b08c6"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-90fde212123005df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case1.g4",
     "hash": "e7e0d629d700077ba7d1c73b090f445f1d1e6a71e05a0ec865a1119f159c0689"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f495faded44a5a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case2.g4",
     "hash": "3e809216e16c70dfb0f29110bb04e4f17b9cc8df65e343e657587db8125919d1"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e97b68a5f8eb1a84",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case3.g4",
     "hash": "3e809216e16c70dfb0f29110bb04e4f17b9cc8df65e343e657587db8125919d1"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-95568ec5360350cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_1.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0e8380a3320c9799",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_2.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7ce6afedab222aed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_3.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-423d80b6abcff4cf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_4.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-89e8b74546257f6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OrderingPredicates.g4",
     "hash": "9e1c1b5e4eb5492597f2e750d5935cb9a2fad092868471a4a1244f39f05c60e5"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dd8dbc75ef94fbfa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredicatedIfIfElse.g4",
     "hash": "440287edf9ce1d9d35ced00c525bdf5620ab0d710872d6c3df66275a20b6a6b7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-24528bcbbdda4e86",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f6b44e68024d9551",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-32bc03565c015b60",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "51acdad9c9d5ac16101b107cd251308154503481b21347eba16ed71c07207cf8"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d4ce43056de06d6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReservedWordsEscaping.g4",
     "hash": "1e3d6a30a764c799a1fb20bef01bebe365e7bea96c458c080dfbb708bfd800e8"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e36f569ab470259",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/TokenOffset.g4",
     "hash": "e74488674b6ea2a5b0c7c5c0da5c63c5f40e5cbd3659293737c5f866eec3dadb"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3757dc9b183c6d1b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Wildcard.g4",
     "hash": "443ea5e8b3a600f483f353e7b727214ae7b46b07d48a05209575e59a4e5f87ff"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99e547016945f080",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "2ddf63624620f170bb9fc4afce010caed86e03e13c5841514ae5f185dda39973"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e11c7fe8b5cee544",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_1.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/expr.wado",
-      "hash": "b1729aca940f2fbbee7bd2431eb992e08102ea9eba1e65b3c5b5eb7a14d0d885",
+      "hash": "ebf6c0c7a204d908c53e446a001e9bc6bde0f3d501889779c934aa9d7532d1db",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/expr.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/expr.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7a5848242a8cb43c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_2.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/expr.wado",
-      "hash": "2a14f881367ed0374e48052c4a64721955fe881d3018fce570bcba2790d87841",
+      "hash": "777e4f718ffb5fbb3dea1e2a2a8144772b62cf62d7d34a1fd2ab42ab72aa0467",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/expr.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/expr.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ce08c1178fa4bbd6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_3.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/expr.wado",
-      "hash": "e67ac93d0cb5eeb7dc14b4c6dd8d77b6a13d22b5867b391d8c4ff5f19f619c46",
+      "hash": "3540ed4c58a8d189a31854797dbb226df3ef370aee0a3e7e6984f58f1b82355e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/expr.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/expr.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a5756784447b5cb1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_4.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/expr.wado",
-      "hash": "95d0b710cb48bbb7b2eb27dfa323fa77224f7095bc441a7a6a97888e16875487",
+      "hash": "539a624b76f3dc3a1235b36546beb90d56180d5a9136c393b63b76bac6633134",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/expr.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/expr.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78ba2eaa26a31c7a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_5.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/expr.wado",
-      "hash": "bf517fec2f82d0ab0c1b3425a70f3afdd57ad7d1fd5f3a0788dc05c8a8fabc40",
+      "hash": "70d472815cbb6d6a2cd79aed046ca7e3eba5a93e69c0279c2f62142f130d90cc",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/expr.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/expr.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_1/ExpressionGrammar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_1/ExpressionGrammar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d350ff94b0999499",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/ExpressionGrammar_1.g4",
     "hash": "fdad284b75dbe1e75f3820211869d5d5e166b393077d55d5450945c644e77f47"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_2/ExpressionGrammar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_2/ExpressionGrammar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-04b9483196cc7a79",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/ExpressionGrammar_2.g4",
     "hash": "fdad284b75dbe1e75f3820211869d5d5e166b393077d55d5450945c644e77f47"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-06d93a2ecac72f18",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/DisableRule.g4",
     "hash": "5b1574a02354c266f21fd591064fe38a2e504dc819f17e3926537f3a06d4fc7f"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-edeedb727dc64900",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/EnumNotID.g4",
     "hash": "85fe205c1e5199d59ecdfde76be2b554d5417cf4f3044467d2c3c2bc6be62a38"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-175dfbd57eb1321b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/IDnotEnum.g4",
     "hash": "6931892d68c03b3e5aa6440e19df4ec4d482979716d8265bb90d754b4ef6ef7a"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bdbec4dcae9cb8c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/IDvsEnum.g4",
     "hash": "56ae33e82f989514e362fec8cc72a6550b7a4460f7cf651186c0fc5577e2596d"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2cf75b8f1d446d2c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/Indent.g4",
     "hash": "ae673bead61ac8db918560678d525133be3f118e57d3af6dc6170f0a5f59854a"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-24a460598d69e977",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/LexerInputPositionSensitivePredicates.g4",
     "hash": "3b657b482bf4474734371c82bad60577eab45adcb768b00be1f1332976f573a7"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1967d0a146b919ae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/PredicatedKeywords.g4",
     "hash": "2d282eb6b99756b6a78e5b9350752b0e8a9c44853cd80fc99024cca551f2c8a2"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-adb09787f2f69b5c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/RuleSempredFunction.g4",
     "hash": "afb90011be3fc07f2b609aab80113b4cdc176601aa78430bdc8af851cd096c57"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc046e1c74bc00e4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "7176de59d1c79178e55d5e86f1c9d45d2a84c42d0306624c059f6291b7bef8aa"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b262d928ef13047",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "ccdf783cb1b30be5a7b33fa50258508b6fa6564ffc640f83cdd701860cefceab"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-82f82319744c039c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/AtomWithClosureInTranslatedLRRule.g4",
     "hash": "92e1a1f0924ff1342f55dce399ac903cbd1ee449cb61b490823161e0100e84ea"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-258490d7808c0aaa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "23c2d14982503d975310e5e3c23f6d5acf82bdea14758b8edf43a21de15fc46b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-299cabef8cbbc639",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4",
     "hash": "9d9906068c7233613cbd6b5d1291c8c6fcb0cd0cdc09eb46491a16d77043a351"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a2a17737b4dbf390",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DisabledAlternative.g4",
     "hash": "dd7e12c1c8029e091a0a98c9844b768fe2beb66e2dd4499affa4dd42426bbebb"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b17683f8371c7cab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "7750e6dc3c86efd7c47184ad7f428310bd808cbee7cc760d88cbf6c76aed00ea"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aa8fcb18255e55f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Order.g4",
     "hash": "fe5bc85134bb1581bdcae00261221a4d8d5cf7fc66861514c518c932db73927c"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e71ac45ba11ee38d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-95c11e3806b83d10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "e612218883337369509a10795a6c896ed4fd346099904bcdea49689b70eacb58"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f7c2d92ccc8ab01b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "63ad05004eaa3eae497c7ac7b869f512be40e3b08c490a4edefce0a7bfd03be4"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-266d6a9f3adecc9a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg2.g4",
     "hash": "54d5032bc72d9ef84bb3c836a5c580fad72122817b40fc5380affd8a13521f6c"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a0250fd5a3ae0033",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "5bc8badde05794d30336979aa4a8e376565246e39e74e5e79ffcc7d3640896ab"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-53a69efbc19a5a01",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "1e8283c5161522a98e12bd6b9c0b904b195ed3b305a7cd1104d32111a16230ac"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-79a58222616de2da",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Simple.g4",
     "hash": "35ff1d3690b2d9d2c179b9064ac1f19102b739667e99e936dc923f266be1a29b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ccd514ab5a0d2628",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "4663e60c7732087dc2db2c9b615d6a9d091258c9088e5494ada4888d59fe97ed"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4ebb006656a43a74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "660b45f425c3ed090eab8100788e1b44cea8e8acf7a3a7df551673b469969613"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-31c6898cd7c0555c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "b92936412d8caa3aa5e0a9f0859db4db2dbd59b422445fc0ac7646ad9de7e7b5"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-475c24ff6a89bd9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/CharSetLiteral.g4",
     "hash": "06e8171bff5cb8897907a7253d3622ee2b3fe0046ae8d0b91af1e53eea95199a"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8e3de5821c86509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerOptionalSet.g4",
     "hash": "805d183407ee6d3e197aa59c47746f31a3a876616ba81d2796b4eade4fd0cb1a"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-53ebf982bbdab05d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerPlusSet.g4",
     "hash": "82d73edf927d0b41773a2aed77c24eb6c1e15ae757745711744a98d92a30ba9f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be939a7d7215f166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerStarSet.g4",
     "hash": "5fc2408d6d827c200d5f3dda95c90ca51c0304141e1966710e5ba3ee4e8c9c62"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c9de52bffebd585f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotChar.g4",
     "hash": "ea4e829495a2862424c660528e60b42538171fd98c4add9d59de52bfebb03636"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e80a5c8f430b7c71",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSet.g4",
     "hash": "e746afb6f30a6057ad02472688eed14093eb3c3667bdf9e3c181886b47e78837"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e782f3d843a78a82",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "13b313e51177c018f7ae34ebaa84db67e86a0d4b36209ad3fd1711f2ad2fb7c7"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8fb74e133297f886",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "3921de873d86bac58271a10481e3c0e015c69cd9d31da1c2278263a953b16c45"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56f8ec02930fac87",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSet.g4",
     "hash": "c13dc8792637b8734bddc522d5c7eb48f4d40806f34c7540b36f59d70a45db0b"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-09f221acb120a53c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSingleElement.g4",
     "hash": "6ed40cb1f8e0cf841fa0926ccc6a4d62bc3164537ac07270baaf99e7bff650ed"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a2300bf82b65d527",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotSet.g4",
     "hash": "5cd8c64df8a97020ac5413953d3f986284c2d0d02ecffa78f56e74501fd843a4"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-752e04a19986bc36",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotToken.g4",
     "hash": "f3628c394dba3dcf943da3c57ae49f9638ad607d2889b3c93a404ffdee955bdd"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed613960e0e6b31f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "0a93f8b72d55e95661fd29f1dc20be1ba499092a4627974f10deafbabfc1902d"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2b60d7dce9a6adea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserSet.g4",
     "hash": "9f4a6537aa3fabe41aabda8b6dceb0b110ae6dc2c1ca606d1bb6a4c17bc0523f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-527bfd9e7200b4d5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "308fe96545620a9956a16a0b905efbd6838f91f1380d112f59c8f5e7ec847df6"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56dd2363f7757e98",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusSet.g4",
     "hash": "e22104935432d1ef1346e156287f6ffc20f7a823a3a6fc35eead1aa59f7e5bff"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e02be559604ea94f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/RuleAsSet.g4",
     "hash": "b292a08285fc28948b206aa219a2c5707f54b8d7d059e4b9435a685e35604a0f"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93598a0a760d2ccc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "1e9c5a53f120329c72dade19fb74f37b769fa3e8620ce55c964187b4b31afa04"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-691c916b19f8f1db",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-87356a0cca836cbd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fd9080e2330af37c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarSet.g4",
     "hash": "b6e8bd3225682605f4be8329a1ae6a16abcad1fcd59e904ef3b62582e975e58c"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-36a6472990f3d431",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPRangeSet.g4",
     "hash": "91d810085adf2f3357827ce10f4bbad8b3e368cee7f7cb7a3f7a1de5dcd9fb25"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6919835710cc9057",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPSet.g4",
     "hash": "1ebdc64bc0460ae535aeffbdc92a3f5761026b451f53b16a67a1e4ca5c5adfd0"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a9bfb68cd21c58f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPRangeSet.g4",
     "hash": "315c93a355628ed83d531af6a8acae7963652887c8317e90194f639f487a1454"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe9f81a1fd457762",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPSet.g4",
     "hash": "537c313c2d870d0c4e8fd6353c23f77e4510a436510e08e010dadf6674649f67"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8d35d2ce9bde26b1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4",
     "hash": "466941b1536dede6ac3205c0840ef6d5769d6ebbb02068e3078667aa3b723bf0"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eb0546dcb0fa39f9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "69ab5aeb81e985edb26b848195ad01840cbc068de1413e0dc41dc606755f5d85"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-41398004e84d4029",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeUnescapedBMPRangeSet.g4",
     "hash": "f35a7b066983f55034da8d5bb525e9f4265b04e208656d8bf80e2647ec315064"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7ec04a23595de320",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeUnescapedBMPSet.g4",
     "hash": "116c1a706a18422d1b24ff9c3f8cc3e9c183c8047ace31fbbb1b2e4e3b9d2b89"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f6d4044f235678bb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/ExprAmbiguity_1.g4",
     "hash": "14b8e903ab55457ab6f1ff7095b057b77680cdb6892d993f7509940795fdfec1"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6748ecbdb491ed11",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/ExprAmbiguity_2.g4",
     "hash": "14b8e903ab55457ab6f1ff7095b057b77680cdb6892d993f7509940795fdfec1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ecf481963e0cdc79",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_1.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f6f731f2db602556",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_10.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c7333c46ee1e2ae3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_2.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-903cadfd5f466fd3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_3.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-86c47cc59e39c88f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_4.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-69e6d41676a958ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_5.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da24a0de62028c37",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_6.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e19f84c31bb1ba1d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_7.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-968aab64fde5c720",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_8.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7c9628ebde9b1092",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_9.g4",
     "hash": "ab366e33ba88e06c67622e9b25984ffe8434f8b59a130d68e80e2de95dc67bf5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3feeacc5bb7c0e2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e336cd99cabce3d1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-75aee7aa9bd1c5e6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "4b5e3eead89a6eaa489efd3914f9510092b1f56710c9bb6e72f89e863f91297d"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2103099bbe8c6685",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_1.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b230e9d9b9e7a116",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_2.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4cd3c5efda6e6f68",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_3.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3d11b7a0de9bdfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_4.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e83472c3c8d59131",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_5.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-936ca045e8760afb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_6.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fabce5812b80e12",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_7.g4",
     "hash": "32e8d3d2eb1c610f3cc8d0c2eff2bd12972a344124be5d3293d475a116b1127e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e60cefc96dbfbbfe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b39e4e6d0638fb0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0cb1bfe7b9b61662",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8ce620c4d041bf4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8a748c4b1072dc5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d835a9bcc70209d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-adcdf24e70551231",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-948fa494f8c39e9d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fd667898473386a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-168d84bfffd30ffc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-16d2a937059aa781",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-591b970bacca2c10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4733ce0433551c40",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "1ef17f998af09c98ee382b29a0c34c1a86c8fff5e8a61cda740dd42e26f3c2ae"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28a5608b944daeba",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a624ec57ce05fcc6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8f00b8e71dfed758",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "95a1bf463c32ed0fe96c514b03e3199f88ea19b6d4e91a1a90878757c11676f8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b2486b1d4d30844f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8d0cdbdd515a30d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3f0e08ebba8a9cc9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "19e59bdafb477560021684995efea8be3c30109cc79480bd66d2bafdbb20cd0a"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4f103577715c8db1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "c92df3158f9ed1c1b43de581aedaf3b0918fa525ff0258f855022b78585b860b"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0858b0f2d3b7c4c7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-db6337cca451074c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "f946ec43c09928b2aae968a817d4ff315478257d5700925eab82fd22d94714d8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b04e1a8213a36b6f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5b1293e53cbeb9bb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-733afd8e981f5ae2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fbf1b14e07366be8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-321bb4a887aeed4a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPred.g4",
     "hash": "a19c17fc308f32463fe399a657b189a837ad4fa52afc1206ab0d1d8a38dcbe04"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c204fd4f09ca499e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "baacd97f45a8e197f2d9363c57506eebffd7f8862b34984e659ed317ac48a7d5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0be243caf6fa7899",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_1.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0a0e80b115ce1b00",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_2.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7e29f3b4c52a634",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_3.g4",
     "hash": "c750f4575b8e313b2b0c10f94fa9f8b8a31176b00894f634ca7c6db90c6edaf1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a7328289d4b21bbf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-71680d2235544569",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9b9906af711e224",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9f755a2bcab50c9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-47145b4638541e1c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-754daf97c5b4efbb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d3acd8c540ac647a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-04125904502f125a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d8261611e9a89d09",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "90eb45c3f7a400509e70b575a1876939ef6ec88ee8aadaba794243ed209decb8"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da61cc30a860cd7c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5a5bb5c5af282292",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f87b05ab4a39bca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56f734d0f6b9deff",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8496a4404edac6de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a687b33884dd47c6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bb13da02739a232a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d7cb3561c793879a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ae687c4a1d9f02d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "7c2fc38528cc263b87ece331b9ea4dc1acaed45f850c71e85505d88c16110729"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-887287c90db5c504",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/ExtraToken.g4",
     "hash": "156ed9b936c29311886ba71c031dac87cd4b6840001fee2eb9fe68aaa966ecb6"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e29fedcc6a82767",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/NoViableAlt.g4",
     "hash": "9231f03d8ef47e85e3d2852cfafaddcc6f66c6b8c974af0a13924510275448b7"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9b0691d83b7c26f5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/RuleRef.g4",
     "hash": "94e77d3cf0e835f48dfd591d6b9b625e723dc68af632bce754d64e7a83682e5f"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a52bb1bbeb99e6a2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Sync.g4",
     "hash": "7f0cc226fbcaf40b919d6fabc5b7e88c8fe92ed6637415b5c5a4be42addac7e8"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-09fbe00d3bc38c84",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Token2.g4",
     "hash": "7f89f3118adb112f187ec9a91475c3230eb8d3e0f11d5f98649b5ca5cd018210"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e99a1057f66caf20",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "01ee51d71cecc10fa33d0b88dd68d026e6e3e811ceaa04d124aaf32b943836ef"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5ca43ba2c46316e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAlts.g4",
     "hash": "18ff657616b51f930ed3ce29a3df32d447b93f1ff9f857f30f3eb53458857f94"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0c4881b44435d2c0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-24528bcbbdda4e86",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionIssue334.g4",
     "hash": "05f509013c98f1d1ef907d23c43aa328f3c9ee0ad9166b21ac03dbc715ee8542"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f6b44e68024d9551",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "8542495134a20f622112aa07fc5cd71fcc1b8e3669f41ff329126b355c4df7f4"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e5ce9a108025ea0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e71ac45ba11ee38d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "b6144b334167648d1e1560be8a7590525c8b34cbba2e27d040c41026fa7c9323"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe209873265cdeca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "741538d9d6c17ba04aef378568b4ab2abdfbffd161000d9ab169b2a4d9abf5d0"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7517e433ec88ae11",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-30b6d0915e1f0a7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "ae15277580dff4b373b83be420cafded143f532c9354310a7c2c3bc748ca8b76"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6b0034f6018d25eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3474970db58e7330",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-42f8d57fbb23a068",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19a60490c6262e02",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0ca22bd1314e7218",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "ae1955a63072b61bfb19d308ec36275bae7fd4ca41cb570ddcd3113f86f61d81"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-65bf707c5ba0786e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a108c538b000f929",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-13b53d6471caafad",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c3d8d8e6f2084845",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "8598d942da23d2752eeb86358ab94f137ea6ecbd4536dad7a93253b6dbba2583"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0fc821cebb8739b9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-519b6ed9e8bcfed9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "97ed3cba25571f64d3b3f1ada1225af38693f6353aa699ec825c47886f968b1e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4cbc959a0677270c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1c9a22fe77a307d0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "d020b96fea143032cbc0f3f58b543f99e6ee62a9921e2c0c402a721dfeb8e67c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-969eb11a43ed2b8c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ContextListGetters.g4",
     "hash": "b7f98ec81bd992592439948185bb23c69116c968bf6f2529cf779cfa9801366f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3d790ace4e4cae9b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "894561cdd0b332fdb9c86599422d88ee6f45086a452209a385b14df01e56f8aa"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b8fabc02665e372",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/APlus.g4",
     "hash": "2b0dbbd74f199abf2352f0d10d69380a3efa3415df6e4766c0ec28607af19cda"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7c282d1165854819",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AStar_2.g4",
     "hash": "a92a7a73eaf0898b23dda4615fc26ca13df1545ef078fde29cdf8c3bc9cbb95e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ca3c42476effe3a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAPlus.g4",
     "hash": "d4aee965be5cd3da519492b2a33a77762e9b3679da9f616bc2e85a73f2202fae"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bf6d86c42643f34a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAStar_2.g4",
     "hash": "6d4d8fd0f1b4d3dc3e2e8faf8ea35103229eb6c35779eaccc5d82b1628327b23"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fd0987522e3c3d04",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorB.g4",
     "hash": "a5be6ae4578376bc6ce8bc8244b8547a686c023b8288b7ee1b788e3109641aef"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ca0a9d2b381f627",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBPlus.g4",
     "hash": "513f4bbe3648eb8ee7cda9846f4decf54510992284d1f855c91d3ff63f4eb561"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1152d091e08d881c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBStar_2.g4",
     "hash": "30bd8a0630f5fee2c9cdd84358bb4330bdbbef41ce747fb918a5317b26d72094"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3a26a14dae7b4e0a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Basic.g4",
     "hash": "12d9ef272c7c1189094b1667f57d2434ee01e7390bde72fef40bbd2c39c655ad"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aa50827c29e482a0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "2a131cc48cdbfa4950f7c16ef0fcb51f4679926cabf71d403883a9fc01e9cb99"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-855c6a6f9c847f68",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "87cddc954cc58d91bcee872b5e1136ec8db7cdba27d288e3158f1263465e1c68"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-44d7757f10ad787e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "9961fd76deec1ff3f156b53cae19057402f659774e286b5109f317f9099548bf"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eedbc49242ab35e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding1.g4",
     "hash": "17ad7d25ee1aed14f17ea5029f7488a334ac41dae14112578dd467489ca814cd"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/t.wado",
-      "hash": "643759c078e7227b5b58fb5650adbc16bf7abf1ee6ca82a93340735e059bff2f",
+      "hash": "25cd83894b6cc8e216a0811c6721bef0bce1e6d792f5758673efd47b11be0dd3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/t.wado
@@ -1233,6 +1233,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1521,6 +1535,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1542,8 +1560,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2124,11 +2166,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2148,16 +2193,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b080b7b9a48eb684",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "82b13e026c76cbd8d6e148ff6b07a4afcaff767d281341b009acb47f2177fa99"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/t.wado",
-      "hash": "edd593f7699393b4e1ea7afcbccf6fc30432add8c274e4a6e909f5ca885d60dd",
+      "hash": "064f7d0e42fe01f280599c92e1000aa5bfb9d5a53ed1f88ff6438086f9b41a81",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/t.wado
@@ -1233,6 +1233,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1521,6 +1535,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1542,8 +1560,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2124,11 +2166,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2148,16 +2193,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe37baada5f5ab17",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_1.g4",
     "hash": "ce8b6e86f90fd838f389c969f26848a74f12cedfc2269000d54013aefc9d7cfd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-779de95f8ee98331",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_2.g4",
     "hash": "4901211c2a6d24bc31faad4232c52b1076c788c30ca1626ee8189f377298edb3"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7fc452d9f90e47c1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_3.g4",
     "hash": "be54343e5d0af2db673e19012a397a002684ea46cbfae40b2d7283c34d120aaf"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ba8d8f5a1a9cd3e8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_4.g4",
     "hash": "f093c2f32b839973701e676ff0a7ac42b07bde81fe26d0dd62242d5bddea35df"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8a3fb073ddef8302",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_5.g4",
     "hash": "288f969b08c50c65a8fe90dca09e2900316e61a1e643ed8dffe19f0baf33caeb"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1649510774c10ce4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_6.g4",
     "hash": "f1f23150782692a30fca3499f09edc2d8b32615fe4158fdd496ca236f257abfd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9f9256112977bfa6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "a2b9873d31df6aa521f495b2f4f63cbcb01917154e56af08ec8162e66ec4b375"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-430ff774fe3ccc56",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "10da0f9ef1418b4e7996ee9ca537b6eb00e24cd75a5e9cadcf6a0f2cd05403d8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-32bc03565c015b60",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "51acdad9c9d5ac16101b107cd251308154503481b21347eba16ed71c07207cf8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e36f569ab470259",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/TokenOffset.g4",
     "hash": "e74488674b6ea2a5b0c7c5c0da5c63c5f40e5cbd3659293737c5f866eec3dadb"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3757dc9b183c6d1b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Wildcard.g4",
     "hash": "443ea5e8b3a600f483f353e7b727214ae7b46b07d48a05209575e59a4e5f87ff"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-99e547016945f080",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "2ddf63624620f170bb9fc4afce010caed86e03e13c5841514ae5f185dda39973"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc046e1c74bc00e4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "7176de59d1c79178e55d5e86f1c9d45d2a84c42d0306624c059f6291b7bef8aa"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b262d928ef13047",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "ccdf783cb1b30be5a7b33fa50258508b6fa6564ffc640f83cdd701860cefceab"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-258490d7808c0aaa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "23c2d14982503d975310e5e3c23f6d5acf82bdea14758b8edf43a21de15fc46b"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b17683f8371c7cab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "7750e6dc3c86efd7c47184ad7f428310bd808cbee7cc760d88cbf6c76aed00ea"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aa8fcb18255e55f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Order.g4",
     "hash": "fe5bc85134bb1581bdcae00261221a4d8d5cf7fc66861514c518c932db73927c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-95c11e3806b83d10",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "e612218883337369509a10795a6c896ed4fd346099904bcdea49689b70eacb58"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f7c2d92ccc8ab01b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "63ad05004eaa3eae497c7ac7b869f512be40e3b08c490a4edefce0a7bfd03be4"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a0250fd5a3ae0033",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "5bc8badde05794d30336979aa4a8e376565246e39e74e5e79ffcc7d3640896ab"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-53a69efbc19a5a01",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "1e8283c5161522a98e12bd6b9c0b904b195ed3b305a7cd1104d32111a16230ac"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-79a58222616de2da",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Simple.g4",
     "hash": "35ff1d3690b2d9d2c179b9064ac1f19102b739667e99e936dc923f266be1a29b"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ccd514ab5a0d2628",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "4663e60c7732087dc2db2c9b615d6a9d091258c9088e5494ada4888d59fe97ed"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4ebb006656a43a74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "660b45f425c3ed090eab8100788e1b44cea8e8acf7a3a7df551673b469969613"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-31c6898cd7c0555c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "b92936412d8caa3aa5e0a9f0859db4db2dbd59b422445fc0ac7646ad9de7e7b5"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-475c24ff6a89bd9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/CharSetLiteral.g4",
     "hash": "06e8171bff5cb8897907a7253d3622ee2b3fe0046ae8d0b91af1e53eea95199a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8e3de5821c86509f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerOptionalSet.g4",
     "hash": "805d183407ee6d3e197aa59c47746f31a3a876616ba81d2796b4eade4fd0cb1a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-53ebf982bbdab05d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerPlusSet.g4",
     "hash": "82d73edf927d0b41773a2aed77c24eb6c1e15ae757745711744a98d92a30ba9f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-be939a7d7215f166",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerStarSet.g4",
     "hash": "5fc2408d6d827c200d5f3dda95c90ca51c0304141e1966710e5ba3ee4e8c9c62"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c9de52bffebd585f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotChar.g4",
     "hash": "ea4e829495a2862424c660528e60b42538171fd98c4add9d59de52bfebb03636"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e80a5c8f430b7c71",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSet.g4",
     "hash": "e746afb6f30a6057ad02472688eed14093eb3c3667bdf9e3c181886b47e78837"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e782f3d843a78a82",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "13b313e51177c018f7ae34ebaa84db67e86a0d4b36209ad3fd1711f2ad2fb7c7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8fb74e133297f886",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "3921de873d86bac58271a10481e3c0e015c69cd9d31da1c2278263a953b16c45"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56f8ec02930fac87",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSet.g4",
     "hash": "c13dc8792637b8734bddc522d5c7eb48f4d40806f34c7540b36f59d70a45db0b"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-09f221acb120a53c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSingleElement.g4",
     "hash": "6ed40cb1f8e0cf841fa0926ccc6a4d62bc3164537ac07270baaf99e7bff650ed"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a2300bf82b65d527",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotSet.g4",
     "hash": "5cd8c64df8a97020ac5413953d3f986284c2d0d02ecffa78f56e74501fd843a4"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-752e04a19986bc36",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotToken.g4",
     "hash": "f3628c394dba3dcf943da3c57ae49f9638ad607d2889b3c93a404ffdee955bdd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed613960e0e6b31f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "0a93f8b72d55e95661fd29f1dc20be1ba499092a4627974f10deafbabfc1902d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2b60d7dce9a6adea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserSet.g4",
     "hash": "9f4a6537aa3fabe41aabda8b6dceb0b110ae6dc2c1ca606d1bb6a4c17bc0523f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-527bfd9e7200b4d5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "308fe96545620a9956a16a0b905efbd6838f91f1380d112f59c8f5e7ec847df6"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56dd2363f7757e98",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusSet.g4",
     "hash": "e22104935432d1ef1346e156287f6ffc20f7a823a3a6fc35eead1aa59f7e5bff"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e02be559604ea94f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/RuleAsSet.g4",
     "hash": "b292a08285fc28948b206aa219a2c5707f54b8d7d059e4b9435a685e35604a0f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93598a0a760d2ccc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "1e9c5a53f120329c72dade19fb74f37b769fa3e8620ce55c964187b4b31afa04"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-691c916b19f8f1db",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-87356a0cca836cbd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "9ef8e31aeee6cc982752fab2eb2bc1f24a2c1c941b2188809dfd5924be72e052"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fd9080e2330af37c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarSet.g4",
     "hash": "b6e8bd3225682605f4be8329a1ae6a16abcad1fcd59e904ef3b62582e975e58c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eb0546dcb0fa39f9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "69ab5aeb81e985edb26b848195ad01840cbc068de1413e0dc41dc606755f5d85"

--- a/package-gale/tests/generated/cst_alt_option/alt_opt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_alt_option/alt_opt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6d7b81c7ff3be074",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/alt_opt.g4",
     "hash": "620ef772a707c22fe42276f8c87130ca600fbd64ce60520cac8fcd711135e1aa"

--- a/package-gale/tests/generated/cst_alt_shared_ident_prefix/alt_shared_ident_prefix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_alt_shared_ident_prefix/alt_shared_ident_prefix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-50b6477f358fef20",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/alt_shared_ident_prefix.g4",
     "hash": "61bb2be46f96c2c573f0cf8deb04193ba17af86139cf1e7d2ec8d3caedfa0518"

--- a/package-gale/tests/generated/cst_antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eb1d55a062909243",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"
@@ -18,7 +18,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_antlr4/antlrv4.wado",
-      "hash": "6552177513e6e3798d01bc9dafb0b42be0bb876aea28544709229bd317a078fc",
+      "hash": "52d18b4aa0e7dd4e39af048d4d3ed6773cefd4c04dd2566a1803faa7334f21b0",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_antlr4/antlrv4.wado
+++ b/package-gale/tests/generated/cst_antlr4/antlrv4.wado
@@ -1237,6 +1237,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1525,6 +1539,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1546,8 +1564,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2128,11 +2170,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2152,16 +2197,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-30b45e30db9a8a52",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/cst_calc/calc_ll.g4.kiln.json
+++ b/package-gale/tests/generated/cst_calc/calc_ll.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d039a6ec854c732e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/calc_ll.g4",
     "hash": "c482319990adba1a727e64e12ccf2a0547c6b46b236670971a827fba64a1067c"

--- a/package-gale/tests/generated/cst_calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/cst_calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-81114d8227696caf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/cst_ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c060d13d079ddca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/cst_ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6916c24511ffe8f0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/cst_css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-30f536c33c6c1e91",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/cst_diagnostics/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_diagnostics/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d44bbe8360411ce",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_error_recovery/error_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_error_recovery/error_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-94a85712da1f2a3f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/error_recovery.g4",
     "hash": "47911f94843fe38ff3fc4d77c7a5068a7d6f2104bd74a737a6a63423dd8dc5db"

--- a/package-gale/tests/generated/cst_follow/follow_gate.g4.kiln.json
+++ b/package-gale/tests/generated/cst_follow/follow_gate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-65c459392f0b1f16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/follow_gate.g4",
     "hash": "524e44bc7007d56c2d229ad20e6c01bb033592fd8bcec53a7521325c564c5ee7"

--- a/package-gale/tests/generated/cst_group_recovery/group_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_group_recovery/group_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-516ceedc223b72f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/group_recovery.g4",
     "hash": "721f7ec1f804bbfcbc0cf0222d5d50b90183eef3707e81b754f25b69d2fa792a"

--- a/package-gale/tests/generated/cst_html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b40000a7050a95b3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/cst_json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d44bbe8360411ce",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5d44bbe8360411ce",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_label_list_collision/label_list_collision.g4.kiln.json
+++ b/package-gale/tests/generated/cst_label_list_collision/label_list_collision.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f15bac9748d64fed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/label_list_collision.g4",
     "hash": "245eac983b4d16903ac917751c3f59e886be8be3e55623cdb25e40c782b58d44"

--- a/package-gale/tests/generated/cst_labels/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_labels/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-581d9f3197686852",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/cst_lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d0edf49e5d97cc93",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/cst_lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f03150287f12de8a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lexer_greedy_suffix.g4",
     "hash": "2286e1ce4403101b6a2c197a88b3ba06ef185d7c31e99ad55033185275953d1a"

--- a/package-gale/tests/generated/cst_ll_basic/ll_basic.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_basic/ll_basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e6f3119ee07db17",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_basic.g4",
     "hash": "f830d43f54bf58f877f51407f191785e0b519d8864d2e9cae12424dfb0c8ab3d"

--- a/package-gale/tests/generated/cst_ll_consume_group/ll_consume_group.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_consume_group/ll_consume_group.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dabfd4591e8b279d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_consume_group.g4",
     "hash": "9222485ca2ed6480753d84cef49f054d149fc919224051f99aa450f812b07a93"

--- a/package-gale/tests/generated/cst_ll_ctx_follow/ll_ctx_follow.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_ctx_follow/ll_ctx_follow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-315cc65580c4084a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_ctx_follow.g4",
     "hash": "c9dd4149b692de6c13dc9dd30cf96e276da36fd421349ed32aa772e16aa9a1ac"

--- a/package-gale/tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abbe9d28ca90530d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_empty_alt_group.g4",
     "hash": "2392939a3ceb27e919a24d1d6ad56e13cc613929c6374a340f75a03ae4ccacb7"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.wado",
-      "hash": "32802ad6ba5541b42137e3ca0f3252c45d88478f650ab7671d3d739feb9f0f9a",
+      "hash": "f556ae56d1578c70500466d17440d8fa7cbcf5ee68567bda00935cfe375acc10",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.wado
+++ b/package-gale/tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.wado
@@ -1233,6 +1233,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1521,6 +1535,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1542,8 +1560,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2124,11 +2166,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2148,16 +2193,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_ll_k_prefix_cascade/ll_k_prefix_cascade.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_k_prefix_cascade/ll_k_prefix_cascade.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7496527adc80ac5a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_k_prefix_cascade.g4",
     "hash": "379589a434dcaabfbf33d2e739723b0deb2128a26b9bff77163d967e06b04d1a"

--- a/package-gale/tests/generated/cst_ll_lr_atom/ll_lr_atom.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_lr_atom/ll_lr_atom.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-641f13d25851160a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_lr_atom.g4",
     "hash": "d92f5f9744e5f022ce077b4e2237660b199a6ee15b00f94cc56387392f52823d"

--- a/package-gale/tests/generated/cst_ll_multi_alt/ll_multi_alt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_alt/ll_multi_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9d0eed881d3690a5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_multi_alt.g4",
     "hash": "b0e9035037ba8016d5020c5a34dd8743c2489ca12333f76ca51a9af81c4de25a"

--- a/package-gale/tests/generated/cst_ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2982a879756ebf6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_multi_alt_overlap.g4",
     "hash": "1c00866868c72e8b9c1da0332be534856dafa01dfc589ba1a985ff2fbb2affd6"

--- a/package-gale/tests/generated/cst_ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f663f981f529919c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_multi_token_tail.g4",
     "hash": "6dd40045f6bebef9292d9845d79c2befb5dddb0b81e2f22f6295dea6e16a7f55"

--- a/package-gale/tests/generated/cst_ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f74b5b921527136",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_nullable_suffix.g4",
     "hash": "13724480e4e66b54852130604fc2ea866cc8ed7d6760c0524d9d72702eb42184"

--- a/package-gale/tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cd52b37f0e8498af",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_optional_non_greedy.g4",
     "hash": "ba2d514d32e3c49ab408c6a2f5e9f1826c68843c9709dc34a5f55fd8e9bf81bf"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.wado",
-      "hash": "ab70cbefc950baca364754ff73bc266032c99438ced7123594bb3da15e9d3119",
+      "hash": "f9824406f728595d27372b9d36a2c248faa4ebc3e417af38df82f09a4782615e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.wado
+++ b/package-gale/tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.wado
@@ -1233,6 +1233,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1521,6 +1535,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1542,8 +1560,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2124,11 +2166,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2148,16 +2193,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-753ba4a70243effe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_wildcard_alt.g4",
     "hash": "d1c18ea6b2be7b57df8d6ea77777c1de0e0c80ca8f86199e3c0183bcbaf325a8"

--- a/package-gale/tests/generated/cst_lr/arith_lr.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr/arith_lr.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3def61f68b12244c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/arith_lr.g4",
     "hash": "26556f22f7a2c98d214fc95cb9ea81fb93d2abeeb84fb9b7c6c73a9086985b05"

--- a/package-gale/tests/generated/cst_lr_between/lr_between.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_between/lr_between.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-42edd11f4e97d9c2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_between.g4",
     "hash": "a1efd5682d5a41a5f4766db73e0bdcc06dc0afdf2e50ab4c403306441ffebe93"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_lr_between/lr_between.wado",
-      "hash": "40fd8b00e7787ea87497f55d2f3aab55ade96fc303595dbef66efb3887bb52b3",
+      "hash": "4824a981aa93e66cd9dda432082e450ae78c64e985a0b4905b61f68b78d3e616",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_lr_between/lr_between.wado
+++ b/package-gale/tests/generated/cst_lr_between/lr_between.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_lr_between_call/lr_between_call.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_between_call/lr_between_call.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ae20cd9190964234",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_between_call.g4",
     "hash": "55189d1a50844969b5054a4be88f80b4ef5ef1e00bdddafb98b8a24084eb682e"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_lr_between_call/lr_between_call.wado",
-      "hash": "d87e3f8d5b5eb9b79a83731887e45039b9771dbcb3595bea498cb6a022aa9be5",
+      "hash": "72f85d0c28752e3bbc92305ba0fdbcff4a5486044dfe23ff18eccda23ea18263",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_lr_between_call/lr_between_call.wado
+++ b/package-gale/tests/generated/cst_lr_between_call/lr_between_call.wado
@@ -1233,6 +1233,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1521,6 +1535,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1542,8 +1560,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2124,11 +2166,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2148,16 +2193,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_lr_call/lr_call.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_call/lr_call.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cdb7960b5f80c82b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_call.g4",
     "hash": "01e881ace397d3af62a29de281d1662a9e7ec86eb7fc2aa4637dea7e6bfe5fd8"

--- a/package-gale/tests/generated/cst_lr_complement_op/lr_complement_op.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_complement_op/lr_complement_op.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-419bb5846ff7cc64",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_complement_op.g4",
     "hash": "501ba73a08ae31f00d1a310bdb79d4a51ef593ec71b3e6b5a01bae2ccb4eaee0"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_lr_complement_op/lr_complement_op.wado",
-      "hash": "d9fc809d0b693388e79129907aad9fd323c7557e0378d6d6bc699c570c0deef2",
+      "hash": "1611090266452c25f69e244fa5865ef15d06b435bd0fc067db7751f6c562ac0d",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_lr_complement_op/lr_complement_op.wado
+++ b/package-gale/tests/generated/cst_lr_complement_op/lr_complement_op.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_lr_dangling_else/lr_dangling_else.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_dangling_else/lr_dangling_else.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8c4aa7ab90a60f74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_dangling_else.g4",
     "hash": "676bce3fd8100375614484afd821174aa60a5a0759b5e46caaf7f2f3627296c2"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_lr_dangling_else/lr_dangling_else.wado",
-      "hash": "2c77d42b24f058a9bb5bfc91d3d9c1291fcaf6497b2fdbc07df21545246be0e8",
+      "hash": "cd44f0923fc5cd33c04100e7ea96e071f0b22660bbf77c29dd7a4569aaa56a79",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_lr_dangling_else/lr_dangling_else.wado
+++ b/package-gale/tests/generated/cst_lr_dangling_else/lr_dangling_else.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_lr_overlap/lr_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_overlap/lr_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-47b56463439fa09a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_overlap.g4",
     "hash": "5674c6a0f2f951dcbabbc831b2cb923c005d687276df03fea69d088cbae12c1a"

--- a/package-gale/tests/generated/cst_lr_paren/lr_paren.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_paren/lr_paren.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-08a1704f6e49270c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_paren.g4",
     "hash": "58cf6be3c20a432eab6caf7bd38be29f462578030956f800dce7b0d8eb96bea1"

--- a/package-gale/tests/generated/cst_lr_scan_caller/lr_scan_caller.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_scan_caller/lr_scan_caller.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-725cad8bf4ce8968",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_scan_caller.g4",
     "hash": "a5c160c8e20e4727da1e40c83d884d6f2658153bda5919e2431c5b8bee5f5648"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_lr_scan_caller/lr_scan_caller.wado",
-      "hash": "aecd19a222a33de948d9f05e82ddac99e31ec2bddef98d0ad4564a2ab6a77f19",
+      "hash": "e4a8506369680427130c6672f4aa08de3d0114cafa8412a30f21da33a7cc637c",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_lr_scan_caller/lr_scan_caller.wado
+++ b/package-gale/tests/generated/cst_lr_scan_caller/lr_scan_caller.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b51a1ec02165e6c2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/lr_wildcard_postfix.g4",
     "hash": "525afce18841d8fd1c19378727fb15e3e62e462ffa9202bfcc2253826c35bf98"
@@ -13,7 +13,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.wado",
-      "hash": "e0962d37a7d786e3a0c2bb83859e519dfb2d6289bb613e63102480b25ad3016f",
+      "hash": "d7b69f84dd58dfb2e4bc50e9f3336775b5a1698c6249bd211d0835070c0cf2b3",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.wado
+++ b/package-gale/tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.wado
@@ -1162,6 +1162,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1450,6 +1464,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1471,8 +1489,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2053,11 +2095,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2077,16 +2122,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-647487251530e941",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/cst_multiple_eof/multiple_eof.g4.kiln.json
+++ b/package-gale/tests/generated/cst_multiple_eof/multiple_eof.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dd78c645eee51a08",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/multiple_eof.g4",
     "hash": "2b097a4cde773ec14e56e4222cd34af3735931774e74c4c77ca7b37f41afaa43"

--- a/package-gale/tests/generated/cst_non_greedy/non_greedy.g4.kiln.json
+++ b/package-gale/tests/generated/cst_non_greedy/non_greedy.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fa31354dd056a49",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/non_greedy.g4",
     "hash": "8df507b6ddb99d4381283f8a2b2af531696f43deadb3aa7e75f7a8d66990d1a0"

--- a/package-gale/tests/generated/cst_non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-81d2ec90d3abd368",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/cst_opt_sep_list/opt_sep_list.g4.kiln.json
+++ b/package-gale/tests/generated/cst_opt_sep_list/opt_sep_list.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ac28c8661c716773",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/opt_sep_list.g4",
     "hash": "c6a879a1e89a7a0cf4fddca366393412ec939a5579f079fab250cee7d8be33fd"

--- a/package-gale/tests/generated/cst_overlap_tournament/ll_overlap_tournament.g4.kiln.json
+++ b/package-gale/tests/generated/cst_overlap_tournament/ll_overlap_tournament.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4d58910b778dfbe7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_overlap_tournament.g4",
     "hash": "c6fd0821861f96cf907e2a88c796e161295e33bdc2a280ae9567fe31cbc15833"

--- a/package-gale/tests/generated/cst_parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e47d85c0f4f373cf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/cst_parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
+++ b/package-gale/tests/generated/cst_parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfaf4d8d4198e0d0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/parser_set_group_dispatch.g4",
     "hash": "c36bfab5dcc4c7f598aa83ca22dca3fd716225387804db2223b3c47986b73355"

--- a/package-gale/tests/generated/cst_recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6226091664c3335e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/cst_right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-15a86639bea3af02",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/cst_rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-64b2b4c6431ad72a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"
@@ -18,7 +18,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_rust/rust.wado",
-      "hash": "266da7800d153718c889b563b00b7e7d02e2bd524bee790971e5bd702b1a7dcb",
+      "hash": "54e0e2427d5be5cf0a7269efe59dba3a51b9263a97081ae83287a1ed37493d20",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_rust/rust.wado
+++ b/package-gale/tests/generated/cst_rust/rust.wado
@@ -1237,6 +1237,20 @@ pub struct AtnSim {
     pub rule_first: List<List<i32>>,
     pub rule_first_neg: List<List<i32>>,
     pub rule_first_open: List<bool>,
+    /// Per-state continuation FIRST / nullability, precomputed once from the
+    /// decoded ATN (after the rule-level fixpoint converges). These are pure
+    /// functions of the constant ATN — `state_cont_nullable[s]` is
+    /// `atn_cont_nullable(s)`, the `state_cont_first*` triple is
+    /// `atn_cont_first(s)` — so caching them turns the per-decision
+    /// caller-mandatory walk (`atn_caller_mandates`) and the loop-entry FIRST
+    /// check (`atn_lr_loop_decision`) into allocation-free array lookups
+    /// instead of an input-independent DFS rerun on every loop iteration.
+    /// Filled only when the ATN has precedence edges (see `atn_decode`); empty
+    /// otherwise (the lexer ATN reuse never reads them).
+    pub state_cont_nullable: List<bool>,
+    pub state_cont_first: List<List<i32>>,
+    pub state_cont_first_neg: List<List<i32>>,
+    pub state_cont_first_open: List<bool>,
 }
 
 /// Sentinel return state inside a `PredictionContext`: this branch's
@@ -1525,6 +1539,10 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
         rule_first: [],
         rule_first_neg: [],
         rule_first_open: [],
+        state_cont_nullable: [],
+        state_cont_first: [],
+        state_cont_first_neg: [],
+        state_cont_first_open: [],
     };
     for let mut r = 0; r < nrules_count; r += 1 {
         sim.rule_nullable.push(false);
@@ -1546,8 +1564,32 @@ pub fn atn_decode(data: &List<i32>) -> AtnSim {
     }
     if has_precedence {
         atn_compute_first_nullable(&mut sim);
+        atn_compute_state_cont(&mut sim);
     }
     return sim;
+}
+
+/// Cache each state's continuation FIRST / nullability into the
+/// `state_cont_*` arrays. Runs once at decode, after the rule-level fixpoint
+/// has converged (it reads `rule_first` / `rule_nullable` through
+/// `atn_cont_first` / `atn_cont_nullable`). The grammar (ATN) is constant, so
+/// this is O(1) w.r.t. input; it pays for itself by removing the per-decision
+/// DFS-and-allocate from `atn_caller_mandates` / `atn_lr_loop_decision`.
+#[allow(dead_code)]
+fn atn_compute_state_cont(sim: &mut AtnSim) {
+    let nstates = sim.state_kind.len();
+    for let mut st = 0; st < nstates; st += 1 {
+        let mut v1: List<i32> = [];
+        let nullable = atn_cont_nullable(sim, st, &mut v1);
+        let mut v2: List<i32> = [];
+        let mut f: List<i32> = [];
+        let mut fneg: List<i32> = [];
+        let open = atn_cont_first(sim, st, &mut v2, &mut f, &mut fneg);
+        sim.state_cont_nullable.push(nullable);
+        sim.state_cont_first.push(f);
+        sim.state_cont_first_neg.push(fneg);
+        sim.state_cont_first_open.push(open);
+    }
 }
 
 /// Fill `rule_nullable` / `rule_first` / `rule_first_open` by a monotone
@@ -2128,11 +2170,14 @@ pub fn atn_lr_loop_decision(
             if sim.tr_prec[s + j] < min_prec {
                 continue;
             }
-            let mut v: List<i32> = [];
-            let mut f: List<i32> = [];
-            let mut fneg: List<i32> = [];
-            let open = atn_cont_first(sim, sim.tr_target[s + j], &mut v, &mut f, &mut fneg);
-            if atn_first_admits(&f, open, &fneg, t, eof) {
+            let tgt = sim.tr_target[s + j];
+            if atn_first_admits(
+                &sim.state_cont_first[tgt],
+                sim.state_cont_first_open[tgt],
+                &sim.state_cont_first_neg[tgt],
+                t,
+                eof,
+            ) {
                 return j;
             }
         }
@@ -2152,16 +2197,17 @@ fn atn_caller_mandates(sim: &AtnSim, rule_stack: &List<i32>, t: i32, eof: i32) -
         if ret < 0 {
             return i == 0 && t == eof;
         }
-        let mut v: List<i32> = [];
-        if atn_cont_nullable(sim, ret, &mut v) {
+        if sim.state_cont_nullable[ret] {
             i -= 1;
             continue;
         }
-        let mut v2: List<i32> = [];
-        let mut f: List<i32> = [];
-        let mut fneg: List<i32> = [];
-        let open = atn_cont_first(sim, ret, &mut v2, &mut f, &mut fneg);
-        return atn_first_admits(&f, open, &fneg, t, eof);
+        return atn_first_admits(
+            &sim.state_cont_first[ret],
+            sim.state_cont_first_open[ret],
+            &sim.state_cont_first_neg[ret],
+            t,
+            eof,
+        );
     }
     return false;
 }

--- a/package-gale/tests/generated/cst_sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4fe2a8cbe6a4a740",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/cst_sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b045247863954c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/cst_sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b045247863954c0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/cst_tie_recovery/tie_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_tie_recovery/tie_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-05ce5ba6deb87d66",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/tie_recovery.g4",
     "hash": "b424904a6f362db6e62af0d40479f785c71a19805baf47bc158037899a334ed1"

--- a/package-gale/tests/generated/cst_tour/amb_tour.g4.kiln.json
+++ b/package-gale/tests/generated/cst_tour/amb_tour.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-324917e95c62f596",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/amb_tour.g4",
     "hash": "074f334123300f55a97b8103d93f22b02603c9fec0e734374e24472343645195"

--- a/package-gale/tests/generated/cst_trace/ll_multi_alt_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_trace/ll_multi_alt_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2982a879756ebf6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/ll_multi_alt_overlap.g4",
     "hash": "1c00866868c72e8b9c1da0332be534856dafa01dfc589ba1a985ff2fbb2affd6"

--- a/package-gale/tests/generated/cst_typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bbdeefd892e60c8f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/cst_unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/cst_unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f3ba3e6ed372c17a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "15ee3fe809199a11b73608f02d80747b4043da3ef4fe6907bec126a5b9658b4e",
+  "generator_source_hash": "f8cfbede8a9d95f2b66323ed61d128d9a095103186bb7f9c1f7520ed396cd7a1",
   "primary": {
     "path": "tests/grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"


### PR DESCRIPTION
## Problem

`Performance/DropLoopEntryBranchInLRRule_3` (18 lines of `not X1 and … and not X7 or`, a deeply left-recursive prefix expression) took **~2.1 s** to parse, tripping the test runner timeout under CI parallelism.

A guest profile pinned **86.8 % self-time in `List<i32>::grow`**, all under `atn_lr_loop_decision → atn_caller_mandates → atn_cont_nullable` / `atn_cont_first`.

## Cause

The LR loop-entry decision runs once per `scan_expr` loop iteration. `atn_caller_mandates` walks the caller return-state stack and, at each level, called `atn_cont_nullable` (and `atn_cont_first` at the first non-nullable level) — each allocating a fresh visited `List<i32>` and re-running a DFS over the ATN. Both results depend **only on the constant ATN**, not the input, yet were recomputed on every decision. Here nearly every stack level is nullable (operator operands sit at rule tails), so the walk reached almost the whole stack each time: O(depth) allocate-and-DFS per decision × O(n) decisions.

## Fix

Precompute the per-state continuation FIRST / nullability once at decode (`atn_compute_state_cont`, gated on `has_precedence` like the rule-level fixpoint) into `AtnSim.state_cont_{nullable,first,first_neg,first_open}` — the per-state analogue of the existing per-rule `rule_first` / `rule_nullable` cache. `atn_caller_mandates` and the loop-entry FIRST check become allocation-free array lookups.

## Result

`DropLoopEntryBranchInLRRule_3` parse time **~2.1 s → ~50 ms** (~40×); the `List::grow` hotspot disappears from the profile. No behavior change (precompute yields identical values). Adding 4 fields to `AtnSim` regenerated every parser that inlines the ATN runtime (both parser-ATN and lexer-ATN goldens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUovPzd3orEDyzXgn1fEjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUovPzd3orEDyzXgn1fEjC)_