### PR TITLE
feat(manifest): human-facing package metadata, OCI publishing, and workspace lockstep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,6 +2557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spdx"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3113,6 +3122,7 @@ dependencies = [
  "semver",
  "serde",
  "sha2 0.11.0",
+ "spdx",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ wit-component = { version = "0.251" }
 wit-encoder = { version = "0.251" }
 wasm-compose = { version = "0.251" }
 semver = { version = "1" }
+spdx = { version = "0.10" }
 wasmtime = { version = "=46.0.1", features = ["async", "component-model", "component-model-async"] }
 wasmtime-wasi = { version = "=46.0.1", features = ["p3"] }
 wasmtime-wasi-http = { version = "=46.0.1", features = ["p3"] }

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -222,13 +222,13 @@ A registry dependency with no `registry` field requires `default` to be set. If 
 
 ### Registry backend
 
-Registry resolution and publishing use **OCI** (the OCI Distribution Spec): a component is an OCI artifact in a container registry (e.g. `ghcr.io`), and the content digest provides integrity. A registry URL takes the form `oci://<host>/<prefix>`; an open coordinate `ns:pkg` resolves to the repository `<host>/<prefix>/<ns>/<pkg>`, with the version as an image tag.
+Registry resolution and publishing use OCI (the OCI Distribution Spec): a component is an OCI artifact in a container registry (e.g. `ghcr.io`), and the content digest provides integrity. A registry URL takes the form `oci://<host>/<prefix>`; an open coordinate `ns:pkg` resolves to the repository `<host>/<prefix>/<ns>/<pkg>`, with the version as an image tag.
 
-The earlier **warg** protocol is dropped. Its registry (`bytecodealliance/registry`) is archived and the ecosystem (`wasm-pkg-tools`) defaults to OCI. A warg-only registry such as wa.dev is reachable only through the external `wkg` tool, not natively; Wado neither implements nor wraps warg. Publishing is likewise done with `wkg`, not a Wado subcommand.
+The earlier warg protocol is dropped. Its registry (`bytecodealliance/registry`) is archived and the ecosystem (`wasm-pkg-tools`) defaults to OCI. A warg-only registry such as wa.dev is reachable only through the external `wkg` tool, not natively; Wado neither implements nor wraps warg. Publishing is likewise done with `wkg`, not a Wado subcommand.
 
 ### `[dependencies]` and `[dev-dependencies]`
 
-Each key is the **specifier** used in Wado source code, byte-for-byte (`"docs:regex"`, `"lib:shared"`). Values are inline tables specifying the dependency source. See [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md) for the key forms and resolution rules.
+Each key is the specifier used in Wado source code, byte-for-byte (`"docs:regex"`, `"lib:shared"`). Values are inline tables specifying the dependency source. See [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md) for the key forms and resolution rules.
 
 `[dev-dependencies]` are only available during `wado test` and are excluded from production builds.
 
@@ -306,8 +306,8 @@ The specifier grammar and the reserved = bundled rule are defined in
 [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md).
 A dependency-backed specifier is one of:
 
-- an **open coordinate** `ns:pkg` (`ns` ∉ {`wasi`, `core`}), or
-- a **`lib:` nickname**.
+- an open coordinate `ns:pkg` (`ns` ∉ {`wasi`, `core`}), or
+- a `lib:` nickname.
 
 Both resolve by looking up the byte-identical key in `[dependencies]` (or
 `[dev-dependencies]` during test). `wasi:`/`core:` resolve to bundled sources,
@@ -350,7 +350,7 @@ When a dependency itself has a `wado.toml` with dependencies, those are transiti
 
 #### Resolution Algorithm: PubGrub
 
-Wado uses the **PubGrub** algorithm for dependency resolution. PubGrub is a conflict-driven nogood learning (CDCL) solver, originally designed for Dart's `pub` and adopted by `uv` (Python), Swift Package Manager, and others.
+Wado uses the PubGrub algorithm for dependency resolution. PubGrub is a conflict-driven nogood learning (CDCL) solver, originally designed for Dart's `pub` and adopted by `uv` (Python), Swift Package Manager, and others.
 
 Why PubGrub over alternatives:
 
@@ -362,9 +362,9 @@ Why PubGrub over alternatives:
 
 PubGrub provides:
 
-- **Conflict-driven learning**: when a conflict is found, the solver derives a precise incompatibility that explains _why_ this combination fails and never re-explores it
-- **Human-readable error messages**: each resolution failure comes with a derivation chain (e.g., "because A requires utils ^1.0 and B requires utils ^2.0, and your project requires both A and B, version solving failed")
-- **Efficient pruning**: near-polynomial performance in practice despite NP-hard worst case
+- Conflict-driven learning: when a conflict is found, the solver derives a precise incompatibility that explains _why_ this combination fails and never re-explores it
+- Human-readable error messages: each resolution failure comes with a derivation chain (e.g., "because A requires utils ^1.0 and B requires utils ^2.0, and your project requires both A and B, version solving failed")
+- Efficient pruning: near-polynomial performance in practice despite NP-hard worst case
 
 The Rust crate `pubgrub` provides a ready-made implementation.
 
@@ -378,7 +378,7 @@ The `version` field requires an explicit range operator — bare versions are er
 | `^`    | Caret (pre-1.0)    | `^0.2.3` | `>=0.2.3, <0.3.0` |
 | `~`    | Tilde (patch-only) | `~1.2.3` | `>=1.2.3, <1.3.0` |
 | `=`    | Exact              | `=1.2.3` | `=1.2.3`          |
-| (none) | **Error**          | `1.2.3`  | compile error     |
+| (none) | Error              | `1.2.3`  | compile error     |
 
 ```
 version = "^1.0.0"   # OK: caret range
@@ -403,7 +403,7 @@ The rule: ignore the first `[a-zA-Z]+` prefix if present. Tags that do not conta
 
 #### Semver Compatibility
 
-Two requirements are **semver-compatible** if they share the same compatibility range (same major version for `>=1.0.0`, same major.minor for `0.x`). Within a compatibility range, the resolver selects **exactly one version** — the highest that satisfies all constraints.
+Two requirements are semver-compatible if they share the same compatibility range (same major version for `>=1.0.0`, same major.minor for `0.x`). Within a compatibility range, the resolver selects exactly one version — the highest that satisfies all constraints.
 
 #### Multiple Version Coexistence
 
@@ -435,7 +435,7 @@ Within a single `wado.toml`, a user can also explicitly depend on multiple major
 
 #### Transitive Version Isolation
 
-The resolver runs on the **full dependency graph** and produces a flat resolution map. Each resolved package is identified by `(package identity, compatibility range)`:
+The resolver runs on the full dependency graph and produces a flat resolution map. Each resolved package is identified by `(package identity, compatibility range)`:
 
 ```
 package identity = registry URL + namespace:name  (for registry deps)
@@ -465,9 +465,9 @@ The compiler sees distinct `ModuleSource::Dependency` values (different `id`) an
 
 When two dependencies require the same transitive dependency:
 
-- **Compatible versions**: unified to one resolved instance (highest compatible). PubGrub finds this automatically.
-- **Incompatible versions**: coexist as separate instances. Each dependent sees its own version. Types do not cross boundaries.
-- **Unsatisfiable**: if constraints within a compatibility range conflict (e.g., `=1.2.0` and `=1.3.0`), PubGrub reports a precise error with derivation chain.
+- Compatible versions: unified to one resolved instance (highest compatible). PubGrub finds this automatically.
+- Incompatible versions: coexist as separate instances. Each dependent sees its own version. Types do not cross boundaries.
+- Unsatisfiable: if constraints within a compatibility range conflict (e.g., `=1.2.0` and `=1.3.0`), PubGrub reports a precise error with derivation chain.
 
 #### Cyclic Dependency Detection
 
@@ -610,7 +610,7 @@ The prefix makes the format extensible — if SHA-256 is ever deprecated, a new 
 | Git        | `resolved-ref` (commit SHA) serves as integrity. Git's content-addressable storage already guarantees integrity. No separate `integrity` field needed. |
 | Local path | Not locked. Always resolved fresh.                                                                                                                     |
 
-For registry packages, the hash input is the **downloaded archive bytes** (not individual source files concatenated). This matches how registries distribute packages and avoids ambiguity about file ordering or line endings.
+For registry packages, the hash input is the downloaded archive bytes (not individual source files concatenated). This matches how registries distribute packages and avoids ambiguity about file ordering or line endings.
 
 The initial algorithm is SHA-256. The resolver verifies integrity on every install: if the computed hash does not match `integrity`, the install fails with an error.
 
@@ -716,7 +716,7 @@ Properties:
 
 ### Lockstep Contract
 
