### PR TITLE
chore: collapse Tidy into a single job with parallel steps

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -67,39 +67,29 @@ jobs:
         if: steps.precheck.outputs.should-run == 'true'
         run: cargo build --bin wado --bin wado-dev-tools
 
-      # Disjoint output trees → run concurrently. Each calls the prebuilt binary
-      # directly so only `doc-stdlib` touches the cargo lock (blocking itself).
-      - name: Regenerate WIR golden fixtures
-        if: steps.precheck.outputs.should-run == 'true'
-        background: true
-        run: |
-          mkdir -p wado-compiler/tests/generated/fixtures
-          ./target/debug/wado-dev-tools golden-dump \
-            --in 'wado-compiler/tests/fixtures/{name}.wado' \
-            --emit wir:'wado-compiler/tests/generated/fixtures/{name}.wir.wado' \
-            -O2
+      # Disjoint output trees → run concurrently via the `parallel` group, which
+      # waits for all of its steps before the next step. Each calls the prebuilt
+      # binary directly so only `doc-stdlib` touches the cargo lock (itself).
+      - parallel:
+          - name: Regenerate WIR golden fixtures
+            if: steps.precheck.outputs.should-run == 'true'
+            run: |
+              mkdir -p wado-compiler/tests/generated/fixtures
+              ./target/debug/wado-dev-tools golden-dump \
+                --in 'wado-compiler/tests/fixtures/{name}.wado' \
+                --emit wir:'wado-compiler/tests/generated/fixtures/{name}.wir.wado' \
+                -O2
+          - name: Regenerate format golden fixtures
+            if: steps.precheck.outputs.should-run == 'true'
+            run: bash scripts/update-golden-format-fixtures.sh
+          - name: Refresh Gale kiln caches
+            if: steps.precheck.outputs.should-run == 'true'
+            run: ./target/debug/wado test --no-run package-gale
+          - name: Regenerate stdlib docs
+            if: steps.precheck.outputs.should-run == 'true'
+            run: mise run doc-stdlib
 
-      - name: Regenerate format golden fixtures
-        if: steps.precheck.outputs.should-run == 'true'
-        background: true
-        run: bash scripts/update-golden-format-fixtures.sh
-
-      - name: Refresh Gale kiln caches
-        if: steps.precheck.outputs.should-run == 'true'
-        background: true
-        run: ./target/debug/wado test --no-run package-gale
-
-      - name: Regenerate stdlib docs
-        if: steps.precheck.outputs.should-run == 'true'
-        background: true
-        run: mise run doc-stdlib
-
-      - name: Join regenerators
-        if: steps.precheck.outputs.should-run == 'true'
-        wait-all: true
-        run: echo "All regenerators completed."
-
-      # Whole-tree formatters, after the barrier so they don't race a regenerator.
+      # Whole-tree formatters, after the parallel join so they don't race a regenerator.
       - name: Format Markdown
         if: steps.precheck.outputs.should-run == 'true'
         run: ./target/debug/wado-dev-tools format-md

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -13,30 +13,13 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  # Single job. The required-check name stays "Tidy" for branch protection
-  # compatibility. Everything that used to be split across `precheck`,
-  # `tidy-rust`, `tidy-wado`, and the `tidy` aggregator now lives here.
+  # One job replaces the old precheck/tidy-rust/tidy-wado/aggregator fan-out.
+  # Required-check name stays "Tidy". Setup runs once; no patch artifacts.
   #
