### PR TITLE
feat(compiler): embed WIT component-type section in compiled components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2990,6 +2990,7 @@ dependencies = [
  "wasmtime-wasi-http",
  "wasmtime-wasi-tls",
  "wat",
+ "wit-component 0.251.0",
  "wit-encoder",
  "wit-parser 0.251.0",
  "zlib-rs",
@@ -3235,6 +3236,18 @@ dependencies = [
  "indexmap",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -3952,9 +3965,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.244.0",
 ]
 
 [[package]]
@@ -3986,9 +3999,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.244.0",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wasmparser 0.244.0",
  "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.251.0",
+ "wasm-metadata 0.251.0",
+ "wasmparser 0.251.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]

--- a/docs/wep-2026-03-21-wit-bundling.md
+++ b/docs/wep-2026-03-21-wit-bundling.md
@@ -102,17 +102,17 @@ This is the same format produced by `wit-component::metadata::encode()` in `wasm
 | Service (`wasi:http/service`)          | Yes (default) | Same as command                                                                   |
 | `-Os` (strip symbols)                  | No (default)  | Frontend-delivery build (`jco` → core wasm + JS); the WIT never reaches a CM host |
 
-The `-Os` row was revised during Phase 2: `-Os` is the production build for browser/frontend delivery, where the embedded WIT is dead weight that a CM host never reads. It therefore defaults to no embedding (as if `--no-wit`); an explicit `--embed-wit=<scope>` still forces it on. See [WIT Interoperability](./wep-2026-05-02-wit-interoperability.md) §"Embedding policy".
+The `-Os` row was revised during Phase 2: `-Os` is the production build for browser/frontend delivery, where the embedded WIT is dead weight that a CM host never reads. It therefore defaults to no embedding (as if `--no-embed-wit`); an explicit `--embed-wit` still forces it on. See [WIT Interoperability](./wep-2026-05-02-wit-interoperability.md) §"Embedding policy".
 
 ### CLI Control
 
 ```sh
-wado compile file.wado                    # WIT embedded (default, scope full)
-wado compile --no-wit file.wado           # WIT omitted (smaller binary)
-wado compile --embed-wit=full file.wado   # force embedding (e.g. under -Os)
+wado compile file.wado                    # WIT embedded (default)
+wado compile --no-embed-wit file.wado     # WIT omitted (smaller binary)
+wado compile --embed-wit file.wado        # force embedding (e.g. under -Os)
 ```
 
-`--no-wit` and `--embed-wit` are mutually exclusive. The `--no-wit` flag is an escape hatch for size-sensitive deployments where the consumer already has the WIT definition through other means.
+`--embed-wit` and `--no-embed-wit` are mutually exclusive and take no value: the embedded section is always the self-contained full closure (a `local`, registry-referencing section is not encodable — §"Phase 2 finding" in the interop WEP). `--no-embed-wit` is an escape hatch for size-sensitive deployments where the consumer already has the WIT definition through other means.
 
 ### Extraction and Verification
 

--- a/docs/wep-2026-03-21-wit-bundling.md
+++ b/docs/wep-2026-03-21-wit-bundling.md
@@ -95,31 +95,49 @@ This is the same format produced by `wit-component::metadata::encode()` in `wasm
 
 ### When It Applies
 
-| Output Type                            | WIT Bundled   | Rationale                                                                               |
-| -------------------------------------- | ------------- | --------------------------------------------------------------------------------------- |
-| Library package (`lib` in `wado.toml`) | Yes (default) | Consumers need the interface to generate bindings                                       |
-| Command (`wasi:cli/command`)           | Yes (default) | Self-describing binaries; tools can inspect the component                               |
-| Service (`wasi:http/service`)          | Yes (default) | Same as command                                                                         |
-| `-Os` (strip symbols)                  | Yes           | WIT is interface metadata, not debug symbols; stripping it would break interoperability |
+| Output Type                            | WIT Bundled   | Rationale                                                                         |
+| -------------------------------------- | ------------- | --------------------------------------------------------------------------------- |
+| Library package (`lib` in `wado.toml`) | Yes (default) | Consumers need the interface to generate bindings                                 |
+| Command (`wasi:cli/command`)           | Yes (default) | Self-describing binaries; tools can inspect the component                         |
+| Service (`wasi:http/service`)          | Yes (default) | Same as command                                                                   |
+| `-Os` (strip symbols)                  | No (default)  | Frontend-delivery build (`jco` → core wasm + JS); the WIT never reaches a CM host |
+
+The `-Os` row was revised during Phase 2: `-Os` is the production build for browser/frontend delivery, where the embedded WIT is dead weight that a CM host never reads. It therefore defaults to no embedding (as if `--no-wit`); an explicit `--embed-wit=<scope>` still forces it on. See [WIT Interoperability](./wep-2026-05-02-wit-interoperability.md) §"Embedding policy".
 
 ### CLI Control
 
 ```sh
-wado compile file.wado                    # WIT bundled (default)
+wado compile file.wado                    # WIT embedded (default, scope full)
 wado compile --no-wit file.wado           # WIT omitted (smaller binary)
+wado compile --embed-wit=full file.wado   # force embedding (e.g. under -Os)
 ```
 
-The `--no-wit` flag is an escape hatch for size-sensitive deployments where the consumer already has the WIT definition through other means.
+`--no-wit` and `--embed-wit` are mutually exclusive. The `--no-wit` flag is an escape hatch for size-sensitive deployments where the consumer already has the WIT definition through other means.
 
 ### Extraction and Verification
 
 Bundled WIT can be extracted using standard tooling:
 
 ```sh
-wasm-tools component wit output.wasm      # extract WIT from a Wado-compiled component
+wasm-tools component wit output.wasm      # show the component's WIT
 ```
 
 This enables any CM-compatible toolchain to consume Wado libraries without Wado-specific tooling.
+
+> **Implementation note (Phase 2, 2026-06).** A Wado artifact is a _full
+> component_, not a core module, and is therefore already self-describing:
+> `wasm-tools component wit` reconstructs WIT from the component's own typed CM
+> imports/exports, **without** reading any `component-type` custom section
+> (`wit_parser::decode` only consults that payload for WIT-package blobs / core
+> modules). The framing above — "a standalone `.wasm` cannot describe its own
+> interface" — is true for the core-module workflow this document modelled on,
+> not for Wado's component output. The embedded `component-type` section that
+> `wado compile` now writes is therefore _additive full-fidelity metadata_
+> (complete upstream interface bodies, exact package versions, a `producers`
+> record) for tools that read it explicitly (`wkg`, `wasm-tools metadata`,
+> relink), and it must be self-contained (full scope). See
+> [WIT Interoperability](./wep-2026-05-02-wit-interoperability.md) §"Phase 2
+> finding" for the detail and the producer-side implementation.
 
 ### Relationship to Wado-to-Wado Optimization
 

--- a/docs/wep-2026-05-02-wit-interoperability.md
+++ b/docs/wep-2026-05-02-wit-interoperability.md
@@ -621,11 +621,11 @@ choice. `local` / `full` therefore stays a `wado wit` _text_ concept (`wado wit
 `[wit].scope` manifest override (Phase 3) is dropped — it would have nothing to
 tune for the binary.
 
-- [x] Phase 3 — Manifest scope override: **dropped.** Embedding is always the
-      self-contained full closure (see the finding above), so there is no
-      embed-time scope to put in `wado.toml`. `wado wit --scope` remains the
-      only place `local` / `full` is meaningful (text output). WIT Bundling's
-      status is reconciled to "implemented, default-on, no scope knob".
+Phase 3 — Manifest scope override: dropped, not implemented. Embedding is
+always the self-contained full closure (see the finding above), so there is no
+embed-time scope to put in `wado.toml`. `wado wit --scope` remains the only
+place `local` / `full` is meaningful (text output). WIT Bundling's status is
+reconciled to "implemented, default-on, no scope knob".
 
 ## Open Design Questions
 

--- a/docs/wep-2026-05-02-wit-interoperability.md
+++ b/docs/wep-2026-05-02-wit-interoperability.md
@@ -365,20 +365,14 @@ the package's own contract; consumers need an external WIT registry to
 resolve `wasi:*` references. Both are well-defined; the choice is
 deployment-policy, not technical.
 
-The default scope is `full`. It needs no configuration and produces a
-self-describing component, which is the first-class outcome for both
-single-file scripts and manifest-backed projects (see "Embedding policy"
-below). A project may change the default to `local` in `wado.toml`:
+The default scope is `full`. The scope table above applies to **`wado wit`
+text** (`wado wit --scope <full|local>`).
 
-```toml
-[wit]
-scope = "local"   # override the built-in `full` default
-```
-
-`[wit].scope` only changes which scope is used; it never decides _whether_
-WIT is embedded (see "Embedding policy" below for that). When WIT _is_
-embedded, the scope resolution order is: explicit `--embed-wit=<scope>`,
-then `[wit].scope`, then the built-in `full`.
+> Revised in the Phase 2 finding: scope does **not** apply to embedding. An
+> embedded `component-type` must be self-contained, so it is always `full`; a
+> `local` section is not encodable. The earlier plan for a `[wit].scope`
+> manifest key and an `--embed-wit=<scope>` resolution order is therefore
+> dropped — see §"Phase 2 finding" and the Phase 3 entry.
 
 Stdlib interfaces under `lib/wasi/**` are emitted with the same machinery
 as user interfaces; there is no special-case "stdlib" code path. Each
@@ -450,19 +444,17 @@ Two roles, clearly separated:
   with `wac`, publishable with `wkg`, transpilable with `jco`, and
   consumable by another Wado compiler.
 
-Because a component without embedded WIT is a second-class CM citizen,
-and because Wado treats single-file scripts as first-class, **`wado
-compile` embeds WIT by default** — with or without a `wado.toml`. The
-manifest is a tuning knob for the _scope_ (`full` vs `local`), never the
-switch that turns embedding on. `--no-wit` is the single, explicit
-opt-out.
+Because Wado treats single-file scripts as first-class, **`wado compile`
+embeds WIT by default** — with or without a `wado.toml`. `--no-embed-wit`
+is the single, explicit opt-out. (The section is always the self-contained
+full closure; there is no scope knob — see the Phase 2 finding.)
 
 `-Os` is the exception: it is the production build for frontend delivery
 (`jco`-transpiled to core Wasm + JS for the browser), where the WIT
 metadata is dead weight that never reaches a CM host. So `-Os` defaults
-to no embedding, exactly as if `--no-wit` were passed. An explicit
-`--embed-wit=<scope>` still forces embedding under `-Os` for the rare
-case that wants both the smallest symbols and a self-describing component.
+to no embedding, exactly as if `--no-embed-wit` were passed. An explicit
+`--embed-wit` still forces embedding under `-Os` for the rare case that
+wants both the smallest symbols and a self-describing component.
 
 Embedding is a property of producing a distributable artifact, so it
 applies to `wado compile` only. `wado run`, `wado serve`, and `wado test`
@@ -496,15 +488,17 @@ Design Questions.
 `wado compile` — embed WIT in the compiled component (default on):
 
 ```sh
-wado compile file.wado                     # embeds, scope = full (default)
-wado compile --embed-wit=local file.wado   # embeds, user-only WIT, refs upstream
-wado compile --no-wit file.wado            # explicit opt-out
+wado compile file.wado                  # embeds (default)
+wado compile --no-embed-wit file.wado   # explicit opt-out
+wado compile --embed-wit file.wado      # force on (e.g. under -Os)
 ```
 
-`--embed-wit=<scope>` overrides the resolved scope for one invocation; it
-always takes a value (`full` or `local`), and `--embed-wit` without a
-value is a CLI error. `--no-wit` takes no value and is mutually exclusive
-with `--embed-wit`.
+> Revised in the Phase 2 finding: the embedded section is always the
+> self-contained full closure, so `wado compile` has no scope value. Both
+> `--embed-wit` and `--no-embed-wit` take no value and are mutually
+> exclusive. The `--embed-wit=<scope>` / `[wit].scope` knobs sketched in this
+> section's earlier draft were dropped; `local` / `full` survives only on
+> `wado wit --scope` (text output).
 
 ### Input resolution
 
@@ -571,11 +565,13 @@ Each phase ends with green E2E tests for the listed fixtures.
         `wit_component::metadata::encode` → custom-section append
         (`embed_component_type` / `encode_component_type`). `wit-parser` and
         `wit-component` moved into `wado-compiler`'s `[dependencies]`.
-  - [x] `--embed-wit=<scope>` and `--no-wit` flags on `CompileOptions`,
-        mutually exclusive; embedding defaults to `full` when neither is
-        given, except under `-Os` which defaults to no embedding (an
-        explicit `--embed-wit` still forces it). `wado run` / `serve` /
-        `test` never embed (they do not route through `compile::run`).
+  - [x] `--embed-wit` and `--no-embed-wit` flags on `CompileOptions`,
+        mutually exclusive and value-less; embedding is on by default except
+        under `-Os` which defaults off (an explicit `--embed-wit` still forces
+        it). The embedded section is always the self-contained full closure, so
+        there is no scope knob on `wado compile` (see the finding below).
+        `wado run` / `serve` / `test` never embed (they do not route through
+        `compile::run`).
   - [x] Hook: postprocess in the `wado compile` CLI path
         (`compile::maybe_embed_wit`), not in `compile_with_options`. This
         keeps the shared compile entry — used by `run`/`serve`/`test` —
@@ -589,7 +585,8 @@ Each phase ends with green E2E tests for the listed fixtures.
         `DecodedWasm::Component`), that embedding is byte-additive and leaves
         the component decodable, and that the encoded payload decodes as a
         standalone `DecodedWasm::WitPackage`. `compile::embed_policy_tests`
-        pins the default-on/`-Os`-off/`--no-wit`/`--embed-wit` resolution.
+        pins the default-on/`-Os`-off/`--no-embed-wit`/`--embed-wit`
+        resolution.
 
 #### Phase 2 finding: the component already self-describes
 
@@ -616,18 +613,19 @@ output; the round-trip therefore splits in two: (a) `decode(component)` matches
 Consequence for scope: an embedded section must be self-contained, because
 `metadata::encode` types the world against a fully-resolved `Resolve`. So
 embedding always emits the **full** interface closure; a `local`
-(registry-referencing) document does not re-parse standalone. `local` scope
-stays meaningful for `wado wit` _text_ only — `--embed-wit=local` is accepted
-but produces the same self-contained section as `full`.
+(registry-referencing) document does not re-parse standalone. This is a Wasm CM
+binary property (component types are structural and self-contained), not a Wado
+choice. `local` / `full` therefore stays a `wado wit` _text_ concept (`wado wit
+--scope`) only. Consequently `wado compile` carries **no scope knob**:
+`--embed-wit` / `--no-embed-wit` take no value, and the originally-planned
+`[wit].scope` manifest override (Phase 3) is dropped — it would have nothing to
+tune for the binary.
 
-- [ ] Phase 3 — Manifest scope override
-  - [ ] Parse `[wit].scope` in `wado-manifest`.
-  - [ ] `wado compile` uses `[wit].scope` as the scope when no CLI flag is
-        given; the built-in default stays `full`; `--embed-wit` overrides
-        the manifest; `--no-wit` opts out entirely.
-  - [ ] Update WEP: WIT Bundling status from "designed" to "implemented"
-        and reconcile its wording with the default-on, manifest-tunes-scope
-        rule documented here.
+- [x] Phase 3 — Manifest scope override: **dropped.** Embedding is always the
+      self-contained full closure (see the finding above), so there is no
+      embed-time scope to put in `wado.toml`. `wado wit --scope` remains the
+      only place `local` / `full` is meaningful (text output). WIT Bundling's
+      status is reconciled to "implemented, default-on, no scope knob".
 
 ## Open Design Questions
 
@@ -733,12 +731,13 @@ will get one when work starts.
       (`import Foo;` / `export Foo;`); brace-form removed. `WorldImportInfo`
       and `WorldExportInfo` carry `cm_interface_fq` resolved from the
       referenced `pub interface Foo`'s `#[cm(...)]`.
-- [~] Producer side: emit WIT text and embed `component-type` in output
-  (WEP: WIT Bundling for the format; this WEP §"Producer Side: WIT
-  Generation and Embedding" for the detailed design). Phase 0
-  (`Semantics` refactor), Phase 1 (`wado wit` text), and Phase 2
-  (`wado compile` embeds WIT by default, scope `full`, `--no-wit` to opt
-  out) are done. Phase 3 (`[wit].scope` in `wado.toml`) remains.
+- [x] Producer side: emit WIT text and embed `component-type` in output
+      (WEP: WIT Bundling for the format; this WEP §"Producer Side: WIT
+      Generation and Embedding" for the detailed design). Phase 0
+      (`Semantics` refactor), Phase 1 (`wado wit` text), and Phase 2
+      (`wado compile` embeds WIT by default, full closure, `--no-embed-wit` to
+      opt out) are done. Phase 3 (`[wit].scope` in `wado.toml`) was dropped —
+      embedding is always self-contained, so there is no embed-time scope to tune.
 - [ ] Decide world structure faithfulness level (L2 vs L3) and document.
 - [ ] Implement `contract` declaration with the chosen scope rules (revise
       WEP: World Conformance accordingly).

--- a/docs/wep-2026-05-02-wit-interoperability.md
+++ b/docs/wep-2026-05-02-wit-interoperability.md
@@ -190,14 +190,15 @@ form is unambiguous and minimal.
   embedded WIT directly.
 - `wado-compiler` still relies on `wado-from-idl`-generated `.wado` files as
   the source of truth; no path reads embedded WIT from external `.wasm` yet
-  (consumer side, still open). `wit-parser` and `wit-encoder` are wired into
-  `wado-compiler` for the producer side; `wit-component` lands with Phase 2
-  embedding and the consumer-side `component-type` reader.
-- Producer-side WIT embedding (the `component-type` custom section described
-  in [WIT Bundling](./wep-2026-03-21-wit-bundling.md)) is not yet wired into
-  codegen (Phase 2). `wado wit` text emission (Phase 1) is done, so the
-  contract is computable; embedding it into the binary is the remaining step
-  before a Wado component is consumable via the embedded-WIT path.
+  (consumer side, still open). `wit-parser`, `wit-encoder`, and `wit-component`
+  are all in `wado-compiler`'s `[dependencies]` for the producer side; the
+  consumer-side `component-type` reader still reuses these crates when it lands.
+- Producer-side WIT embedding (the `component-type` custom section described in
+  [WIT Bundling](./wep-2026-03-21-wit-bundling.md)) is **done** (Phase 2):
+  `wado compile` embeds by default via `wit_bundle::embed_component_type`. Note
+  the Phase 2 finding below — the Wado component is already self-describing, so
+  the section is additive full-fidelity metadata rather than the inspection
+  mechanism.
 
 Resolved since the first draft: HTTP handler specialization in
 `codegen/component.rs` is gone — CM imports/exports are now emitted from the
@@ -429,9 +430,14 @@ The section payload matches `wit_component::metadata::encode()` exactly:
    string encoding).
 3. A `producers` subsection identifying the Wado compiler version.
 
-Consumers extract via `wasm-tools component wit output.wasm`. Round-trip
-verification (Wado emits → wasm-tools decodes → matches the text from
-`wado wit`) is a required fixture for every world shape.
+Consumers run `wasm-tools component wit output.wasm`, but note (per the Phase 2
+finding above) that for a Wado _component_ this reconstructs WIT from the
+component's own type, **not** from the appended `component-type` section. The
+embedded section is consumed by tools that read it explicitly (`wkg`,
+`wasm-tools metadata`, relink flows) and decodes standalone as a WIT package.
+Round-trip verification therefore splits: (a) `decode(component)` matches
+`wado wit` semantically, and (b) the embedded payload decodes as a
+`DecodedWasm::WitPackage`. Both are covered by `tests/wit_bundle.rs`.
 
 ### Embedding policy
 
@@ -560,19 +566,59 @@ Each phase ends with green E2E tests for the listed fixtures.
     `default_interface_name`) instead. Only `wit-parser` and `wit-encoder` are
     pulled into `wado-compiler`; `wit-component` lands with Phase 2.
 
-- [ ] Phase 2 — `wado compile` embedding (default on, scope `full`)
-  - [ ] `wado-compiler/src/wit_bundle.rs`: text → `Resolve` →
-        `wit_component::metadata::encode` → custom-section append.
-  - [ ] `--embed-wit=<scope>` and `--no-wit` flags on `CompileOptions`,
+- [x] Phase 2 — `wado compile` embedding (default on, scope `full`)
+  - [x] `wado-compiler/src/wit_bundle.rs`: text → `Resolve` →
+        `wit_component::metadata::encode` → custom-section append
+        (`embed_component_type` / `encode_component_type`). `wit-parser` and
+        `wit-component` moved into `wado-compiler`'s `[dependencies]`.
+  - [x] `--embed-wit=<scope>` and `--no-wit` flags on `CompileOptions`,
         mutually exclusive; embedding defaults to `full` when neither is
         given, except under `-Os` which defaults to no embedding (an
         explicit `--embed-wit` still forces it). `wado run` / `serve` /
-        `test` never embed.
-  - [ ] Postprocess hook in `codegen/postprocess.rs` (or the immediate
-        caller of `build_component`).
-  - [ ] Round-trip fixture: for every Phase 1 fixture, compile (default
-        `full`), then run `wasm-tools component wit` on the output and
-        assert it matches `wado wit`.
+        `test` never embed (they do not route through `compile::run`).
+  - [x] Hook: postprocess in the `wado compile` CLI path
+        (`compile::maybe_embed_wit`), not in `compile_with_options`. This
+        keeps the shared compile entry — used by `run`/`serve`/`test` —
+        embedding-free, matching "applies to `wado compile` only". The
+        faithful world import set comes from the same `resolve_world_imports`
+        the `wado wit` path uses; `Semantics` is re-derived with one extra
+        frontend pass (`wado_compiler::semantics`), since
+        `compile_with_options` consumes its own `Semantics` into `Package`.
+  - [x] Tests: `tests/wit_bundle.rs` asserts, per world shape, that the
+        un-embedded component already self-describes (`decode` →
+        `DecodedWasm::Component`), that embedding is byte-additive and leaves
+        the component decodable, and that the encoded payload decodes as a
+        standalone `DecodedWasm::WitPackage`. `compile::embed_policy_tests`
+        pins the default-on/`-Os`-off/`--no-wit`/`--embed-wit` resolution.
+
+#### Phase 2 finding: the component already self-describes
+
+A Wado artifact is a _full Component Model component_, not a core module, so it
+is already self-describing: `wit_parser::decode` (the `wasm-tools component wit`
+backend) reconstructs the WIT from the component's own typed CM imports/exports
+via its `decode_component` path — verified empirically on the CLI corpus. `decode`
+only consults a `component-type` payload when the _whole file_ is a WIT-package
+blob (`is_wit_package()` keys off top-level component-type exports); a
+`component-type` custom section on an already-formed component is opaquely
+carried, **never read** by `component wit`.
+
+The embedded section is therefore _additive full-fidelity metadata_, not the
+mechanism that makes the binary inspectable. Its value over the intrinsic type:
+the component's own type is always tree-shaken to the used surface, whereas the
+embedded payload carries the complete upstream interface bodies, exact package
+versions, and a `producers` record (the `metadata::encode` convention `wkg` /
+`wasm-tools metadata` / relink flows consume). The earlier framing in
+[WIT Bundling](./wep-2026-03-21-wit-bundling.md) ("a standalone `.wasm` cannot
+describe its own interface") holds for core modules, not for Wado's component
+output; the round-trip therefore splits in two: (a) `decode(component)` matches
+`wado wit` semantically, and (b) the embedded payload decodes as a WIT package.
+
+Consequence for scope: an embedded section must be self-contained, because
+`metadata::encode` types the world against a fully-resolved `Resolve`. So
+embedding always emits the **full** interface closure; a `local`
+(registry-referencing) document does not re-parse standalone. `local` scope
+stays meaningful for `wado wit` _text_ only — `--embed-wit=local` is accepted
+but produces the same self-contained section as `full`.
 
 - [ ] Phase 3 — Manifest scope override
   - [ ] Parse `[wit].scope` in `wado-manifest`.
@@ -687,12 +733,12 @@ will get one when work starts.
       (`import Foo;` / `export Foo;`); brace-form removed. `WorldImportInfo`
       and `WorldExportInfo` carry `cm_interface_fq` resolved from the
       referenced `pub interface Foo`'s `#[cm(...)]`.
-- [ ] Producer side: emit WIT text and embed `component-type` in output
-      (WEP: WIT Bundling for the format; this WEP §"Producer Side: WIT
-      Generation and Embedding" for the detailed design). Phase 0
-      (`Semantics` refactor) and Phase 1 (`wado wit` text) are done; Phase 2
-      (`wado compile` embeds WIT by default, scope `full`, `--no-wit` to opt
-      out) and Phase 3 (`[wit].scope` in `wado.toml`) remain.
+- [~] Producer side: emit WIT text and embed `component-type` in output
+  (WEP: WIT Bundling for the format; this WEP §"Producer Side: WIT
+  Generation and Embedding" for the detailed design). Phase 0
+  (`Semantics` refactor), Phase 1 (`wado wit` text), and Phase 2
+  (`wado compile` embeds WIT by default, scope `full`, `--no-wit` to opt
+  out) are done. Phase 3 (`[wit].scope` in `wado.toml`) remains.
 - [ ] Decide world structure faithfulness level (L2 vs L3) and document.
 - [ ] Implement `contract` declaration with the chosen scope rules (revise
       WEP: World Conformance accordingly).

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -93,43 +93,44 @@ pub struct CompileOptions {
     pub param_overrides: wado_compiler::hashmap::IndexMap<String, String>,
     /// `--param-*` policy levels.
     pub param_policy: wado_compiler::param_resolution::ParamPolicy,
-    /// `--no-wit`: opt out of embedding the `component-type` WIT section.
-    pub no_wit: bool,
-    /// `--embed-wit=<scope>`: force embedding at this scope, overriding the
-    /// default-on resolution (and the `-Os` default-off). Mutually exclusive
-    /// with `--no-wit`.
-    pub embed_wit: Option<WitScope>,
+    /// `--no-embed-wit`: opt out of embedding the `component-type` WIT section.
+    pub no_embed_wit: bool,
+    /// `--embed-wit`: force embedding on, overriding the `-Os` default-off.
+    /// Takes no value — the embedded section is always the self-contained full
+    /// closure (a `local`, registry-referencing section is not encodable; see
+    /// WEP §"Phase 2 finding"). Mutually exclusive with `--no-embed-wit`.
+    pub embed_wit: bool,
 }
 
 impl CompileOptions {
-    /// Resolve whether to embed the `component-type` WIT section, and at what
-    /// scope. Returns `(scope, explicit)`; `explicit` is true when the user
-    /// passed `--embed-wit`, so an embedding failure is fatal rather than a
-    /// warning. Embedding is default-on except under `-Os` (frontend delivery,
-    /// where the WIT metadata never reaches a CM host). See WEP
+    /// Resolve whether to embed the `component-type` WIT section. Returns
+    /// `Some(explicit)`, where `explicit` is true when the user passed
+    /// `--embed-wit` (so an embedding failure is fatal rather than a warning),
+    /// or `None` to skip. Embedding is default-on except under `-Os` (frontend
+    /// delivery, where the WIT metadata never reaches a CM host). See WEP
     /// `wep-2026-05-02-wit-interoperability.md` §"Embedding policy".
-    fn embed_decision(&self) -> Option<(WitScope, bool)> {
-        resolve_embed_decision(self.no_wit, self.embed_wit, self.opt_level)
+    fn embed_decision(&self) -> Option<bool> {
+        resolve_embed_decision(self.no_embed_wit, self.embed_wit, self.opt_level)
     }
 }
 
 /// Pure embedding-policy resolution, factored out of [`CompileOptions`] for
 /// testing. See [`CompileOptions::embed_decision`].
 fn resolve_embed_decision(
-    no_wit: bool,
-    embed_wit: Option<WitScope>,
+    no_embed_wit: bool,
+    embed_wit: bool,
     opt_level: OptLevel,
-) -> Option<(WitScope, bool)> {
-    if no_wit {
+) -> Option<bool> {
+    if no_embed_wit {
         return None;
     }
-    if let Some(scope) = embed_wit {
-        return Some((scope, true));
+    if embed_wit {
+        return Some(true);
     }
     if opt_level == OptLevel::Os {
         return None;
     }
-    Some((WitScope::Full, false))
+    Some(false)
 }
 
 /// Compile-time options shared by `compile`/`run`/`serve`/`test`.
@@ -204,7 +205,7 @@ enum Opt {
     NoCache,
     Allocator,
     Feature,
-    NoWit,
+    NoEmbedWit,
     EmbedWit,
     Help,
 }
@@ -224,7 +225,7 @@ impl Opt {
         Self::NoCache,
         Self::Allocator,
         Self::Feature,
-        Self::NoWit,
+        Self::NoEmbedWit,
         Self::EmbedWit,
         Self::Help,
     ];
@@ -264,8 +265,8 @@ impl Opt {
             Self::NoCache => args::NO_CACHE_SPEC,
             Self::Allocator => args::ALLOCATOR_SPEC,
             Self::Feature => args::FEATURE_SPEC,
-            Self::NoWit => args::OptSpec {
-                long: Some("no-wit"),
+            Self::NoEmbedWit => args::OptSpec {
+                long: Some("no-embed-wit"),
                 short: None,
                 value: None,
                 desc: "Do not embed the WIT `component-type` section in the output",
@@ -273,8 +274,8 @@ impl Opt {
             Self::EmbedWit => args::OptSpec {
                 long: Some("embed-wit"),
                 short: None,
-                value: Some("<full|local>"),
-                desc: "Embed WIT at this scope, forcing it on (default: full, off under -Os)",
+                value: None,
+                desc: "Force embedding the WIT section on (e.g. under -Os, where it is off by default)",
             },
             Self::Help => args::HELP_SPEC,
         }
@@ -318,8 +319,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     let mut codegen_flags: Vec<String> = Vec::new();
     let mut no_cache = false;
     let mut lib = false;
-    let mut no_wit = false;
-    let mut embed_wit: Option<WitScope> = None;
+    let mut no_embed_wit = false;
+    let mut embed_wit = false;
     let mut param_args = args::ParamArgs::default();
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(p) = args::match_opt(&arg, args::ParamOpt::ALL, |p| p.spec()) {
@@ -356,19 +357,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
                     allocator = Some(args::require_string(&mut parser)?);
                 }
                 Opt::Feature => codegen_flags.push(args::require_string(&mut parser)?),
-                Opt::NoWit => no_wit = true,
-                Opt::EmbedWit => {
-                    let value = args::require_string(&mut parser)?;
-                    embed_wit = Some(match value.as_str() {
-                        "full" => WitScope::Full,
-                        "local" => WitScope::Local,
-                        other => {
-                            return Err(CliExit::error(format!(
-                                "unknown --embed-wit value '{other}' (expected 'full' or 'local')"
-                            )));
-                        }
-                    });
-                }
+                Opt::NoEmbedWit => no_embed_wit = true,
+                Opt::EmbedWit => embed_wit = true,
                 Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
@@ -385,9 +375,9 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
         ));
     }
 
-    if no_wit && embed_wit.is_some() {
+    if no_embed_wit && embed_wit {
         return Err(CliExit::error(
-            "`--no-wit` and `--embed-wit` are mutually exclusive",
+            "`--no-embed-wit` and `--embed-wit` are mutually exclusive",
         ));
     }
 
@@ -421,7 +411,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
         lib_world,
         param_overrides: param_args.overrides,
         param_policy: param_args.policy,
-        no_wit,
+        no_embed_wit,
         embed_wit,
     })
 }
@@ -958,7 +948,7 @@ fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
 /// valid, self-describing artifact, so a non-explicit embedding failure warns
 /// and yields the un-embedded bytes; an explicit `--embed-wit` makes it fatal.
 async fn maybe_embed_wit(opts: &CompileOptions, wasm: Vec<u8>) -> Result<Vec<u8>, CliExit> {
-    let Some((scope, explicit)) = opts.embed_decision() else {
+    let Some(explicit) = opts.embed_decision() else {
         return Ok(wasm);
     };
 
@@ -987,8 +977,10 @@ async fn maybe_embed_wit(opts: &CompileOptions, wasm: Vec<u8>) -> Result<Vec<u8>
         return Ok(wasm);
     }
 
+    // Embedding always uses the full, self-contained closure (`wit_bundle`
+    // re-forces this); a `local` section is not encodable.
     let emit_opts = WitEmitOptions {
-        scope,
+        scope: WitScope::Full,
         world_fq: world.clone(),
         default_interface_name: crate::wit::default_interface_name(input),
         world_imports: crate::wit::resolve_world_imports(&source, input, &world).await,
@@ -1049,35 +1041,35 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
 
 #[cfg(test)]
 mod embed_policy_tests {
-    use super::{OptLevel, WitScope, resolve_embed_decision};
+    use super::{OptLevel, resolve_embed_decision};
 
     #[test]
-    fn default_on_full_except_os() {
-        // Default (no flags): embed at full, non-explicit.
+    fn default_on_except_os() {
+        // Default (no flags): embed, non-explicit.
         assert_eq!(
-            resolve_embed_decision(false, None, OptLevel::O2),
-            Some((WitScope::Full, false))
+            resolve_embed_decision(false, false, OptLevel::O2),
+            Some(false)
         );
         // `-Os`: default off (frontend delivery; WIT is dead weight).
-        assert_eq!(resolve_embed_decision(false, None, OptLevel::Os), None);
+        assert_eq!(resolve_embed_decision(false, false, OptLevel::Os), None);
     }
 
     #[test]
-    fn no_wit_opts_out_everywhere() {
-        assert_eq!(resolve_embed_decision(true, None, OptLevel::O2), None);
-        assert_eq!(resolve_embed_decision(true, None, OptLevel::Os), None);
+    fn no_embed_wit_opts_out_everywhere() {
+        assert_eq!(resolve_embed_decision(true, false, OptLevel::O2), None);
+        assert_eq!(resolve_embed_decision(true, false, OptLevel::Os), None);
     }
 
     #[test]
     fn explicit_embed_wit_forces_on_even_under_os() {
-        // Explicit scope is marked explicit=true so failures become fatal.
+        // `--embed-wit` marks the decision explicit, so failures become fatal.
         assert_eq!(
-            resolve_embed_decision(false, Some(WitScope::Local), OptLevel::O2),
-            Some((WitScope::Local, true))
+            resolve_embed_decision(false, true, OptLevel::O2),
+            Some(true)
         );
         assert_eq!(
-            resolve_embed_decision(false, Some(WitScope::Full), OptLevel::Os),
-            Some((WitScope::Full, true))
+            resolve_embed_decision(false, true, OptLevel::Os),
+            Some(true)
         );
     }
 }

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -167,6 +167,10 @@ pub struct CompileFlags {
     pub param_overrides: wado_compiler::hashmap::IndexMap<String, String>,
     /// `--param-*` policy levels. Forwarded to `CompilerOptions::param_policy`.
     pub param_policy: wado_compiler::param_resolution::ParamPolicy,
+    /// Retain the WIR module in the result. `wado compile` sets it when
+    /// embedding WIT, to read the faithful import plan
+    /// (`imported_cm_interfaces`) without a second compile.
+    pub retain_wir: bool,
 }
 
 impl CompileOptions {
@@ -186,6 +190,7 @@ impl CompileOptions {
             lib_world: self.lib_world.clone(),
             param_overrides: self.param_overrides.clone(),
             param_policy: self.param_policy,
+            retain_wir: false,
         }
     }
 }
@@ -515,6 +520,7 @@ pub async fn try_compile_with_kiln_cache(
         lib_world: flags.lib_world.clone(),
         param_overrides: flags.param_overrides.clone(),
         param_policy: flags.param_policy,
+        retain_wir: flags.retain_wir,
         ..Default::default()
     };
 
@@ -943,47 +949,57 @@ fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
     Ok(wat)
 }
 
-/// Embed the WIT `component-type` section into `wasm` per `opts.embed_decision`,
-/// or return `wasm` unchanged when embedding is off. The component is already a
-/// valid, self-describing artifact, so a non-explicit embedding failure warns
-/// and yields the un-embedded bytes; an explicit `--embed-wit` makes it fatal.
-async fn maybe_embed_wit(opts: &CompileOptions, wasm: Vec<u8>) -> Result<Vec<u8>, CliExit> {
-    let Some(explicit) = opts.embed_decision() else {
-        return Ok(wasm);
-    };
-
+/// Append the WIT `component-type` section to `wasm`, using `world_imports`
+/// (the faithful plan read from the main compile's retained WIR, so no second
+/// optimize pass). `explicit` is true for `--embed-wit`: it makes a failure
+/// fatal, where the default-on path only warns and yields the un-embedded
+/// (still valid, self-describing) component.
+async fn embed_wit_section(
+    opts: &CompileOptions,
+    wasm: Vec<u8>,
+    world_imports: Vec<String>,
+    explicit: bool,
+) -> Result<Vec<u8>, CliExit> {
     let input = &opts.input;
-    let Ok(source) = fs::read_to_string(input) else {
+    let path = Path::new(input);
+    let Ok(source) = fs::read_to_string(path) else {
         // The file compiled moments ago; an unreadable source now is unexpected.
         return Ok(wasm);
     };
 
     // The embedded world FQ mirrors what was compiled: the `--lib` world, then
-    // `--world`, then the CLI default — matching `wado wit`.
+    // `--world`, then the CLI default.
     let world = opts
         .lib_world
         .clone()
         .or_else(|| opts.target_world.clone())
         .unwrap_or_else(|| "wasi:cli/command".to_string());
 
-    let base_path = Path::new(input)
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_default();
-    // Quiet host: diagnostics were already surfaced by the main compile.
-    let host = FilesystemCompilerHost::silent(base_path);
+    let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
+    // Attach the manifest `[dependencies]` so a multi-package project's
+    // re-analysis resolves the same imports the main compile did; a quiet host
+    // avoids re-emitting diagnostics.
+    let manifest_pair = load_nearest_manifest(path);
+    let host = attach_manifest_deps(
+        FilesystemCompilerHost::silent(base_path.clone()),
+        manifest_pair.as_ref(),
+        &base_path,
+    );
     let sem = wado_compiler::semantics(&source, &host, Some(input)).await;
     if !sem.is_complete() {
+        let msg = "WIT analysis did not complete";
+        if explicit {
+            return Err(CliExit::error(format!("--embed-wit: {msg}")));
+        }
+        eprintln!("warning: skipped embedding WIT component-type section: {msg}");
         return Ok(wasm);
     }
 
-    // Embedding always uses the full, self-contained closure (`wit_bundle`
-    // re-forces this); a `local` section is not encodable.
     let emit_opts = WitEmitOptions {
         scope: WitScope::Full,
-        world_fq: world.clone(),
+        world_fq: world,
         default_interface_name: crate::wit::default_interface_name(input),
-        world_imports: crate::wit::resolve_world_imports(&source, input, &world).await,
+        world_imports,
     };
 
     match wit_bundle::embed_component_type(&wasm, &sem, &emit_opts) {
@@ -997,16 +1013,8 @@ async fn maybe_embed_wit(opts: &CompileOptions, wasm: Vec<u8>) -> Result<Vec<u8>
 }
 
 pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
-    let flags = opts.flags();
-    let wasm = compile(&opts.input, &flags).await?;
-
-    if opts.wat_to_stdout {
-        let wat = wasm_to_wat(&wasm)?;
-        print!("{wat}");
-        return Ok(());
-    }
-
-    // Format precedence: explicit `--format` > guessed from `-o` extension > wasm.
+    // Output format is independent of the compiled bytes; resolve it first so we
+    // know whether to retain WIR (only the wasm-output embedding path needs it).
     let format = opts
         .format
         .or_else(|| {
@@ -1015,6 +1023,23 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
                 .and_then(|p| OutputFormat::from_extension(Path::new(p)))
         })
         .unwrap_or(OutputFormat::Wasm);
+    // WAT is a debug/inspection format, so it is left un-embedded.
+    let embed = (!opts.wat_to_stdout && format == OutputFormat::Wasm)
+        .then(|| opts.embed_decision())
+        .flatten();
+
+    let mut flags = opts.flags();
+    flags.retain_wir = embed.is_some();
+    let result = try_compile(&opts.input, &flags)
+        .await
+        .map_err(|_| CliExit::silent_failure(1))?;
+    let wasm = result.wasm;
+
+    if opts.wat_to_stdout {
+        let wat = wasm_to_wat(&wasm)?;
+        print!("{wat}");
+        return Ok(());
+    }
 
     let output_path = if let Some(path) = &opts.output {
         Path::new(path).to_path_buf()
@@ -1026,12 +1051,16 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
         Path::new(&opts.input).with_extension(ext)
     };
 
-    let bytes = match format {
-        // Embed the WIT `component-type` section into the distributable wasm
-        // artifact (default on). WAT output is an inspection/debug format, so it
-        // is left un-embedded to keep the text readable.
-        OutputFormat::Wasm => maybe_embed_wit(&opts, wasm).await?,
-        OutputFormat::Wat => wasm_to_wat(&wasm)?.into_bytes(),
+    let bytes = match (format, embed) {
+        (OutputFormat::Wasm, Some(explicit)) => {
+            let world_imports = result
+                .wir_package
+                .map(|p| p.imported_cm_interfaces)
+                .unwrap_or_default();
+            embed_wit_section(&opts, wasm, world_imports, explicit).await?
+        }
+        (OutputFormat::Wasm, None) => wasm,
+        (OutputFormat::Wat, _) => wasm_to_wat(&wasm)?.into_bytes(),
     };
     fs::write(&output_path, &bytes)
         .map_err(|e| CliExit::error(format!("writing output file: {e}")))?;

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -8,6 +8,8 @@ use wado_manifest::DependencySource;
 use lexopt::Arg::Value;
 use lexopt::Parser;
 use wado_compiler::LogLevel;
+use wado_compiler::wit_bundle;
+use wado_compiler::wit_emit::{WitEmitOptions, WitScope};
 
 use crate::args::{self, CliExit};
 use crate::compiler_host::{FilesystemCompilerHost, KilnComponentCache};
@@ -91,6 +93,43 @@ pub struct CompileOptions {
     pub param_overrides: wado_compiler::hashmap::IndexMap<String, String>,
     /// `--param-*` policy levels.
     pub param_policy: wado_compiler::param_resolution::ParamPolicy,
+    /// `--no-wit`: opt out of embedding the `component-type` WIT section.
+    pub no_wit: bool,
+    /// `--embed-wit=<scope>`: force embedding at this scope, overriding the
+    /// default-on resolution (and the `-Os` default-off). Mutually exclusive
+    /// with `--no-wit`.
+    pub embed_wit: Option<WitScope>,
+}
+
+impl CompileOptions {
+    /// Resolve whether to embed the `component-type` WIT section, and at what
+    /// scope. Returns `(scope, explicit)`; `explicit` is true when the user
+    /// passed `--embed-wit`, so an embedding failure is fatal rather than a
+    /// warning. Embedding is default-on except under `-Os` (frontend delivery,
+    /// where the WIT metadata never reaches a CM host). See WEP
+    /// `wep-2026-05-02-wit-interoperability.md` §"Embedding policy".
+    fn embed_decision(&self) -> Option<(WitScope, bool)> {
+        resolve_embed_decision(self.no_wit, self.embed_wit, self.opt_level)
+    }
+}
+
+/// Pure embedding-policy resolution, factored out of [`CompileOptions`] for
+/// testing. See [`CompileOptions::embed_decision`].
+fn resolve_embed_decision(
+    no_wit: bool,
+    embed_wit: Option<WitScope>,
+    opt_level: OptLevel,
+) -> Option<(WitScope, bool)> {
+    if no_wit {
+        return None;
+    }
+    if let Some(scope) = embed_wit {
+        return Some((scope, true));
+    }
+    if opt_level == OptLevel::Os {
+        return None;
+    }
+    Some((WitScope::Full, false))
 }
 
 /// Compile-time options shared by `compile`/`run`/`serve`/`test`.
@@ -165,6 +204,8 @@ enum Opt {
     NoCache,
     Allocator,
     Feature,
+    NoWit,
+    EmbedWit,
     Help,
 }
 
@@ -183,6 +224,8 @@ impl Opt {
         Self::NoCache,
         Self::Allocator,
         Self::Feature,
+        Self::NoWit,
+        Self::EmbedWit,
         Self::Help,
     ];
 
@@ -221,6 +264,18 @@ impl Opt {
             Self::NoCache => args::NO_CACHE_SPEC,
             Self::Allocator => args::ALLOCATOR_SPEC,
             Self::Feature => args::FEATURE_SPEC,
+            Self::NoWit => args::OptSpec {
+                long: Some("no-wit"),
+                short: None,
+                value: None,
+                desc: "Do not embed the WIT `component-type` section in the output",
+            },
+            Self::EmbedWit => args::OptSpec {
+                long: Some("embed-wit"),
+                short: None,
+                value: Some("<full|local>"),
+                desc: "Embed WIT at this scope, forcing it on (default: full, off under -Os)",
+            },
             Self::Help => args::HELP_SPEC,
         }
     }
@@ -263,6 +318,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     let mut codegen_flags: Vec<String> = Vec::new();
     let mut no_cache = false;
     let mut lib = false;
+    let mut no_wit = false;
+    let mut embed_wit: Option<WitScope> = None;
     let mut param_args = args::ParamArgs::default();
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(p) = args::match_opt(&arg, args::ParamOpt::ALL, |p| p.spec()) {
@@ -299,6 +356,19 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
                     allocator = Some(args::require_string(&mut parser)?);
                 }
                 Opt::Feature => codegen_flags.push(args::require_string(&mut parser)?),
+                Opt::NoWit => no_wit = true,
+                Opt::EmbedWit => {
+                    let value = args::require_string(&mut parser)?;
+                    embed_wit = Some(match value.as_str() {
+                        "full" => WitScope::Full,
+                        "local" => WitScope::Local,
+                        other => {
+                            return Err(CliExit::error(format!(
+                                "unknown --embed-wit value '{other}' (expected 'full' or 'local')"
+                            )));
+                        }
+                    });
+                }
                 Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
@@ -312,6 +382,12 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     if lib && target_world.is_some() {
         return Err(CliExit::error(
             "`--lib` and `--world` are mutually exclusive",
+        ));
+    }
+
+    if no_wit && embed_wit.is_some() {
+        return Err(CliExit::error(
+            "`--no-wit` and `--embed-wit` are mutually exclusive",
         ));
     }
 
@@ -345,6 +421,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
         lib_world,
         param_overrides: param_args.overrides,
         param_policy: param_args.policy,
+        no_wit,
+        embed_wit,
     })
 }
 
@@ -875,6 +953,57 @@ fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
     Ok(wat)
 }
 
+/// Embed the WIT `component-type` section into `wasm` per `opts.embed_decision`,
+/// or return `wasm` unchanged when embedding is off. The component is already a
+/// valid, self-describing artifact, so a non-explicit embedding failure warns
+/// and yields the un-embedded bytes; an explicit `--embed-wit` makes it fatal.
+async fn maybe_embed_wit(opts: &CompileOptions, wasm: Vec<u8>) -> Result<Vec<u8>, CliExit> {
+    let Some((scope, explicit)) = opts.embed_decision() else {
+        return Ok(wasm);
+    };
+
+    let input = &opts.input;
+    let Ok(source) = fs::read_to_string(input) else {
+        // The file compiled moments ago; an unreadable source now is unexpected.
+        return Ok(wasm);
+    };
+
+    // The embedded world FQ mirrors what was compiled: the `--lib` world, then
+    // `--world`, then the CLI default — matching `wado wit`.
+    let world = opts
+        .lib_world
+        .clone()
+        .or_else(|| opts.target_world.clone())
+        .unwrap_or_else(|| "wasi:cli/command".to_string());
+
+    let base_path = Path::new(input)
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_default();
+    // Quiet host: diagnostics were already surfaced by the main compile.
+    let host = FilesystemCompilerHost::silent(base_path);
+    let sem = wado_compiler::semantics(&source, &host, Some(input)).await;
+    if !sem.is_complete() {
+        return Ok(wasm);
+    }
+
+    let emit_opts = WitEmitOptions {
+        scope,
+        world_fq: world.clone(),
+        default_interface_name: crate::wit::default_interface_name(input),
+        world_imports: crate::wit::resolve_world_imports(&source, input, &world).await,
+    };
+
+    match wit_bundle::embed_component_type(&wasm, &sem, &emit_opts) {
+        Ok(embedded) => Ok(embedded),
+        Err(e) if explicit => Err(CliExit::error(format!("--embed-wit: {e}"))),
+        Err(e) => {
+            eprintln!("warning: skipped embedding WIT component-type section: {e}");
+            Ok(wasm)
+        }
+    }
+}
+
 pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
     let flags = opts.flags();
     let wasm = compile(&opts.input, &flags).await?;
@@ -906,13 +1035,51 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
     };
 
     let bytes = match format {
-        OutputFormat::Wasm => wasm,
+        // Embed the WIT `component-type` section into the distributable wasm
+        // artifact (default on). WAT output is an inspection/debug format, so it
+        // is left un-embedded to keep the text readable.
+        OutputFormat::Wasm => maybe_embed_wit(&opts, wasm).await?,
         OutputFormat::Wat => wasm_to_wat(&wasm)?.into_bytes(),
     };
     fs::write(&output_path, &bytes)
         .map_err(|e| CliExit::error(format!("writing output file: {e}")))?;
     eprintln!("Generated: {}", output_path.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod embed_policy_tests {
+    use super::{OptLevel, WitScope, resolve_embed_decision};
+
+    #[test]
+    fn default_on_full_except_os() {
+        // Default (no flags): embed at full, non-explicit.
+        assert_eq!(
+            resolve_embed_decision(false, None, OptLevel::O2),
+            Some((WitScope::Full, false))
+        );
+        // `-Os`: default off (frontend delivery; WIT is dead weight).
+        assert_eq!(resolve_embed_decision(false, None, OptLevel::Os), None);
+    }
+
+    #[test]
+    fn no_wit_opts_out_everywhere() {
+        assert_eq!(resolve_embed_decision(true, None, OptLevel::O2), None);
+        assert_eq!(resolve_embed_decision(true, None, OptLevel::Os), None);
+    }
+
+    #[test]
+    fn explicit_embed_wit_forces_on_even_under_os() {
+        // Explicit scope is marked explicit=true so failures become fatal.
+        assert_eq!(
+            resolve_embed_decision(false, Some(WitScope::Local), OptLevel::O2),
+            Some((WitScope::Local, true))
+        );
+        assert_eq!(
+            resolve_embed_decision(false, Some(WitScope::Full), OptLevel::Os),
+            Some((WitScope::Full, true))
+        );
+    }
 }
 
 #[cfg(test)]

--- a/wado-cli/src/run.rs
+++ b/wado-cli/src/run.rs
@@ -368,6 +368,7 @@ pub async fn run(opts: RunOptions) -> Result<(), CliExit> {
         lib_world: None,
         param_overrides: opts.param_overrides,
         param_policy: opts.param_policy,
+        retain_wir: false,
     };
     let cranelift_opt = opts.opt_level.to_wasmtime();
     let wasm = compile::compile(&opts.input, &flags).await?;

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -1195,6 +1195,7 @@ pub async fn run(opts: ServeOptions) -> Result<(), CliExit> {
         lib_world: None,
         param_overrides: opts.param_overrides.clone(),
         param_policy: opts.param_policy,
+        retain_wir: false,
     };
     let cranelift_opt = opts.opt_level.to_wasmtime();
     let wasm = compile::compile(&opts.input, &flags).await?;

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -76,6 +76,7 @@ impl TestOptions {
             lib_world: None,
             param_overrides: self.param_overrides.clone(),
             param_policy: self.param_policy,
+            retain_wir: false,
         }
     }
 }

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -165,7 +165,7 @@ pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
 /// re-emitted) and read the faithful import set from the WIR-level plan
 /// (`NirPackage::imported_cm_interfaces`). Returns empty on any failure; the
 /// caller has already validated the program with `semantics`.
-async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<String> {
+pub(crate) async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<String> {
     let base_path = Path::new(input)
         .parent()
         .map(Path::to_path_buf)
@@ -195,7 +195,7 @@ async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<St
 
 /// The default interface name: the manifest `[package].name` when the input
 /// resolves through a project, otherwise the entry file stem.
-fn default_interface_name(input: &str) -> String {
+pub(crate) fn default_interface_name(input: &str) -> String {
     if let Some((manifest, _root)) = crate::compile::load_nearest_manifest(Path::new(input))
         && let Some(package) = manifest.package
     {

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -165,7 +165,7 @@ pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
 /// re-emitted) and read the faithful import set from the WIR-level plan
 /// (`NirPackage::imported_cm_interfaces`). Returns empty on any failure; the
 /// caller has already validated the program with `semantics`.
-pub(crate) async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<String> {
+async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<String> {
     let base_path = Path::new(input)
         .parent()
         .map(Path::to_path_buf)

--- a/wado-cli/tests/run_inprocess.rs
+++ b/wado-cli/tests/run_inprocess.rs
@@ -105,8 +105,8 @@ fn hello_compile_opts(output_path: &Path, format: Option<OutputFormat>) -> Compi
         lib_world: None,
         param_overrides: wado_compiler::hashmap::IndexMap::default(),
         param_policy: wado_compiler::param_resolution::ParamPolicy::default(),
-        no_wit: false,
-        embed_wit: None,
+        no_embed_wit: false,
+        embed_wit: false,
     }
 }
 

--- a/wado-cli/tests/run_inprocess.rs
+++ b/wado-cli/tests/run_inprocess.rs
@@ -105,6 +105,8 @@ fn hello_compile_opts(output_path: &Path, format: Option<OutputFormat>) -> Compi
         lib_world: None,
         param_overrides: wado_compiler::hashmap::IndexMap::default(),
         param_policy: wado_compiler::param_resolution::ParamPolicy::default(),
+        no_wit: false,
+        embed_wit: None,
     }
 }
 

--- a/wado-compiler/Cargo.toml
+++ b/wado-compiler/Cargo.toml
@@ -23,12 +23,13 @@ wasmprinter = { workspace = true }
 walrus = { workspace = true }
 wat = { workspace = true }
 wit-encoder = { workspace = true }
+wit-parser = { workspace = true }
+wit-component = { workspace = true }
 semver = { workspace = true }
 
 [dev-dependencies]
 datatest-mini = { workspace = true }
 anyhow = { workspace = true }
-wit-parser = { workspace = true }
 tempfile = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -58,6 +58,7 @@ pub mod wir_build;
 pub mod wir_optimize;
 pub mod wir_unparse;
 pub mod wir_visitor;
+pub mod wit_bundle;
 pub mod wit_emit;
 pub mod world_registry;
 

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -470,8 +470,8 @@ pub(super) fn synthesize_lower_wasi_variant_to_memory(
         return;
     };
     let mem_cases: Vec<CmMemCase> = cases
-        .to_vec()
-        .into_iter()
+        .iter()
+        .cloned()
         .map(|case| {
             let payload = case.payload.map(|ty| {
                 let tid = {

--- a/wado-compiler/src/wit_bundle.rs
+++ b/wado-compiler/src/wit_bundle.rs
@@ -1,0 +1,105 @@
+//! Embed a `component-type` custom section into a compiled component.
+//!
+//! This is the producer-side embedding step of WIT interoperability (WEP
+//! `wep-2026-05-02-wit-interoperability.md`, Phase 2; format from
+//! `wep-2026-03-21-wit-bundling.md`). [`wit_emit`](crate::wit_emit) produces the
+//! WIT *text*; this module turns that text into the binary `component-type`
+//! section and appends it to the component the codegen already emitted.
+//!
+//! ## What the section is, and what it is not
+//!
+//! A Wado-compiled artifact is a *full Component Model component*, not a core
+//! module. Such a component is already self-describing: its typed CM
+//! imports/exports let `wasm-tools component wit` (i.e. `wit_parser::decode`)
+//! reconstruct WIT directly via its `decode_component` path, with no custom
+//! section involved. `wit_parser::decode` only consults a `component-type`
+//! payload when the *whole file* is a WIT-package blob (the wit-bindgen → core
+//! module → `wasm-tools component new` flow); a `component-type` custom section
+//! on an already-formed component is opaquely carried, never read by
+//! `component wit`.
+//!
+//! The embedded section is therefore *additive metadata*, not the mechanism
+//! that makes the component inspectable. Its value: the component's intrinsic
+//! type is always tree-shaken to the used surface, whereas the embedded payload
+//! carries the **full-fidelity contract** — complete upstream interface bodies,
+//! exact package versions, and a `producers` record — matching the
+//! `wit_component::metadata::encode` toolchain convention so `wkg`,
+//! `wasm-tools metadata`, and relink flows see a faithful, full-scope WIT.
+
+use std::borrow::Cow;
+
+use wasm_encoder::{Encode, Section};
+use wit_component::StringEncoding;
+
+use crate::semantics::Semantics;
+use crate::wit_emit::{self, WitEmitError, WitEmitOptions, WitScope};
+
+/// Append a `component-type` custom section to `component_bytes`, derived from
+/// the WIT text [`wit_emit::emit_wit_text`] renders for `sem` under `opts`.
+///
+/// The embedded section is always self-contained: `metadata::encode` types the
+/// world against a fully-resolved [`wit_parser::Resolve`], which requires every
+/// referenced upstream package's body to be present. `opts.scope` is therefore
+/// ignored here and the full interface closure is always emitted — a `local`
+/// (registry-referencing) document does not re-parse standalone. `local` scope
+/// remains meaningful only for `wado wit` *text*. The returned bytes are the
+/// original component with one extra custom section — the component's own type
+/// structure (what `wasm-tools component wit` reads) is untouched, so the
+/// artifact still decodes as a `Component`.
+pub fn embed_component_type(
+    component_bytes: &[u8],
+    sem: &Semantics,
+    opts: &WitEmitOptions,
+) -> Result<Vec<u8>, WitEmitError> {
+    let payload = encode_component_type(sem, opts)?;
+
+    let section = wasm_encoder::CustomSection {
+        name: "component-type".into(),
+        data: Cow::Borrowed(&payload),
+    };
+    let mut out = Vec::with_capacity(component_bytes.len() + payload.len() + 16);
+    out.extend_from_slice(component_bytes);
+    out.push(section.id());
+    section.encode(&mut out);
+    Ok(out)
+}
+
+/// Render the WIT for `sem`/`opts` and encode it as a `component-type` section
+/// payload (a serialized WIT-package component plus the string-encoding and
+/// producers subsections). Exposed for tests that assert the payload decodes as
+/// a standalone WIT package.
+pub fn encode_component_type(
+    sem: &Semantics,
+    opts: &WitEmitOptions,
+) -> Result<Vec<u8>, WitEmitError> {
+    // Force full scope: the section must be a self-contained WIT package so
+    // `metadata::encode` can type the world without an external registry.
+    let opts = WitEmitOptions {
+        scope: WitScope::Full,
+        ..opts.clone()
+    };
+    let text = wit_emit::emit_wit_text(sem, &opts)?;
+
+    let mut resolve = wit_parser::Resolve::new();
+    let pkg = resolve
+        .push_str("wado-embedded.wit", &text)
+        .map_err(|e| WitEmitError::Embed {
+            description: format!("re-parsing emitted WIT failed: {e}"),
+        })?;
+
+    let world_name = wit_emit::world_name(&opts);
+    let world = resolve
+        .select_world(&[pkg], Some(world_name.as_str()))
+        .map_err(|e| WitEmitError::Embed {
+            description: format!("selecting world `{world_name}` failed: {e}"),
+        })?;
+
+    // UTF-8 matches Wado's native string encoding (WEP: WIT Bundling §"What Is
+    // Embedded"). `None` extra producers — `metadata::encode` writes its own
+    // `processed-by` record.
+    wit_component::metadata::encode(&resolve, world, StringEncoding::UTF8, None).map_err(|e| {
+        WitEmitError::Embed {
+            description: format!("encoding component-type metadata failed: {e}"),
+        }
+    })
+}

--- a/wado-compiler/src/wit_bundle.rs
+++ b/wado-compiler/src/wit_bundle.rs
@@ -1,30 +1,19 @@
 //! Embed a `component-type` custom section into a compiled component.
 //!
-//! This is the producer-side embedding step of WIT interoperability (WEP
-//! `wep-2026-05-02-wit-interoperability.md`, Phase 2; format from
-//! `wep-2026-03-21-wit-bundling.md`). [`wit_emit`](crate::wit_emit) produces the
-//! WIT *text*; this module turns that text into the binary `component-type`
-//! section and appends it to the component the codegen already emitted.
+//! Producer-side embedding step of WIT interoperability (WEP
+//! `wep-2026-05-02-wit-interoperability.md`, Phase 2). [`wit_emit`](crate::wit_emit)
+//! renders the WIT *text*; this module encodes it to the binary `component-type`
+//! section and appends it to the component codegen emitted.
 //!
-//! ## What the section is, and what it is not
-//!
-//! A Wado-compiled artifact is a *full Component Model component*, not a core
-//! module. Such a component is already self-describing: its typed CM
-//! imports/exports let `wasm-tools component wit` (i.e. `wit_parser::decode`)
-//! reconstruct WIT directly via its `decode_component` path, with no custom
-//! section involved. `wit_parser::decode` only consults a `component-type`
-//! payload when the *whole file* is a WIT-package blob (the wit-bindgen → core
-//! module → `wasm-tools component new` flow); a `component-type` custom section
-//! on an already-formed component is opaquely carried, never read by
-//! `component wit`.
-//!
-//! The embedded section is therefore *additive metadata*, not the mechanism
-//! that makes the component inspectable. Its value: the component's intrinsic
-//! type is always tree-shaken to the used surface, whereas the embedded payload
-//! carries the **full-fidelity contract** — complete upstream interface bodies,
-//! exact package versions, and a `producers` record — matching the
-//! `wit_component::metadata::encode` toolchain convention so `wkg`,
-//! `wasm-tools metadata`, and relink flows see a faithful, full-scope WIT.
+//! The section is *additive*: a Wado artifact is already a self-describing
+//! component, so `wasm-tools component wit` (`wit_parser::decode`) recovers WIT
+//! from the component's own types and does not read this section (it consults a
+//! `component-type` payload only for a WIT-package blob / core module). The
+//! section's value is full fidelity — the component's own type is tree-shaken to
+//! the used surface, whereas the encoded payload carries the complete upstream
+//! interfaces, exact versions, and a `producers` record (the
+//! `wit_component::metadata::encode` convention `wkg` / `wasm-tools metadata`
+//! consume).
 
 use std::borrow::Cow;
 

--- a/wado-compiler/src/wit_emit.rs
+++ b/wado-compiler/src/wit_emit.rs
@@ -63,6 +63,14 @@ pub enum WitEmitError {
         /// Human-readable description of the offending type.
         description: String,
     },
+    /// The emitted WIT text could not be re-parsed, the target world could not
+    /// be selected, or the `component-type` metadata could not be encoded while
+    /// embedding (see [`crate::wit_bundle`]). A bug in the emitter or an
+    /// unexpected world FQ, not user-actionable beyond reporting.
+    Embed {
+        /// Human-readable description of the failure.
+        description: String,
+    },
 }
 
 impl std::fmt::Display for WitEmitError {
@@ -73,6 +81,9 @@ impl std::fmt::Display for WitEmitError {
             }
             Self::UnrepresentableType { description } => {
                 write!(f, "type is not representable in WIT: {description}")
+            }
+            Self::Embed { description } => {
+                write!(f, "cannot embed component-type metadata: {description}")
             }
         }
     }
@@ -1062,6 +1073,14 @@ fn collect_named_type_sources(ty: &crate::ast::Type, out: &mut Vec<String>) {
         }
         Type::TypePackSpread(_, _) | Type::Infer(_) | Type::Error(_) => {}
     }
+}
+
+/// The WIT world name the emitter renders for `opts`, in kebab-case. This is
+/// the name to pass to `Resolve::select_world` when re-parsing the emitted text
+/// (see [`crate::wit_bundle`]).
+#[must_use]
+pub fn world_name(opts: &WitEmitOptions) -> String {
+    to_kebab(&world_local_name(&opts.world_fq))
 }
 
 /// Extract the local name of a world FQ: `wasi:cli/command` -> `command`.

--- a/wado-compiler/src/wit_emit.rs
+++ b/wado-compiler/src/wit_emit.rs
@@ -63,10 +63,9 @@ pub enum WitEmitError {
         /// Human-readable description of the offending type.
         description: String,
     },
-    /// The emitted WIT text could not be re-parsed, the target world could not
-    /// be selected, or the `component-type` metadata could not be encoded while
-    /// embedding (see [`crate::wit_bundle`]). A bug in the emitter or an
-    /// unexpected world FQ, not user-actionable beyond reporting.
+    /// Re-parsing the emitted WIT, selecting the world, or encoding the
+    /// `component-type` metadata failed while embedding (see
+    /// [`crate::wit_bundle`]) — a compiler bug or an invalid world FQ.
     Embed {
         /// Human-readable description of the failure.
         description: String,

--- a/wado-compiler/tests/cm_catalog.rs
+++ b/wado-compiler/tests/cm_catalog.rs
@@ -229,7 +229,7 @@ fn run_round_trips(opt_level: OptLevel) {
             };
             let result_arity = func.ty(&store).results().len();
             let mut results = vec![Val::Bool(false); result_arity];
-            match func.call_async(&mut store, &[value.clone()], &mut results).await {
+            match func.call_async(&mut store, std::slice::from_ref(&value), &mut results).await {
                 Ok(()) => {
                     if results.len() != 1 {
                         failures.push(format!(

--- a/wado-compiler/tests/wit_bundle.rs
+++ b/wado-compiler/tests/wit_bundle.rs
@@ -1,0 +1,188 @@
+//! Tests for `wit_bundle` — the `component-type` embedding (WEP
+//! `wep-2026-05-02-wit-interoperability.md`, Phase 2).
+//!
+//! These pin down the Phase 2 design decisions, including the central finding:
+//! a Wado component is *already* self-describing, so `wit_parser::decode` (what
+//! `wasm-tools component wit` uses) reconstructs WIT from the component itself,
+//! and the embedded `component-type` section is additive full-fidelity metadata
+//! decodable as a standalone WIT package.
+
+#![allow(unused_crate_dependencies)]
+
+mod common;
+
+use common::InMemoryHost;
+use wado_compiler::semantics::semantics;
+use wado_compiler::wit_bundle::{embed_component_type, encode_component_type};
+use wado_compiler::wit_emit::{WitEmitOptions, WitScope};
+use wado_compiler::{OptLevel, dump_with_host_and_world};
+
+use wit_parser::decoding::{DecodedWasm, decode};
+
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    tokio::runtime::Runtime::new().unwrap().block_on(future)
+}
+
+/// Faithful world import set (the WIR-level plan), as the CLI feeds the emitter.
+fn import_plan(source: &str, world_fq: &str) -> Vec<String> {
+    let host = InMemoryHost::new();
+    match block_on(dump_with_host_and_world(
+        source,
+        &host,
+        Some("entry.wado"),
+        OptLevel::O2,
+        Some(world_fq),
+        None,
+        None,
+        &[],
+        &wado_compiler::hashmap::IndexMap::default(),
+        wado_compiler::param_resolution::ParamPolicy::default(),
+    )) {
+        Ok(dump) => dump
+            .wir_package
+            .map(|pkg| pkg.imported_cm_interfaces)
+            .unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Compile `source` to component bytes at the given world.
+fn compile(source: &str, world_fq: &str) -> Vec<u8> {
+    let host = InMemoryHost::new();
+    let mut options = wado_compiler::CompilerOptions {
+        opt_level: OptLevel::O2,
+        target_world: Some(world_fq.to_string()),
+        ..Default::default()
+    };
+    options.log_level = Some(wado_compiler::LogLevel::Error);
+    block_on(wado_compiler::compile_with_options(
+        source,
+        &host,
+        Some("entry.wado"),
+        options,
+    ))
+    .map(|r| r.wasm)
+    .unwrap_or_else(|_| panic!("compile failed:\n{:#?}", host.diagnostics()))
+}
+
+fn emit_opts(source: &str, world_fq: &str) -> WitEmitOptions {
+    WitEmitOptions {
+        scope: WitScope::Full,
+        world_fq: world_fq.to_string(),
+        default_interface_name: "entry".to_string(),
+        world_imports: import_plan(source, world_fq),
+    }
+}
+
+const CLI_WORLD: &str = "wasi:cli/command";
+
+/// A CLI command: `run` with the `Stdout` effect (the canonical hello shape).
+const HELLO: &str = r#"
+use { println, Stdout } from "core:cli";
+
+export fn run() with Stdout {
+    println("Hello, world!");
+}
+"#;
+
+/// A pure-compute command: a `run` entry with no effects, exercising embedding
+/// with a near-empty import set.
+const PURE: &str = r#"
+export fn run() {
+    let x = 1 + 2;
+    assert x == 3;
+}
+"#;
+
+/// The un-embedded Wado component already self-describes: `decode` reconstructs
+/// a `Component` from the component's own CM type structure, no custom section.
+#[test]
+fn component_is_self_describing_without_embedding() {
+    let wasm = compile(HELLO, CLI_WORLD);
+    let DecodedWasm::Component(resolve, world) = decode(&wasm).expect("decode component") else {
+        panic!("expected a Component, not a WIT package");
+    };
+    // The reconstructed world carries the real CM imports/exports.
+    let w = &resolve.worlds[world];
+    let import_names: Vec<String> = w
+        .imports
+        .keys()
+        .map(|k| resolve.name_world_key(k))
+        .collect();
+    let export_names: Vec<String> = w
+        .exports
+        .keys()
+        .map(|k| resolve.name_world_key(k))
+        .collect();
+    assert!(
+        import_names
+            .iter()
+            .any(|n| n.starts_with("wasi:cli/stdout")),
+        "imports: {import_names:?}"
+    );
+    assert!(
+        export_names.iter().any(|n| n.starts_with("wasi:cli/run")),
+        "exports: {export_names:?}"
+    );
+}
+
+/// Embedding is byte-additive: it appends a `component-type` custom section,
+/// leaving the original component bytes (and thus its intrinsic type) untouched.
+#[test]
+fn embedding_appends_section_and_preserves_component() {
+    let wasm = compile(HELLO, CLI_WORLD);
+    let host = InMemoryHost::new();
+    let sem = block_on(semantics(HELLO, &host, Some("entry.wado")));
+    assert!(sem.is_complete());
+
+    let embedded = embed_component_type(&wasm, &sem, &emit_opts(HELLO, CLI_WORLD))
+        .expect("embed_component_type");
+
+    assert!(embedded.len() > wasm.len(), "section should add bytes");
+    assert_eq!(
+        &embedded[..wasm.len()],
+        &wasm[..],
+        "original bytes preserved"
+    );
+
+    // `wasm-tools component wit` still reads the intrinsic component type — the
+    // embedded section does not flip the artifact to a WIT package.
+    assert!(
+        matches!(decode(&embedded), Ok(DecodedWasm::Component(..))),
+        "embedded artifact must still decode as a Component"
+    );
+
+    // Exactly one `component-type` custom section was added.
+    let count = wasmparser::Parser::new(0)
+        .parse_all(&embedded)
+        .filter(|p| matches!(p, Ok(wasmparser::Payload::CustomSection(r)) if r.name() == "component-type"))
+        .count();
+    assert_eq!(count, 1, "exactly one component-type section");
+}
+
+/// The encoded payload is a standalone WIT package (the full-fidelity contract),
+/// for `wkg` / `wasm-tools metadata` and relink flows.
+#[test]
+fn encoded_payload_decodes_as_wit_package() {
+    let host = InMemoryHost::new();
+    let sem = block_on(semantics(HELLO, &host, Some("entry.wado")));
+    let payload =
+        encode_component_type(&sem, &emit_opts(HELLO, CLI_WORLD)).expect("encode_component_type");
+    assert!(
+        matches!(decode(&payload), Ok(DecodedWasm::WitPackage(..))),
+        "payload must decode as a standalone WIT package"
+    );
+}
+
+/// A minimal-import command embeds and round-trips just like the hello shape.
+#[test]
+fn pure_compute_world_embeds() {
+    let wasm = compile(PURE, CLI_WORLD);
+    let host = InMemoryHost::new();
+    let sem = block_on(semantics(PURE, &host, Some("entry.wado")));
+    let embedded = embed_component_type(&wasm, &sem, &emit_opts(PURE, CLI_WORLD)).expect("embed");
+    assert!(matches!(decode(&embedded), Ok(DecodedWasm::Component(..))));
+
+    let payload = encode_component_type(&sem, &emit_opts(PURE, CLI_WORLD)).expect("encode");
+    assert!(matches!(decode(&payload), Ok(DecodedWasm::WitPackage(..))));
+}


### PR DESCRIPTION
## Summary

Implements **Phase 2** of WIT interoperability (`wep-2026-05-02-wit-interoperability.md`; format from `wep-2026-03-21-wit-bundling.md`): `wado compile` now embeds a `component-type` custom section into the output component, derived from the same WIT `wado wit` emits (WIT text → `wit_parser::Resolve` → `wit_component::metadata::encode` → section append).

## Key finding (verified empirically, documented in the WEPs)

A Wado artifact is already a **self-describing Component Model component**, not a core module. `wasm-tools component wit` (`wit_parser::decode`) reconstructs WIT from the component's own typed CM imports/exports via its `decode_component` path and **never reads** an outer-component `component-type` section (`decode` consults that payload only for a WIT-package blob / core module).

So the embedded section is **additive full-fidelity metadata**, not the mechanism that makes the binary inspectable: the component's intrinsic type is tree-shaken to the used surface, whereas the encoded payload carries the complete upstream interfaces, exact package versions, and a `producers` record (the `metadata::encode` convention `wkg` / `wasm-tools metadata` / relink flows consume). The earlier WEP framing ("a standalone `.wasm` cannot describe its own interface") held for core modules only and is corrected.

## Behavior

- Embedding is **on by default** for `wado compile` wasm output; `--no-embed-wit` opts out, `--embed-wit` forces it on under `-Os` (where it defaults off, as frontend-delivery builds never reach a CM host). Both flags are value-less and mutually exclusive.
- `wado run` / `serve` / `test` never embed (they don't route through `compile::run`).
- The embedded section is always the self-contained full closure — a `local`, registry-referencing section is not encodable (a Wasm CM binary property). `local` / `full` survives only on `wado wit --scope` (text). The originally-planned `[wit].scope` manifest knob is dropped accordingly.
- The faithful world import set is read from the main compile's retained WIR (`imported_cm_interfaces`), so embedding adds no extra optimize pass and stays faithful at any opt level. The re-analysis host attaches `wado.toml` `[dependencies]`, so multi-package projects embed correctly. On failure the default path warns and yields the (still valid) un-embedded component; `--embed-wit` makes it fatal.

## Changes

- New `wado-compiler/src/wit_bundle.rs` (`embed_component_type` / `encode_component_type`); `world_name` helper and an `Embed` error variant in `wit_emit.rs`.
- `wit-parser` / `wit-component` moved into `wado-compiler` `[dependencies]` (wasm32 build still passes).
- `--embed-wit` / `--no-embed-wit` flags and the embed orchestration in `wado-cli/src/compile.rs`; `retain_wir` threaded through `CompileFlags`.
- WEP updates (`wep-2026-03-21`, `wep-2026-05-02`) reconciled to the implemented design and the finding above.
- Tests: `tests/wit_bundle.rs` (self-describing component, byte-additive embedding, payload decodes as a WIT package) and `compile::embed_policy_tests`.
- Drive-by: two pre-existing clippy lints fixed (`cm_binding/lower.rs`, `tests/cm_catalog.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ex1eLwGWWzL3iC5KuCRfp)_