### PR TITLE
fix: canonicalize local module identity so each file loads once

### DIFF
--- a/docs/wep-2026-01-24-module-loader.md
+++ b/docs/wep-2026-01-24-module-loader.md
@@ -142,6 +142,18 @@ use {foo} from "xxx:yyy"
     └─ other      → ERROR: invalid module path
 ```
 
+### Canonical module identity
+
+A `Local` module's identity is its path relative to the **entry directory** — the parent of the entry file. Resolving an import by composing relative steps from the importer (`name::resolve_module_path`) is correct only while the chain stays at or below the entry directory. A path that climbs _above_ it and re-enters (importing `../src/gen/parser.wado` for the file the entry imports directly as `./gen/parser.wado`) spells the same physical file non-minimally; lexical normalization alone cannot fold `../src` because the entry directory's own name is absent from the relative form.
+
+Left unfolded, the loader interns two `ModuleSource`s for one file and loads it twice — duplicate top-level symbols and a split type identity (the two copies' `struct`s are distinct nominal types), and any `(decl_file, …)`-keyed lookup such as the Kiln redirect index matches only one spelling.
+
+`name::canonical_local_path(entry_dir, resolved)` removes the ambiguity: it anchors `resolved` back under `entry_dir`, normalizes (which now cancels the escape, since the absolute-ish form carries every directory name), and re-expresses the result relative to `entry_dir` via `path::relative_path`. Every import path to a file therefore yields one identity, so the loader interns it once.
+
+`name::resolve_local_identity(entry_dir, from_path, import)` (compose then canonicalize) is the single resolver every site goes through, so they cannot drift: the loader's `resolve_import`, the analyze/elaborator re-resolution `name::resolve_import_with_entry`, and the CLI Kiln harvest (they must agree, or a module is looked up under a different identity than it was loaded). It is applied to the `Local`-importer branch and to the `EntryPoint` branch (an escape-reentry spelled in the entry itself must collapse too) and to the wasm-asset path; the stdlib/`Dependency`/`Remote` branches keep their own identity spaces. Every re-resolution site threads the entry `ModuleSource` so `entry_dir` is non-empty exactly where the loader had it; a site that passed `None` would silently skip canonicalization and diverge for escape-reentry imports.
+
+Anchoring at the entry directory — rather than the manifest root — keeps non-escape identities byte-identical to the pre-canonicalization scheme, so no qualified name or golden output changes; only the previously-double-loaded escape case is affected. With entry context absent (`entry_dir` empty, e.g. a bare entry filename or a stdlib-identity entry) the input passes through unchanged, matching the older behavior.
+
 ## Consequences
 
 ### Positive

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -465,6 +465,14 @@ Two pieces of compiler-internal state drive the redirect:
 
 `InvocationIndex::redirect(decl_file, from)` performs a single lookup keyed by `(decl_file, from)`. There is no project-wide fallback (no `DeclScope::Any`); a manifest section that could implicitly redirect imports across the project does not exist by design.
 
+#### Cross-module harvest and identity remap
+
+A `with` clause may live in an imported module, not just the entry, so the CLI harvests inline invocations across the entry's transitive local `.wado` imports (`collect_inline_invocations_for_entry_with_identities`). The harvest keys each invocation by the module's full path (`decl_site.module`), but the loader presents a base-relative _loader identity_ (`./eval.wado`) at resolve time. `remap_index_decl_files` rewrites the index's `decl_file` keys from the harvest key to that identity.
+
+The loader identity is _canonical_ — every import path to a file derives the same identity (see "Canonical module identity" in the [module-loader WEP](./wep-2026-01-24-module-loader.md)). The harvest derives loader identities through the same `name::canonical_local_path`, so the map is single-valued: a plain diamond and an `..`-escape-and-reenter both collapse to one identity, and a back-reference to the entry folds onto `EntryPoint`. Without canonical identities (#1423) the escape case produced two spellings (`./gen/p.wado` vs `../src/gen/p.wado`) and the redirect was lost on the path the first-reached spelling didn't cover.
+
+As a defensive check, if two distinct harvest keys ever collapse onto the same `(loader_identity, from)` but redirect to different generated modules, the remap reports `Code::KilnRedirectConflict` (a compile error) instead of silently letting the last write win and dropping one redirect (two entries that agree on the target are a benign duplicate). With canonical identities this is unreachable through ordinary imports — distinct files have distinct identities — so it guards only against a future identity-scheme regression.
+
 #### URI scheme
 
 Kiln-produced URIs use the `kiln:` scheme with no authority: `kiln:/abs/path/to/generated.wado`. Not `file://`. The choice is forced by a single invariant elsewhere in the compiler: qualified names take the form `{module_source}//{name}`, using `//` as the boundary between module source and symbol name. A `file:///abs/path/to/foo.wado` URI contains its own `//` inside `file://`, which collides with the name separator and breaks every parser that splits on `//` (for example `wir_build::types::sort_types_topologically`). `kiln:/abs/path` has no internal `//`, so the boundary stays unambiguous.

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -172,7 +172,14 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
         )
         .await
         .map_err(|e| CliExit::error(FormatPipelineError(&e)))?;
-        crate::compile::remap_index_decl_files(&mut outcome.invocations, &identities);
+        let conflict_errors = crate::compile::remap_and_report_conflicts(
+            &mut outcome.invocations,
+            &identities,
+            &host,
+        );
+        if conflict_errors > 0 {
+            return Err(CliExit::silent_failure(1));
+        }
         outcome
     };
 

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -546,10 +546,13 @@ pub(crate) async fn maybe_run_pipeline(
         no_cache,
     )
     .await?;
-    // The index is keyed by `decl_site.module` (the harvest key, a full path);
-    // rewrite those keys to the loader identities so a redirect from a
-    // transitively-imported module matches.
-    remap_index_decl_files(&mut outcome.invocations, &identities);
+    // The harvested index is keyed by full path; remap to loader identities.
+    let conflict_errors = remap_and_report_conflicts(&mut outcome.invocations, &identities, host);
+    if conflict_errors > 0 {
+        return Err(crate::kiln_driver::PipelineError::RedirectConflict(
+            conflict_errors,
+        ));
+    }
     Ok(outcome)
 }
 