-  # Why one job instead of the old fan-out/fan-in:
-  #   * Setup (checkout, submodule, rust-cache, mise) is paid ONCE instead of
-  #     four times.
-  #   * No patch artifacts: the old design uploaded each job's `git diff` and
-  #     re-applied both with `git apply --3way` in the aggregator, purely to
-  #     merge results from two separate runners. One runner means one working
-  #     tree, so we just `git add -A && commit && push` directly.
-  #
-  # What does NOT speed up: the two whole-workspace compiles. `cargo build`
-  # (binaries) and `clippy-fix` (clippy-driver check) produce separate
-  # artifacts and serialize on cargo's target-dir lock, so they run
-  # sequentially here rather than truly in parallel as they did on two runners.
-  # We order `cargo build` first so the dependency artifacts it produces are
-  # reused by the later clippy pass (only the workspace crates are re-checked).
-  #
-  # Where parallel steps DO help: the post-build, binary-bound regenerators
-  # write disjoint output trees (WIR goldens, format goldens, Gale kilns,
-  # stdlib docs), so they run as `background` steps and join at `wait-all`.
-  # Whole-tree formatters (`format-md`, `format-wado`) run after the barrier to
-  # avoid racing the regenerators on shared paths.
+  # The two whole-workspace compiles (`cargo build`, `clippy-fix`) serialize on
+  # cargo's target lock, so they can't run in parallel here — build goes first
+  # so clippy reuses its dependency artifacts. The post-build regenerators write
+  # disjoint trees, so they run as `background` steps joined at `wait-all`.
   tidy:
     name: Tidy
     runs-on: ubuntu-latest
@@ -46,23 +29,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
-          # The push at the end authenticates with a GitHub App token (a
-          # GITHUB_TOKEN push would not retrigger workflows). Don't persist the
-          # default credentials so the app-token remote is the sole auth.
+          # The final push uses a GitHub App token; don't keep the default creds.
           persist-credentials: false
 
-      # Detects when the latest commit on the PR was produced by this workflow
-      # itself ("chore: tidy" by a GitHub App bot). In that case the heavy steps
-      # are skipped and the job short-circuits to success. This avoids
-      # re-running tidy on its own (idempotent) output and prevents a buggy step
-      # from producing an infinite push loop.
+      # Skip the heavy steps when the latest commit is tidy's own output, so we
+      # don't re-tidy idempotent output or spin up a push loop.
       - name: Precheck — short-circuit on a tidy bot commit
         id: precheck
         run: |
           msg=$(git log -1 --pretty=%s)
           email=$(git log -1 --pretty=%ae)
           if [ "$msg" = "chore: tidy" ] && [[ "$email" == *"[bot]"* ]]; then
-            echo "Latest commit is a tidy bot commit; short-circuiting."
             echo "should-run=false" >> "$GITHUB_OUTPUT"
           else
             echo "should-run=true" >> "$GITHUB_OUTPUT"
@@ -90,10 +67,8 @@ jobs:
         if: steps.precheck.outputs.should-run == 'true'
         run: cargo build --bin wado --bin wado-dev-tools
 
-      # Post-build regenerators with disjoint output trees, run concurrently.
-      # Each calls the prebuilt binary/script directly (no `cargo run`) so none
-      # contends for the cargo target lock; `mise run doc-stdlib` is the lone
-      # cargo user and only blocks itself, not the binary-only lanes.
+      # Disjoint output trees → run concurrently. Each calls the prebuilt binary
+      # directly so only `doc-stdlib` touches the cargo lock (blocking itself).
       - name: Regenerate WIR golden fixtures
         if: steps.precheck.outputs.should-run == 'true'
         background: true
@@ -124,9 +99,7 @@ jobs:
         wait-all: true
         run: echo "All regenerators completed."
 
-      # Whole-tree formatters, after the barrier so they never race a
-      # regenerator on a shared path. `format-md` formats the docs/stdlib-*.md
-      # just emitted by `doc-stdlib`; both invoke the prebuilt binary directly.
+      # Whole-tree formatters, after the barrier so they don't race a regenerator.
       - name: Format Markdown
         if: steps.precheck.outputs.should-run == 'true'
         run: ./target/debug/wado-dev-tools format-md
@@ -135,17 +108,13 @@ jobs:
         if: steps.precheck.outputs.should-run == 'true'
         run: ./target/debug/wado format -w .
 