-Workspace metadata inheritance and root-only publishing together guarantee that **a workspace's packages cannot drift to mismatched public versions**, enforced in two places:
+Workspace metadata inheritance and root-only publishing together guarantee that a workspace's packages cannot drift to mismatched public versions, enforced in two places:
 
 - Repository: `version`, `repository`, and `namespace` are declared once in `[workspace.package]` and cannot be overridden, so there is one definition site and drift is impossible by construction, not merely linted.
 - Registry: `wado publish` runs only from the workspace root and publishes every member together at that shared version (see [Publishing](#publishing)), so members can't be pushed piecemeal at different versions.
@@ -732,7 +732,7 @@ When no `wado.toml` exists, the compiler operates in single-file mode:
 - `core:*`, `wasi:*`, `./`, `../`, and `https://` imports work as always.
 - A dependency specifier (`ns:pkg` or `lib:nick`) must carry an inline
   `with { ... }` supplying its source — the same vocabulary as a
-  `[dependencies]` value, with an **exact** `version` (no lock to resolve a
+  `[dependencies]` value, with an exact `version` (no lock to resolve a
   range). See [Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md).
 - A dependency specifier without `with` produces a clear error:
   `dependency "lib:foo" needs a source (add a with-clause or a wado.toml)`.
@@ -850,18 +850,18 @@ This enables seamless local development while ensuring published packages are se
 
 ### Trade-offs
 
-- **PubGrub over MVS**: PubGrub selects the highest compatible version (users get security patches automatically) at the cost of needing a lock file for reproducibility. MVS would give O(n) resolution and reproducibility without a lock file, but users would be stuck on old versions unless every library author proactively bumps minimums. For an ecosystem that values security and freshness, PubGrub is the better default.
-- **`version` XOR `ref` for git**: `version` enables semver resolution on tags (like Go/Swift PM), `ref` pins to an exact ref. XOR ensures the intent is always unambiguous — no implicit defaults.
-- **Bare version = error**: more verbose than Cargo's implicit caret, but eliminates a source of confusion ("does `1.0.0` mean exact or `^1.0.0`?"). Every `version` field is self-documenting.
-- **Registry names per-project**: avoids global configuration but requires repetition across projects. The `default` registry mitigates this for the common case. A future `~/.wado/config.toml` could provide user-level defaults.
-- **Dependency specifier resolution**: an open coordinate or `lib:` nickname requires a `wado.toml` lookup at compile time, adding a project-discovery step. The compiler itself is not affected — only `CompilerHost` implementations need to handle this.
-- **Self-sufficient lock file**: duplicates entry points and dependency edges from each package's `wado.toml`. This makes the lock file larger and introduces a potential staleness risk (if a dependency's `wado.toml` changes entry points without version bump). The trade-off is worth it — builds skip all transitive manifest I/O, and staleness is caught by `wado update` or integrity mismatch.
-- **Archive-level integrity** (not source-level): simpler and unambiguous, but means the hash depends on the registry's archive format. If a registry changes its packaging format, hashes change even if sources are identical.
-- **Lockstep over per-field opt-in** (see [Lockstep Contract](#lockstep-contract)): `[workspace.package]` inherits automatically (no `{ workspace = true }` marker) and forced fields can't be overridden, plus root-only publishing — trading per-member independence for one definition site and structurally drift-free releases. Independence means leaving the workspace, not an in-workspace opt-out.
-- **`[world]` table keyed by FQ world name**: hosted worlds are declared by their Component Model world name (`"wasi:cli/command"`) rather than a short alias (`command`/`bin`/`cli`). The key is the world the entry conforms to, so new worlds need no new manifest field and the mapping to the CM world is explicit. The library world is the one exception — it has no externally-fixed FQ name, so it is named after the package and declared by `[package].lib`.
-- **`[package]` over `[project]`**: `[package]` aligns with CM's "package" concept (`package ns:name@version` in WIT). The file itself represents the project; `[package]` describes the distributable unit within it. `[workspace]` > `[package]` hierarchy is natural, whereas `[workspace]` > `[project]` would be confusing.
-- **`path` + `registry` dual source**: adds complexity to the dependency spec but eliminates the "path deps can't be published" problem. The alternative (Cargo's separate `[patch]` section) is more complex and harder to maintain.
+- PubGrub over MVS: PubGrub selects the highest compatible version (users get security patches automatically) at the cost of needing a lock file for reproducibility. MVS would give O(n) resolution and reproducibility without a lock file, but users would be stuck on old versions unless every library author proactively bumps minimums. For an ecosystem that values security and freshness, PubGrub is the better default.
+- `version` XOR `ref` for git: `version` enables semver resolution on tags (like Go/Swift PM), `ref` pins to an exact ref. XOR ensures the intent is always unambiguous — no implicit defaults.
+- Bare version = error: more verbose than Cargo's implicit caret, but eliminates a source of confusion ("does `1.0.0` mean exact or `^1.0.0`?"). Every `version` field is self-documenting.
+- Registry names per-project: avoids global configuration but requires repetition across projects. The `default` registry mitigates this for the common case. A future `~/.wado/config.toml` could provide user-level defaults.
+- Dependency specifier resolution: an open coordinate or `lib:` nickname requires a `wado.toml` lookup at compile time, adding a project-discovery step. The compiler itself is not affected — only `CompilerHost` implementations need to handle this.
+- Self-sufficient lock file: duplicates entry points and dependency edges from each package's `wado.toml`. This makes the lock file larger and introduces a potential staleness risk (if a dependency's `wado.toml` changes entry points without version bump). The trade-off is worth it — builds skip all transitive manifest I/O, and staleness is caught by `wado update` or integrity mismatch.
+- Archive-level integrity (not source-level): simpler and unambiguous, but means the hash depends on the registry's archive format. If a registry changes its packaging format, hashes change even if sources are identical.
+- Lockstep over per-field opt-in (see [Lockstep Contract](#lockstep-contract)): `[workspace.package]` inherits automatically (no `{ workspace = true }` marker) and forced fields can't be overridden, plus root-only publishing — trading per-member independence for one definition site and structurally drift-free releases. Independence means leaving the workspace, not an in-workspace opt-out.
+- `[world]` table keyed by FQ world name: hosted worlds are declared by their Component Model world name (`"wasi:cli/command"`) rather than a short alias (`command`/`bin`/`cli`). The key is the world the entry conforms to, so new worlds need no new manifest field and the mapping to the CM world is explicit. The library world is the one exception — it has no externally-fixed FQ name, so it is named after the package and declared by `[package].lib`.
+- `[package]` over `[project]`: `[package]` aligns with CM's "package" concept (`package ns:name@version` in WIT). The file itself represents the project; `[package]` describes the distributable unit within it. `[workspace]` > `[package]` hierarchy is natural, whereas `[workspace]` > `[project]` would be confusing.
+- `path` + `registry` dual source: adds complexity to the dependency spec but eliminates the "path deps can't be published" problem. The alternative (Cargo's separate `[patch]` section) is more complex and harder to maintain.
 
 ### Not Included
 
-- **URL dependencies (`url = "..."`)**: Not included in this WEP. Remote module imports via `use ... from "https://..."` remain a source-level feature (not a `wado.toml` dependency). A `url` dependency source type may be added in a future WEP if a compelling use case emerges that cannot be served by git or registry dependencies.
+- URL dependencies (`url = "..."`): Not included in this WEP. Remote module imports via `use ... from "https://..."` remain a source-level feature (not a `wado.toml` dependency). A `url` dependency source type may be added in a future WEP if a compelling use case emerges that cannot be served by git or registry dependencies.

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -61,10 +61,10 @@ an open coordinate `ns:pkg`, or a `lib:` nickname for indirection. Bare keys
 | `version`              | `string`   | Yes      | Semver version (e.g., `"0.1.0"`)                                                              |
 | `lib`                  | `string`   | No       | Entry module of the package's library world                                                   |
 | `description`          | `string`   | No       | Short, human-readable summary                                                                 |
-| `homepage`             | `string`   | No       | Project home page URL                                                                         |
+| `homepage`             | `string`   | No       | Project home page URL (defaults to `repository`)                                              |
 | `repository`           | `string`   | No       | Source repository URL (bare repo URL, no subdirectory)                                        |
 | `repository-directory` | `string`   | No       | Subdirectory holding the package within a monorepo (Wado-custom; not an OCI key)              |
-| `documentation`        | `string`   | No       | Documentation URL                                                                             |
+| `documentation`        | `string`   | No       | Documentation URL (defaults to `repository`)                                                  |
 | `license`              | `string`   | No       | SPDX License Expression (e.g., `"MIT OR Apache-2.0"`). Mutually exclusive with `license-file` |
 | `license-file`         | `string`   | No       | Path to a non-standard license file. Mutually exclusive with `license`                        |
 | `authors`              | `string[]` | No       | Contact details of the people or organization responsible                                     |
@@ -767,8 +767,15 @@ validations apply:
 - `namespace` and `name` must be present
 - `version` must be present and valid semver
 - `publish` must not be `false`
+- `description`, `repository`, and `authors` must be present
 - exactly one of `license` or `license-file` must be present
 - All `path` dependencies must have accompanying registry or git source information
+
+A published package must carry its descriptive metadata, so the non-exclusive
+fields above are required. The exceptions: `homepage` and `documentation` are
+redundant with `repository` and default to it when omitted; `repository-directory`
+is meaningful only for a monorepo; and `wado-version` is a build constraint, not
+descriptive metadata. These four stay optional even when publishing.
 
 #### Path Dependency Replacement
 
@@ -813,7 +820,7 @@ This enables seamless local development while ensuring published packages are se
 - The `[world]` table and `[package].lib` map directly to CM worlds; `wado run` / `wado serve` select a hosted world by its FQ name
 - `export` as CM boundary gives clear, consistent public API semantics across all consumption modes
 - Wado-to-Wado optimization eliminates CM overhead for same-language dependencies without changing semantics
-- `namespace` absence naturally indicates non-publishable packages — no extra `publish = false` flag needed
+- `namespace` absence naturally indicates non-publishable packages; a namespaced package can still opt out explicitly with `publish = false`
 - Path deps with dual source (`path` + `registry`) enable seamless dev-to-publish workflow
 - Workspace support enables multi-package development with shared lock files and dependency declarations
 - Name/namespace validation (`[a-zA-Z0-9_-]+` per segment) keeps dependency keys (`"ns:pkg"`, `"lib:nick"`) unambiguous as specifiers

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -830,6 +830,15 @@ descriptive metadata. These four stay optional even when publishing.
 (it does not upload). The OCI upload itself is not yet implemented, so a bare
 `wado publish` errors rather than pretending to publish.
 
+In a workspace, `wado publish` is gated to the workspace root: it publishes every
+publishable member (and the root's own `[package]`, if any) together at the
+shared, force-inherited version. Members that are not publishable (`publish =
+false` or no `namespace`) are skipped. Running `wado publish` from a member
+directory is an error pointing at the root. Forced `version` inheritance already
+prevents version drift _within_ the repository; publishing only from the root
+extends that guarantee to the registry — members can never be published
+piecemeal at mismatched versions.
+
 #### Path Dependency Replacement
 
 `path` dependencies that also specify a registry or git source are automatically replaced with the non-path source when publishing, similar to Cargo:

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -668,6 +668,13 @@ A workspace groups multiple packages for co-development. The workspace root has 
 [workspace]
 members = ["packages/*"]
 
+[workspace.package]
+version = "0.1.0"
+repository = "https://github.com/myorg/monorepo"
+namespace = "myorg"
+license = "MIT"
+authors = ["Alice <alice@example.com>"]
+
 [workspace.dependencies]
 "std:json" = { version = "^1.0.0" }
 
@@ -678,17 +685,18 @@ members = ["packages/*"]
 ```toml
 # packages/core/wado.toml
 [package]
-namespace = "myorg"
 name = "core"
-version = "0.1.0"
+description = "Shared core types"
 lib = "src/lib.wado"
+# version / repository / namespace / license / authors inherited
 ```
 
 ```toml
 # packages/cli/wado.toml
 [package]
 name = "my-tool"
-version = "0.1.0"
+description = "The command-line tool"
+repository-directory = "packages/cli"
 
 [world]
 "wasi:cli/command" = "src/main.wado"
@@ -701,7 +709,46 @@ version = "0.1.0"
 | --------- | ---------- | -------- | -------------------------------------------- |
 | `members` | `string[]` | Yes      | Glob patterns for member package directories |
 
-`[workspace.dependencies]` and `[workspace.dev-dependencies]` declare shared dependency versions. Member packages reference them without repeating version information:
+#### `[workspace.package]` — Shared Package Metadata
+
+`[workspace.package]` declares package metadata shared by every member.
+Inheritance is automatic — unlike dependencies, members do **not** write
+`{ workspace = true }`. Whether a member may override an inherited field depends
+on the field:
+
+| Field          | Inheritance                     | Member override          |
+| -------------- | ------------------------------- | ------------------------ |
+| `version`      | Forced                          | Error if set in a member |
+| `repository`   | Forced                          | Error if set in a member |
+| `namespace`    | Forced                          | Error if set in a member |
+| `license`      | Default                         | Allowed                  |
+| `license-file` | Default (path relative to root) | Allowed                  |
+| `authors`      | Default                         | Allowed                  |
+| `wado-version` | Default                         | Allowed                  |
+
+Only these seven fields may appear in `[workspace.package]`; any other key
+(`name`, `lib`, `description`, `homepage`, `documentation`,
+`repository-directory`, `publish`) is package-specific and is not inheritable —
+there is no mechanism to set it workspace-wide.
+
+The forced fields are repository-identity invariants: `version`, `repository`,
+and `namespace` have exactly one definition site (the workspace root), so they
+cannot drift between members. A member that sets a forced field is an error
+(`version is inherited from [workspace.package]; remove it here`). This is the
+deliberate difference from Cargo's per-field opt-in, where same-repo versions
+routinely fall out of sync.
+
+`license` and `license-file` form one logical license slot: if a member sets
+either, it replaces the inherited slot entirely (and the two remain mutually
+exclusive within any single manifest). `license-file` inherited from the
+workspace resolves relative to the workspace root.
+
+Forced inheritance is all-or-nothing per field: putting `version` in
+`[workspace.package]` locks every member to it. A workspace that needs
+independent per-member versioning simply omits `version` from
+`[workspace.package]`, and each member declares its own.
+
+`[workspace.dependencies]` and `[workspace.dev-dependencies]` declare shared dependency versions. Member packages reference them with explicit opt-in (unlike metadata):
 
 ```toml
 # In a workspace member's wado.toml
@@ -718,7 +765,7 @@ Properties:
 
 - All member packages share one `wado.lock` at the workspace root
 - `wado` commands run from any member directory discover the workspace root automatically
-- Each member has its own `[package]` with independent `name`, `version`, and entry points
+- Each member has its own `[package]` with an independent `name` and entry points; `version`/`repository`/`namespace` are inherited from `[workspace.package]`
 - Members can depend on each other via `path` dependencies
 
 ### Single-File Mode

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -83,6 +83,10 @@ Dependency keys in `[dependencies]` are quoted specifiers — an open coordinate
 
 A package must declare at least one world: a `[world]` entry, `[package].lib`, or both.
 
+#### Unknown keys
+
+Keys the schema does not recognize — at the top level, in `[package]`, or in `[workspace.package]` — are reported as warnings, never errors. A typo (`descripton`, `licence`) is surfaced without breaking the build, and an inherited `[workspace.package]` typo surfaces on the member that inherits it.
+
 ### Package Metadata and Publishing
 
 The human-facing `[package]` fields are universal package metadata that happen
@@ -743,10 +747,16 @@ either, it replaces the inherited slot entirely (and the two remain mutually
 exclusive within any single manifest). `license-file` inherited from the
 workspace resolves relative to the workspace root.
 
-Forced inheritance is all-or-nothing per field: putting `version` in
-`[workspace.package]` locks every member to it. A workspace that needs
-independent per-member versioning simply omits `version` from
-`[workspace.package]`, and each member declares its own.
+Forced inheritance is all-or-nothing per field: a field placed in
+`[workspace.package]` is single-sourced, and members cannot diverge from it.
+Workspace membership is the lockstep boundary. There is deliberately **no**
+per-field opt-out that would let a member override a forced field while staying
+in the workspace — and none is planned. A package that must set its identity
+(and publish) independently is kept out of the workspace and lives as a
+standalone project; that binary (in the workspace = locked, outside = free) is
+the whole contract. (A workspace that does not want to share a particular field
+simply omits it from `[workspace.package]`; the field is then not shared and
+each member sets it itself.)
 
 `[workspace.dependencies]` and `[workspace.dev-dependencies]` declare shared dependency versions. Member packages reference them with explicit opt-in (unlike metadata):
 
@@ -818,7 +828,7 @@ validations apply:
 - `publish` must not be `false`
 - `description`, `repository`, and `authors` must be present
 - exactly one of `license` or `license-file` must be present
-- All `path` dependencies must have accompanying registry or git source information
+- every shipped dependency must carry a concrete source: a `path` dependency needs an accompanying registry/git source, and a `workspace = true` dependency must resolve to one (the workspace context is gone once the package is extracted)
 
 A published package must carry its descriptive metadata, so the non-exclusive
 fields above are required. The exceptions: `homepage` and `documentation` are
@@ -886,6 +896,9 @@ This enables seamless local development while ensuring published packages are se
 - Path deps with dual source (`path` + `registry`) enable seamless dev-to-publish workflow
 - Workspace support enables multi-package development with shared lock files and dependency declarations
 - Name/namespace validation (`[a-zA-Z0-9_-]+` per segment) keeps dependency keys (`"ns:pkg"`, `"lib:nick"`) unambiguous as specifiers
+- Human-facing metadata lives in `[package]` with `wado.toml` as the single source of truth, mapped to standard OCI annotations on publish (no `wkg.toml`); `license` is validated as an SPDX expression
+- `[workspace.package]` removes metadata duplication across members; force-inherited `version`/`repository`/`namespace` make in-repo drift impossible, and root-only `wado publish` extends that guarantee to the registry
+- Unknown manifest keys warn instead of erroring, so typos are caught without breaking builds
 
 ### Negative
 
@@ -903,6 +916,8 @@ This enables seamless local development while ensuring published packages are se
 - **Dependency specifier resolution**: an open coordinate or `lib:` nickname requires a `wado.toml` lookup at compile time, adding a project-discovery step. The compiler itself is not affected — only `CompilerHost` implementations need to handle this.
 - **Self-sufficient lock file**: duplicates entry points and dependency edges from each package's `wado.toml`. This makes the lock file larger and introduces a potential staleness risk (if a dependency's `wado.toml` changes entry points without version bump). The trade-off is worth it — builds skip all transitive manifest I/O, and staleness is caught by `wado update` or integrity mismatch.
 - **Archive-level integrity** (not source-level): simpler and unambiguous, but means the hash depends on the registry's archive format. If a registry changes its packaging format, hashes change even if sources are identical.
+- **Workspace membership as the lockstep boundary**: force-inherited identity fields plus root-only publishing make version drift across members structurally impossible, at the cost of per-member independence. Independence is regained only by leaving the workspace (standalone), never by an in-workspace per-field opt-out — Wado intentionally provides none, keeping the contract a simple binary rather than a Cargo-style per-field opt-in that lets same-repo versions silently diverge.
+- **Forced metadata inheritance has no `{ workspace = true }` marker** (unlike dependencies): a field in `[workspace.package]` is inherited automatically and a member that re-declares a forced one is an error. This trades a small surprise (no opt-in syntax) for the guarantee that forced fields have exactly one definition site.
 - **`[world]` table keyed by FQ world name**: hosted worlds are declared by their Component Model world name (`"wasi:cli/command"`) rather than a short alias (`command`/`bin`/`cli`). The key is the world the entry conforms to, so new worlds need no new manifest field and the mapping to the CM world is explicit. The library world is the one exception — it has no externally-fixed FQ name, so it is named after the package and declared by `[package].lib`.
 - **`[package]` over `[project]`**: `[package]` aligns with CM's "package" concept (`package ns:name@version` in WIT). The file itself represents the project; `[package]` describes the distributable unit within it. `[workspace]` > `[package]` hierarchy is natural, whereas `[workspace]` > `[project]` would be confusing.
 - **`path` + `registry` dual source**: adds complexity to the dependency spec but eliminates the "path deps can't be published" problem. The alternative (Cargo's separate `[patch]` section) is more complex and harder to maintain.

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -759,7 +759,7 @@ independent per-member versioning simply omits `version` from
 "lib:bench" = { workspace = true }  # inherits from [workspace.dev-dependencies]
 ```
 
-A workspace root `wado.toml` can have both `[workspace]` and `[package]` — the root itself is both a workspace and a package (like Cargo).
+A workspace root `wado.toml` can have both `[workspace]` and `[package]` — the root itself is both a workspace and a package (like Cargo). The root's own `[package]` is the authority, not a governed member: it does not force-inherit from `[workspace.package]` and declares its own `version`/`repository`/`namespace` directly.
 
 Properties:
 

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -109,11 +109,13 @@ no standard key for them, so they would not reach an OCI registry.
 #### License
 
 `license` (an SPDX expression such as `"MIT OR Apache-2.0"`) is the primary
-form. For a standard license the SPDX identifier is the canonical reference, so
-no file is shipped. A non-standard or proprietary license uses `license-file`
-instead: the annotation becomes `LicenseRef-<name>` (SPDX's syntax for custom
-licenses) and the file's text is embedded in the component. `license` and
-`license-file` are mutually exclusive; publishing requires one of them.
+form, and is validated as a well-formed SPDX expression at parse time. For a
+standard license the SPDX identifier is the canonical reference, so no file is
+shipped. A non-standard or proprietary license uses `license-file` instead: the
+annotation becomes `LicenseRef-<name>` (SPDX's syntax for custom licenses, also
+accepted in the `license` field) and the file's text is embedded in the
+component. `license` and `license-file` are mutually exclusive; publishing
+requires one of them.
 
 #### Repository subdirectory (monorepo)
 
@@ -776,6 +778,10 @@ fields above are required. The exceptions: `homepage` and `documentation` are
 redundant with `repository` and default to it when omitted; `repository-directory`
 is meaningful only for a monorepo; and `wado-version` is a build constraint, not
 descriptive metadata. These four stay optional even when publishing.
+
+`wado publish --dry-run` runs these checks and reports every problem at once
+(it does not upload). The OCI upload itself is not yet implemented, so a bare
+`wado publish` errors rather than pretending to publish.
 
 #### Path Dependency Replacement
 

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -24,6 +24,13 @@ namespace = "myorg"
 name = "my-app"
 version = "0.1.0"
 lib = "src/lib.wado"
+description = "A fast widget toolkit"
+homepage = "https://wado-lang.org"
+repository = "https://github.com/myorg/my-app"
+documentation = "https://docs.wado-lang.org"
+license = "MIT OR Apache-2.0"
+authors = ["Alice <alice@example.com>"]
+wado-version = ">=0.5"
 
 [world]
 "wasi:cli/command" = "src/main.wado"
@@ -47,14 +54,26 @@ an open coordinate `ns:pkg`, or a `lib:` nickname for indirection. Bare keys
 
 ### `[package]`
 
-| Field       | Type     | Required | Description                                      |
-| ----------- | -------- | -------- | ------------------------------------------------ |
-| `namespace` | `string` | No       | Organization or user namespace (e.g., `"myorg"`) |
-| `name`      | `string` | Yes      | Package name (e.g., `"my-app"`)                  |
-| `version`   | `string` | Yes      | Semver version (e.g., `"0.1.0"`)                 |
-| `lib`       | `string` | No       | Entry module of the package's library world      |
+| Field                  | Type       | Required | Description                                                                                   |
+| ---------------------- | ---------- | -------- | --------------------------------------------------------------------------------------------- |
+| `namespace`            | `string`   | No       | Organization or user namespace (e.g., `"myorg"`)                                              |
+| `name`                 | `string`   | Yes      | Package name (e.g., `"my-app"`)                                                               |
+| `version`              | `string`   | Yes      | Semver version (e.g., `"0.1.0"`)                                                              |
+| `lib`                  | `string`   | No       | Entry module of the package's library world                                                   |
+| `description`          | `string`   | No       | Short, human-readable summary                                                                 |
+| `homepage`             | `string`   | No       | Project home page URL                                                                         |
+| `repository`           | `string`   | No       | Source repository URL (bare repo URL, no subdirectory)                                        |
+| `repository-directory` | `string`   | No       | Subdirectory holding the package within a monorepo (Wado-custom; not an OCI key)              |
+| `documentation`        | `string`   | No       | Documentation URL                                                                             |
+| `license`              | `string`   | No       | SPDX License Expression (e.g., `"MIT OR Apache-2.0"`). Mutually exclusive with `license-file` |
+| `license-file`         | `string`   | No       | Path to a non-standard license file. Mutually exclusive with `license`                        |
+| `authors`              | `string[]` | No       | Contact details of the people or organization responsible                                     |
+| `wado-version`         | `string`   | No       | Minimum Wado compiler version required to build (e.g., `">=0.5"`)                             |
+| `publish`              | `bool`     | No       | `false` opts a namespaced package out of publishing. Default `true`                           |
 
-`namespace` and `name` together form the registry identity (`namespace:name`, e.g., `myorg:my-app`). Without `namespace`, the package cannot be published to a registry — this is the natural state for closed-source applications and internal tools.
+`namespace` and `name` together form the registry identity (`namespace:name`, e.g., `myorg:my-app`). Without `namespace`, the package cannot be published to a registry — this is the natural state for closed-source applications and internal tools. A namespaced package can still opt out explicitly with `publish = false`.
+
+The human-facing fields (`description`, `homepage`, `repository`, `documentation`, `license`, `authors`) are backend-agnostic package metadata; they live in `[package]` rather than a registry-flavored section, and map to OCI annotations only as a serialization detail. See [Package Metadata and Publishing](#package-metadata-and-publishing).
 
 #### Name and Namespace Validation
 
@@ -63,6 +82,69 @@ Both `namespace` and `name` must match `[a-zA-Z0-9_-]+` (minimum 1 character, ma
 Dependency keys in `[dependencies]` are quoted specifiers — an open coordinate `"ns:pkg"` or a `"lib:nick"` nickname — each segment matching the same `[a-zA-Z0-9_-]+` rule. The `lib:`-or-coordinate form makes a real registry identity and a local indirection distinguishable on sight.
 
 A package must declare at least one world: a `[world]` entry, `[package].lib`, or both.
+
+### Package Metadata and Publishing
+
+The human-facing `[package]` fields are universal package metadata that happen
+to map to OCI annotations. The registry backend is OCI (see [Registry backend](#registry-backend)), so on publish each field is serialized to a
+standard `org.opencontainers.image.*` annotation:
+
+| `[package]` field      | OCI annotation                                       | Notes                                                |
+| ---------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| `description`          | `org.opencontainers.image.description`               | Short human-readable summary                         |
+| `homepage`             | `org.opencontainers.image.url`                       |                                                      |
+| `repository`           | `org.opencontainers.image.source`                    | Bare repo URL — enables registry → repo auto-linking |
+| `documentation`        | `org.opencontainers.image.documentation`             |                                                      |
+| `license`              | `org.opencontainers.image.licenses`                  | SPDX License Expression                              |
+| `authors`              | `org.opencontainers.image.authors`                   | Array, serialized comma-separated                    |
+| `version`              | `org.opencontainers.image.version`                   | Set by the registry tool at publish time             |
+| (git commit SHA)       | `org.opencontainers.image.revision`                  | Auto-derived at build time                           |
+| `repository-directory` | — (Wado-custom)                                      | No OCI key exists; embedded in the component only    |
+| `license-file`         | `org.opencontainers.image.licenses` = `LicenseRef-…` | License text embedded as a custom section            |
+
+`created` is not modeled: no embeddable field exists for it, and the registry
+tool owns publish-time timestamps. `keywords`/`categories` are omitted — OCI has
+no standard key for them, so they would not reach an OCI registry.
+
+#### License
+
+`license` (an SPDX expression such as `"MIT OR Apache-2.0"`) is the primary
+form. For a standard license the SPDX identifier is the canonical reference, so
+no file is shipped. A non-standard or proprietary license uses `license-file`
+instead: the annotation becomes `LicenseRef-<name>` (SPDX's syntax for custom
+licenses) and the file's text is embedded in the component. `license` and
+`license-file` are mutually exclusive; publishing requires one of them.
+
+#### Repository subdirectory (monorepo)
+
+Neither OCI nor git has a standard way to address a subdirectory within a
+repository. `repository` therefore stays a bare repo URL (so the registry can
+link the artifact back to its repository); a package's location inside a
+monorepo is recorded in `repository-directory`. This value is not emitted as an
+OCI annotation — it is embedded as Wado-custom metadata and preserved in the
+component for Wado tooling.
+
+The same need on the consuming side — depending on a package that lives in a
+subdirectory of a git repository — is served by the git dependency's
+`directory` field (see [Git](#git)).
+
+#### Metadata embedding and the publish backend
+
+Metadata is embedded into the compiled component using the `wasm-metadata`
+custom-section format that the registry tooling reads. `wado publish` shells out
+to `wkg` (wasm-pkg-tools), which derives the OCI annotations from the embedded
+metadata. There is no `wkg.toml`: `wado.toml` is the single source of truth, and
+users interact only with `wado publish` — `wkg` is an implementation detail. The
+only requirement is that `wkg` is installed; a missing `wkg` produces an error
+with install guidance and exits.
+
+Registry authentication is delegated to the ambient OCI credential store
+(`docker login`, read by `wkg`), with an environment-variable token override for
+CI. Wado stores no credentials of its own.
+
+`revision` (the git commit SHA) is derived at build time. When the working tree
+is dirty, the revision is omitted (with a warning) rather than recording an
+unreproducible state.
 
 ### Entry Points and Worlds
 
@@ -192,11 +274,23 @@ Each dependency must have exactly one primary source type (`git`, `registry`, or
 "user:router" = { git = "https://github.com/user/router.git", ref = "main" }
 ```
 
-| Field     | Required | Description                                   |
-| --------- | -------- | --------------------------------------------- |
-| `git`     | Yes      | Full git URL (any host: GitHub, GitLab, etc.) |
-| `version` | XOR      | Semver range on git tags (e.g., `"^1.0.0"`)   |
-| `ref`     | XOR      | Exact git ref (tag, branch, or commit SHA)    |
+| Field       | Required | Description                                                                                   |
+| ----------- | -------- | --------------------------------------------------------------------------------------------- |
+| `git`       | Yes      | Full git URL (any host: GitHub, GitLab, etc.)                                                 |
+| `version`   | XOR      | Semver range on git tags (e.g., `"^1.0.0"`)                                                   |
+| `ref`       | XOR      | Exact git ref (tag, branch, or commit SHA)                                                    |
+| `directory` | No       | Subdirectory holding the package within the repository (monorepo). Defaults to the repo root. |
+
+```toml
+# Package in a subdirectory of a monorepo
+"org:foo" = { git = "https://github.com/org/monorepo.git", version = "^1.0.0", directory = "packages/foo" }
+```
+
+`directory` addresses the subdirectory through an explicit field rather than
+encoding it into the URL — git has no URL syntax for subdirectories, and the
+ecosystem conventions that bolt one on (`//subdir`, `#subdirectory=`, `?path=`)
+are not interoperable. The inline table already has room for a dedicated key, so
+the path is unambiguous and host-independent.
 
 Exactly one of `version` or `ref` must be specified. `version` resolves against semver-tagged releases in the repository. `ref` pins to an exact git ref — use explicit branch names (e.g., `"main"`) rather than implicit defaults.
 
@@ -665,10 +759,15 @@ See [WEP: CLI Subcommands for Package Management](./wep-2026-02-22-cli-subcomman
 
 ### Publishing
 
-When publishing a package to a registry (`wado publish`), the following validations apply:
+`wado publish` builds the component, embeds the `[package]` metadata, and
+delegates the OCI upload to `wkg` (see [Metadata embedding and the publish
+backend](#metadata-embedding-and-the-publish-backend)). The following
+validations apply:
 
 - `namespace` and `name` must be present
 - `version` must be present and valid semver
+- `publish` must not be `false`
+- exactly one of `license` or `license-file` must be present
 - All `path` dependencies must have accompanying registry or git source information
 
 #### Path Dependency Replacement

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -735,28 +735,19 @@ Only these seven fields may appear in `[workspace.package]`; any other key
 `repository-directory`, `publish`) is package-specific and is not inheritable —
 there is no mechanism to set it workspace-wide.
 
-The forced fields are repository-identity invariants: `version`, `repository`,
-and `namespace` have exactly one definition site (the workspace root), so they
-cannot drift between members. A member that sets a forced field is an error
-(`version is inherited from [workspace.package]; remove it here`). This is the
-deliberate difference from Cargo's per-field opt-in, where same-repo versions
-routinely fall out of sync.
+The forced fields (`version`, `repository`, `namespace`) have exactly one
+definition site, the workspace root. A member that re-declares one is an error
+(`version is inherited from [workspace.package]; remove it here`). Why this is
+forced rather than opt-in is the [Lockstep Contract](#lockstep-contract).
 
 `license` and `license-file` form one logical license slot: if a member sets
 either, it replaces the inherited slot entirely (and the two remain mutually
 exclusive within any single manifest). `license-file` inherited from the
 workspace resolves relative to the workspace root.
 
-Forced inheritance is all-or-nothing per field: a field placed in
-`[workspace.package]` is single-sourced, and members cannot diverge from it.
-Workspace membership is the lockstep boundary. There is deliberately **no**
-per-field opt-out that would let a member override a forced field while staying
-in the workspace — and none is planned. A package that must set its identity
-(and publish) independently is kept out of the workspace and lives as a
-standalone project; that binary (in the workspace = locked, outside = free) is
-the whole contract. (A workspace that does not want to share a particular field
-simply omits it from `[workspace.package]`; the field is then not shared and
-each member sets it itself.)
+Inheritance is all-or-nothing per field: a field placed in `[workspace.package]`
+is single-sourced; a workspace that does not want to share a field simply omits
+it, and each member sets its own.
 
 `[workspace.dependencies]` and `[workspace.dev-dependencies]` declare shared dependency versions. Member packages reference them with explicit opt-in (unlike metadata):
 
@@ -777,6 +768,34 @@ Properties:
 - `wado` commands run from any member directory discover the workspace root automatically
 - Each member has its own `[package]` with an independent `name` and entry points; `version`/`repository`/`namespace` are inherited from `[workspace.package]`
 - Members can depend on each other via `path` dependencies
+
+### Lockstep Contract
+
+Workspace metadata inheritance and root-only publishing together provide a single
+guarantee: **a workspace's packages cannot drift to mismatched public versions.**
+Two mechanisms enforce it, one for the repository and one for the registry.
+
+- Force-inherited identity. `version`, `repository`, and `namespace` are declared
+  once in `[workspace.package]` and cannot be overridden by a member. There is
+  exactly one definition site, so in-repository drift is impossible by
+  construction — not merely linted against.
+- Root-only publish. `wado publish` runs only from the workspace root and
+  publishes every publishable member together at that shared version (see
+  [Publishing](#publishing)). Members can never be pushed piecemeal at different
+  versions, so the registry cannot drift either.
+
+Membership is the boundary. A package is either inside the workspace — bound by
+the contract — or outside it as a standalone project with full freedom. There is
+deliberately no per-field opt-out that lets a member stay in the workspace yet
+diverge from a forced field, and none is planned: the binary keeps the contract
+simple and the guarantee total.
+
+This is the clean departure from Cargo. Cargo's `[workspace.package]` is opt-in
+per field (`version.workspace = true`), so a crate that omits the opt-in silently
+keeps its own version; same-repository version skew (familiar from the
+`wasmtime` / `wasm-tools` crate families) is the routine result. Wado inverts the
+default: for the fields that define a package's published identity, sharing is
+the only in-workspace option, so the drift Cargo permits cannot arise.
 
 ### Single-File Mode
 
@@ -842,12 +861,10 @@ descriptive metadata. These four stay optional even when publishing.
 
 In a workspace, `wado publish` is gated to the workspace root: it publishes every
 publishable member (and the root's own `[package]`, if any) together at the
-shared, force-inherited version. Members that are not publishable (`publish =
-false` or no `namespace`) are skipped. Running `wado publish` from a member
-directory is an error pointing at the root. Forced `version` inheritance already
-prevents version drift _within_ the repository; publishing only from the root
-extends that guarantee to the registry — members can never be published
-piecemeal at mismatched versions.
+shared version. Members that are not publishable (`publish = false` or no
+`namespace`) are skipped, and any member with unmet requirements aborts the whole
+publish. Running `wado publish` from a member directory is an error pointing at
+the root. This is the registry half of the [Lockstep Contract](#lockstep-contract).
 
 #### Path Dependency Replacement
 
@@ -916,7 +933,7 @@ This enables seamless local development while ensuring published packages are se
 - **Dependency specifier resolution**: an open coordinate or `lib:` nickname requires a `wado.toml` lookup at compile time, adding a project-discovery step. The compiler itself is not affected — only `CompilerHost` implementations need to handle this.
 - **Self-sufficient lock file**: duplicates entry points and dependency edges from each package's `wado.toml`. This makes the lock file larger and introduces a potential staleness risk (if a dependency's `wado.toml` changes entry points without version bump). The trade-off is worth it — builds skip all transitive manifest I/O, and staleness is caught by `wado update` or integrity mismatch.
 - **Archive-level integrity** (not source-level): simpler and unambiguous, but means the hash depends on the registry's archive format. If a registry changes its packaging format, hashes change even if sources are identical.
-- **Workspace membership as the lockstep boundary**: force-inherited identity fields plus root-only publishing make version drift across members structurally impossible, at the cost of per-member independence. Independence is regained only by leaving the workspace (standalone), never by an in-workspace per-field opt-out — Wado intentionally provides none, keeping the contract a simple binary rather than a Cargo-style per-field opt-in that lets same-repo versions silently diverge.
+- **Workspace membership as the lockstep boundary** (see [Lockstep Contract](#lockstep-contract)): forced identity inheritance plus root-only publishing make version drift structurally impossible, at the cost of per-member independence — regained only by leaving the workspace, not by an in-workspace opt-out.
 - **Forced metadata inheritance has no `{ workspace = true }` marker** (unlike dependencies): a field in `[workspace.package]` is inherited automatically and a member that re-declares a forced one is an error. This trades a small surprise (no opt-in syntax) for the guarantee that forced fields have exactly one definition site.
 - **`[world]` table keyed by FQ world name**: hosted worlds are declared by their Component Model world name (`"wasi:cli/command"`) rather than a short alias (`command`/`bin`/`cli`). The key is the world the entry conforms to, so new worlds need no new manifest field and the mapping to the CM world is explicit. The library world is the one exception — it has no externally-fixed FQ name, so it is named after the package and declared by `[package].lib`.
 - **`[package]` over `[project]`**: `[package]` aligns with CM's "package" concept (`package ns:name@version` in WIT). The file itself represents the project; `[package]` describes the distributable unit within it. `[workspace]` > `[package]` hierarchy is natural, whereas `[workspace]` > `[project]` would be confusing.

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -73,7 +73,7 @@ an open coordinate `ns:pkg`, or a `lib:` nickname for indirection. Bare keys
 
 `namespace` and `name` together form the registry identity (`namespace:name`, e.g., `myorg:my-app`). Without `namespace`, the package cannot be published to a registry — this is the natural state for closed-source applications and internal tools. A namespaced package can still opt out explicitly with `publish = false`.
 
-The human-facing fields (`description`, `homepage`, `repository`, `documentation`, `license`, `authors`) are backend-agnostic package metadata; they live in `[package]` rather than a registry-flavored section, and map to OCI annotations only as a serialization detail. See [Package Metadata and Publishing](#package-metadata-and-publishing).
+The human-facing fields are backend-agnostic metadata kept in `[package]` (not a registry-flavored section); the OCI mapping is just a serialization detail (see [Package Metadata and Publishing](#package-metadata-and-publishing)).
 
 #### Name and Namespace Validation
 
@@ -89,9 +89,7 @@ Keys the schema does not recognize — at the top level, in `[package]`, or in `
 
 ### Package Metadata and Publishing
 
-The human-facing `[package]` fields are universal package metadata that happen
-to map to OCI annotations. The registry backend is OCI (see [Registry backend](#registry-backend)), so on publish each field is serialized to a
-standard `org.opencontainers.image.*` annotation:
+The human-facing `[package]` fields are universal package metadata; on publish to OCI (see [Registry backend](#registry-backend)) each maps to a standard `org.opencontainers.image.*` annotation:
 
 | `[package]` field      | OCI annotation                                       | Notes                                                |
 | ---------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
@@ -106,51 +104,20 @@ standard `org.opencontainers.image.*` annotation:
 | `repository-directory` | — (Wado-custom)                                      | No OCI key exists; embedded in the component only    |
 | `license-file`         | `org.opencontainers.image.licenses` = `LicenseRef-…` | License text embedded as a custom section            |
 
-`created` is not modeled: no embeddable field exists for it, and the registry
-tool owns publish-time timestamps. `keywords`/`categories` are omitted — OCI has
-no standard key for them, so they would not reach an OCI registry.
+`created` is not modeled (the registry tool owns publish timestamps);
+`keywords`/`categories` are omitted (no OCI key, so they would not reach the registry).
 
 #### License
 
-`license` (an SPDX expression such as `"MIT OR Apache-2.0"`) is the primary
-form, and is validated as a well-formed SPDX expression at parse time. For a
-standard license the SPDX identifier is the canonical reference, so no file is
-shipped. A non-standard or proprietary license uses `license-file` instead: the
-annotation becomes `LicenseRef-<name>` (SPDX's syntax for custom licenses, also
-accepted in the `license` field) and the file's text is embedded in the
-component. `license` and `license-file` are mutually exclusive; publishing
-requires one of them.
+`license` is an SPDX expression (`"MIT OR Apache-2.0"`), validated at parse time; the SPDX id is the canonical reference, so no file ships. A non-standard license uses `license-file` instead — the annotation becomes `LicenseRef-<name>` and the file's text is embedded. The two are mutually exclusive; publishing requires one.
 
 #### Repository subdirectory (monorepo)
 
-Neither OCI nor git has a standard way to address a subdirectory within a
-repository. `repository` therefore stays a bare repo URL (so the registry can
-link the artifact back to its repository); a package's location inside a
-monorepo is recorded in `repository-directory`. This value is not emitted as an
-OCI annotation — it is embedded as Wado-custom metadata and preserved in the
-component for Wado tooling.
-
-The same need on the consuming side — depending on a package that lives in a
-subdirectory of a git repository — is served by the git dependency's
-`directory` field (see [Git](#git)).
+Neither OCI nor git addresses a repository subdirectory, so `repository` stays a bare repo URL (for registry → repo linking) and the package's location is recorded in `repository-directory` — embedded as Wado-custom metadata, not an OCI annotation. The consuming side is served by the git dependency's `directory` field (see [Git](#git)).
 
 #### Metadata embedding and the publish backend
 
-Metadata is embedded into the compiled component using the `wasm-metadata`
-custom-section format that the registry tooling reads. `wado publish` shells out
-to `wkg` (wasm-pkg-tools), which derives the OCI annotations from the embedded
-metadata. There is no `wkg.toml`: `wado.toml` is the single source of truth, and
-users interact only with `wado publish` — `wkg` is an implementation detail. The
-only requirement is that `wkg` is installed; a missing `wkg` produces an error
-with install guidance and exits.
-
-Registry authentication is delegated to the ambient OCI credential store
-(`docker login`, read by `wkg`), with an environment-variable token override for
-CI. Wado stores no credentials of its own.
-
-`revision` (the git commit SHA) is derived at build time. When the working tree
-is dirty, the revision is omitted (with a warning) rather than recording an
-unreproducible state.
+`wado publish` embeds the metadata into the component in the `wasm-metadata` custom-section format and shells out to `wkg` (wasm-pkg-tools), which derives the OCI annotations. There is no `wkg.toml` — `wado.toml` is the only source of truth, and `wkg` is an implementation detail (a missing `wkg` errors with install guidance). Authentication is delegated to the ambient OCI credential store (`docker login`), with an env-var token override for CI; Wado stores no credentials. `revision` is the git commit SHA, derived at build time and omitted (with a warning) on a dirty tree.
 
 ### Entry Points and Worlds
 
@@ -292,11 +259,7 @@ Each dependency must have exactly one primary source type (`git`, `registry`, or
 "org:foo" = { git = "https://github.com/org/monorepo.git", version = "^1.0.0", directory = "packages/foo" }
 ```
 
-`directory` addresses the subdirectory through an explicit field rather than
-encoding it into the URL — git has no URL syntax for subdirectories, and the
-ecosystem conventions that bolt one on (`//subdir`, `#subdirectory=`, `?path=`)
-are not interoperable. The inline table already has room for a dedicated key, so
-the path is unambiguous and host-independent.
+`directory` is an explicit field rather than URL-encoded: git has no subdirectory URL syntax and the ecosystem conventions that bolt one on (`//subdir`, `#subdirectory=`, `?path=`) are not interoperable, so a dedicated key keeps the path unambiguous and host-independent.
 
 Exactly one of `version` or `ref` must be specified. `version` resolves against semver-tagged releases in the repository. `ref` pins to an exact git ref — use explicit branch names (e.g., `"main"`) rather than implicit defaults.
 
@@ -715,10 +678,7 @@ repository-directory = "packages/cli"
 
 #### `[workspace.package]` — Shared Package Metadata
 
-`[workspace.package]` declares package metadata shared by every member.
-Inheritance is automatic — unlike dependencies, members do **not** write
-`{ workspace = true }`. Whether a member may override an inherited field depends
-on the field:
+`[workspace.package]` holds metadata shared by every member. Inheritance is automatic — unlike dependencies, members do not write `{ workspace = true }`. Override depends on the field:
 
 | Field          | Inheritance                     | Member override          |
 | -------------- | ------------------------------- | ------------------------ |
@@ -730,24 +690,9 @@ on the field:
 | `authors`      | Default                         | Allowed                  |
 | `wado-version` | Default                         | Allowed                  |
 
-Only these seven fields may appear in `[workspace.package]`; any other key
-(`name`, `lib`, `description`, `homepage`, `documentation`,
-`repository-directory`, `publish`) is package-specific and is not inheritable —
-there is no mechanism to set it workspace-wide.
+Only these seven fields are inheritable; any other key (`name`, `lib`, `description`, `homepage`, `documentation`, `repository-directory`, `publish`) is package-specific. A member that re-declares a forced field is an error (`version is inherited from [workspace.package]; remove it here`) — see the [Lockstep Contract](#lockstep-contract).
 
-The forced fields (`version`, `repository`, `namespace`) have exactly one
-definition site, the workspace root. A member that re-declares one is an error
-(`version is inherited from [workspace.package]; remove it here`). Why this is
-forced rather than opt-in is the [Lockstep Contract](#lockstep-contract).
-
-`license` and `license-file` form one logical license slot: if a member sets
-either, it replaces the inherited slot entirely (and the two remain mutually
-exclusive within any single manifest). `license-file` inherited from the
-workspace resolves relative to the workspace root.
-
-Inheritance is all-or-nothing per field: a field placed in `[workspace.package]`
-is single-sourced; a workspace that does not want to share a field simply omits
-it, and each member sets its own.
+`license` and `license-file` are one slot: a member setting either replaces it whole (still mutually exclusive within a manifest), and an inherited `license-file` resolves relative to the root. A field a workspace does not want to share is simply omitted, and each member sets its own.
 
 `[workspace.dependencies]` and `[workspace.dev-dependencies]` declare shared dependency versions. Member packages reference them with explicit opt-in (unlike metadata):
 
@@ -771,31 +716,14 @@ Properties:
 
 ### Lockstep Contract
 
-Workspace metadata inheritance and root-only publishing together provide a single
-guarantee: **a workspace's packages cannot drift to mismatched public versions.**
-Two mechanisms enforce it, one for the repository and one for the registry.
+Workspace metadata inheritance and root-only publishing together guarantee that **a workspace's packages cannot drift to mismatched public versions**, enforced in two places:
 
-- Force-inherited identity. `version`, `repository`, and `namespace` are declared
-  once in `[workspace.package]` and cannot be overridden by a member. There is
-  exactly one definition site, so in-repository drift is impossible by
-  construction — not merely linted against.
-- Root-only publish. `wado publish` runs only from the workspace root and
-  publishes every publishable member together at that shared version (see
-  [Publishing](#publishing)). Members can never be pushed piecemeal at different
-  versions, so the registry cannot drift either.
+- Repository: `version`, `repository`, and `namespace` are declared once in `[workspace.package]` and cannot be overridden, so there is one definition site and drift is impossible by construction, not merely linted.
+- Registry: `wado publish` runs only from the workspace root and publishes every member together at that shared version (see [Publishing](#publishing)), so members can't be pushed piecemeal at different versions.
 
-Membership is the boundary. A package is either inside the workspace — bound by
-the contract — or outside it as a standalone project with full freedom. There is
-deliberately no per-field opt-out that lets a member stay in the workspace yet
-diverge from a forced field, and none is planned: the binary keeps the contract
-simple and the guarantee total.
+Membership is the boundary: a package is either inside the workspace (bound) or a standalone project (free). There is deliberately no per-field opt-out to diverge while staying in — and none is planned.
 
-This is the clean departure from Cargo. Cargo's `[workspace.package]` is opt-in
-per field (`version.workspace = true`), so a crate that omits the opt-in silently
-keeps its own version; same-repository version skew (familiar from the
-`wasmtime` / `wasm-tools` crate families) is the routine result. Wado inverts the
-default: for the fields that define a package's published identity, sharing is
-the only in-workspace option, so the drift Cargo permits cannot arise.
+This is the departure from Cargo, whose `[workspace.package]` is opt-in per field (`version.workspace = true`): a crate that omits it silently keeps its own version, so same-repo skew (familiar from `wasmtime` / `wasm-tools`) is routine. Wado makes sharing the only in-workspace option for identity fields, so that drift cannot arise.
 
 ### Single-File Mode
 
@@ -849,11 +777,7 @@ validations apply:
 - exactly one of `license` or `license-file` must be present
 - every shipped dependency must carry a concrete source: a `path` dependency needs an accompanying registry/git source, and a `workspace = true` dependency must resolve to one (the workspace context is gone once the package is extracted)
 
-A published package must carry its descriptive metadata, so the non-exclusive
-fields above are required. The exceptions: `homepage` and `documentation` are
-redundant with `repository` and default to it when omitted; `repository-directory`
-is meaningful only for a monorepo; and `wado-version` is a build constraint, not
-descriptive metadata. These four stay optional even when publishing.
+The descriptive fields are required because a published package must carry its metadata. The rest stay optional: `homepage`/`documentation` default to `repository`, `repository-directory` is monorepo-only, and `wado-version` is a build constraint.
 
 `wado publish --dry-run` runs these checks and reports every problem at once
 (it does not upload). The OCI upload itself is not yet implemented, so a bare
@@ -933,8 +857,7 @@ This enables seamless local development while ensuring published packages are se
 - **Dependency specifier resolution**: an open coordinate or `lib:` nickname requires a `wado.toml` lookup at compile time, adding a project-discovery step. The compiler itself is not affected — only `CompilerHost` implementations need to handle this.
 - **Self-sufficient lock file**: duplicates entry points and dependency edges from each package's `wado.toml`. This makes the lock file larger and introduces a potential staleness risk (if a dependency's `wado.toml` changes entry points without version bump). The trade-off is worth it — builds skip all transitive manifest I/O, and staleness is caught by `wado update` or integrity mismatch.
 - **Archive-level integrity** (not source-level): simpler and unambiguous, but means the hash depends on the registry's archive format. If a registry changes its packaging format, hashes change even if sources are identical.
-- **Workspace membership as the lockstep boundary** (see [Lockstep Contract](#lockstep-contract)): forced identity inheritance plus root-only publishing make version drift structurally impossible, at the cost of per-member independence — regained only by leaving the workspace, not by an in-workspace opt-out.
-- **Forced metadata inheritance has no `{ workspace = true }` marker** (unlike dependencies): a field in `[workspace.package]` is inherited automatically and a member that re-declares a forced one is an error. This trades a small surprise (no opt-in syntax) for the guarantee that forced fields have exactly one definition site.
+- **Lockstep over per-field opt-in** (see [Lockstep Contract](#lockstep-contract)): `[workspace.package]` inherits automatically (no `{ workspace = true }` marker) and forced fields can't be overridden, plus root-only publishing — trading per-member independence for one definition site and structurally drift-free releases. Independence means leaving the workspace, not an in-workspace opt-out.
 - **`[world]` table keyed by FQ world name**: hosted worlds are declared by their Component Model world name (`"wasi:cli/command"`) rather than a short alias (`command`/`bin`/`cli`). The key is the world the entry conforms to, so new worlds need no new manifest field and the mapping to the CM world is explicit. The library world is the one exception — it has no externally-fixed FQ name, so it is named after the package and declared by `[package].lib`.
 - **`[package]` over `[project]`**: `[package]` aligns with CM's "package" concept (`package ns:name@version` in WIT). The file itself represents the project; `[package]` describes the distributable unit within it. `[workspace]` > `[package]` hierarchy is natural, whereas `[workspace]` > `[project]` would be confusing.
 - **`path` + `registry` dual source**: adds complexity to the dependency spec but eliminates the "path deps can't be published" problem. The alternative (Cargo's separate `[patch]` section) is more complex and harder to maintain.

--- a/package-cm-catalog/wado.toml
+++ b/package-cm-catalog/wado.toml
@@ -1,12 +1,6 @@
 [package]
-namespace = "wado-lang"
 name = "cm-catalog"
-version = "0.1.0"
-
 description = "A Wasm CM catalog package for those who implement Wasm CM ABI"
-repository = "https://github.com/wado-lang/wado"
 repository-directory = "package-cm-catalog"
-license = "MIT"
-authors = ["FUJI Goro <g.psy.va@gmail.com>"]
-
 lib = "src/lib.wado"
+# version / repository / namespace / license / authors inherited from [workspace.package]

--- a/package-cm-catalog/wado.toml
+++ b/package-cm-catalog/wado.toml
@@ -4,7 +4,9 @@ name = "cm-catalog"
 version = "0.1.0"
 
 description = "A Wasm CM catalog package for those who implement Wasm CM ABI"
-url = "https://github.com/wado-lang/wado/tree/main/package-cm-catalog"
+repository = "https://github.com/wado-lang/wado"
+repository-directory = "package-cm-catalog"
 license = "MIT"
+authors = ["FUJI Goro <g.psy.va@gmail.com>"]
 
 lib = "src/lib.wado"

--- a/package-gale/wado.toml
+++ b/package-gale/wado.toml
@@ -1,13 +1,8 @@
 [package]
-namespace = "wado-lang"
 name = "gale"
-version = "0.1.0"
-
 description = "A Wado-native parser generator compatible with ANTLR4 .g4 grammars"
-repository = "https://github.com/wado-lang/wado"
 repository-directory = "package-gale"
-license = "MIT"
-authors = ["FUJI Goro <g.psy.va@gmail.com>"]
+# version / repository / namespace / license / authors inherited from [workspace.package]
 
 [world]
 "wasi:cli/command" = "src/main.wado"

--- a/package-gale/wado.toml
+++ b/package-gale/wado.toml
@@ -1,6 +1,13 @@
 [package]
+namespace = "wado-lang"
 name = "gale"
 version = "0.1.0"
+
+description = "A Wado-native parser generator compatible with ANTLR4 .g4 grammars"
+repository = "https://github.com/wado-lang/wado"
+repository-directory = "package-gale"
+license = "MIT"
+authors = ["FUJI Goro <g.psy.va@gmail.com>"]
 
 [world]
 "wasi:cli/command" = "src/main.wado"

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -713,7 +713,9 @@ fn build_dep_generator_local_path(
 /// both spellings land on the same entry file.
 fn package_generator_entry(pkg_dir: &Path) -> Option<String> {
     let manifest_text = fs::read_to_string(pkg_dir.join("wado.toml")).ok()?;
-    let manifest: wado_manifest::Manifest = manifest_text.parse().ok()?;
+    // Workspace-aware: a generator package may be a member that inherits
+    // required fields (e.g. version) from [workspace.package].
+    let manifest = crate::manifest::resolve_manifest(pkg_dir, &manifest_text).ok()?;
     Some(manifest.world_entry("core:kiln/generator")?.to_string())
 }
 
@@ -732,6 +734,7 @@ pub fn empty_manifest() -> wado_manifest::Manifest {
         test: wado_manifest::TestSettings::default(),
         format: wado_manifest::FormatSettings::default(),
         unknown_sections: Vec::new(),
+        inherited_unknown_fields: Vec::new(),
     }
 }
 
@@ -927,17 +930,12 @@ pub fn load_nearest_manifest(
     if dir.as_os_str().is_empty() {
         dir = std::path::PathBuf::from(".");
     }
-    loop {
-        let candidate = dir.join("wado.toml");
-        if candidate.is_file() {
-            let text = fs::read_to_string(&candidate).ok()?;
-            let manifest: wado_manifest::Manifest = text.parse().ok()?;
-            return Some((manifest, dir));
-        }
-        if !dir.pop() {
-            return None;
-        }
-    }
+    // Reuse workspace-aware discovery so a member manifest that inherits
+    // required fields from [workspace.package] resolves instead of failing to
+    // parse standalone. A malformed manifest yields `None` (no Kiln config), as
+    // before.
+    let project = crate::manifest::discover(&dir).ok().flatten()?;
+    Some((project.manifest, project.root))
 }
 
 fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -713,8 +713,6 @@ fn build_dep_generator_local_path(
 /// both spellings land on the same entry file.
 fn package_generator_entry(pkg_dir: &Path) -> Option<String> {
     let manifest_text = fs::read_to_string(pkg_dir.join("wado.toml")).ok()?;
-    // Workspace-aware: a generator package may be a member that inherits
-    // required fields (e.g. version) from [workspace.package].
     let manifest = crate::manifest::resolve_manifest(pkg_dir, &manifest_text).ok()?;
     Some(manifest.world_entry("core:kiln/generator")?.to_string())
 }
@@ -930,10 +928,6 @@ pub fn load_nearest_manifest(
     if dir.as_os_str().is_empty() {
         dir = std::path::PathBuf::from(".");
     }
-    // Reuse workspace-aware discovery so a member manifest that inherits
-    // required fields from [workspace.package] resolves instead of failing to
-    // parse standalone. A malformed manifest yields `None` (no Kiln config), as
-    // before.
     let project = crate::manifest::discover(&dir).ok().flatten()?;
     Some((project.manifest, project.root))
 }

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -731,6 +731,7 @@ pub fn empty_manifest() -> wado_manifest::Manifest {
         workspace: None,
         test: wado_manifest::TestSettings::default(),
         format: wado_manifest::FormatSettings::default(),
+        unknown_sections: Vec::new(),
     }
 }
 

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -22,6 +22,7 @@ pub mod kiln_provider;
 pub mod kiln_runtime;
 pub mod lsp;
 pub mod manifest;
+pub mod publish;
 pub mod query;
 pub mod query_adapter;
 pub mod registry;

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -25,6 +25,7 @@ enum Cmd {
     Syntax,
     Lsp,
     Query,
+    Publish,
 }
 
 impl Cmd {
@@ -43,6 +44,7 @@ impl Cmd {
         Self::Syntax,
         Self::Lsp,
         Self::Query,
+        Self::Publish,
     ];
 
     const fn name(self) -> &'static str {
@@ -61,6 +63,7 @@ impl Cmd {
             Self::Syntax => "syntax",
             Self::Lsp => "lsp",
             Self::Query => "query",
+            Self::Publish => "publish",
         }
     }
 
@@ -70,7 +73,7 @@ impl Cmd {
             Self::Wit => "[options] [file.wado | dir]",
             Self::Test => "[options] [files or dirs...]",
             Self::Format | Self::Doc | Self::Dump => "[options] <file.wado>...",
-            Self::Init | Self::Update | Self::Syntax | Self::Lsp => "[options]",
+            Self::Init | Self::Update | Self::Syntax | Self::Lsp | Self::Publish => "[options]",
             Self::Query => "<kind> [options] <file.wado>",
         }
     }
@@ -91,6 +94,7 @@ impl Cmd {
             Self::Syntax => "Generate syntax definition files",
             Self::Lsp => "Start the language server (LSP over stdio)",
             Self::Query => "Query language service information",
+            Self::Publish => "Check whether the package can be published",
         }
     }
 
@@ -241,6 +245,10 @@ async fn dispatch() -> Result<(), CliExit> {
                 Cmd::Query => {
                     let opts = wado_cli::query::parse_args(parser)?;
                     Box::pin(wado_cli::query::run(opts)).await
+                }
+                Cmd::Publish => {
+                    let opts = wado_cli::publish::parse_args(parser)?;
+                    wado_cli::publish::run(opts)
                 }
             }
         }

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -665,8 +665,6 @@ authors = ["Alice"]
 
     #[test]
     fn workspace_root_that_is_also_a_package_parses_standalone() {
-        // A root declaring both [workspace] and [package] is the authority, not
-        // a governed member: it does not force-inherit and must not error.
         let tmp = tempfile::tempdir().unwrap();
         let toml = format!("{WS_ROOT}\n[package]\nname = \"root-pkg\"\nversion = \"0.1.0\"\nrepository = \"https://github.com/org/monorepo\"\nnamespace = \"org\"\n");
         write(&tmp.path().join("wado.toml"), &toml);
@@ -683,10 +681,8 @@ authors = ["Alice"]
             &member_dir.join("wado.toml"),
             "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n",
         );
-        // From a member: returns the root dir.
         let root = governing_workspace_root_dir(&member_dir).unwrap().unwrap();
         assert_eq!(root, tmp.path());
-        // From the root itself: it is the authority, not a governed member.
         assert!(
             governing_workspace_root_dir(tmp.path())
                 .unwrap()
@@ -716,7 +712,6 @@ authors = ["Alice"]
             &tmp.path().join("packages/b/wado.toml"),
             "[package]\nname = \"b\"\n",
         );
-        // A dir without a wado.toml is not a member.
         fs::create_dir_all(tmp.path().join("packages/empty")).unwrap();
         let dirs = workspace_member_dirs(tmp.path(), &["packages/*".to_string()]);
         assert_eq!(
@@ -727,8 +722,6 @@ authors = ["Alice"]
 
     #[test]
     fn non_member_directory_does_not_inherit() {
-        // A dir outside the members globs is standalone: omitting an inherited
-        // required field must fail rather than silently inherit.
         let tmp = tempfile::tempdir().unwrap();
         write(&tmp.path().join("wado.toml"), WS_ROOT);
         let outside = tmp.path().join("tools/helper");

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -48,7 +48,7 @@ pub fn discover(start_dir: &Path) -> Result<Option<ProjectManifest>, DiscoveryEr
         let candidate = dir.join(MANIFEST_FILENAME);
         if candidate.is_file() {
             let content = fs::read_to_string(&candidate).map_err(DiscoveryError::Io)?;
-            let manifest: Manifest = content.parse().map_err(DiscoveryError::Parse)?;
+            let manifest = resolve_manifest(&dir, &content)?;
             return Ok(Some(ProjectManifest {
                 manifest,
                 root: dir,
@@ -58,6 +58,73 @@ pub fn discover(start_dir: &Path) -> Result<Option<ProjectManifest>, DiscoveryEr
             return Ok(None);
         }
     }
+}
+
+/// Parse a member's `wado.toml`, applying `[workspace.package]` inheritance when
+/// the directory belongs to a workspace; otherwise parse it standalone.
+fn resolve_manifest(member_dir: &Path, member_content: &str) -> Result<Manifest, DiscoveryError> {
+    match find_workspace_root(member_dir, member_content) {
+        Some(root_content) => wado_manifest::resolve_member(member_content, &root_content)
+            .map_err(DiscoveryError::Parse),
+        None => member_content.parse().map_err(DiscoveryError::Parse),
+    }
+}
+
+/// The workspace-root `wado.toml` contents governing `member_dir`, if any. The
+/// member's own manifest may declare the workspace (root = self); otherwise walk
+/// up to the nearest ancestor whose `[workspace].members` glob covers the member.
+fn find_workspace_root(member_dir: &Path, member_content: &str) -> Option<String> {
+    if read_workspace_members(member_content).is_some() {
+        return Some(member_content.to_string());
+    }
+    let mut dir = member_dir.to_path_buf();
+    while dir.pop() {
+        let candidate = dir.join(MANIFEST_FILENAME);
+        if !candidate.is_file() {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&candidate) else {
+            continue;
+        };
+        if let Some(members) = read_workspace_members(&content)
+            && workspace_governs(&dir, &members, member_dir)
+        {
+            return Some(content);
+        }
+    }
+    None
+}
+
+/// Read `[workspace].members` without full validation (the member may omit
+/// inherited required fields, which a full parse would reject).
+fn read_workspace_members(content: &str) -> Option<Vec<String>> {
+    let table: toml::Table = toml::from_str(content).ok()?;
+    let members = table.get("workspace")?.as_table()?.get("members")?.as_array()?;
+    Some(
+        members
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_owned))
+            .collect(),
+    )
+}
+
+/// Whether `member_dir` matches any `members` glob, resolved relative to the
+/// workspace root directory.
+fn workspace_governs(root_dir: &Path, members: &[String], member_dir: &Path) -> bool {
+    let Ok(target) = member_dir.canonicalize() else {
+        return false;
+    };
+    members.iter().any(|pattern| {
+        let Some(joined) = root_dir.join(pattern).to_str().map(str::to_owned) else {
+            return false;
+        };
+        let Ok(paths) = glob::glob(&joined) else {
+            return false;
+        };
+        paths
+            .filter_map(Result::ok)
+            .any(|p| p.canonicalize().is_ok_and(|c| c == target))
+    })
 }
 
 /// The kind of entry point to resolve, identified by the CM world it targets.
@@ -174,7 +241,7 @@ pub fn resolve_entry_point(project: &ProjectManifest, kind: EntryPointKind) -> O
 fn load_from_dir(dir: &Path) -> Result<ProjectManifest, DiscoveryError> {
     let candidate = dir.join(MANIFEST_FILENAME);
     let content = fs::read_to_string(&candidate).map_err(DiscoveryError::Io)?;
-    let manifest: Manifest = content.parse().map_err(DiscoveryError::Parse)?;
+    let manifest = resolve_manifest(dir, &content)?;
     Ok(ProjectManifest {
         manifest,
         root: dir.to_path_buf(),

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -62,7 +62,10 @@ pub fn discover(start_dir: &Path) -> Result<Option<ProjectManifest>, DiscoveryEr
 
 /// Parse a member's `wado.toml`, applying `[workspace.package]` inheritance when
 /// the directory belongs to a workspace; otherwise parse it standalone.
-fn resolve_manifest(member_dir: &Path, member_content: &str) -> Result<Manifest, DiscoveryError> {
+pub(crate) fn resolve_manifest(
+    member_dir: &Path,
+    member_content: &str,
+) -> Result<Manifest, DiscoveryError> {
     match find_workspace_root(member_dir, member_content) {
         Some(root_content) => wado_manifest::resolve_member(member_content, &root_content)
             .map_err(DiscoveryError::Parse),
@@ -70,12 +73,15 @@ fn resolve_manifest(member_dir: &Path, member_content: &str) -> Result<Manifest,
     }
 }
 
-/// The workspace-root `wado.toml` contents governing `member_dir`, if any. The
-/// member's own manifest may declare the workspace (root = self); otherwise walk
-/// up to the nearest ancestor whose `[workspace].members` glob covers the member.
+/// The workspace-root `wado.toml` contents governing `member_dir`, if any.
+///
+/// A manifest that itself declares `[workspace]` is the workspace authority, not
+/// a governed member, so it does not inherit (it returns `None` and is parsed
+/// standalone). Otherwise walk up to the nearest ancestor whose
+/// `[workspace].members` glob covers the member.
 fn find_workspace_root(member_dir: &Path, member_content: &str) -> Option<String> {
     if read_workspace_members(member_content).is_some() {
-        return Some(member_content.to_string());
+        return None;
     }
     let mut dir = member_dir.to_path_buf();
     while dir.pop() {
@@ -108,22 +114,17 @@ fn read_workspace_members(content: &str) -> Option<Vec<String>> {
     )
 }
 
-/// Whether `member_dir` matches any `members` glob, resolved relative to the
-/// workspace root directory.
+/// Whether `member_dir` matches any `members` glob, evaluated as a pure path
+/// match (no filesystem walk, no canonicalize) against the member path relative
+/// to the workspace root. Reuses the walker's glob options so membership and
+/// test-discovery agree.
 fn workspace_governs(root_dir: &Path, members: &[String], member_dir: &Path) -> bool {
-    let Ok(target) = member_dir.canonicalize() else {
+    let Ok(rel) = member_dir.strip_prefix(root_dir) else {
         return false;
     };
     members.iter().any(|pattern| {
-        let Some(joined) = root_dir.join(pattern).to_str().map(str::to_owned) else {
-            return false;
-        };
-        let Ok(paths) = glob::glob(&joined) else {
-            return false;
-        };
-        paths
-            .filter_map(Result::ok)
-            .any(|p| p.canonicalize().is_ok_and(|c| c == target))
+        glob::Pattern::new(pattern)
+            .is_ok_and(|p| p.matches_path_with(rel, crate::discover::WALK_MATCH_OPTIONS))
     })
 }
 
@@ -588,5 +589,69 @@ version = "0.1.0"
 
         let project = discover(tmp.path()).unwrap().unwrap();
         assert!(resolve_entry_point(&project, EntryPointKind::Service).is_none());
+    }
+
+    const WS_ROOT: &str = r#"
+[workspace]
+members = ["packages/*"]
+
+[workspace.package]
+version = "0.1.0"
+repository = "https://github.com/org/monorepo"
+namespace = "org"
+license = "MIT"
+authors = ["Alice"]
+"#;
+
+    fn write(path: &Path, content: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn member_inherits_workspace_metadata_via_discovery() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("wado.toml"), WS_ROOT);
+        let member_dir = tmp.path().join("packages/core");
+        write(
+            &member_dir.join("wado.toml"),
+            "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n",
+        );
+        let project = discover(&member_dir).unwrap().unwrap();
+        let pkg = project.manifest.package.unwrap();
+        assert_eq!(pkg.name, "core");
+        assert_eq!(pkg.version, "0.1.0");
+        assert_eq!(pkg.namespace.as_deref(), Some("org"));
+        assert_eq!(pkg.license.as_deref(), Some("MIT"));
+    }
+
+    #[test]
+    fn workspace_root_that_is_also_a_package_parses_standalone() {
+        // A root declaring both [workspace] and [package] is the authority, not
+        // a governed member: it does not force-inherit and must not error.
+        let tmp = tempfile::tempdir().unwrap();
+        let toml = format!("{WS_ROOT}\n[package]\nname = \"root-pkg\"\nversion = \"0.1.0\"\nrepository = \"https://github.com/org/monorepo\"\nnamespace = \"org\"\n");
+        write(&tmp.path().join("wado.toml"), &toml);
+        let project = discover(tmp.path()).unwrap().unwrap();
+        assert_eq!(project.manifest.package.unwrap().name, "root-pkg");
+    }
+
+    #[test]
+    fn non_member_directory_does_not_inherit() {
+        // A dir outside the members globs is standalone: omitting an inherited
+        // required field must fail rather than silently inherit.
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("wado.toml"), WS_ROOT);
+        let outside = tmp.path().join("tools/helper");
+        write(
+            &outside.join("wado.toml"),
+            "[package]\nname = \"helper\"\nlib = \"src/lib.wado\"\n",
+        );
+        let err = discover(&outside).unwrap_err();
+        assert!(
+            matches!(&err, DiscoveryError::Parse(e)
+                if matches!(e, wado_manifest::ManifestError::MissingField { field, .. } if field == "version")),
+            "{err:?}"
+        );
     }
 }

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -143,7 +143,11 @@ pub(crate) fn workspace_member_dirs(root_dir: &Path, members: &[String]) -> Vec<
 /// inherited required fields, which a full parse would reject).
 fn read_workspace_members(content: &str) -> Option<Vec<String>> {
     let table: toml::Table = toml::from_str(content).ok()?;
-    let members = table.get("workspace")?.as_table()?.get("members")?.as_array()?;
+    let members = table
+        .get("workspace")?
+        .as_table()?
+        .get("members")?
+        .as_array()?;
     Some(
         members
             .iter()
@@ -666,7 +670,9 @@ authors = ["Alice"]
     #[test]
     fn workspace_root_that_is_also_a_package_parses_standalone() {
         let tmp = tempfile::tempdir().unwrap();
-        let toml = format!("{WS_ROOT}\n[package]\nname = \"root-pkg\"\nversion = \"0.1.0\"\nrepository = \"https://github.com/org/monorepo\"\nnamespace = \"org\"\n");
+        let toml = format!(
+            "{WS_ROOT}\n[package]\nname = \"root-pkg\"\nversion = \"0.1.0\"\nrepository = \"https://github.com/org/monorepo\"\nnamespace = \"org\"\n"
+        );
         write(&tmp.path().join("wado.toml"), &toml);
         let project = discover(tmp.path()).unwrap().unwrap();
         assert_eq!(project.manifest.package.unwrap().name, "root-pkg");
@@ -683,11 +689,7 @@ authors = ["Alice"]
         );
         let root = governing_workspace_root_dir(&member_dir).unwrap().unwrap();
         assert_eq!(root, tmp.path());
-        assert!(
-            governing_workspace_root_dir(tmp.path())
-                .unwrap()
-                .is_none()
-        );
+        assert!(governing_workspace_root_dir(tmp.path()).unwrap().is_none());
     }
 
     #[test]

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -73,13 +73,13 @@ pub(crate) fn resolve_manifest(
     }
 }
 
-/// The workspace-root `wado.toml` contents governing `member_dir`, if any.
+/// The workspace governing `member_dir` — its root directory and `wado.toml`
+/// contents — if `member_dir` is a member of one.
 ///
 /// A manifest that itself declares `[workspace]` is the workspace authority, not
-/// a governed member, so it does not inherit (it returns `None` and is parsed
-/// standalone). Otherwise walk up to the nearest ancestor whose
-/// `[workspace].members` glob covers the member.
-fn find_workspace_root(member_dir: &Path, member_content: &str) -> Option<String> {
+/// a governed member, so it returns `None`. Otherwise walk up to the nearest
+/// ancestor whose `[workspace].members` glob covers the member.
+fn governing_workspace(member_dir: &Path, member_content: &str) -> Option<(PathBuf, String)> {
     if read_workspace_members(member_content).is_some() {
         return None;
     }
@@ -95,10 +95,48 @@ fn find_workspace_root(member_dir: &Path, member_content: &str) -> Option<String
         if let Some(members) = read_workspace_members(&content)
             && workspace_governs(&dir, &members, member_dir)
         {
-            return Some(content);
+            return Some((dir, content));
         }
     }
     None
+}
+
+/// The workspace-root `wado.toml` contents governing `member_dir`, if any.
+fn find_workspace_root(member_dir: &Path, member_content: &str) -> Option<String> {
+    governing_workspace(member_dir, member_content).map(|(_, content)| content)
+}
+
+/// The workspace root directory governing the package at `member_dir`, if it is
+/// a workspace member. Used to gate `wado publish` to the workspace root.
+pub(crate) fn governing_workspace_root_dir(
+    member_dir: &Path,
+) -> Result<Option<PathBuf>, DiscoveryError> {
+    let content =
+        fs::read_to_string(member_dir.join(MANIFEST_FILENAME)).map_err(DiscoveryError::Io)?;
+    Ok(governing_workspace(member_dir, &content).map(|(dir, _)| dir))
+}
+
+/// Member package directories of the workspace rooted at `root_dir`, expanded
+/// from its `members` globs (directories containing a `wado.toml`, excluding the
+/// root itself).
+pub(crate) fn workspace_member_dirs(root_dir: &Path, members: &[String]) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    for pattern in members {
+        let Some(joined) = root_dir.join(pattern).to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Ok(paths) = glob::glob(&joined) else {
+            continue;
+        };
+        for path in paths.filter_map(Result::ok) {
+            if path != root_dir && path.join(MANIFEST_FILENAME).is_file() {
+                dirs.push(path);
+            }
+        }
+    }
+    dirs.sort();
+    dirs.dedup();
+    dirs
 }
 
 /// Read `[workspace].members` without full validation (the member may omit
@@ -634,6 +672,57 @@ authors = ["Alice"]
         write(&tmp.path().join("wado.toml"), &toml);
         let project = discover(tmp.path()).unwrap().unwrap();
         assert_eq!(project.manifest.package.unwrap().name, "root-pkg");
+    }
+
+    #[test]
+    fn governing_workspace_root_dir_identifies_root_for_member() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("wado.toml"), WS_ROOT);
+        let member_dir = tmp.path().join("packages/core");
+        write(
+            &member_dir.join("wado.toml"),
+            "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n",
+        );
+        // From a member: returns the root dir.
+        let root = governing_workspace_root_dir(&member_dir).unwrap().unwrap();
+        assert_eq!(root, tmp.path());
+        // From the root itself: it is the authority, not a governed member.
+        assert!(
+            governing_workspace_root_dir(tmp.path())
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn governing_workspace_root_dir_none_for_standalone() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            &tmp.path().join("wado.toml"),
+            "[package]\nname = \"solo\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+        );
+        assert!(governing_workspace_root_dir(tmp.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn workspace_member_dirs_expands_globs() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("wado.toml"), WS_ROOT);
+        write(
+            &tmp.path().join("packages/a/wado.toml"),
+            "[package]\nname = \"a\"\n",
+        );
+        write(
+            &tmp.path().join("packages/b/wado.toml"),
+            "[package]\nname = \"b\"\n",
+        );
+        // A dir without a wado.toml is not a member.
+        fs::create_dir_all(tmp.path().join("packages/empty")).unwrap();
+        let dirs = workspace_member_dirs(tmp.path(), &["packages/*".to_string()]);
+        assert_eq!(
+            dirs,
+            vec![tmp.path().join("packages/a"), tmp.path().join("packages/b")]
+        );
     }
 
     #[test]

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -44,7 +44,9 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<PublishOptions, CliExit>
     let mut dry_run = false;
     while let Some(arg) = args::next_arg(&mut parser)? {
         match arg {
-            lexopt::Arg::Long("help") | lexopt::Arg::Short('h') => return Err(CliExit::help(usage)),
+            lexopt::Arg::Long("help") | lexopt::Arg::Short('h') => {
+                return Err(CliExit::help(usage));
+            }
             lexopt::Arg::Long("dry-run") => dry_run = true,
             other => return Err(args::unexpected_arg(other, &usage)),
         }
@@ -124,9 +126,9 @@ fn publish_single_dry_run(manifest: &Manifest) -> Result<(), CliExit> {
             &problems,
         )),
         Verdict::NotAPackage => Err(CliExit::error("no [package] to publish")),
-        Verdict::Skipped(reason) => {
-            Err(CliExit::error(format!("package is not publishable: {reason}")))
-        }
+        Verdict::Skipped(reason) => Err(CliExit::error(format!(
+            "package is not publishable: {reason}"
+        ))),
     }
 }
 

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -1,0 +1,116 @@
+//! `wado publish` — publish the package to a registry.
+//!
+//! Only `--dry-run` is implemented: it runs the publish-readiness checks
+//! ([`wado_manifest::validate_for_publish`]) and reports any problems. The
+//! actual OCI upload (via `wkg`, with metadata embedded into the component) is
+//! not wired yet, so a non-dry-run invocation errors instead of pretending to
+//! publish.
+
+use std::fmt::Write as _;
+
+use wado_manifest::validate_for_publish;
+
+use crate::args::{self, CliExit};
+use crate::manifest::discover;
+
+#[derive(Debug)]
+pub struct PublishOptions {
+    dry_run: bool,
+}
+
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado publish [options]").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Check whether the package can be published.").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Options:").unwrap();
+    writeln!(
+        buf,
+        "      --dry-run  Run publish-readiness checks without uploading"
+    )
+    .unwrap();
+    writeln!(buf, "  -h, --help     Show this help message").unwrap();
+    buf
+}
+
+pub fn parse_args(mut parser: lexopt::Parser) -> Result<PublishOptions, CliExit> {
+    let usage = format_usage();
+    let mut dry_run = false;
+    while let Some(arg) = args::next_arg(&mut parser)? {
+        match arg {
+            lexopt::Arg::Long("help") | lexopt::Arg::Short('h') => return Err(CliExit::help(usage)),
+            lexopt::Arg::Long("dry-run") => dry_run = true,
+            other => return Err(args::unexpected_arg(other, &usage)),
+        }
+    }
+    Ok(PublishOptions { dry_run })
+}
+
+pub fn run(opts: PublishOptions) -> Result<(), CliExit> {
+    let cwd = std::env::current_dir()
+        .map_err(|e| CliExit::error(format!("cannot get current directory: {e}")))?;
+    let project = discover(&cwd)
+        .map_err(CliExit::error)?
+        .ok_or_else(|| CliExit::error("no wado.toml found"))?;
+    crate::manifest::emit_manifest_warnings(&project);
+
+    if !opts.dry_run {
+        return Err(CliExit::error(
+            "wado publish: only --dry-run is supported for now \
+             (OCI upload via wkg is not yet implemented)",
+        ));
+    }
+
+    let problems = validate_for_publish(&project.manifest);
+    if problems.is_empty() {
+        // `validate_for_publish` reports `NoPackage`/`MissingNamespace` as
+        // problems, so an empty result guarantees a namespaced package here.
+        let pkg = project
+            .manifest
+            .package
+            .as_ref()
+            .expect("publishable manifest has a [package]");
+        let namespace = pkg
+            .namespace
+            .as_deref()
+            .expect("publishable package has a namespace");
+        eprintln!(
+            "{}:{}@{} is ready to publish",
+            namespace, pkg.name, pkg.version
+        );
+        Ok(())
+    } else {
+        let mut msg = String::from("package is not ready to publish:");
+        for problem in &problems {
+            write!(msg, "\n  - {problem}").unwrap();
+        }
+        Err(CliExit::error(msg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_args_defaults_to_no_dry_run() {
+        let parser = lexopt::Parser::from_args(Vec::<String>::new());
+        let opts = parse_args(parser).unwrap();
+        assert!(!opts.dry_run);
+    }
+
+    #[test]
+    fn parse_args_accepts_dry_run() {
+        let parser = lexopt::Parser::from_args(vec!["--dry-run"]);
+        let opts = parse_args(parser).unwrap();
+        assert!(opts.dry_run);
+    }
+
+    #[test]
+    fn parse_args_rejects_unknown_flag() {
+        let parser = lexopt::Parser::from_args(vec!["--nope"]);
+        let err = parse_args(parser).unwrap_err();
+        assert_eq!(err.exit_code, 1);
+    }
+}

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -5,13 +5,18 @@
 //! actual OCI upload (via `wkg`, with metadata embedded into the component) is
 //! not wired yet, so a non-dry-run invocation errors instead of pretending to
 //! publish.
+//!
+//! In a workspace, publishing is gated to the workspace root: it publishes every
+//! publishable member together at the shared (force-inherited) version, so the
+//! registry can never end up with members at mismatched versions. Running it
+//! from a member directory is an error pointing at the root.
 
 use std::fmt::Write as _;
 
-use wado_manifest::validate_for_publish;
+use wado_manifest::{Manifest, PublishError, validate_for_publish};
 
 use crate::args::{self, CliExit};
-use crate::manifest::discover;
+use crate::manifest::{ProjectManifest, discover, emit_manifest_warnings};
 
 #[derive(Debug)]
 pub struct PublishOptions {
@@ -48,13 +53,6 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<PublishOptions, CliExit>
 }
 
 pub fn run(opts: PublishOptions) -> Result<(), CliExit> {
-    let cwd = std::env::current_dir()
-        .map_err(|e| CliExit::error(format!("cannot get current directory: {e}")))?;
-    let project = discover(&cwd)
-        .map_err(CliExit::error)?
-        .ok_or_else(|| CliExit::error("no wado.toml found"))?;
-    crate::manifest::emit_manifest_warnings(&project);
-
     if !opts.dry_run {
         return Err(CliExit::error(
             "wado publish: only --dry-run is supported for now \
@@ -62,31 +60,147 @@ pub fn run(opts: PublishOptions) -> Result<(), CliExit> {
         ));
     }
 
-    let problems = validate_for_publish(&project.manifest);
-    if problems.is_empty() {
-        // `validate_for_publish` reports `NoPackage`/`MissingNamespace` as
-        // problems, so an empty result guarantees a namespaced package here.
-        let pkg = project
-            .manifest
-            .package
-            .as_ref()
-            .expect("publishable manifest has a [package]");
-        let namespace = pkg
-            .namespace
-            .as_deref()
-            .expect("publishable package has a namespace");
-        eprintln!(
-            "{}:{}@{} is ready to publish",
-            namespace, pkg.name, pkg.version
-        );
-        Ok(())
-    } else {
-        let mut msg = String::from("package is not ready to publish:");
-        for problem in &problems {
-            write!(msg, "\n  - {problem}").unwrap();
-        }
-        Err(CliExit::error(msg))
+    let cwd = std::env::current_dir()
+        .map_err(|e| CliExit::error(format!("cannot get current directory: {e}")))?;
+    let project = discover(&cwd)
+        .map_err(CliExit::error)?
+        .ok_or_else(|| CliExit::error("no wado.toml found"))?;
+
+    if project.manifest.workspace.is_some() {
+        // cwd resolves to a workspace root: publish the whole workspace.
+        return publish_workspace_dry_run(&project);
     }
+    if let Some(root) =
+        crate::manifest::governing_workspace_root_dir(&project.root).map_err(CliExit::error)?
+    {
+        return Err(CliExit::error(format!(
+            "this package belongs to a workspace; run `wado publish` from the workspace \
+             root to publish all members together at the shared version:\n  {}",
+            root.display()
+        )));
+    }
+
+    emit_manifest_warnings(&project);
+    publish_single_dry_run(&project.manifest)
+}
+
+/// One package's publish-readiness verdict.
+enum Verdict {
+    /// No `[package]` — not a publishable unit; ignored.
+    NotAPackage,
+    /// Intentionally not published (`publish = false` or no `namespace`).
+    Skipped(String),
+    /// Ready: the `namespace:name@version` coordinate.
+    Ready(String),
+    /// Has unmet publish requirements.
+    Failed(Vec<PublishError>),
+}
+
+fn classify(manifest: &Manifest) -> Verdict {
+    let Some(pkg) = manifest.package.as_ref() else {
+        return Verdict::NotAPackage;
+    };
+    if !pkg.publish {
+        return Verdict::Skipped("publish = false".to_string());
+    }
+    let Some(namespace) = pkg.namespace.as_deref() else {
+        return Verdict::Skipped("no namespace".to_string());
+    };
+    let problems = validate_for_publish(manifest);
+    if problems.is_empty() {
+        Verdict::Ready(format!("{namespace}:{}@{}", pkg.name, pkg.version))
+    } else {
+        Verdict::Failed(problems)
+    }
+}
+
+fn publish_single_dry_run(manifest: &Manifest) -> Result<(), CliExit> {
+    match classify(manifest) {
+        Verdict::Ready(coord) => {
+            eprintln!("{coord} is ready to publish");
+            Ok(())
+        }
+        Verdict::Failed(problems) => Err(problems_error(
+            "package is not ready to publish:",
+            &problems,
+        )),
+        // A standalone `wado publish` on a non-package / opted-out manifest is
+        // a user error worth surfacing rather than a silent success.
+        Verdict::NotAPackage => Err(CliExit::error("no [package] to publish")),
+        Verdict::Skipped(reason) => {
+            Err(CliExit::error(format!("package is not publishable: {reason}")))
+        }
+    }
+}
+
+fn publish_workspace_dry_run(root: &ProjectManifest) -> Result<(), CliExit> {
+    emit_manifest_warnings(root);
+    let members = root
+        .manifest
+        .workspace
+        .as_ref()
+        .map(|w| w.members.as_slice())
+        .unwrap_or_default();
+    let member_dirs = crate::manifest::workspace_member_dirs(&root.root, members);
+
+    let mut ready: Vec<String> = Vec::new();
+    let mut skipped: Vec<(String, String)> = Vec::new();
+    let mut failed: Vec<(String, Vec<PublishError>)> = Vec::new();
+
+    // The root's own [package] (if any) plus every member package.
+    let mut candidates: Vec<(String, Manifest)> = vec![(".".to_string(), root.manifest.clone())];
+    for dir in member_dirs {
+        let project = discover(&dir)
+            .map_err(CliExit::error)?
+            .ok_or_else(|| CliExit::error(format!("no wado.toml in member {}", dir.display())))?;
+        emit_manifest_warnings(&project);
+        let label = dir
+            .strip_prefix(&root.root)
+            .unwrap_or(&dir)
+            .display()
+            .to_string();
+        candidates.push((label, project.manifest));
+    }
+
+    for (label, manifest) in &candidates {
+        match classify(manifest) {
+            Verdict::NotAPackage => {}
+            Verdict::Skipped(reason) => skipped.push((label.clone(), reason)),
+            Verdict::Ready(coord) => ready.push(coord),
+            Verdict::Failed(problems) => failed.push((label.clone(), problems)),
+        }
+    }
+
+    if !failed.is_empty() {
+        let mut msg = String::from("workspace is not ready to publish:");
+        for (label, problems) in &failed {
+            let _ = write!(msg, "\n  {label}:");
+            for problem in problems {
+                let _ = write!(msg, "\n    - {problem}");
+            }
+        }
+        return Err(CliExit::error(msg));
+    }
+    for (label, reason) in &skipped {
+        eprintln!("(skip) {label}: {reason}");
+    }
+    if ready.is_empty() {
+        return Err(CliExit::error("no publishable packages in this workspace"));
+    }
+    eprintln!(
+        "{} package(s) ready to publish: {}",
+        ready.len(),
+        ready.join(", ")
+    );
+    Ok(())
+}
+
+fn problems_error(header: &str, problems: &[PublishError]) -> CliExit {
+    let mut msg = String::from(header);
+    for problem in problems {
+        let _ = write!(msg, "\n  - {problem}");
+    }
+    CliExit::error(msg)
 }
 
 #[cfg(test)]
@@ -112,5 +226,41 @@ mod tests {
         let parser = lexopt::Parser::from_args(vec!["--nope"]);
         let err = parse_args(parser).unwrap_err();
         assert_eq!(err.exit_code, 1);
+    }
+
+    fn manifest(toml: &str) -> Manifest {
+        toml.parse().unwrap()
+    }
+
+    #[test]
+    fn classify_ready_package() {
+        let m = manifest(
+            "[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"0.1.0\"\ndescription = \"d\"\nrepository = \"https://x/y\"\nlicense = \"MIT\"\nauthors = [\"A\"]\n",
+        );
+        assert!(matches!(classify(&m), Verdict::Ready(c) if c == "org:app@0.1.0"));
+    }
+
+    #[test]
+    fn classify_skips_publish_false_and_no_namespace() {
+        let no_ns = manifest("[package]\nname = \"app\"\nversion = \"0.1.0\"\n");
+        assert!(matches!(classify(&no_ns), Verdict::Skipped(r) if r == "no namespace"));
+        let opted_out = manifest(
+            "[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"0.1.0\"\npublish = false\n",
+        );
+        assert!(matches!(classify(&opted_out), Verdict::Skipped(r) if r == "publish = false"));
+    }
+
+    #[test]
+    fn classify_failed_when_metadata_missing() {
+        let m = manifest("[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"0.1.0\"\n");
+        // namespace present + publish default true, but description/repository/
+        // authors/license missing → Failed, not Skipped.
+        assert!(matches!(classify(&m), Verdict::Failed(p) if !p.is_empty()));
+    }
+
+    #[test]
+    fn classify_not_a_package_for_workspace_only_manifest() {
+        let m = manifest("[workspace]\nmembers = [\"packages/*\"]\n");
+        assert!(matches!(classify(&m), Verdict::NotAPackage));
     }
 }

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -67,7 +67,6 @@ pub fn run(opts: PublishOptions) -> Result<(), CliExit> {
         .ok_or_else(|| CliExit::error("no wado.toml found"))?;
 
     if project.manifest.workspace.is_some() {
-        // cwd resolves to a workspace root: publish the whole workspace.
         return publish_workspace_dry_run(&project);
     }
     if let Some(root) =
@@ -124,8 +123,6 @@ fn publish_single_dry_run(manifest: &Manifest) -> Result<(), CliExit> {
             "package is not ready to publish:",
             &problems,
         )),
-        // A standalone `wado publish` on a non-package / opted-out manifest is
-        // a user error worth surfacing rather than a silent success.
         Verdict::NotAPackage => Err(CliExit::error("no [package] to publish")),
         Verdict::Skipped(reason) => {
             Err(CliExit::error(format!("package is not publishable: {reason}")))
@@ -147,7 +144,6 @@ fn publish_workspace_dry_run(root: &ProjectManifest) -> Result<(), CliExit> {
     let mut skipped: Vec<(String, String)> = Vec::new();
     let mut failed: Vec<(String, Vec<PublishError>)> = Vec::new();
 
-    // The root's own [package] (if any) plus every member package.
     let mut candidates: Vec<(String, Manifest)> = vec![(".".to_string(), root.manifest.clone())];
     for dir in member_dirs {
         let project = discover(&dir)
@@ -253,8 +249,6 @@ mod tests {
     #[test]
     fn classify_failed_when_metadata_missing() {
         let m = manifest("[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"0.1.0\"\n");
-        // namespace present + publish default true, but description/repository/
-        // authors/license missing → Failed, not Skipped.
         assert!(matches!(classify(&m), Verdict::Failed(p) if !p.is_empty()));
     }
 

--- a/wado-manifest/Cargo.toml
+++ b/wado-manifest/Cargo.toml
@@ -10,6 +10,7 @@ indexmap = { workspace = true, features = ["serde"] }
 semver = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
+spdx = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]

--- a/wado-manifest/src/lib.rs
+++ b/wado-manifest/src/lib.rs
@@ -14,4 +14,5 @@ pub use provider::{
     DependencyProvider, GitTagInfo, InMemoryDependencyProvider, ProviderError, RegistryPackageInfo,
 };
 pub use resolve::{ResolveError, resolve};
+pub use validate::{PublishError, validate_for_publish};
 pub use version::{Version, VersionError, VersionSpecifier};

--- a/wado-manifest/src/lib.rs
+++ b/wado-manifest/src/lib.rs
@@ -8,7 +8,7 @@ mod version;
 pub use lockfile::{LockFile, LockFileError, LockedPackage};
 pub use manifest::{
     Dependency, DependencySource, FormatSettings, GitPin, Manifest, ManifestError, ManifestWarning,
-    Package, TestSettings, Workspace,
+    Package, TestSettings, Workspace, resolve_member,
 };
 pub use provider::{
     DependencyProvider, GitTagInfo, InMemoryDependencyProvider, ProviderError, RegistryPackageInfo,

--- a/wado-manifest/src/lib.rs
+++ b/wado-manifest/src/lib.rs
@@ -8,7 +8,7 @@ mod version;
 pub use lockfile::{LockFile, LockFileError, LockedPackage};
 pub use manifest::{
     Dependency, DependencySource, FormatSettings, GitPin, Manifest, ManifestError, ManifestWarning,
-    Package, TestSettings, Workspace, resolve_member,
+    Package, TestSettings, Workspace, WorkspacePackage, resolve_member,
 };
 pub use provider::{
     DependencyProvider, GitTagInfo, InMemoryDependencyProvider, ProviderError, RegistryPackageInfo,

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -446,8 +446,6 @@ struct RawManifest {
     unknown: BTreeMap<String, toml::Value>,
 }
 
-// Sorted, deterministic list of the keys captured by a `#[serde(flatten)]`
-// catch-all — the keys the schema did not recognize.
 fn unknown_keys(captured: &BTreeMap<String, toml::Value>) -> Vec<String> {
     captured.keys().cloned().collect()
 }
@@ -580,8 +578,6 @@ pub fn resolve_member(member_toml: &str, root_toml: &str) -> Result<Manifest, Ma
         .unwrap_or_default();
 
     if let (Some(pkg), Some(ws)) = (member_raw.package.as_mut(), ws_pkg.as_ref()) {
-        // Validate the source [workspace.package] so license problems are
-        // attributed to the root, not the inheriting member.
         validate::validate_workspace_package(ws)?;
         inherit_workspace_package(pkg, ws)?;
     }
@@ -599,8 +595,6 @@ fn inherit_workspace_package(
     inherit_forced(&mut pkg.version, ws.version.as_ref(), "version")?;
     inherit_forced(&mut pkg.repository, ws.repository.as_ref(), "repository")?;
     inherit_forced(&mut pkg.namespace, ws.namespace.as_ref(), "namespace")?;
-    // `license` and `license-file` are one logical slot: the member overrides
-    // the whole slot or inherits the whole slot.
     if pkg.license.is_none() && pkg.license_file.is_none() {
         pkg.license.clone_from(&ws.license);
         pkg.license_file.clone_from(&ws.license_file);
@@ -1538,7 +1532,6 @@ lib = "src/lib.wado"
         assert_eq!(pkg.namespace.as_deref(), Some("org"));
         assert_eq!(pkg.license.as_deref(), Some("MIT"));
         assert_eq!(pkg.authors, vec!["Alice <a@example.com>"]);
-        // member-specific fields stay
         assert_eq!(pkg.name, "core");
         assert_eq!(pkg.description.as_deref(), Some("Shared core"));
     }
@@ -1571,7 +1564,6 @@ authors = ["Bob"]
         let pkg = resolve_member(member, ROOT_WS).unwrap().package.unwrap();
         assert_eq!(pkg.license.as_deref(), Some("Apache-2.0"));
         assert_eq!(pkg.authors, vec!["Bob"]);
-        // forced fields still inherited
         assert_eq!(pkg.version, "0.2.0");
     }
 
@@ -1645,7 +1637,6 @@ license-file = "LICENSE"
             matches!(err, ManifestError::WorkspaceConflictingLicense),
             "{err:?}"
         );
-        // Same problem when the root is parsed directly.
         let err = root.parse::<Manifest>().unwrap_err();
         assert!(
             matches!(err, ManifestError::WorkspaceConflictingLicense),

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -23,6 +23,9 @@ pub struct Manifest {
     pub workspace: Option<Workspace>,
     pub test: TestSettings,
     pub format: FormatSettings,
+    /// Unknown top-level keys/sections (typos, unsupported). Reported as
+    /// warnings, never errors.
+    pub unknown_sections: Vec<String>,
 }
 
 impl Manifest {
@@ -71,9 +74,25 @@ impl Manifest {
             .keys()
             .chain(self.dev_dependencies.keys())
             .chain(self.build_dependencies.keys());
-        keys.filter(|k| !k.contains(':'))
+        let mut warnings: Vec<ManifestWarning> = keys
+            .filter(|k| !k.contains(':'))
             .map(|k| ManifestWarning::BareDependencyKey { key: k.clone() })
-            .collect()
+            .collect();
+        for field in &self.unknown_sections {
+            warnings.push(ManifestWarning::UnknownField {
+                section: None,
+                field: field.clone(),
+            });
+        }
+        if let Some(pkg) = &self.package {
+            for field in &pkg.unknown_fields {
+                warnings.push(ManifestWarning::UnknownField {
+                    section: Some("package".to_string()),
+                    field: field.clone(),
+                });
+            }
+        }
+        warnings
     }
 }
 
@@ -81,6 +100,12 @@ impl Manifest {
 pub enum ManifestWarning {
     /// Bare key (no `:`); deprecated in favor of `ns:pkg` / `lib:nick` (WEP).
     BareDependencyKey { key: String },
+    /// Unknown key not recognized by the schema. `section` is the table it
+    /// appeared in (`None` for a top-level key/section).
+    UnknownField {
+        section: Option<String>,
+        field: String,
+    },
 }
 
 impl std::fmt::Display for ManifestWarning {
@@ -91,6 +116,14 @@ impl std::fmt::Display for ManifestWarning {
                 "dependency key {key:?} is a bare name (deprecated); use a coordinate \
                  like \"ns:{key}\" or a \"lib:{key}\" indirection",
             ),
+            ManifestWarning::UnknownField {
+                section: Some(section),
+                field,
+            } => write!(f, "unknown field {field:?} in [{section}] (ignored)"),
+            ManifestWarning::UnknownField {
+                section: None,
+                field,
+            } => write!(f, "unknown top-level key {field:?} (ignored)"),
         }
     }
 }
@@ -138,6 +171,50 @@ pub struct Package {
     /// dependency (`use { … } from "<dep-name>"`). Only `export` items are
     /// visible to consumers.
     pub lib: Option<String>,
+    /// Short, human-readable summary (→ `org.opencontainers.image.description`).
+    pub description: Option<String>,
+    /// Project home page URL (→ `org.opencontainers.image.url`). Falls back to
+    /// `repository` when unset; see [`Package::effective_homepage`].
+    pub homepage: Option<String>,
+    /// Source repository URL, bare (no subdirectory)
+    /// (→ `org.opencontainers.image.source`).
+    pub repository: Option<String>,
+    /// Subdirectory holding the package within a monorepo. Wado-custom; not an
+    /// OCI annotation.
+    pub repository_directory: Option<String>,
+    /// Documentation URL (→ `org.opencontainers.image.documentation`). Falls
+    /// back to `repository`; see [`Package::effective_documentation`].
+    pub documentation: Option<String>,
+    /// SPDX License Expression (→ `org.opencontainers.image.licenses`).
+    /// Mutually exclusive with `license_file`.
+    pub license: Option<String>,
+    /// Path to a non-standard license file. Mutually exclusive with `license`.
+    pub license_file: Option<String>,
+    /// Contact details of the people/organization responsible
+    /// (→ `org.opencontainers.image.authors`).
+    pub authors: Vec<String>,
+    /// Minimum Wado compiler version required to build (a semver requirement,
+    /// e.g. `">=0.5"`).
+    pub wado_version: Option<String>,
+    /// Whether the package may be published. `false` opts out even when a
+    /// `namespace` is present. Defaults to `true`.
+    pub publish: bool,
+    /// Unknown `[package]` keys (typos, unsupported). Reported as warnings.
+    pub unknown_fields: Vec<String>,
+}
+
+impl Package {
+    /// Homepage, falling back to the repository URL when unset.
+    #[must_use]
+    pub fn effective_homepage(&self) -> Option<&str> {
+        self.homepage.as_deref().or(self.repository.as_deref())
+    }
+
+    /// Documentation URL, falling back to the repository URL when unset.
+    #[must_use]
+    pub fn effective_documentation(&self) -> Option<&str> {
+        self.documentation.as_deref().or(self.repository.as_deref())
+    }
 }
 
 /// The `[workspace]` section of `wado.toml`.
@@ -196,7 +273,8 @@ impl FromStr for Manifest {
     fn from_str(toml_str: &str) -> Result<Self, Self::Err> {
         let raw: RawManifest = toml::from_str::<RawManifest>(toml_str)
             .map_err(|e| ManifestError::Toml(e.to_string()))?;
-        let manifest = convert_raw(raw)?;
+        let mut manifest = convert_raw(raw)?;
+        collect_unknown_fields(toml_str, &mut manifest)?;
         validate::validate(&manifest)?;
         Ok(manifest)
     }
@@ -229,6 +307,10 @@ pub enum ManifestError {
     },
     /// Registry dependency without a default registry defined.
     NoDefaultRegistry { dep_name: String },
+    /// `[package]` set both `license` and `license-file` (mutually exclusive).
+    ConflictingLicense,
+    /// `[package].wado-version` is not a valid semver requirement.
+    InvalidWadoVersion { value: String, reason: String },
 }
 
 impl fmt::Display for ManifestError {
@@ -269,6 +351,14 @@ impl fmt::Display for ManifestError {
                     "dependency {dep_name:?}: registry dependency requires [registries].default"
                 )
             }
+            ManifestError::ConflictingLicense => write!(
+                f,
+                "[package]: `license` and `license-file` are mutually exclusive"
+            ),
+            ManifestError::InvalidWadoVersion { value, reason } => write!(
+                f,
+                "[package].wado-version {value:?} is not a valid version requirement: {reason}"
+            ),
         }
     }
 }
@@ -310,6 +400,19 @@ struct RawPackage {
     name: Option<String>,
     version: Option<String>,
     lib: Option<String>,
+    description: Option<String>,
+    homepage: Option<String>,
+    repository: Option<String>,
+    #[serde(rename = "repository-directory")]
+    repository_directory: Option<String>,
+    documentation: Option<String>,
+    license: Option<String>,
+    #[serde(rename = "license-file")]
+    license_file: Option<String>,
+    authors: Option<Vec<String>>,
+    #[serde(rename = "wado-version")]
+    wado_version: Option<String>,
+    publish: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -353,7 +456,62 @@ fn convert_raw(raw: RawManifest) -> Result<Manifest, ManifestError> {
         workspace,
         test,
         format,
+        unknown_sections: Vec::new(),
     })
+}
+
+// Top-level keys and `[package]` keys recognized by the schema. Unknown keys
+// are reported as warnings (not errors); these lists must stay in sync with
+// `RawManifest` / `RawPackage` (using their serde-renamed, hyphenated forms).
+const KNOWN_TOP_LEVEL: &[&str] = &[
+    "package",
+    "world",
+    "registries",
+    "dependencies",
+    "dev-dependencies",
+    "build-dependencies",
+    "workspace",
+    "test",
+    "format",
+];
+const KNOWN_PACKAGE: &[&str] = &[
+    "namespace",
+    "name",
+    "version",
+    "lib",
+    "description",
+    "homepage",
+    "repository",
+    "repository-directory",
+    "documentation",
+    "license",
+    "license-file",
+    "authors",
+    "wado-version",
+    "publish",
+];
+
+// Re-parse the raw TOML table to flag keys the schema does not recognize.
+// Done outside serde so unknown keys warn instead of being silently dropped
+// (serde) or hard-erroring (`deny_unknown_fields`).
+fn collect_unknown_fields(toml_str: &str, manifest: &mut Manifest) -> Result<(), ManifestError> {
+    let table: toml::Table =
+        toml::from_str(toml_str).map_err(|e| ManifestError::Toml(e.to_string()))?;
+    manifest.unknown_sections = table
+        .keys()
+        .filter(|k| !KNOWN_TOP_LEVEL.contains(&k.as_str()))
+        .cloned()
+        .collect();
+    if let (Some(pkg), Some(toml::Value::Table(pkg_table))) =
+        (manifest.package.as_mut(), table.get("package"))
+    {
+        pkg.unknown_fields = pkg_table
+            .keys()
+            .filter(|k| !KNOWN_PACKAGE.contains(&k.as_str()))
+            .cloned()
+            .collect();
+    }
+    Ok(())
 }
 
 fn convert_test(raw: RawTestSettings) -> TestSettings {
@@ -384,6 +542,17 @@ fn convert_package(raw: RawPackage) -> Result<Package, ManifestError> {
         name,
         version,
         lib: raw.lib,
+        description: raw.description,
+        homepage: raw.homepage,
+        repository: raw.repository,
+        repository_directory: raw.repository_directory,
+        documentation: raw.documentation,
+        license: raw.license,
+        license_file: raw.license_file,
+        authors: raw.authors.unwrap_or_default(),
+        wado_version: raw.wado_version,
+        publish: raw.publish.unwrap_or(true),
+        unknown_fields: Vec::new(),
     })
 }
 
@@ -1030,5 +1199,152 @@ json = { workspace = true }
             m.dependencies["json"].source,
             DependencySource::Workspace
         ));
+    }
+
+    #[test]
+    fn parse_package_metadata() {
+        let toml = r#"
+[package]
+namespace = "myorg"
+name = "my-app"
+version = "0.1.0"
+description = "A fast widget toolkit"
+homepage = "https://wado-lang.org"
+repository = "https://github.com/myorg/my-app"
+repository-directory = "packages/foo"
+documentation = "https://docs.wado-lang.org"
+license = "MIT OR Apache-2.0"
+authors = ["Alice <a@example.com>", "Bob"]
+wado-version = ">=0.5"
+publish = false
+"#;
+        let pkg = toml.parse::<Manifest>().unwrap().package.unwrap();
+        assert_eq!(pkg.description.as_deref(), Some("A fast widget toolkit"));
+        assert_eq!(pkg.homepage.as_deref(), Some("https://wado-lang.org"));
+        assert_eq!(
+            pkg.repository.as_deref(),
+            Some("https://github.com/myorg/my-app")
+        );
+        assert_eq!(pkg.repository_directory.as_deref(), Some("packages/foo"));
+        assert_eq!(
+            pkg.documentation.as_deref(),
+            Some("https://docs.wado-lang.org")
+        );
+        assert_eq!(pkg.license.as_deref(), Some("MIT OR Apache-2.0"));
+        assert_eq!(pkg.authors, vec!["Alice <a@example.com>", "Bob"]);
+        assert_eq!(pkg.wado_version.as_deref(), Some(">=0.5"));
+        assert!(!pkg.publish);
+    }
+
+    #[test]
+    fn metadata_defaults_when_omitted() {
+        let toml = "[package]\nname = \"app\"\nversion = \"0.1.0\"\n";
+        let pkg = toml.parse::<Manifest>().unwrap().package.unwrap();
+        assert!(pkg.description.is_none());
+        assert!(pkg.authors.is_empty());
+        assert!(pkg.wado_version.is_none());
+        assert!(pkg.publish, "publish defaults to true");
+        assert!(pkg.repository_directory.is_none());
+    }
+
+    #[test]
+    fn homepage_and_documentation_fall_back_to_repository() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+repository = "https://github.com/org/app"
+"#;
+        let pkg = toml.parse::<Manifest>().unwrap().package.unwrap();
+        assert_eq!(
+            pkg.effective_homepage(),
+            Some("https://github.com/org/app")
+        );
+        assert_eq!(
+            pkg.effective_documentation(),
+            Some("https://github.com/org/app")
+        );
+    }
+
+    #[test]
+    fn explicit_homepage_overrides_repository_fallback() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+homepage = "https://app.example"
+repository = "https://github.com/org/app"
+"#;
+        let pkg = toml.parse::<Manifest>().unwrap().package.unwrap();
+        assert_eq!(pkg.effective_homepage(), Some("https://app.example"));
+    }
+
+    #[test]
+    fn unknown_package_field_warns_but_parses() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+descshunption = "typo"
+"#;
+        let m = toml.parse::<Manifest>().unwrap();
+        let warnings = m.warnings();
+        assert!(
+            warnings.iter().any(|w| matches!(
+                w,
+                ManifestWarning::UnknownField { section: Some(s), field }
+                    if s == "package" && field == "descshunption"
+            )),
+            "got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_top_level_section_warns_but_parses() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+
+[dependancies]
+"ns:x" = { version = "^1.0.0" }
+"#;
+        let m = toml.parse::<Manifest>().unwrap();
+        let warnings = m.warnings();
+        assert!(
+            warnings.iter().any(|w| matches!(
+                w,
+                ManifestWarning::UnknownField { section: None, field } if field == "dependancies"
+            )),
+            "got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn license_and_license_file_conflict_rejected() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+license = "MIT"
+license-file = "LICENSE"
+"#;
+        let err = toml.parse::<Manifest>().unwrap_err();
+        assert!(matches!(err, ManifestError::ConflictingLicense), "{err:?}");
+    }
+
+    #[test]
+    fn invalid_wado_version_rejected() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+wado-version = "not a req"
+"#;
+        let err = toml.parse::<Manifest>().unwrap_err();
+        assert!(
+            matches!(err, ManifestError::InvalidWadoVersion { .. }),
+            "{err:?}"
+        );
     }
 }

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -309,6 +309,8 @@ pub enum ManifestError {
     NoDefaultRegistry { dep_name: String },
     /// `[package]` set both `license` and `license-file` (mutually exclusive).
     ConflictingLicense,
+    /// `[package].license` is not a valid SPDX license expression.
+    InvalidLicense { value: String, reason: String },
     /// `[package].wado-version` is not a valid semver requirement.
     InvalidWadoVersion { value: String, reason: String },
 }
@@ -354,6 +356,10 @@ impl fmt::Display for ManifestError {
             ManifestError::ConflictingLicense => write!(
                 f,
                 "[package]: `license` and `license-file` are mutually exclusive"
+            ),
+            ManifestError::InvalidLicense { value, reason } => write!(
+                f,
+                "[package].license {value:?} is not a valid SPDX expression: {reason}"
             ),
             ManifestError::InvalidWadoVersion { value, reason } => write!(
                 f,
@@ -1346,5 +1352,39 @@ wado-version = "not a req"
             matches!(err, ManifestError::InvalidWadoVersion { .. }),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn valid_spdx_license_accepted() {
+        for license in ["MIT", "MIT OR Apache-2.0", "Apache-2.0 WITH LLVM-exception"] {
+            let toml = format!("[package]\nname = \"app\"\nversion = \"0.1.0\"\nlicense = \"{license}\"\n");
+            assert!(
+                toml.parse::<Manifest>().is_ok(),
+                "expected {license:?} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn license_ref_for_nonstandard_license_accepted() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+license = "LicenseRef-Commercial"
+"#;
+        assert!(toml.parse::<Manifest>().is_ok());
+    }
+
+    #[test]
+    fn invalid_spdx_license_rejected() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+license = "Definitely Not A License"
+"#;
+        let err = toml.parse::<Manifest>().unwrap_err();
+        assert!(matches!(err, ManifestError::InvalidLicense { .. }), "{err:?}");
     }
 }

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
 
@@ -26,6 +27,10 @@ pub struct Manifest {
     /// Unknown top-level keys/sections (typos, unsupported). Reported as
     /// warnings, never errors.
     pub unknown_sections: Vec<String>,
+    /// Unknown `[workspace.package]` keys inherited from the workspace root
+    /// during member resolution. Surfaced as `workspace.package` warnings on the
+    /// member (whose own `workspace` is `None`). Empty otherwise.
+    pub inherited_unknown_fields: Vec<String>,
 }
 
 impl Manifest {
@@ -92,13 +97,19 @@ impl Manifest {
                 });
             }
         }
-        if let Some(ws) = &self.workspace {
-            for field in &ws.package_unknown_fields {
-                warnings.push(ManifestWarning::UnknownField {
-                    section: Some("workspace.package".to_string()),
-                    field: field.clone(),
-                });
-            }
+        let workspace_pkg_unknowns = self
+            .workspace
+            .as_ref()
+            .and_then(|ws| ws.package.as_ref())
+            .map(|p| p.unknown_fields.as_slice())
+            .unwrap_or_default()
+            .iter()
+            .chain(&self.inherited_unknown_fields);
+        for field in workspace_pkg_unknowns {
+            warnings.push(ManifestWarning::UnknownField {
+                section: Some("workspace.package".to_string()),
+                field: field.clone(),
+            });
         }
         warnings
     }
@@ -231,9 +242,25 @@ pub struct Workspace {
     pub members: Vec<String>,
     pub dependencies: IndexMap<String, Dependency>,
     pub dev_dependencies: IndexMap<String, Dependency>,
-    /// Unknown keys in `[workspace.package]` (typos, or fields that are not
-    /// inheritable). Reported as warnings.
-    pub package_unknown_fields: Vec<String>,
+    /// The `[workspace.package]` table: metadata members inherit.
+    pub package: Option<WorkspacePackage>,
+}
+
+/// The `[workspace.package]` table: package metadata shared by members.
+/// `version`/`repository`/`namespace` are force-inherited; the rest are
+/// overridable defaults. See [`resolve_member`].
+#[derive(Debug, Clone, Default)]
+pub struct WorkspacePackage {
+    pub version: Option<String>,
+    pub repository: Option<String>,
+    pub namespace: Option<String>,
+    pub license: Option<String>,
+    pub license_file: Option<String>,
+    pub authors: Vec<String>,
+    pub wado_version: Option<String>,
+    /// Unknown keys in `[workspace.package]` (typos, or non-inheritable fields).
+    /// Reported as warnings.
+    pub unknown_fields: Vec<String>,
 }
 
 /// A single dependency declaration.
@@ -284,8 +311,7 @@ impl FromStr for Manifest {
     fn from_str(toml_str: &str) -> Result<Self, Self::Err> {
         let raw: RawManifest = toml::from_str::<RawManifest>(toml_str)
             .map_err(|e| ManifestError::Toml(e.to_string()))?;
-        let mut manifest = convert_raw(raw)?;
-        collect_unknown_fields(toml_str, &mut manifest)?;
+        let manifest = convert_raw(raw)?;
         validate::validate(&manifest)?;
         Ok(manifest)
     }
@@ -327,6 +353,10 @@ pub enum ManifestError {
     /// A workspace member set a field that is force-inherited from
     /// `[workspace.package]` (`version`, `repository`, or `namespace`).
     WorkspaceFieldOverride { field: String },
+    /// `[workspace.package]` set both `license` and `license-file`.
+    WorkspaceConflictingLicense,
+    /// `[workspace.package].license` is not a valid SPDX expression.
+    WorkspaceInvalidLicense { value: String, reason: String },
 }
 
 impl fmt::Display for ManifestError {
@@ -383,6 +413,14 @@ impl fmt::Display for ManifestError {
                 f,
                 "[package].{field} is inherited from [workspace.package]; remove it from this member"
             ),
+            ManifestError::WorkspaceConflictingLicense => write!(
+                f,
+                "[workspace.package]: `license` and `license-file` are mutually exclusive"
+            ),
+            ManifestError::WorkspaceInvalidLicense { value, reason } => write!(
+                f,
+                "[workspace.package].license {value:?} is not a valid SPDX expression: {reason}"
+            ),
         }
     }
 }
@@ -404,6 +442,14 @@ struct RawManifest {
     workspace: Option<RawWorkspace>,
     test: Option<RawTestSettings>,
     format: Option<RawFormatSettings>,
+    #[serde(flatten)]
+    unknown: BTreeMap<String, toml::Value>,
+}
+
+// Sorted, deterministic list of the keys captured by a `#[serde(flatten)]`
+// catch-all — the keys the schema did not recognize.
+fn unknown_keys(captured: &BTreeMap<String, toml::Value>) -> Vec<String> {
+    captured.keys().cloned().collect()
 }
 
 #[derive(Deserialize)]
@@ -437,6 +483,8 @@ struct RawPackage {
     #[serde(rename = "wado-version")]
     wado_version: Option<String>,
     publish: Option<bool>,
+    #[serde(flatten)]
+    unknown: BTreeMap<String, toml::Value>,
 }
 
 #[derive(Deserialize)]
@@ -461,6 +509,8 @@ struct RawWorkspacePackage {
     authors: Option<Vec<String>>,
     #[serde(rename = "wado-version")]
     wado_version: Option<String>,
+    #[serde(flatten)]
+    unknown: BTreeMap<String, toml::Value>,
 }
 
 #[derive(Deserialize)]
@@ -476,6 +526,7 @@ struct RawDependency {
 }
 
 fn convert_raw(raw: RawManifest) -> Result<Manifest, ManifestError> {
+    let unknown_sections = unknown_keys(&raw.unknown);
     let package = raw.package.map(convert_package).transpose()?;
     let world = raw.world.unwrap_or_default();
     let registries = raw.registries.unwrap_or_default();
@@ -496,84 +547,10 @@ fn convert_raw(raw: RawManifest) -> Result<Manifest, ManifestError> {
         workspace,
         test,
         format,
-        unknown_sections: Vec::new(),
+        unknown_sections,
+        inherited_unknown_fields: Vec::new(),
     })
 }
-
-// Top-level keys and `[package]` keys recognized by the schema. Unknown keys
-// are reported as warnings (not errors); these lists must stay in sync with
-// `RawManifest` / `RawPackage` (using their serde-renamed, hyphenated forms).
-const KNOWN_TOP_LEVEL: &[&str] = &[
-    "package",
-    "world",
-    "registries",
-    "dependencies",
-    "dev-dependencies",
-    "build-dependencies",
-    "workspace",
-    "test",
-    "format",
-];
-const KNOWN_PACKAGE: &[&str] = &[
-    "namespace",
-    "name",
-    "version",
-    "lib",
-    "description",
-    "homepage",
-    "repository",
-    "repository-directory",
-    "documentation",
-    "license",
-    "license-file",
-    "authors",
-    "wado-version",
-    "publish",
-];
-
-// Re-parse the raw TOML table to flag keys the schema does not recognize.
-// Done outside serde so unknown keys warn instead of being silently dropped
-// (serde) or hard-erroring (`deny_unknown_fields`).
-fn collect_unknown_fields(toml_str: &str, manifest: &mut Manifest) -> Result<(), ManifestError> {
-    let table: toml::Table =
-        toml::from_str(toml_str).map_err(|e| ManifestError::Toml(e.to_string()))?;
-    manifest.unknown_sections = table
-        .keys()
-        .filter(|k| !KNOWN_TOP_LEVEL.contains(&k.as_str()))
-        .cloned()
-        .collect();
-    if let (Some(pkg), Some(toml::Value::Table(pkg_table))) =
-        (manifest.package.as_mut(), table.get("package"))
-    {
-        pkg.unknown_fields = pkg_table
-            .keys()
-            .filter(|k| !KNOWN_PACKAGE.contains(&k.as_str()))
-            .cloned()
-            .collect();
-    }
-    if let Some(ws) = manifest.workspace.as_mut()
-        && let Some(toml::Value::Table(ws_table)) = table.get("workspace")
-        && let Some(toml::Value::Table(ws_pkg)) = ws_table.get("package")
-    {
-        ws.package_unknown_fields = ws_pkg
-            .keys()
-            .filter(|k| !KNOWN_WORKSPACE_PACKAGE.contains(&k.as_str()))
-            .cloned()
-            .collect();
-    }
-    Ok(())
-}
-
-// Fields accepted in `[workspace.package]` (forced + default inheritance).
-const KNOWN_WORKSPACE_PACKAGE: &[&str] = &[
-    "version",
-    "repository",
-    "namespace",
-    "license",
-    "license-file",
-    "authors",
-    "wado-version",
-];
 
 /// Parse a workspace member's manifest, inheriting metadata from the workspace
 /// root's `[workspace.package]`.
@@ -585,29 +562,39 @@ const KNOWN_WORKSPACE_PACKAGE: &[&str] = &[
 /// `version`) may be supplied by the workspace.
 ///
 /// # Errors
-/// Propagates TOML, inheritance, and validation errors for the merged member.
+/// Propagates TOML, inheritance, and validation errors for the merged member,
+/// including problems in the root's `[workspace.package]` itself.
 pub fn resolve_member(member_toml: &str, root_toml: &str) -> Result<Manifest, ManifestError> {
     let mut member_raw: RawManifest =
         toml::from_str(member_toml).map_err(|e| ManifestError::Toml(e.to_string()))?;
     let root_raw: RawManifest =
         toml::from_str(root_toml).map_err(|e| ManifestError::Toml(e.to_string()))?;
 
-    if let (Some(pkg), Some(ws_pkg)) = (
-        member_raw.package.as_mut(),
-        root_raw.workspace.and_then(|w| w.package),
-    ) {
-        inherit_workspace_package(pkg, &ws_pkg)?;
+    let ws_pkg = root_raw
+        .workspace
+        .and_then(|w| w.package)
+        .map(convert_workspace_package);
+    let inherited_unknown_fields = ws_pkg
+        .as_ref()
+        .map(|p| p.unknown_fields.clone())
+        .unwrap_or_default();
+
+    if let (Some(pkg), Some(ws)) = (member_raw.package.as_mut(), ws_pkg.as_ref()) {
+        // Validate the source [workspace.package] so license problems are
+        // attributed to the root, not the inheriting member.
+        validate::validate_workspace_package(ws)?;
+        inherit_workspace_package(pkg, ws)?;
     }
 
     let mut manifest = convert_raw(member_raw)?;
-    collect_unknown_fields(member_toml, &mut manifest)?;
+    manifest.inherited_unknown_fields = inherited_unknown_fields;
     validate::validate(&manifest)?;
     Ok(manifest)
 }
 
 fn inherit_workspace_package(
     pkg: &mut RawPackage,
-    ws: &RawWorkspacePackage,
+    ws: &WorkspacePackage,
 ) -> Result<(), ManifestError> {
     inherit_forced(&mut pkg.version, ws.version.as_ref(), "version")?;
     inherit_forced(&mut pkg.repository, ws.repository.as_ref(), "repository")?;
@@ -618,8 +605,8 @@ fn inherit_workspace_package(
         pkg.license.clone_from(&ws.license);
         pkg.license_file.clone_from(&ws.license_file);
     }
-    if pkg.authors.is_none() {
-        pkg.authors.clone_from(&ws.authors);
+    if pkg.authors.is_none() && !ws.authors.is_empty() {
+        pkg.authors = Some(ws.authors.clone());
     }
     if pkg.wado_version.is_none() {
         pkg.wado_version.clone_from(&ws.wado_version);
@@ -681,7 +668,7 @@ fn convert_package(raw: RawPackage) -> Result<Package, ManifestError> {
         authors: raw.authors.unwrap_or_default(),
         wado_version: raw.wado_version,
         publish: raw.publish.unwrap_or(true),
-        unknown_fields: Vec::new(),
+        unknown_fields: unknown_keys(&raw.unknown),
     })
 }
 
@@ -696,8 +683,21 @@ fn convert_workspace(raw: RawWorkspace) -> Result<Workspace, ManifestError> {
         members,
         dependencies,
         dev_dependencies,
-        package_unknown_fields: Vec::new(),
+        package: raw.package.map(convert_workspace_package),
     })
+}
+
+fn convert_workspace_package(raw: RawWorkspacePackage) -> WorkspacePackage {
+    WorkspacePackage {
+        version: raw.version,
+        repository: raw.repository,
+        namespace: raw.namespace,
+        license: raw.license,
+        license_file: raw.license_file,
+        authors: raw.authors.unwrap_or_default(),
+        wado_version: raw.wado_version,
+        unknown_fields: unknown_keys(&raw.unknown),
+    }
 }
 
 fn convert_deps(
@@ -1601,6 +1601,71 @@ repository = "https://github.com/org/monorepo"
         let err = resolve_member(member, root).unwrap_err();
         assert!(
             matches!(&err, ManifestError::MissingField { field, .. } if field == "version"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn member_resolution_surfaces_root_workspace_package_typo() {
+        let root = r#"
+[workspace]
+members = ["packages/*"]
+
+[workspace.package]
+version = "0.1.0"
+licence = "MIT"
+"#;
+        let member = "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n";
+        let m = resolve_member(member, root).unwrap();
+        let warnings = m.warnings();
+        assert!(
+            warnings.iter().any(|w| matches!(
+                w,
+                ManifestWarning::UnknownField { section: Some(s), field }
+                    if s == "workspace.package" && field == "licence"
+            )),
+            "got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn workspace_package_conflicting_license_attributed_to_workspace() {
+        let root = r#"
+[workspace]
+members = ["packages/*"]
+
+[workspace.package]
+version = "0.1.0"
+license = "MIT"
+license-file = "LICENSE"
+"#;
+        let member = "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n";
+        let err = resolve_member(member, root).unwrap_err();
+        assert!(
+            matches!(err, ManifestError::WorkspaceConflictingLicense),
+            "{err:?}"
+        );
+        // Same problem when the root is parsed directly.
+        let err = root.parse::<Manifest>().unwrap_err();
+        assert!(
+            matches!(err, ManifestError::WorkspaceConflictingLicense),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn workspace_package_invalid_spdx_rejected() {
+        let root = r#"
+[workspace]
+members = ["packages/*"]
+
+[workspace.package]
+version = "0.1.0"
+license = "Not A License"
+"#;
+        let err = root.parse::<Manifest>().unwrap_err();
+        assert!(
+            matches!(err, ManifestError::WorkspaceInvalidLicense { .. }),
             "{err:?}"
         );
     }

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -1380,10 +1380,7 @@ version = "0.1.0"
 repository = "https://github.com/org/app"
 "#;
         let pkg = toml.parse::<Manifest>().unwrap().package.unwrap();
-        assert_eq!(
-            pkg.effective_homepage(),
-            Some("https://github.com/org/app")
-        );
+        assert_eq!(pkg.effective_homepage(), Some("https://github.com/org/app"));
         assert_eq!(
             pkg.effective_documentation(),
             Some("https://github.com/org/app")
@@ -1475,7 +1472,9 @@ wado-version = "not a req"
     #[test]
     fn valid_spdx_license_accepted() {
         for license in ["MIT", "MIT OR Apache-2.0", "Apache-2.0 WITH LLVM-exception"] {
-            let toml = format!("[package]\nname = \"app\"\nversion = \"0.1.0\"\nlicense = \"{license}\"\n");
+            let toml = format!(
+                "[package]\nname = \"app\"\nversion = \"0.1.0\"\nlicense = \"{license}\"\n"
+            );
             assert!(
                 toml.parse::<Manifest>().is_ok(),
                 "expected {license:?} to be accepted"
@@ -1503,7 +1502,10 @@ version = "0.1.0"
 license = "Definitely Not A License"
 "#;
         let err = toml.parse::<Manifest>().unwrap_err();
-        assert!(matches!(err, ManifestError::InvalidLicense { .. }), "{err:?}");
+        assert!(
+            matches!(err, ManifestError::InvalidLicense { .. }),
+            "{err:?}"
+        );
     }
 
     const ROOT_WS: &str = r#"
@@ -1528,7 +1530,10 @@ lib = "src/lib.wado"
 "#;
         let pkg = resolve_member(member, ROOT_WS).unwrap().package.unwrap();
         assert_eq!(pkg.version, "0.2.0");
-        assert_eq!(pkg.repository.as_deref(), Some("https://github.com/org/monorepo"));
+        assert_eq!(
+            pkg.repository.as_deref(),
+            Some("https://github.com/org/monorepo")
+        );
         assert_eq!(pkg.namespace.as_deref(), Some("org"));
         assert_eq!(pkg.license.as_deref(), Some("MIT"));
         assert_eq!(pkg.authors, vec!["Alice <a@example.com>"]);

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -92,6 +92,14 @@ impl Manifest {
                 });
             }
         }
+        if let Some(ws) = &self.workspace {
+            for field in &ws.package_unknown_fields {
+                warnings.push(ManifestWarning::UnknownField {
+                    section: Some("workspace.package".to_string()),
+                    field: field.clone(),
+                });
+            }
+        }
         warnings
     }
 }
@@ -223,6 +231,9 @@ pub struct Workspace {
     pub members: Vec<String>,
     pub dependencies: IndexMap<String, Dependency>,
     pub dev_dependencies: IndexMap<String, Dependency>,
+    /// Unknown keys in `[workspace.package]` (typos, or fields that are not
+    /// inheritable). Reported as warnings.
+    pub package_unknown_fields: Vec<String>,
 }
 
 /// A single dependency declaration.
@@ -313,6 +324,9 @@ pub enum ManifestError {
     InvalidLicense { value: String, reason: String },
     /// `[package].wado-version` is not a valid semver requirement.
     InvalidWadoVersion { value: String, reason: String },
+    /// A workspace member set a field that is force-inherited from
+    /// `[workspace.package]` (`version`, `repository`, or `namespace`).
+    WorkspaceFieldOverride { field: String },
 }
 
 impl fmt::Display for ManifestError {
@@ -364,6 +378,10 @@ impl fmt::Display for ManifestError {
             ManifestError::InvalidWadoVersion { value, reason } => write!(
                 f,
                 "[package].wado-version {value:?} is not a valid version requirement: {reason}"
+            ),
+            ManifestError::WorkspaceFieldOverride { field } => write!(
+                f,
+                "[package].{field} is inherited from [workspace.package]; remove it from this member"
             ),
         }
     }
@@ -424,9 +442,25 @@ struct RawPackage {
 #[derive(Deserialize)]
 struct RawWorkspace {
     members: Option<Vec<String>>,
+    package: Option<RawWorkspacePackage>,
     dependencies: Option<IndexMap<String, RawDependency>>,
     #[serde(rename = "dev-dependencies")]
     dev_dependencies: Option<IndexMap<String, RawDependency>>,
+}
+
+/// The `[workspace.package]` table: shared metadata inherited by members. Only
+/// the inheritable fields are accepted; other keys are reported as warnings.
+#[derive(Deserialize, Default)]
+struct RawWorkspacePackage {
+    version: Option<String>,
+    repository: Option<String>,
+    namespace: Option<String>,
+    license: Option<String>,
+    #[serde(rename = "license-file")]
+    license_file: Option<String>,
+    authors: Option<Vec<String>>,
+    #[serde(rename = "wado-version")]
+    wado_version: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -517,6 +551,95 @@ fn collect_unknown_fields(toml_str: &str, manifest: &mut Manifest) -> Result<(),
             .cloned()
             .collect();
     }
+    if let Some(ws) = manifest.workspace.as_mut()
+        && let Some(toml::Value::Table(ws_table)) = table.get("workspace")
+        && let Some(toml::Value::Table(ws_pkg)) = ws_table.get("package")
+    {
+        ws.package_unknown_fields = ws_pkg
+            .keys()
+            .filter(|k| !KNOWN_WORKSPACE_PACKAGE.contains(&k.as_str()))
+            .cloned()
+            .collect();
+    }
+    Ok(())
+}
+
+// Fields accepted in `[workspace.package]` (forced + default inheritance).
+const KNOWN_WORKSPACE_PACKAGE: &[&str] = &[
+    "version",
+    "repository",
+    "namespace",
+    "license",
+    "license-file",
+    "authors",
+    "wado-version",
+];
+
+/// Parse a workspace member's manifest, inheriting metadata from the workspace
+/// root's `[workspace.package]`.
+///
+/// `version`/`repository`/`namespace` are force-inherited: if the member sets
+/// one (and the workspace defines it) it is a [`ManifestError::WorkspaceFieldOverride`].
+/// `license`/`license-file`/`authors`/`wado-version` are defaults the member may
+/// override. The merge runs before conversion, so required fields (e.g.
+/// `version`) may be supplied by the workspace.
+///
+/// # Errors
+/// Propagates TOML, inheritance, and validation errors for the merged member.
+pub fn resolve_member(member_toml: &str, root_toml: &str) -> Result<Manifest, ManifestError> {
+    let mut member_raw: RawManifest =
+        toml::from_str(member_toml).map_err(|e| ManifestError::Toml(e.to_string()))?;
+    let root_raw: RawManifest =
+        toml::from_str(root_toml).map_err(|e| ManifestError::Toml(e.to_string()))?;
+
+    if let (Some(pkg), Some(ws_pkg)) = (
+        member_raw.package.as_mut(),
+        root_raw.workspace.and_then(|w| w.package),
+    ) {
+        inherit_workspace_package(pkg, &ws_pkg)?;
+    }
+
+    let mut manifest = convert_raw(member_raw)?;
+    collect_unknown_fields(member_toml, &mut manifest)?;
+    validate::validate(&manifest)?;
+    Ok(manifest)
+}
+
+fn inherit_workspace_package(
+    pkg: &mut RawPackage,
+    ws: &RawWorkspacePackage,
+) -> Result<(), ManifestError> {
+    inherit_forced(&mut pkg.version, ws.version.as_ref(), "version")?;
+    inherit_forced(&mut pkg.repository, ws.repository.as_ref(), "repository")?;
+    inherit_forced(&mut pkg.namespace, ws.namespace.as_ref(), "namespace")?;
+    // `license` and `license-file` are one logical slot: the member overrides
+    // the whole slot or inherits the whole slot.
+    if pkg.license.is_none() && pkg.license_file.is_none() {
+        pkg.license.clone_from(&ws.license);
+        pkg.license_file.clone_from(&ws.license_file);
+    }
+    if pkg.authors.is_none() {
+        pkg.authors.clone_from(&ws.authors);
+    }
+    if pkg.wado_version.is_none() {
+        pkg.wado_version.clone_from(&ws.wado_version);
+    }
+    Ok(())
+}
+
+fn inherit_forced(
+    field: &mut Option<String>,
+    ws_value: Option<&String>,
+    name: &'static str,
+) -> Result<(), ManifestError> {
+    if let Some(ws_value) = ws_value {
+        if field.is_some() {
+            return Err(ManifestError::WorkspaceFieldOverride {
+                field: name.to_string(),
+            });
+        }
+        *field = Some(ws_value.clone());
+    }
     Ok(())
 }
 
@@ -573,6 +696,7 @@ fn convert_workspace(raw: RawWorkspace) -> Result<Workspace, ManifestError> {
         members,
         dependencies,
         dev_dependencies,
+        package_unknown_fields: Vec::new(),
     })
 }
 
@@ -1386,5 +1510,120 @@ license = "Definitely Not A License"
 "#;
         let err = toml.parse::<Manifest>().unwrap_err();
         assert!(matches!(err, ManifestError::InvalidLicense { .. }), "{err:?}");
+    }
+
+    const ROOT_WS: &str = r#"
+[workspace]
+members = ["packages/*"]
+
+[workspace.package]
+version = "0.2.0"
+repository = "https://github.com/org/monorepo"
+namespace = "org"
+license = "MIT"
+authors = ["Alice <a@example.com>"]
+"#;
+
+    #[test]
+    fn member_inherits_workspace_metadata() {
+        let member = r#"
+[package]
+name = "core"
+description = "Shared core"
+lib = "src/lib.wado"
+"#;
+        let pkg = resolve_member(member, ROOT_WS).unwrap().package.unwrap();
+        assert_eq!(pkg.version, "0.2.0");
+        assert_eq!(pkg.repository.as_deref(), Some("https://github.com/org/monorepo"));
+        assert_eq!(pkg.namespace.as_deref(), Some("org"));
+        assert_eq!(pkg.license.as_deref(), Some("MIT"));
+        assert_eq!(pkg.authors, vec!["Alice <a@example.com>"]);
+        // member-specific fields stay
+        assert_eq!(pkg.name, "core");
+        assert_eq!(pkg.description.as_deref(), Some("Shared core"));
+    }
+
+    #[test]
+    fn member_overriding_forced_field_is_error() {
+        for (field, line) in [
+            ("version", "version = \"9.9.9\""),
+            ("repository", "repository = \"https://example.com/other\""),
+            ("namespace", "namespace = \"other\""),
+        ] {
+            let member = format!("[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n{line}\n");
+            let err = resolve_member(&member, ROOT_WS).unwrap_err();
+            assert!(
+                matches!(&err, ManifestError::WorkspaceFieldOverride { field: f } if f == field),
+                "field {field}: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn member_may_override_default_fields() {
+        let member = r#"
+[package]
+name = "core"
+lib = "src/lib.wado"
+license = "Apache-2.0"
+authors = ["Bob"]
+"#;
+        let pkg = resolve_member(member, ROOT_WS).unwrap().package.unwrap();
+        assert_eq!(pkg.license.as_deref(), Some("Apache-2.0"));
+        assert_eq!(pkg.authors, vec!["Bob"]);
+        // forced fields still inherited
+        assert_eq!(pkg.version, "0.2.0");
+    }
+
+    #[test]
+    fn member_license_file_overrides_inherited_license_slot() {
+        let member = r#"
+[package]
+name = "core"
+lib = "src/lib.wado"
+license-file = "LICENSE-CUSTOM"
+"#;
+        let pkg = resolve_member(member, ROOT_WS).unwrap().package.unwrap();
+        assert_eq!(pkg.license_file.as_deref(), Some("LICENSE-CUSTOM"));
+        assert!(pkg.license.is_none(), "inherited license must not coexist");
+    }
+
+    #[test]
+    fn member_missing_version_without_workspace_version_errors() {
+        let root = r#"
+[workspace]
+members = ["packages/*"]
+
+[workspace.package]
+repository = "https://github.com/org/monorepo"
+"#;
+        let member = "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n";
+        let err = resolve_member(member, root).unwrap_err();
+        assert!(
+            matches!(&err, ManifestError::MissingField { field, .. } if field == "version"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_workspace_package_field_warns() {
+        let toml = r#"
+[workspace]
+members = ["packages/*"]
+
+[workspace.package]
+version = "0.1.0"
+description = "not inheritable"
+"#;
+        let m = toml.parse::<Manifest>().unwrap();
+        let warnings = m.warnings();
+        assert!(
+            warnings.iter().any(|w| matches!(
+                w,
+                ManifestWarning::UnknownField { section: Some(s), field }
+                    if s == "workspace.package" && field == "description"
+            )),
+            "got {warnings:?}"
+        );
     }
 }

--- a/wado-manifest/src/validate.rs
+++ b/wado-manifest/src/validate.rs
@@ -24,7 +24,114 @@ fn validate_package(pkg: &crate::manifest::Package) -> Result<(), ManifestError>
         version: pkg.version.clone(),
         reason: e.to_string(),
     })?;
+    // `license` and `license-file` are mutually exclusive.
+    if pkg.license.is_some() && pkg.license_file.is_some() {
+        return Err(ManifestError::ConflictingLicense);
+    }
+    // `wado-version` is a semver requirement (e.g. ">=0.5"); accepts the full
+    // comparator grammar, unlike dependency specifiers.
+    if let Some(req) = &pkg.wado_version {
+        semver::VersionReq::parse(req).map_err(|e| ManifestError::InvalidWadoVersion {
+            value: req.clone(),
+            reason: e.to_string(),
+        })?;
+    }
     Ok(())
+}
+
+/// Reasons a package is not ready to publish. Returned by
+/// [`validate_for_publish`]; an empty result means the package is publishable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishError {
+    /// No `[package]` section.
+    NoPackage,
+    /// `namespace` is absent, so the package has no registry identity.
+    MissingNamespace,
+    /// `publish = false` opts the package out.
+    PublishDisabled,
+    /// A required descriptive field (`description`, `repository`, `authors`) is
+    /// missing.
+    MissingMetadata { field: &'static str },
+    /// Neither `license` nor `license-file` is set.
+    MissingLicense,
+    /// A shipped `path` dependency lacks a registry/git source for publishing.
+    PathDependencyWithoutSource { dep_name: String },
+}
+
+impl std::fmt::Display for PublishError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PublishError::NoPackage => write!(f, "no [package] section to publish"),
+            PublishError::MissingNamespace => {
+                write!(f, "[package].namespace is required to publish")
+            }
+            PublishError::PublishDisabled => {
+                write!(f, "[package].publish = false opts out of publishing")
+            }
+            PublishError::MissingMetadata { field } => {
+                write!(f, "[package].{field} is required to publish")
+            }
+            PublishError::MissingLicense => write!(
+                f,
+                "[package] requires `license` or `license-file` to publish"
+            ),
+            PublishError::PathDependencyWithoutSource { dep_name } => write!(
+                f,
+                "path dependency {dep_name:?} needs a registry or git source to publish"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PublishError {}
+
+/// Check whether a manifest meets the requirements to publish, collecting every
+/// problem rather than stopping at the first. An empty `Vec` means publishable.
+///
+/// Per WEP, a published package must carry its descriptive metadata
+/// (`description`, `repository`, `authors`) and a license; `homepage` and
+/// `documentation` fall back to `repository`, and `repository-directory` /
+/// `wado-version` stay optional.
+#[must_use]
+pub fn validate_for_publish(manifest: &Manifest) -> Vec<PublishError> {
+    let mut errors = Vec::new();
+    let Some(pkg) = &manifest.package else {
+        return vec![PublishError::NoPackage];
+    };
+    if !pkg.publish {
+        errors.push(PublishError::PublishDisabled);
+    }
+    if pkg.namespace.is_none() {
+        errors.push(PublishError::MissingNamespace);
+    }
+    if pkg.description.is_none() {
+        errors.push(PublishError::MissingMetadata {
+            field: "description",
+        });
+    }
+    if pkg.repository.is_none() {
+        errors.push(PublishError::MissingMetadata { field: "repository" });
+    }
+    if pkg.authors.is_empty() {
+        errors.push(PublishError::MissingMetadata { field: "authors" });
+    }
+    if pkg.license.is_none() && pkg.license_file.is_none() {
+        errors.push(PublishError::MissingLicense);
+    }
+    // Shipped dependencies (not dev-dependencies) must be self-contained: a
+    // `path` source needs a registry/git fallback for the published manifest.
+    for (name, dep) in manifest.dependencies.iter().chain(&manifest.build_dependencies) {
+        if let DependencySource::Path {
+            publish_source: None,
+            ..
+        } = &dep.source
+        {
+            errors.push(PublishError::PathDependencyWithoutSource {
+                dep_name: name.clone(),
+            });
+        }
+    }
+    errors
 }
 
 /// Validate that a name matches `[a-zA-Z0-9_-]+` and is 1-64 characters.
@@ -239,5 +346,103 @@ version = "not-a-version"
 "#;
         let err = toml.parse::<crate::Manifest>().unwrap_err();
         assert!(matches!(err, ManifestError::InvalidVersion { .. }));
+    }
+
+    #[test]
+    fn publishable_package_has_no_publish_errors() {
+        let toml = r#"
+[package]
+namespace = "myorg"
+name = "app"
+version = "0.1.0"
+description = "An app"
+repository = "https://github.com/myorg/app"
+license = "MIT"
+authors = ["Alice"]
+"#;
+        let m = toml.parse::<crate::Manifest>().unwrap();
+        assert!(super::validate_for_publish(&m).is_empty());
+    }
+
+    #[test]
+    fn publish_collects_all_missing_requirements() {
+        // Only name+version: namespace, description, repository, authors, license missing.
+        let toml = "[package]\nname = \"app\"\nversion = \"0.1.0\"\n";
+        let m = toml.parse::<crate::Manifest>().unwrap();
+        let errs = super::validate_for_publish(&m);
+        use super::PublishError::*;
+        assert!(errs.contains(&MissingNamespace), "{errs:?}");
+        assert!(errs.contains(&MissingLicense), "{errs:?}");
+        assert!(
+            errs.contains(&MissingMetadata { field: "description" }),
+            "{errs:?}"
+        );
+        assert!(
+            errs.contains(&MissingMetadata { field: "repository" }),
+            "{errs:?}"
+        );
+        assert!(
+            errs.contains(&MissingMetadata { field: "authors" }),
+            "{errs:?}"
+        );
+    }
+
+    #[test]
+    fn publish_disabled_is_an_error() {
+        let toml = r#"
+[package]
+namespace = "myorg"
+name = "app"
+version = "0.1.0"
+description = "An app"
+repository = "https://github.com/myorg/app"
+license = "MIT"
+authors = ["Alice"]
+publish = false
+"#;
+        let m = toml.parse::<crate::Manifest>().unwrap();
+        assert!(super::validate_for_publish(&m).contains(&super::PublishError::PublishDisabled));
+    }
+
+    #[test]
+    fn license_file_satisfies_publish_license_requirement() {
+        let toml = r#"
+[package]
+namespace = "myorg"
+name = "app"
+version = "0.1.0"
+description = "An app"
+repository = "https://github.com/myorg/app"
+license-file = "LICENSE-COMMERCIAL"
+authors = ["Alice"]
+"#;
+        let m = toml.parse::<crate::Manifest>().unwrap();
+        assert!(super::validate_for_publish(&m).is_empty());
+    }
+
+    #[test]
+    fn publish_flags_path_dependency_without_source() {
+        let toml = r#"
+[package]
+namespace = "myorg"
+name = "app"
+version = "0.1.0"
+description = "An app"
+repository = "https://github.com/myorg/app"
+license = "MIT"
+authors = ["Alice"]
+
+[dependencies]
+"lib:shared" = { path = "../shared" }
+"#;
+        let m = toml.parse::<crate::Manifest>().unwrap();
+        let errs = super::validate_for_publish(&m);
+        assert!(
+            errs.iter().any(|e| matches!(
+                e,
+                super::PublishError::PathDependencyWithoutSource { dep_name } if dep_name == "lib:shared"
+            )),
+            "{errs:?}"
+        );
     }
 }

--- a/wado-manifest/src/validate.rs
+++ b/wado-manifest/src/validate.rs
@@ -154,7 +154,9 @@ pub fn validate_for_publish(manifest: &Manifest) -> Vec<PublishError> {
         });
     }
     if pkg.repository.is_none() {
-        errors.push(PublishError::MissingMetadata { field: "repository" });
+        errors.push(PublishError::MissingMetadata {
+            field: "repository",
+        });
     }
     if pkg.authors.is_empty() {
         errors.push(PublishError::MissingMetadata { field: "authors" });
@@ -162,7 +164,11 @@ pub fn validate_for_publish(manifest: &Manifest) -> Vec<PublishError> {
     if pkg.license.is_none() && pkg.license_file.is_none() {
         errors.push(PublishError::MissingLicense);
     }
-    for (name, dep) in manifest.dependencies.iter().chain(&manifest.build_dependencies) {
+    for (name, dep) in manifest
+        .dependencies
+        .iter()
+        .chain(&manifest.build_dependencies)
+    {
         match &dep.source {
             DependencySource::Path {
                 publish_source: None,
@@ -420,11 +426,15 @@ authors = ["Alice"]
         assert!(errs.contains(&MissingNamespace), "{errs:?}");
         assert!(errs.contains(&MissingLicense), "{errs:?}");
         assert!(
-            errs.contains(&MissingMetadata { field: "description" }),
+            errs.contains(&MissingMetadata {
+                field: "description"
+            }),
             "{errs:?}"
         );
         assert!(
-            errs.contains(&MissingMetadata { field: "repository" }),
+            errs.contains(&MissingMetadata {
+                field: "repository"
+            }),
             "{errs:?}"
         );
         assert!(

--- a/wado-manifest/src/validate.rs
+++ b/wado-manifest/src/validate.rs
@@ -58,20 +58,15 @@ fn validate_package(pkg: &crate::manifest::Package) -> Result<(), ManifestError>
         version: pkg.version.clone(),
         reason: e.to_string(),
     })?;
-    // `license` and `license-file` are mutually exclusive.
     if pkg.license.is_some() && pkg.license_file.is_some() {
         return Err(ManifestError::ConflictingLicense);
     }
-    // `license`, when set, must be a valid SPDX license expression. `LicenseRef-`
-    // (for a bundled non-standard license) is part of the SPDX grammar.
     if let Some(license) = &pkg.license {
         spdx::Expression::parse(license).map_err(|e| ManifestError::InvalidLicense {
             value: license.clone(),
             reason: e.to_string(),
         })?;
     }
-    // `wado-version` is a semver requirement (e.g. ">=0.5"); accepts the full
-    // comparator grammar, unlike dependency specifiers.
     if let Some(req) = &pkg.wado_version {
         semver::VersionReq::parse(req).map_err(|e| ManifestError::InvalidWadoVersion {
             value: req.clone(),
@@ -167,8 +162,6 @@ pub fn validate_for_publish(manifest: &Manifest) -> Vec<PublishError> {
     if pkg.license.is_none() && pkg.license_file.is_none() {
         errors.push(PublishError::MissingLicense);
     }
-    // Shipped dependencies (not dev-dependencies) must be self-contained: a
-    // `path` source needs a registry/git fallback for the published manifest.
     for (name, dep) in manifest.dependencies.iter().chain(&manifest.build_dependencies) {
         match &dep.source {
             DependencySource::Path {
@@ -420,7 +413,6 @@ authors = ["Alice"]
 
     #[test]
     fn publish_collects_all_missing_requirements() {
-        // Only name+version: namespace, description, repository, authors, license missing.
         let toml = "[package]\nname = \"app\"\nversion = \"0.1.0\"\n";
         let m = toml.parse::<crate::Manifest>().unwrap();
         let errs = super::validate_for_publish(&m);

--- a/wado-manifest/src/validate.rs
+++ b/wado-manifest/src/validate.rs
@@ -28,6 +28,14 @@ fn validate_package(pkg: &crate::manifest::Package) -> Result<(), ManifestError>
     if pkg.license.is_some() && pkg.license_file.is_some() {
         return Err(ManifestError::ConflictingLicense);
     }
+    // `license`, when set, must be a valid SPDX license expression. `LicenseRef-`
+    // (for a bundled non-standard license) is part of the SPDX grammar.
+    if let Some(license) = &pkg.license {
+        spdx::Expression::parse(license).map_err(|e| ManifestError::InvalidLicense {
+            value: license.clone(),
+            reason: e.to_string(),
+        })?;
+    }
     // `wado-version` is a semver requirement (e.g. ">=0.5"); accepts the full
     // comparator grammar, unlike dependency specifiers.
     if let Some(req) = &pkg.wado_version {

--- a/wado-manifest/src/validate.rs
+++ b/wado-manifest/src/validate.rs
@@ -1,4 +1,4 @@
-use crate::manifest::{DependencySource, Manifest, ManifestError};
+use crate::manifest::{DependencySource, Manifest, ManifestError, WorkspacePackage};
 use crate::version::{Version, VersionSpecifier};
 
 /// Validate a parsed manifest for semantic consistency.
@@ -9,7 +9,41 @@ pub fn validate(manifest: &Manifest) -> Result<(), ManifestError> {
     if let Some(pkg) = &manifest.package {
         validate_package(pkg)?;
     }
+    if let Some(ws_pkg) = manifest.workspace.as_ref().and_then(|w| w.package.as_ref()) {
+        validate_workspace_package(ws_pkg)?;
+    }
     validate_dependencies(manifest)?;
+    Ok(())
+}
+
+/// Validate the `[workspace.package]` table at its source, so problems are
+/// attributed to the workspace root rather than to an inheriting member.
+pub(crate) fn validate_workspace_package(p: &WorkspacePackage) -> Result<(), ManifestError> {
+    if p.license.is_some() && p.license_file.is_some() {
+        return Err(ManifestError::WorkspaceConflictingLicense);
+    }
+    if let Some(license) = &p.license {
+        spdx::Expression::parse(license).map_err(|e| ManifestError::WorkspaceInvalidLicense {
+            value: license.clone(),
+            reason: e.to_string(),
+        })?;
+    }
+    if let Some(version) = &p.version {
+        Version::parse(version).map_err(|e| ManifestError::InvalidVersion {
+            context: "workspace.package.version".to_string(),
+            version: version.clone(),
+            reason: e.to_string(),
+        })?;
+    }
+    if let Some(namespace) = &p.namespace {
+        validate_name("workspace.package.namespace", namespace)?;
+    }
+    if let Some(req) = &p.wado_version {
+        semver::VersionReq::parse(req).map_err(|e| ManifestError::InvalidWadoVersion {
+            value: req.clone(),
+            reason: e.to_string(),
+        })?;
+    }
     Ok(())
 }
 
@@ -64,6 +98,9 @@ pub enum PublishError {
     MissingLicense,
     /// A shipped `path` dependency lacks a registry/git source for publishing.
     PathDependencyWithoutSource { dep_name: String },
+    /// A shipped `workspace = true` dependency has no concrete source once the
+    /// package is extracted from its workspace.
+    WorkspaceDependency { dep_name: String },
 }
 
 impl std::fmt::Display for PublishError {
@@ -86,6 +123,10 @@ impl std::fmt::Display for PublishError {
             PublishError::PathDependencyWithoutSource { dep_name } => write!(
                 f,
                 "path dependency {dep_name:?} needs a registry or git source to publish"
+            ),
+            PublishError::WorkspaceDependency { dep_name } => write!(
+                f,
+                "workspace dependency {dep_name:?} must resolve to a concrete source to publish"
             ),
         }
     }
@@ -129,14 +170,19 @@ pub fn validate_for_publish(manifest: &Manifest) -> Vec<PublishError> {
     // Shipped dependencies (not dev-dependencies) must be self-contained: a
     // `path` source needs a registry/git fallback for the published manifest.
     for (name, dep) in manifest.dependencies.iter().chain(&manifest.build_dependencies) {
-        if let DependencySource::Path {
-            publish_source: None,
-            ..
-        } = &dep.source
-        {
-            errors.push(PublishError::PathDependencyWithoutSource {
+        match &dep.source {
+            DependencySource::Path {
+                publish_source: None,
+                ..
+            } => errors.push(PublishError::PathDependencyWithoutSource {
                 dep_name: name.clone(),
-            });
+            }),
+            DependencySource::Workspace => errors.push(PublishError::WorkspaceDependency {
+                dep_name: name.clone(),
+            }),
+            DependencySource::Path { .. }
+            | DependencySource::Git { .. }
+            | DependencySource::Registry { .. } => {}
         }
     }
     errors
@@ -426,6 +472,32 @@ authors = ["Alice"]
 "#;
         let m = toml.parse::<crate::Manifest>().unwrap();
         assert!(super::validate_for_publish(&m).is_empty());
+    }
+
+    #[test]
+    fn publish_flags_workspace_dependency() {
+        let toml = r#"
+[package]
+namespace = "myorg"
+name = "app"
+version = "0.1.0"
+description = "An app"
+repository = "https://github.com/myorg/app"
+license = "MIT"
+authors = ["Alice"]
+
+[dependencies]
+"ns:shared" = { workspace = true }
+"#;
+        let m = toml.parse::<crate::Manifest>().unwrap();
+        let errs = super::validate_for_publish(&m);
+        assert!(
+            errs.iter().any(|e| matches!(
+                e,
+                super::PublishError::WorkspaceDependency { dep_name } if dep_name == "ns:shared"
+            )),
+            "{errs:?}"
+        );
     }
 
     #[test]

--- a/wado.toml
+++ b/wado.toml
@@ -1,3 +1,9 @@
-[package]
-name = "wado"
+[workspace]
+members = ["package-cm-catalog", "package-gale"]
+
+[workspace.package]
 version = "0.1.0"
+repository = "https://github.com/wado-lang/wado"
+namespace = "wado-lang"
+license = "MIT"
+authors = ["FUJI Goro <g.psy.va@gmail.com>"]


### PR DESCRIPTION
## Summary

Adds human-facing package metadata to `[package]`, a `wado publish` command (dry-run), and `[workspace.package]` metadata inheritance with a lockstep release contract. Metadata is designed around OCI annotations, with `wado.toml` as the single source of truth.

## `[package]` metadata

New fields: `description`, `homepage`, `repository`, `repository-directory`, `documentation`, `license`, `license-file`, `authors`, `wado-version`, `publish`.

- Each maps to a standard `org.opencontainers.image.*` annotation on publish; `homepage`/`documentation` fall back to `repository`.
- `license` is validated as an SPDX expression (via the `spdx` crate); `license` and `license-file` are mutually exclusive, with `license-file` represented as `LicenseRef-<name>`.
- `repository` stays a bare repo URL (for registry→repo linking); a monorepo subdirectory goes in `repository-directory`. The consuming side gets a git-dependency `directory` field.
- Unknown manifest keys (top-level, `[package]`, `[workspace.package]`) are reported as warnings, not errors.

## `wado publish --dry-run`

Runs the publish-readiness checks (`validate_for_publish`) and reports every problem at once; namespace + descriptive metadata + a license are required, and shipped `path`/`workspace` deps must carry a concrete source. The OCI upload itself is not wired yet (it will shell out to `wkg` with metadata embedded via `wasm-metadata`), so a non-dry-run invocation errors rather than pretending to publish.

## Workspace metadata inheritance and the lockstep contract

`[workspace.package]` declares metadata shared by every member, inherited automatically (no `{ workspace = true }` marker):

- `version`/`repository`/`namespace` are force-inherited — a member that re-declares one is an error, so there is exactly one definition site and in-repo drift is impossible.
- `license`/`license-file`/`authors`/`wado-version` are overridable defaults.
- A manifest that is itself a workspace root is the authority, not a governed member.

`wado publish` is gated to the workspace root and publishes every publishable member together at the shared version, extending the no-drift guarantee to the registry. Membership is the boundary: a package is either in the workspace (locked) or standalone (free); there is no in-workspace per-field opt-out. This is the deliberate departure from Cargo's per-field opt-in, where same-repo versions routinely drift.

## Implementation notes

- New `wado-manifest` API: `resolve_member`, `validate_for_publish`, `WorkspacePackage`, and `PublishError`. Unknown-field detection uses `serde(flatten)` (single parse). The crate still builds for `wasm32-unknown-unknown`.
- CLI manifest discovery is workspace-aware (member manifests resolve against the governing root); membership uses a pure no-I/O glob match.
- The repo's own `package-cm-catalog` and `package-gale` are converted to workspace members that inherit shared metadata (dog-food).
- Design is documented in `docs/wep-2026-02-14-package-manifest.md`, including a dedicated Lockstep Contract section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUgCWpuua4DvC6ZCqB8nHZ)_