@@ -665,23 +668,12 @@ pub fn empty_manifest() -> wado_manifest::Manifest {
 /// must be discovered here; otherwise that module's grammar `use` falls through
 /// to the Wado lexer.
 ///
-/// Two distinct module identities are at play, and a non-entry module needs a
-/// different one for each:
-///
-/// - The **harvest key** keys `decl_site.module`, which Kiln resolves the
-///   `module` / `output_dir` paths against (relative to the manifest root). It
-///   must be the module's full path, exactly as the entry's is — so it is built
-///   by `resolve_module_path` chaining from the entry's full path.
-/// - The **loader identity** is the `ModuleSource::Local.path` the loader feeds
-///   into `InvocationIndex::redirect`. The loader resolves the entry's own
-///   imports through its `EntryPoint` branch (`normalize_module_path`) and
-///   deeper imports through its `Local` branch (`resolve_module_path`), so the
-///   identity is base-path-relative (`./eval.wado`), not the full path.
-///
-/// The returned map is `harvest_key → loader_identity`; the caller rewrites the
-/// generated index's `decl_file` keys through it (see `remap_index_decl_files`).
-/// For the entry the two coincide (its `EntryPoint.filename` is the full path),
-/// so it maps to itself.
+/// Returns the invocations plus a `harvest_key → loader_identity` map: the
+/// harvest keys `decl_site.module` by full path, but the loader presents a
+/// base-relative identity at resolve time, so the caller rewrites the index's
+/// keys through this map (see `remap_index_decl_files`). The loader identity is
+/// canonical (see [`wado_compiler::name::canonical_local_path`]), so the map is
+/// single-valued.
 pub(crate) fn collect_inline_invocations_for_entry_with_identities(
     entry_file: &Path,
     manifest_root: &Path,
@@ -691,7 +683,9 @@ pub(crate) fn collect_inline_invocations_for_entry_with_identities(
     Vec<wado_compiler::Diagnostic>,
 ) {
     use std::collections::VecDeque;
-    use wado_compiler::name::{normalize_module_path, resolve_module_path};
+    use wado_compiler::name::{
+        canonical_local_path, normalize_module_path, resolve_local_identity, resolve_module_path,
+    };
 
     let mut modules =
         wado_compiler::hashmap::IndexMap::<String, wado_compiler::ast::Module>::default();
@@ -706,7 +700,14 @@ pub(crate) fn collect_inline_invocations_for_entry_with_identities(
     // `resolve_module_path` (used for children below) is panic-free on its own,
     // so a path with URI-unsafe characters no longer crashes (#1417).
     let entry_key = entry_file.to_string_lossy().to_string();
-    queue.push_back((entry_key.clone(), entry_key, entry_file.to_path_buf(), true));
+    let entry_dir = wado_compiler::name::module_parent_dir(&entry_key).to_string();
+    identities.insert(entry_key.clone(), entry_key.clone());
+    queue.push_back((
+        entry_key.clone(),
+        entry_key.clone(),
+        entry_file.to_path_buf(),
+        true,
+    ));
 
     while let Some((key, loader_id, fs_path, is_entry)) = queue.pop_front() {
         if modules.contains_key(&key) {
@@ -742,16 +743,20 @@ pub(crate) fn collect_inline_invocations_for_entry_with_identities(
                 continue;
             }
             let child_key = resolve_module_path(&key, src);
+            // Must match the loader's identity derivation (entry vs deeper).
             let child_loader_id = if is_entry {
-                normalize_module_path(src)
+                canonical_local_path(&entry_dir, &normalize_module_path(src))
             } else {
-                resolve_module_path(&loader_id, src)
+                resolve_local_identity(&entry_dir, &loader_id, src)
             };
+            // Don't overwrite the entry's pinned identity (back-refs fold to it).
+            if child_key != entry_key {
+                identities.insert(child_key.clone(), child_loader_id.clone());
+            }
             if !modules.contains_key(&child_key) {
                 queue.push_back((child_key, child_loader_id, parent_dir.join(src), false));
             }
         }
-        identities.insert(key.clone(), loader_id);
         modules.insert(key, ast);
     }
 
@@ -770,14 +775,17 @@ pub(crate) fn collect_inline_invocations_for_entry_with_identities(
     (invocations, identities, diagnostics)
 }
 
-/// Rewrite the redirect index's `decl_file` keys from the harvest key (a
-/// module's full path) to the loader identity the loader will present at
-/// resolve time. Entries whose `decl_file` is not in `identities` (the entry
-/// itself, or anything already in loader form) pass through unchanged.
+/// Rewrite the index's `decl_file` keys from harvest keys to loader identities
+/// (keys absent from `identities` pass through). Returns a diagnostic for each
+/// *conflict* — two keys resolving to the same `(loader_identity, from)` but
+/// different targets — instead of silently dropping a redirect (last-write-wins);
+/// matching targets are a harmless duplicate. Unreachable with canonical
+/// identities; guards against a future identity-scheme regression.
+#[must_use]
 pub(crate) fn remap_index_decl_files(
     index: &mut wado_compiler::kiln::InvocationIndex,
     identities: &wado_compiler::hashmap::IndexMap<String, String>,
-) {
+) -> Vec<wado_compiler::Diagnostic> {
     let rewritten: Vec<(String, String, String)> = index
         .entries()
         .map(|(decl, from, uri)| {
@@ -785,11 +793,51 @@ pub(crate) fn remap_index_decl_files(
             (decl.to_string(), from.to_string(), uri.to_string())
         })
         .collect();
+
+    let mut diagnostics = Vec::new();
     let mut fresh = wado_compiler::kiln::InvocationIndex::new();
     for (decl, from, uri) in rewritten {
+        // `redirect` normalizes `from` identically to `insert`, so this sees
+        // the key `insert` would write.
+        if let Some(existing) = fresh.redirect(&decl, &from)
+            && existing != uri
+        {
+            diagnostics.push(wado_compiler::Diagnostic {
+                severity: wado_compiler::Severity::Error,
+                code: wado_compiler::Code::KilnRedirectConflict,
+                message: format!(
+                    "kiln: two generator invocations for `use ... from {from:?}` in `{decl}` \
+                     redirect to different generated modules (`{existing}` and `{uri}`); \
+                     a module cannot resolve one import to two generated entries",
+                ),
+                span: None,
+            });
+            continue;
+        }
         fresh.insert(&decl, &from, &uri);
     }
     *index = fresh;
+    diagnostics
+}
+
+/// Remap `index` to loader identities via [`remap_index_decl_files`], emit any
+/// conflict diagnostics through `host`, and return the count of `Error`-severity
+/// conflicts. Shared by `compile` and `check`, which differ only in how a
+/// non-zero count maps to their own error type.
+pub(crate) fn remap_and_report_conflicts(
+    index: &mut wado_compiler::kiln::InvocationIndex,
+    identities: &wado_compiler::hashmap::IndexMap<String, String>,
+    host: &FilesystemCompilerHost,
+) -> usize {
+    let conflicts = remap_index_decl_files(index, identities);
+    let errors = conflicts
+        .iter()
+        .filter(|d| d.severity == wado_compiler::Severity::Error)
+        .count();
+    for d in conflicts {
+        wado_compiler::CompilerHost::emit_diagnostic(host, d);
+    }
+    errors
 }
 
 /// Walk up from `entry_file` looking for the nearest `wado.toml`. Returns
@@ -1021,6 +1069,89 @@ mod kiln_dir_module_tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    // #1423: a module reached directly and via a `../`-chained sibling above the
+    // entry dir must collapse to one canonical identity.
+    #[test]
+    fn escape_diamond_canonicalizes_to_one_loader_identity() {
+        let root = unique_tmp("escape-diamond");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src/gen")).unwrap();
+        std::fs::create_dir_all(root.join("shared")).unwrap();
+        std::fs::write(
+            root.join("src/main.wado"),
+            "use { p } from \"./gen/parser.wado\";\nuse { h } from \"../shared/helper.wado\";\nexport fn run() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("src/gen/parser.wado"),
+            "use x from \"./G.g4\" with { generator: { module: \"../../tool/gen.wado\" } };\npub fn p() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("shared/helper.wado"),
+            "use { p } from \"../src/gen/parser.wado\";\npub fn h() {}\n",
+        )
+        .unwrap();
+
+        let entry = root.join("src/main.wado");
+        let (invs, identities, _d) =
+            collect_inline_invocations_for_entry_with_identities(&entry, &root);
+        assert_eq!(invs.len(), 1);
+        let parser_key = &invs[0].decl_site.module;
+        assert_eq!(
+            identities.get(parser_key).map(String::as_str),
+            Some("./gen/parser.wado"),
+            "escape-reentry must canonicalize to the direct spelling",
+        );
+
+        let mut idx = wado_compiler::kiln::InvocationIndex::new();
+        idx.insert(parser_key, "./G.g4", "kiln:file:///g/parser.wado");
+        let conflicts = remap_index_decl_files(&mut idx, &identities);
+        assert!(conflicts.is_empty());
+        assert_eq!(
+            idx.redirect("./gen/parser.wado", "./G.g4"),
+            Some("kiln:file:///g/parser.wado"),
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    // A `../`-chained back-reference to the entry folds onto `EntryPoint`, so
+    // the entry keeps a single identity.
+    #[test]
+    fn entry_backref_folds_to_single_identity() {
+        let root = unique_tmp("entry-backref");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("shared")).unwrap();
+        std::fs::write(
+            root.join("src/main.wado"),
+            "use g from \"./G.g4\" with { generator: { module: \"../tool/gen.wado\" } };\nuse { h } from \"../shared/helper.wado\";\nexport fn run() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("shared/helper.wado"),
+            "use { run } from \"../src/main.wado\";\npub fn h() {}\n",
+        )
+        .unwrap();
+
+        let entry = root.join("src/main.wado");
+        let entry_key = entry.to_string_lossy().to_string();
+        let (_invs, identities, _d) =
+            collect_inline_invocations_for_entry_with_identities(&entry, &root);
+        assert_eq!(
+            identities.get(&entry_key).map(String::as_str),
+            Some(entry_key.as_str()),
+            "the entry maps to itself only",
+        );
+        assert!(
+            !identities.values().any(|v| v == "./main.wado"),
+            "a back-reference must not introduce a relative entry identity: {identities:?}",
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     #[test]
     fn remap_index_decl_files_swaps_to_loader_identity() {
         use wado_compiler::kiln::InvocationIndex;
@@ -1038,7 +1169,8 @@ mod kiln_dir_module_tests {
             "./eval.wado".to_string(),
         );
 
-        remap_index_decl_files(&mut idx, &identities);
+        let conflicts = remap_index_decl_files(&mut idx, &identities);
+        assert!(conflicts.is_empty(), "no conflict for a single mapping");
 
         assert!(
             idx.redirect("/abs/example/eval.wado", "./Arith.g4")
@@ -1050,5 +1182,100 @@ mod kiln_dir_module_tests {
             Some("kiln:file:///g/arith.wado"),
             "the loader identity must redirect to the same URI"
         );
+    }
+
+    // Two keys collapsing onto one `(identity, from)` with different targets
+    // must be reported, not silently resolved last-write-wins (#1423).
+    #[test]
+    fn remap_index_decl_files_reports_conflict_on_identity_collision() {
+        use wado_compiler::kiln::InvocationIndex;
+
+        let mut idx = InvocationIndex::new();
+        idx.insert("/abs/a.wado", "./G.g4", "kiln:file:///g/from_a.wado");
+        idx.insert("/abs/b.wado", "./G.g4", "kiln:file:///g/from_b.wado");
+
+        let mut identities = wado_compiler::hashmap::IndexMap::default();
+        identities.insert("/abs/a.wado".to_string(), "./shared.wado".to_string());
+        identities.insert("/abs/b.wado".to_string(), "./shared.wado".to_string());
+
+        let conflicts = remap_index_decl_files(&mut idx, &identities);
+        assert_eq!(conflicts.len(), 1, "the collision must be reported");
+        assert_eq!(conflicts[0].code, wado_compiler::Code::KilnRedirectConflict);
+        assert_eq!(conflicts[0].severity, wado_compiler::Severity::Error);
+        // The first redirect survives; the conflicting second is dropped.
+        assert_eq!(
+            idx.redirect("./shared.wado", "./G.g4"),
+            Some("kiln:file:///g/from_a.wado"),
+        );
+    }
+
+    // Same identity *and* target is a benign duplicate: no diagnostic.
+    #[test]
+    fn remap_index_decl_files_allows_duplicate_identical_target() {
+        use wado_compiler::kiln::InvocationIndex;
+
+        let mut idx = InvocationIndex::new();
+        idx.insert("/abs/a.wado", "./G.g4", "kiln:file:///g/shared.wado");
+        idx.insert("/abs/b.wado", "./G.g4", "kiln:file:///g/shared.wado");
+
+        let mut identities = wado_compiler::hashmap::IndexMap::default();
+        identities.insert("/abs/a.wado".to_string(), "./shared.wado".to_string());
+        identities.insert("/abs/b.wado".to_string(), "./shared.wado".to_string());
+
+        let conflicts = remap_index_decl_files(&mut idx, &identities);
+        assert!(conflicts.is_empty(), "identical target is not a conflict");
+        assert_eq!(
+            idx.redirect("./shared.wado", "./G.g4"),
+            Some("kiln:file:///g/shared.wado"),
+        );
+    }
+
+    // An in-directory diamond already collapses to one canonical identity.
+    #[test]
+    fn diamond_import_yields_single_canonical_identity() {
+        let root = unique_tmp("diamond");
+        let _ = std::fs::remove_dir_all(&root);
+        let ex = root.join("example");
+        std::fs::create_dir_all(ex.join("a")).unwrap();
+        std::fs::create_dir_all(ex.join("b")).unwrap();
+        // `b/bar.wado` re-imports `a/foo.wado` via `../a/foo.wado`.
+        std::fs::write(
+            ex.join("main.wado"),
+            "use { f } from \"./a/foo.wado\";\nuse { g } from \"./b/bar.wado\";\nexport fn run() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ex.join("a/foo.wado"),
+            "use x from \"./G.g4\" with { generator: { module: \"../../src/gen.wado\" } };\npub fn f() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ex.join("b/bar.wado"),
+            "use { f } from \"../a/foo.wado\";\npub fn g() {}\n",
+        )
+        .unwrap();
+
+        let entry = ex.join("main.wado");
+        let (invs, identities, _d) =
+            collect_inline_invocations_for_entry_with_identities(&entry, &root);
+
+        assert_eq!(invs.len(), 1, "the generator clause is harvested once");
+        let foo_key = &invs[0].decl_site.module;
+        assert_eq!(
+            identities.get(foo_key).map(String::as_str),
+            Some("./a/foo.wado"),
+            "diamond must collapse to one canonical loader identity",
+        );
+
+        let mut idx = wado_compiler::kiln::InvocationIndex::new();
+        idx.insert(foo_key, "./G.g4", "kiln:file:///g/foo.wado");
+        let conflicts = remap_index_decl_files(&mut idx, &identities);
+        assert!(conflicts.is_empty());
+        assert_eq!(
+            idx.redirect("./a/foo.wado", "./G.g4"),
+            Some("kiln:file:///g/foo.wado"),
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -802,6 +802,11 @@ pub enum PipelineError {
     /// (e.g. a bare, non-`./` path). The per-clause diagnostics have already
     /// been emitted through the host; this carries the count for the summary.
     InlineClause(usize),
+    /// One or more generator invocations resolve to the same loader identity
+    /// and `from` schema but redirect to different generated modules. The
+    /// per-conflict diagnostics have already been emitted through the host;
+    /// this carries the count for the summary.
+    RedirectConflict(usize),
 }
 
 impl std::fmt::Display for PipelineError {
@@ -822,6 +827,9 @@ impl std::fmt::Display for PipelineError {
             }
             PipelineError::InlineClause(n) => {
                 write!(f, "kiln: {n} invalid inline generator clause(s)")
+            }
+            PipelineError::RedirectConflict(n) => {
+                write!(f, "kiln: {n} conflicting generator redirect(s)")
             }
         }
     }

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -30,7 +30,7 @@ fn resolve_use_decl_module_source(
     invocations: &crate::kiln::InvocationIndex,
 ) -> Option<ModuleSource> {
     if let Some(kind) = wasm_asset_kind_from_attrs(use_decl.attributes.as_ref()) {
-        return resolve_wasm_asset_path(from, &use_decl.source)
+        return resolve_wasm_asset_path(from, &use_decl.source, &crate::name::entry_dir_of(entry))
             .ok()
             .map(|path| interner.wasm(&path, kind));
     }

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -168,6 +168,11 @@ pub enum Code {
     /// `wado check` re-ran the generator and the output bytes differ from
     /// the on-disk (committed) file. Promoted to error in CI default.
     KilnGeneratedStaleOnDisk,
+    /// Two distinct generator invocations resolve to the same loader identity
+    /// and `from` schema but redirect to different generated modules. The
+    /// redirect index cannot represent both, so the conflict is reported
+    /// instead of silently dropping one.
+    KilnRedirectConflict,
     /// A `#[compiler_item("...")]` attribute is malformed — the name
     /// is unknown, the attribute is attached to the wrong declaration
     /// kind, or it appears outside a `core::*` stdlib module.
@@ -225,6 +230,7 @@ impl std::fmt::Display for Code {
             Code::KilnGeneratedModified => "KILN_GENERATED_MODIFIED",
             Code::KilnGeneratedRegenerated => "KILN_GENERATED_REGENERATED",
             Code::KilnGeneratedStaleOnDisk => "KILN_GENERATED_STALE_ON_DISK",
+            Code::KilnRedirectConflict => "KILN_REDIRECT_CONFLICT",
             Code::CompilerItemAttr => "COMPILER_ITEM_ATTR",
             Code::ParamAttr => "PARAM_ATTR",
             Code::ParamUnknown => "PARAM_UNKNOWN",

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -1005,17 +1005,20 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         interner: &mut ModuleSourceInterner,
         module: &Module,
         module_source: &ModuleSource,
+        entry: Option<&ModuleSource>,
         invocations: &crate::kiln::InvocationIndex,
     ) -> IndexMap<String, ModuleSource> {
         let mut sources = IndexMap::default();
         for item in &module.items {
             match item {
                 Item::Use(use_decl) => {
+                    // `entry` must be threaded so identities match the loader
+                    // (see `name::resolve_local_identity`).
                     let source = name::resolve_import_with_invocations(
                         interner,
                         module_source,
                         &use_decl.source,
-                        None,
+                        entry,
                         invocations,
                     );
                     for use_item in &use_decl.items {
@@ -1258,6 +1261,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             &mut self.interner.borrow_mut(),
             module,
             &module_source,
+            Some(&self.entry_module_source),
             &self.invocations,
         );
 
@@ -1298,7 +1302,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     &mut self.interner.borrow_mut(),
                     &module_source,
                     &use_decl.source,
-                    None,
+                    Some(&self.entry_module_source),
                     &self.invocations,
                 );
 

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -395,6 +395,7 @@ pub fn wasm_asset_kind_from_attrs(
 pub fn resolve_wasm_asset_path(
     from: &ModuleSource,
     import_source: &str,
+    entry_dir: &str,
 ) -> Result<String, LoadError> {
     if !import_source.starts_with("./") && !import_source.starts_with("../") {
         return Err(LoadError::InvalidModulePath {
@@ -410,11 +411,17 @@ pub fn resolve_wasm_asset_path(
             "wasi:{}",
             join_namespace_relative_path(interface, import_source)
         )),
-        ModuleSource::Local { path } | ModuleSource::Dependency { path } => {
-            Ok(resolve_module_path(path, import_source))
-        }
+        ModuleSource::Local { path } => Ok(crate::name::resolve_local_identity(
+            entry_dir,
+            path,
+            import_source,
+        )),
+        ModuleSource::Dependency { path } => Ok(resolve_module_path(path, import_source)),
         ModuleSource::Remote { url } => Ok(resolve_module_path(url, import_source)),
-        ModuleSource::EntryPoint { .. } => Ok(normalize_module_path(import_source)),
+        ModuleSource::EntryPoint { .. } => Ok(crate::name::canonical_local_path(
+            entry_dir,
+            &normalize_module_path(import_source),
+        )),
         ModuleSource::Redirected { uri } => Ok(resolve_module_path(uri, import_source)),
         ModuleSource::Wasm { .. } => Err(LoadError::InvalidModulePath {
             path: import_source.to_string(),
@@ -993,6 +1000,10 @@ pub struct ModuleLoader<'a, H: CompilerHost> {
     entry_module_source: Option<ModuleSource>,
     /// Canonical name of the entry module (e.g., "./`cross_module_type_identity.wado`")
     entry_canonical_name: Option<String>,
+    /// Entry directory: the anchor for canonicalizing local module identities
+    /// (see [`crate::name::canonical_local_path`]). Empty until the entry is
+    /// loaded, or when the entry filename has no parent.
+    entry_dir: String,
     /// Kiln invocation redirects: `(decl_file, from_path)` → generated entry
     /// module path. Consulted by `resolve_import` so a bare `use { X } from
     /// "<schema>"` picks up the generator's output.
@@ -1017,6 +1028,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             pending_implicit_wasm_imports: Vec::new(),
             entry_module_source: None,
             entry_canonical_name: None,
+            entry_dir: String::new(),
             invocations: crate::kiln::InvocationIndex::new(),
         }
     }
@@ -1094,6 +1106,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             .unwrap_or(tentative_entry_source);
         self.entry_module_source = Some(entry_module_source.clone());
         self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(resolved_filename));
+        self.entry_dir = crate::name::entry_dir_of(Some(&entry_module_source));
 
         let entry_name = entry_module_source.to_string();
         self.logger.span_start(&format!("load {entry_name}"));
@@ -1257,7 +1270,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         kind: WasmAssetKind,
         use_decl: &crate::ast::UseDecl,
     ) -> Result<(), LoadError> {
-        let path = resolve_wasm_asset_path(from_module_source, &use_decl.source)?;
+        let path = resolve_wasm_asset_path(from_module_source, &use_decl.source, &self.entry_dir)?;
         let source = self.interner.wasm(&path, kind);
 
         let _ = use_decl; // accepted for both wildcard and named forms; the
@@ -1481,9 +1494,9 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         if import_source.starts_with("./") || import_source.starts_with("../") {
             // For relative imports, resolve against from_module_source
             if let ModuleSource::Local { path: from_file } = from_module_source {
-                let resolved = resolve_module_path(from_file, import_source);
-                // If the resolved path matches the entry module's canonical name,
-                // return the EntryPoint source to avoid duplicate module identity.
+                let resolved =
+                    crate::name::resolve_local_identity(&self.entry_dir, from_file, import_source);
+                // Fold a back-reference to the entry onto its EntryPoint identity.
                 if let Some(ref entry_canonical) = self.entry_canonical_name
                     && resolved == *entry_canonical
                     && let Some(ref entry_ms) = self.entry_module_source
@@ -1502,7 +1515,15 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
                 let resolved = resolve_module_path(path, import_source);
                 return Ok(self.interner.dependency(&resolved));
             }
-            // Entry point or stdlib: treat as relative to project root
+            // Entry imports canonicalize against the entry dir; stdlib / bare
+            // relative imports are not anchored there, so they only normalize.
+            if matches!(from_module_source, ModuleSource::EntryPoint { .. }) {
+                let resolved = crate::name::canonical_local_path(
+                    &self.entry_dir,
+                    &normalize_module_path(import_source),
+                );
+                return Ok(self.interner.local(&resolved));
+            }
             let canonical = normalize_module_path(import_source);
             return Ok(self.interner.local(&canonical));
         }

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -877,6 +877,56 @@ pub fn resolve_module_path(base: &str, relative: &str) -> String {
     normalize_module_path(&joined)
 }
 
+/// Canonicalize a resolved local module identity to the unique minimal form
+/// for its physical file, relative to the entry directory `entry_dir`.
+///
+/// Composing relative steps from the importer ([`resolve_module_path`]) is not
+/// canonical: a path that climbs *above* `entry_dir` and re-enters spells the
+/// same file non-minimally (`../src/gen/p.wado` vs `./gen/p.wado`), which
+/// lexical normalization cannot fold. Re-anchoring under `entry_dir` gives one
+/// identity per file on every import path, so the loader interns each once
+/// (#1423). Empty `entry_dir` (no entry context) returns the input normalized
+/// and otherwise unchanged, so such callers never regress.
+#[must_use]
+pub fn canonical_local_path(entry_dir: &str, resolved: &str) -> String {
+    if entry_dir.is_empty() {
+        return normalize_module_path(resolved);
+    }
+    // `relative_path` normalizes both arguments, so the anchored join needs no
+    // separate normalize pass.
+    crate::path::relative_path(entry_dir, &format!("{entry_dir}/{resolved}"))
+}
+
+/// The entry directory of an entry [`ModuleSource`], for use as the
+/// [`canonical_local_path`] anchor. `EntryPoint`'s filename's parent; empty
+/// for any other source or a parentless filename (both disable
+/// canonicalization, falling back to plain relative composition).
+#[must_use]
+pub fn entry_dir_of(entry_module: Option<&ModuleSource>) -> String {
+    match entry_module {
+        Some(ModuleSource::EntryPoint { filename }) => module_parent_dir(filename).to_string(),
+        _ => String::new(),
+    }
+}
+
+/// The parent directory of a module path (everything before the last `/`, or
+/// empty if none). Shared by every site that derives a [`canonical_local_path`]
+/// anchor, so they agree on it.
+#[must_use]
+pub fn module_parent_dir(path: &str) -> &str {
+    get_parent_path(path)
+}
+
+/// The canonical loader identity for a relative `import_source` imported from a
+/// local module `from_path`, anchored at `entry_dir`: compose
+/// ([`resolve_module_path`]) then canonicalize ([`canonical_local_path`]). The
+/// one resolver shared by the loader, the analyze/elaborator re-resolution, and
+/// the CLI Kiln harvest, so all three agree on identities.
+#[must_use]
+pub fn resolve_local_identity(entry_dir: &str, from_path: &str, import_source: &str) -> String {
+    canonical_local_path(entry_dir, &resolve_module_path(from_path, import_source))
+}
+
 /// Resolve an import source to a `ModuleSource`.
 ///
 /// This is the primary function for resolving import paths to module identifiers.
@@ -970,7 +1020,8 @@ pub fn resolve_import_with_entry(
     if let ModuleSource::Local { path: from_path } = from_module
         && (from_path.starts_with("./") || from_path.starts_with("../"))
     {
-        let resolved = resolve_module_path(from_path, import_source);
+        let resolved =
+            resolve_local_identity(&entry_dir_of(entry_module), from_path, import_source);
         // If this resolves to the entry module's canonical name, return the
         // entry ModuleSource to maintain a single type identity.
         if let Some(entry) = entry_module {
@@ -985,8 +1036,16 @@ pub fn resolve_import_with_entry(
         return interner.local(&resolved);
     }
 
-    // Fallback: normalize and return as Local path
-    // This handles EntryPoint imports and bare imports
+    // Entry imports canonicalize against the entry dir, mirroring the loader.
+    if matches!(from_module, ModuleSource::EntryPoint { .. }) {
+        let resolved = canonical_local_path(
+            &entry_dir_of(entry_module),
+            &normalize_module_path(import_source),
+        );
+        return interner.local(&resolved);
+    }
+
+    // Fallback: normalize and return as Local path (bare/other imports).
     interner.local(&normalize_module_path(import_source))
 }
 

--- a/wado-compiler/src/path.rs
+++ b/wado-compiler/src/path.rs
@@ -89,9 +89,123 @@ fn split_root(path: &str) -> (String, &str) {
     (String::new(), path)
 }
 
+/// Express `target` as a path relative to the directory `base`, lexically.
+///
+/// Both arguments are normalized first ([`normalize`]). The result is the
+/// minimal `./`- or `../`-prefixed path that, joined with `base` and
+/// normalized, yields `target` again — the unique spelling of `target` as seen
+/// from `base`. Purely lexical (no filesystem, `wasm32`-safe).
+///
+/// `base` and `target` must share rootedness (both relative, or both absolute
+/// under the same root); a mismatch returns `normalize(target)` unchanged.
+///
+/// Examples:
+/// - base `/p/src`, target `/p/src/gen/x.wado` → `./gen/x.wado`
+/// - base `/p/src`, target `/p/shared/h.wado` → `../shared/h.wado`
+/// - base `.`, target `./x.wado` → `./x.wado`
+#[must_use]
+pub fn relative_path(base: &str, target: &str) -> String {
+    let base = normalize(base);
+    let target = normalize(target);
+    let (base_root, base_rest) = split_root(&base);
+    let (target_root, target_rest) = split_root(&target);
+    if base_root != target_root {
+        return target;
+    }
+
+    // `normalize` drops every `..` from an absolute path, so only relative
+    // paths carry them; a `..` at the same index is the same ancestor on both
+    // sides, so string equality gives the common prefix. Drop `.` (a `.` base or
+    // a leading `./`) — it would add a phantom segment that inflates the climb
+    // count (e.g. `relative_path(".", "../x")` → `../../x`).
+    let drop = |s: &&str| !s.is_empty() && *s != ".";
+    let base_comps: Vec<&str> = base_rest.split('/').filter(drop).collect();
+    let target_comps: Vec<&str> = target_rest.split('/').filter(drop).collect();
+
+    let common = base_comps
+        .iter()
+        .zip(&target_comps)
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    // Climb out of every base component past the common prefix (a trailing
+    // `..` is itself climbed with a `..`), then descend into target's tail.
+    let ups = base_comps.len() - common;
+    let mut out: Vec<&str> = std::iter::repeat_n("..", ups).collect();
+    out.extend(&target_comps[common..]);
+
+    if out.is_empty() {
+        ".".to_string()
+    } else if out[0] == ".." {
+        out.join("/")
+    } else {
+        format!("./{}", out.join("/"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn relative_path_under_base() {
+        assert_eq!(relative_path("/p/src", "/p/src/gen/x.wado"), "./gen/x.wado");
+        assert_eq!(relative_path("/p/src", "/p/src/x.wado"), "./x.wado");
+        assert_eq!(relative_path(".", "./x.wado"), "./x.wado");
+        assert_eq!(relative_path("src", "src/gen/x.wado"), "./gen/x.wado");
+    }
+
+    #[test]
+    fn relative_path_above_base() {
+        assert_eq!(
+            relative_path("/p/src", "/p/shared/h.wado"),
+            "../shared/h.wado"
+        );
+        assert_eq!(relative_path("/p/a/b", "/p/x.wado"), "../../x.wado");
+        assert_eq!(relative_path("src", "shared/h.wado"), "../shared/h.wado");
+    }
+
+    #[test]
+    fn relative_path_escape_reentry_canonicalizes() {
+        // The #1423 case: `..`-escape that re-enters the base must collapse to
+        // the direct spelling — base joined with the non-canonical form
+        // normalizes to the same target, and `relative_path` yields the minimal
+        // form.
+        let base = "/p/src";
+        let target = normalize(&format!("{base}/../src/gen/parser.wado"));
+        assert_eq!(target, "/p/src/gen/parser.wado");
+        assert_eq!(relative_path(base, &target), "./gen/parser.wado");
+    }
+
+    #[test]
+    fn relative_path_same_dir_and_root() {
+        assert_eq!(relative_path("/p/src", "/p/src"), ".");
+        assert_eq!(relative_path(".", "."), ".");
+    }
+
+    // A `.`-rooted base (the common `wado compile ./main.wado` → entry_dir `.`)
+    // must not inflate the climb count with a phantom `.` segment.
+    #[test]
+    fn relative_path_dot_base() {
+        assert_eq!(relative_path(".", "gen/x.wado"), "./gen/x.wado");
+        assert_eq!(relative_path(".", "./gen/x.wado"), "./gen/x.wado");
+        assert_eq!(relative_path(".", "../shared.wado"), "../shared.wado");
+        assert_eq!(relative_path(".", "../../shared.wado"), "../../shared.wado");
+    }
+
+    #[test]
+    fn relative_path_relative_bases_with_parent() {
+        // Both climb above the cwd: the shared `..` prefix is common.
+        assert_eq!(relative_path("../a", "../a/x.wado"), "./x.wado");
+        assert_eq!(relative_path("../a", "../b.wado"), "../b.wado");
+        assert_eq!(relative_path("..", "../../b.wado"), "../b.wado");
+    }
+
+    #[test]
+    fn relative_path_root_mismatch_falls_back() {
+        // No relative spelling across an absolute/relative boundary.
+        assert_eq!(relative_path("/p/src", "rel/x.wado"), "rel/x.wado");
+    }
 
     #[test]
     fn relative_dot_segments() {

--- a/wado-compiler/tests/loader_canonical_identity.rs
+++ b/wado-compiler/tests/loader_canonical_identity.rs
@@ -1,0 +1,217 @@
+//! A physical module reached through several import paths must be interned
+//! under one canonical identity, so the loader loads it once.
+//!
+//! Regression for #1423: an import that escapes *above* the entry directory and
+//! re-enters (`../src/gen/parser.wado` for what the entry imports directly as
+//! `./gen/parser.wado`) used to intern a second `ModuleSource` for the same
+//! file, double-loading it (duplicate symbols / type identities) and breaking
+//! the Kiln redirect on that path. Canonical identities collapse both spellings
+//! onto `./gen/parser.wado`.
+
+#![allow(unused_crate_dependencies)]
+
+use std::sync::Mutex;
+
+use indexmap::IndexMap;
+use wado_compiler::{
+    CompilerHost, Diagnostic, LogLevel, ModuleSource, SourceError, kiln::InvocationIndex, load,
+    parse, semantics_of,
+};
+
+struct MapHost {
+    sources: IndexMap<String, String>,
+    diagnostics: Mutex<Vec<Diagnostic>>,
+}
+
+impl MapHost {
+    fn new(sources: &[(&str, &str)]) -> Self {
+        Self {
+            sources: sources
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+            diagnostics: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl CompilerHost for MapHost {
+    fn load_source(
+        &self,
+        path: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<u8>, SourceError>> + Send {
+        let result = self.sources.get(path).cloned();
+        let path = path.to_string();
+        async move {
+            match result {
+                Some(s) => Ok(s.into_bytes()),
+                None => Err(SourceError::NotFound { path }),
+            }
+        }
+    }
+
+    fn emit_diagnostic(&self, diagnostic: Diagnostic) {
+        self.diagnostics.lock().unwrap().push(diagnostic);
+    }
+}
+
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(future)
+}
+
+#[test]
+fn escape_reentry_import_loads_one_module() {
+    // The host keys files by the path the loader hands `load_source`. The entry
+    // is `p/src/main.wado`; `parser.wado` sits under the entry dir and `helper`
+    // sits *above* it. `helper` re-imports `parser` via a `../`-chain.
+    let host = MapHost::new(&[
+        (
+            "p/src/main.wado",
+            "use { parse_it } from \"./gen/parser.wado\";\n\
+             use { use_helper } from \"../shared/helper.wado\";\n\
+             export fn run() { let _ = parse_it(); let _ = use_helper(); }\n",
+        ),
+        (
+            "./gen/parser.wado",
+            "pub struct Ast { pub n: i32 }\npub fn parse_it() -> Ast { return Ast { n: 1 } }\n",
+        ),
+        (
+            "../shared/helper.wado",
+            "use { Ast, parse_it } from \"../src/gen/parser.wado\";\n\
+             pub fn use_helper() -> i32 { let a: Ast = parse_it(); return a.n }\n",
+        ),
+    ]);
+
+    let loaded = block_on(async {
+        let parsed = parse(host.sources.get("p/src/main.wado").unwrap());
+        load(
+            parsed,
+            Some("p/src/main.wado"),
+            &host,
+            InvocationIndex::new(),
+            LogLevel::default(),
+        )
+        .await
+        .expect("loader should succeed")
+    });
+
+    // `parser.wado` must appear once — under the canonical `./gen/parser.wado`,
+    // never additionally as `../src/gen/parser.wado`.
+    let parser_ids: Vec<&str> = loaded
+        .modules
+        .keys()
+        .filter_map(|ms| match ms {
+            ModuleSource::Local { path } if path.ends_with("gen/parser.wado") => {
+                Some(path.as_str())
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        parser_ids,
+        vec!["./gen/parser.wado"],
+        "the shared module must be interned once under its canonical identity",
+    );
+    assert!(
+        !loaded.modules.keys().any(
+            |ms| matches!(ms, ModuleSource::Local { path } if path == "../src/gen/parser.wado")
+        ),
+        "the non-canonical escape-reentry spelling must not intern a second module",
+    );
+}
+
+#[test]
+fn entry_escape_reentry_loads_once() {
+    // The entry itself spells an import with a redundant `..`-escape that
+    // re-enters its own directory; it must canonicalize to the direct identity,
+    // not intern a second copy (the entry branch is canonicalized too).
+    let host = MapHost::new(&[
+        (
+            "p/src/main.wado",
+            "use { p } from \"../src/gen/parser.wado\";\n\
+             use { q } from \"./gen/parser.wado\";\n\
+             export fn run() { let _ = p(); let _ = q(); }\n",
+        ),
+        (
+            "./gen/parser.wado",
+            "pub fn p() -> i32 { return 1 }\npub fn q() -> i32 { return 2 }\n",
+        ),
+    ]);
+
+    let loaded = block_on(async {
+        let parsed = parse(host.sources.get("p/src/main.wado").unwrap());
+        load(
+            parsed,
+            Some("p/src/main.wado"),
+            &host,
+            InvocationIndex::new(),
+            LogLevel::default(),
+        )
+        .await
+        .expect("loader should succeed")
+    });
+
+    let parser_count = loaded
+        .modules
+        .keys()
+        .filter(
+            |ms| matches!(ms, ModuleSource::Local { path } if path.ends_with("gen/parser.wado")),
+        )
+        .count();
+    assert_eq!(
+        parser_count,
+        1,
+        "the entry's escape-reentry import must not double-load: {:?}",
+        loaded.modules.keys().collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn imported_global_resolves_through_escape_reentry() {
+    // A module above the entry dir imports a GLOBAL from a module it reaches via
+    // a `..`-chain that re-enters. The elaborator's imported-global resolution
+    // must canonicalize like the loader, or the global is looked up under an
+    // identity absent from the loaded modules and silently dropped.
+    let host = MapHost::new(&[
+        (
+            "p/src/main.wado",
+            "use { uses_g } from \"../shared/helper.wado\";\n\
+             use { p } from \"./gen/parser.wado\";\n\
+             export fn run() { let _ = uses_g(); let _ = p(); }\n",
+        ),
+        (
+            "./gen/parser.wado",
+            "pub global ANSWER: i32 = 42;\npub fn p() -> i32 { return ANSWER }\n",
+        ),
+        (
+            "../shared/helper.wado",
+            "use { ANSWER } from \"../src/gen/parser.wado\";\n\
+             pub fn uses_g() -> i32 { return ANSWER }\n",
+        ),
+    ]);
+
+    let sem = block_on(async {
+        let parsed = parse(host.sources.get("p/src/main.wado").unwrap());
+        let loaded = load(
+            parsed,
+            Some("p/src/main.wado"),
+            &host,
+            InvocationIndex::new(),
+            LogLevel::default(),
+        )
+        .await
+        .expect("loader should succeed");
+        semantics_of(loaded, &host, LogLevel::default(), true)
+    });
+
+    assert!(
+        sem.is_complete(),
+        "imported global through escape-reentry must resolve; diagnostics: {:#?}",
+        host.diagnostics
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>(),
+    );
+}


### PR DESCRIPTION
Fixes #1423.

## Root cause

#1423 reported two Kiln cross-module harvest hazards (collision overwrite + first-reaching identity). Both share a root cause in the **module loader**, not the Kiln harvest: a `Local` module's identity is composed by chaining relative steps from the importer, which is not canonical. A path that climbs *above* the entry directory and re-enters spells the same physical file two ways — `./gen/parser.wado` vs `../src/gen/parser.wado` — and lexical normalization cannot fold `../src` because the entry directory's own name is absent from the relative form.

The loader then interns two `ModuleSource`s for one file and loads it **twice**: duplicate top-level symbols, a split nominal type identity, and any `(decl_file, …)`-keyed lookup (the Kiln redirect index) matches only one spelling.

## Fix

Canonicalize the identity at its source. `name::resolve_local_identity` (compose then `canonical_local_path`) is the single resolver every site goes through, so they cannot drift:

- the loader's `resolve_import`,
- the analyze/elaborator re-resolution `resolve_import_with_entry`,
- the CLI Kiln harvest.

`canonical_local_path` anchors the resolved path back under the entry directory, normalizes (cancelling the escape), and re-expresses it via the new pure helper `path::relative_path`. It is applied to the `Local`, `EntryPoint`, and wasm-asset branches (an escape-reentry spelled in the entry itself must collapse too); `stdlib` / `Dependency` / `Remote` keep their own identity spaces. Every re-resolution site threads the entry `ModuleSource` so its anchor matches the loader.

Anchoring at the **entry directory** (not the manifest root) keeps non-escape identities byte-identical, so no qualified names or golden outputs change — only the previously double-loaded escape case is affected.

With identities canonical, the Kiln harvest collapses to a single identity per module, so `remap_index_decl_files` is single-valued. Its redirect-conflict check (`Code::KilnRedirectConflict`, surfaced by both `compile` and `check`) is kept as a defensive guard against a future identity-scheme regression.

## Notes

- New `path::relative_path` is pure/lexical and `wasm32`-safe (no filesystem).
- Regression coverage: `path::relative_path` edge cases (incl. `.`-rooted base), loader-level single-load for escape-reentry and entry back-reference, and semantics-level imported-global resolution through reentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwatGAGqSrZXVq6iMvxyzw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwatGAGqSrZXVq6iMvxyzw)_