-      # Second whole-workspace compile (clippy-driver). Runs last: it reuses the
-      # dependency artifacts from `cargo build` and only re-checks the workspace
-      # crates, and serializing it keeps the cargo target lock uncontended.
+      # Second compile; runs last to keep the cargo lock uncontended.
       - name: Clippy autofix and rustfmt
         if: steps.precheck.outputs.should-run == 'true'
         run: |
           mise run clippy-fix
           cargo fmt --all
 
-      # --- Join: stage changes, then commit/push from this same working tree.
-      # No patch artifacts or 3-way merge — everything happened in one tree.
       - name: Determine push capability
         id: cap
         if: steps.precheck.outputs.should-run == 'true'
@@ -181,13 +150,10 @@ jobs:
           private-key: "${{ secrets.GH_APP_PRIVATE_KEY }}"
           permission-contents: write
 
-      # Internal PR (head repo == this repo): push a `chore: tidy` commit and
-      # exit green. The push retriggers this workflow; the next run hits the
-      # precheck short-circuit and stays green. We deliberately do NOT fail
-      # here: the push itself starts a fresh CI round, so the PR is never
-      # momentarily all-green and auto-merge cannot fire prematurely. A red
-      # check on the (now superseded) run only confuses tooling and coding
-      # agents into thinking tidy is broken.
+      # Internal PR: push `chore: tidy` and exit green. The push retriggers this
+      # workflow, which then short-circuits — so the PR is never momentarily
+      # all-green and auto-merge can't fire early. Failing here would only mislead
+      # tooling on a superseded run.
       - name: Commit and push (internal PR only)
         if: >-
           steps.precheck.outputs.should-run == 'true' &&
@@ -204,9 +170,7 @@ jobs:
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "HEAD:${{ github.head_ref }}"
 
-      # Fork PR (no write access, secrets unavailable): skip the push, emit
-      # guidance for the fork author, and exit non-zero so the check stays red
-      # until tidy is satisfied.
+      # Fork PR: can't push, so emit guidance and stay red until tidy is satisfied.
       - name: Report tidy result
         if: >-
           steps.precheck.outputs.should-run == 'true' &&

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -13,26 +13,51 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  # Detects when the latest commit on the PR was produced by this workflow
-  # itself ("chore: tidy" by a GitHub App bot). In that case the heavy tidy
-  # jobs are skipped and the aggregator `tidy` job short-circuits to success.
-  # This avoids re-running tidy on its own output (which is idempotent by
-  # construction) and prevents a buggy step from producing an infinite
-  # push loop.
-  precheck:
-    name: Precheck
+  # Single job. The required-check name stays "Tidy" for branch protection
+  # compatibility. Everything that used to be split across `precheck`,
+  # `tidy-rust`, `tidy-wado`, and the `tidy` aggregator now lives here.
+  #
+  # Why one job instead of the old fan-out/fan-in:
+  #   * Setup (checkout, submodule, rust-cache, mise) is paid ONCE instead of
+  #     four times.
+  #   * No patch artifacts: the old design uploaded each job's `git diff` and
+  #     re-applied both with `git apply --3way` in the aggregator, purely to
+  #     merge results from two separate runners. One runner means one working
+  #     tree, so we just `git add -A && commit && push` directly.
+  #
+  # What does NOT speed up: the two whole-workspace compiles. `cargo build`
+  # (binaries) and `clippy-fix` (clippy-driver check) produce separate
+  # artifacts and serialize on cargo's target-dir lock, so they run
+  # sequentially here rather than truly in parallel as they did on two runners.
+  # We order `cargo build` first so the dependency artifacts it produces are
+  # reused by the later clippy pass (only the workspace crates are re-checked).
+  #
+  # Where parallel steps DO help: the post-build, binary-bound regenerators
+  # write disjoint output trees (WIR goldens, format goldens, Gale kilns,
+  # stdlib docs), so they run as `background` steps and join at `wait-all`.
+  # Whole-tree formatters (`format-md`, `format-wado`) run after the barrier to
+  # avoid racing the regenerators on shared paths.
+  tidy:
+    name: Tidy
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    outputs:
-      should-run: ${{ steps.check.outputs.should-run }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
-          fetch-depth: 1
+          # The push at the end authenticates with a GitHub App token (a
+          # GITHUB_TOKEN push would not retrigger workflows). Don't persist the
+          # default credentials so the app-token remote is the sole auth.
+          persist-credentials: false
 
-      - id: check
+      # Detects when the latest commit on the PR was produced by this workflow
+      # itself ("chore: tidy" by a GitHub App bot). In that case the heavy steps
+      # are skipped and the job short-circuits to success. This avoids
+      # re-running tidy on its own (idempotent) output and prevents a buggy step
+      # from producing an infinite push loop.
+      - name: Precheck — short-circuit on a tidy bot commit
+        id: precheck
         run: |
           msg=$(git log -1 --pretty=%s)
           email=$(git log -1 --pretty=%ae)
@@ -43,163 +68,87 @@ jobs:
             echo "should-run=true" >> "$GITHUB_OUTPUT"
           fi
 
-  # Rust-only lint/format. Needs no built `wado` / `wado-dev-tools` binary, so
-  # it compiles the workspace exactly once (via clippy) and never pays a second
-  # `cargo build`. Runs in parallel with `tidy-wado`; uploads its diff as an
-  # artifact for the aggregator to apply.
-  #
-  # Every binary-dependent step — including `format-md` — lives in `tidy-wado`,
-  # not here. Invoking `format-md` from this job would mean
-  # `cargo run -p wado-dev-tools`, which forces a second, non-clippy compile of
-  # the whole workspace on top of clippy's (clippy and `cargo build` produce
-  # separate artifacts). Keeping every binary step on the job that already runs
-  # `cargo build` avoids that redundant compile and frees this runner sooner.
-  tidy-rust:
-    name: Tidy (Rust)
-    needs: precheck
-    if: needs.precheck.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-
       - name: Check out the vendored wasmtime fork (path dependency)
+        if: steps.precheck.outputs.should-run == 'true'
         run: git submodule update --init --depth 1 vendor/wasmtime
 
       - uses: Swatinem/rust-cache@v2
+        if: steps.precheck.outputs.should-run == 'true'
         with:
           shared-key: ci
 
       - uses: jdx/mise-action@v4
+        if: steps.precheck.outputs.should-run == 'true'
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           MISE_VERBOSE: ${{ runner.debug }}
 
-      - run: mise run clippy-fix
-      - run: cargo fmt --all
+      # One compile serves every binary-dependent step below.
+      - name: Build wado binaries
+        if: steps.precheck.outputs.should-run == 'true'
+        run: cargo build --bin wado --bin wado-dev-tools
 
-      - name: Capture diff
+      # Post-build regenerators with disjoint output trees, run concurrently.
+      # Each calls the prebuilt binary/script directly (no `cargo run`) so none
+      # contends for the cargo target lock; `mise run doc-stdlib` is the lone
+      # cargo user and only blocks itself, not the binary-only lanes.
+      - name: Regenerate WIR golden fixtures
+        if: steps.precheck.outputs.should-run == 'true'
+        background: true
         run: |
-          git add -A
-          git diff --cached --binary > tidy-rust.patch
-          touch tidy-rust.patch
+          mkdir -p wado-compiler/tests/generated/fixtures
+          ./target/debug/wado-dev-tools golden-dump \
+            --in 'wado-compiler/tests/fixtures/{name}.wado' \
+            --emit wir:'wado-compiler/tests/generated/fixtures/{name}.wir.wado' \
+            -O2
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: tidy-rust-patch
-          path: tidy-rust.patch
-          retention-days: 1
-          include-hidden-files: false
+      - name: Regenerate format golden fixtures
+        if: steps.precheck.outputs.should-run == 'true'
+        background: true
+        run: bash scripts/update-golden-format-fixtures.sh
 
-  # Everything that needs a built `wado` / `wado-dev-tools` binary. A single
-  # `cargo build` serves all of these steps, so they share one compile. This is
-  # the workflow's critical path (build + golden regeneration + gale test
-  # compile); `format-md` and `doc-stdlib` are nearly free on top.
-  #
-  # `format-md` runs here (after `doc-stdlib`) so the regenerated
-  # `docs/stdlib-*.md` are formatted within the same job rather than relying on
-  # a follow-up pass from a parallel job. `wado doc -f markdown` is already
-  # dprint-stable (see wado-cli/src/doc.rs), so this is belt-and-braces. It is
-  # invoked as `./target/debug/wado-dev-tools format-md` to reuse the `cargo
-  # build` artifacts instead of triggering a fresh `cargo run` rebuild.
-  #
-  # Where the two parallel jobs do touch the same file (e.g. `Cargo.lock`), the
-  # aggregator's `--3way` apply merges the overlapping patches — see the
-  # "Apply patches" step.
-  tidy-wado:
-    name: Tidy (Wado)
-    needs: precheck
-    if: needs.precheck.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
+      - name: Refresh Gale kiln caches
+        if: steps.precheck.outputs.should-run == 'true'
+        background: true
+        run: ./target/debug/wado test --no-run package-gale
 
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
+      - name: Regenerate stdlib docs
+        if: steps.precheck.outputs.should-run == 'true'
+        background: true
+        run: mise run doc-stdlib
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
+      - name: Join regenerators
+        if: steps.precheck.outputs.should-run == 'true'
+        wait-all: true
+        run: echo "All regenerators completed."
 
-      - uses: jdx/mise-action@v4
-        with:
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          MISE_VERBOSE: ${{ runner.debug }}
+      # Whole-tree formatters, after the barrier so they never race a
+      # regenerator on a shared path. `format-md` formats the docs/stdlib-*.md
+      # just emitted by `doc-stdlib`; both invoke the prebuilt binary directly.
+      - name: Format Markdown
+        if: steps.precheck.outputs.should-run == 'true'
+        run: ./target/debug/wado-dev-tools format-md
 
-      - run: cargo build --bin wado --bin wado-dev-tools
-      - run: mise run format-wado
-      - run: mise run update-golden-fixtures
-      - run: mise run update-golden-format-fixtures
-      - run: mise run doc-stdlib
-      - run: ./target/debug/wado-dev-tools format-md
-      # See tidy.yml history for the rationale of refreshing Gale kiln caches
-      # (package-gale/tests/generated/**/*.kiln.json) on every tidy run.
-      - run: ./target/debug/wado test --no-run package-gale
+      - name: Format Wado sources
+        if: steps.precheck.outputs.should-run == 'true'
+        run: ./target/debug/wado format -w .
 
-      - name: Capture diff
+      # Second whole-workspace compile (clippy-driver). Runs last: it reuses the
+      # dependency artifacts from `cargo build` and only re-checks the workspace
+      # crates, and serializing it keeps the cargo target lock uncontended.
+      - name: Clippy autofix and rustfmt
+        if: steps.precheck.outputs.should-run == 'true'
         run: |
-          git add -A
-          git diff --cached --binary > tidy-wado.patch
-          touch tidy-wado.patch
+          mise run clippy-fix
+          cargo fmt --all
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: tidy-wado-patch
-          path: tidy-wado.patch
-          retention-days: 1
-          include-hidden-files: false
-
-  # Aggregator. Required-check name stays "Tidy" for branch protection
-  # compatibility. Behavior:
-  # - If `precheck.should-run=false` (latest commit is a tidy bot commit),
-  #   short-circuit to success immediately.
-  # - Otherwise apply both upstream patches. If the result differs from
-  #   HEAD:
-  #     * On an internal PR (head repo == this repo), push a `chore: tidy`
-  #       commit and exit green. The push retriggers this workflow; the next
-  #       run hits the short-circuit and stays green. We deliberately do NOT
-  #       fail here: the push itself starts a fresh CI round, so the PR is
-  #       never momentarily all-green and auto-merge cannot fire prematurely.
-  #       A red check on the (now superseded) run only confuses tooling and
-  #       coding agents into thinking tidy is broken.
-  #     * On a fork PR (no write access, secrets unavailable), skip the push,
-  #       emit guidance for the fork author, and exit non-zero so the check
-  #       stays red until tidy is satisfied.
-  tidy:
-    name: Tidy
-    needs: [precheck, tidy-rust, tidy-wado]
-    if: always() && needs.precheck.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Short-circuit when latest commit is a tidy bot commit
-        if: needs.precheck.outputs.should-run == 'false'
-        run: echo "Latest commit was produced by tidy; nothing to do."
-
-      - name: Fail if upstream tidy jobs did not succeed
-        if: >-
-          needs.precheck.outputs.should-run == 'true' &&
-          (needs.tidy-rust.result != 'success' || needs.tidy-wado.result != 'success')
-        run: |
-          echo "tidy-rust: ${{ needs.tidy-rust.result }}"
-          echo "tidy-wado: ${{ needs.tidy-wado.result }}"
-          exit 1
-
+      # --- Join: stage changes, then commit/push from this same working tree.
+      # No patch artifacts or 3-way merge — everything happened in one tree.
       - name: Determine push capability
         id: cap
-        if: needs.precheck.outputs.should-run == 'true'
+        if: steps.precheck.outputs.should-run == 'true'
         run: |
           if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
             echo "can-push=true" >> "$GITHUB_OUTPUT"
@@ -207,63 +156,11 @@ jobs:
             echo "can-push=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Generate GitHub App token
-        id: app-token
-        if: needs.precheck.outputs.should-run == 'true' && steps.cap.outputs.can-push == 'true'
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: "${{ secrets.GH_APP_ID }}"
-          private-key: "${{ secrets.GH_APP_PRIVATE_KEY }}"
-          permission-contents: write
-
-      - uses: actions/checkout@v6
-        if: needs.precheck.outputs.should-run == 'true'
-        with:
-          token: "${{ steps.app-token.outputs.token || github.token }}"
-          ref: "${{ github.head_ref }}"
-
-      - uses: actions/download-artifact@v4
-        if: needs.precheck.outputs.should-run == 'true'
-        with:
-          name: tidy-rust-patch
-
-      - uses: actions/download-artifact@v4
-        if: needs.precheck.outputs.should-run == 'true'
-        with:
-          name: tidy-wado-patch
-
-      - name: Apply patches
-        if: needs.precheck.outputs.should-run == 'true'
-        run: |
-          set -e
-          # Both patches are full diffs taken from the same HEAD by two
-          # parallel jobs, so any file touched by both makes a plain
-          # `git apply` of the second patch reject ("patch does not apply").
-          # This happens whenever the jobs converge on the same file — most
-          # commonly `Cargo.lock`, which both `clippy-fix`/`cargo fmt`
-          # (tidy-rust) and `cargo build` (tidy-wado) regenerate identically
-          # once it is stale, but also any doc both jobs rewrite.
-          #
-          # `--3way` falls back to a 3-way merge against the blob ids recorded
-          # in the patch (the HEAD blobs, present because the aggregator checked
-          # out the same ref): identical or non-overlapping edits merge cleanly,
-          # and only a genuine content conflict between the two tidy jobs fails
-          # — which is a real bug worth surfacing red. `--3way` implies `--index`.
-          apply_patch() {
-            local patch="$1"
-            [ -s "$patch" ] || return 0
-            if ! git apply --3way --whitespace=nowarn "$patch"; then
-              echo "::error::Failed to apply ${patch}: the two parallel tidy jobs produced conflicting edits to the same file."
-              exit 1
-            fi
-          }
-          apply_patch tidy-rust.patch
-          apply_patch tidy-wado.patch
-
       - name: Detect changes
         id: changes
-        if: needs.precheck.outputs.should-run == 'true'
+        if: steps.precheck.outputs.should-run == 'true'
         run: |
+          git add -A
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -272,9 +169,28 @@ jobs:
             git diff --cached --stat
           fi
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: >-
+          steps.precheck.outputs.should-run == 'true' &&
+          steps.changes.outputs.changed == 'true' &&
+          steps.cap.outputs.can-push == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: "${{ secrets.GH_APP_ID }}"
+          private-key: "${{ secrets.GH_APP_PRIVATE_KEY }}"
+          permission-contents: write
+
+      # Internal PR (head repo == this repo): push a `chore: tidy` commit and
+      # exit green. The push retriggers this workflow; the next run hits the
+      # precheck short-circuit and stays green. We deliberately do NOT fail
+      # here: the push itself starts a fresh CI round, so the PR is never
+      # momentarily all-green and auto-merge cannot fire prematurely. A red
+      # check on the (now superseded) run only confuses tooling and coding
+      # agents into thinking tidy is broken.
       - name: Commit and push (internal PR only)
         if: >-
-          needs.precheck.outputs.should-run == 'true' &&
+          steps.precheck.outputs.should-run == 'true' &&
           steps.changes.outputs.changed == 'true' &&
           steps.cap.outputs.can-push == 'true'
         env:
@@ -285,19 +201,18 @@ jobs:
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           git commit -m "chore: tidy"
-          git push
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "HEAD:${{ github.head_ref }}"
 
+      # Fork PR (no write access, secrets unavailable): skip the push, emit
+      # guidance for the fork author, and exit non-zero so the check stays red
+      # until tidy is satisfied.
       - name: Report tidy result
         if: >-
-          needs.precheck.outputs.should-run == 'true' &&
+          steps.precheck.outputs.should-run == 'true' &&
           steps.changes.outputs.changed == 'true'
         run: |
           if [ "${{ steps.cap.outputs.can-push }}" = "true" ]; then
-            # Exit green: the `chore: tidy` push above already retriggered this
-            # workflow, so a fresh CI round is in flight and the PR is never
-            # momentarily all-green — auto-merge cannot fire prematurely. A red
-            # check on this superseded run only misleads tooling and coding
-            # agents.
             echo "::notice::Tidy produced changes and pushed a 'chore: tidy' commit. Pull the latest before continuing."
           else
             echo "::error::Tidy produced changes. Fork PRs cannot be auto-pushed; run 'mise run clippy-fix && cargo fmt --all && mise run format-wado && mise run update-golden-fixtures && mise run update-golden-format-fixtures && mise run doc-stdlib && cargo run -p wado-dev-tools -- format-md' locally and push the result."


### PR DESCRIPTION
Replaces the `precheck` / `tidy-rust` / `tidy-wado` / `tidy` fan-out/fan-in with a single `Tidy` job, using the new [Actions parallel steps](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/). The required-check name stays `Tidy`, so branch protection is unaffected.

## What changes

- **Setup paid once** instead of four times (checkout, submodule, `rust-cache`, `mise`).
- **Patch machinery gone.** The old design uploaded each job's `git diff` as an artifact and re-applied both with `git apply --3way` purely to merge results from two runners. One runner = one working tree, so it just `git add -A && commit && push`.
- **Post-build regenerators run in parallel.** WIR goldens, format goldens, Gale kilns, and stdlib docs write disjoint trees, so they run inside a `parallel:` group (which joins implicitly). Each calls the prebuilt binary directly, so they don't contend on the cargo target lock.

## What does *not* speed up

The two whole-workspace compiles (`cargo build` and `clippy-fix`) serialize on cargo's target-dir lock, so they run sequentially rather than on two runners. `cargo build` runs first so the later clippy pass reuses its dependency artifacts. The win is **simplicity + freed runner slots + no inter-job queue wait**.

## Validation

- `background:` / `wait-all:` were rejected by the Actions validator (`Unexpected value 'wait-all'`); the `parallel:` group is accepted and joins implicitly.
- Tidy ran green in ~17.5 min on this PR — no regression versus the old layout, where `tidy-wado` alone took ~17 min plus inter-job queue overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LT4aCmcjHAxnD1inxT6W3s