### PR TITLE
feat(cli): embed package metadata into compiled components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,6 +3025,8 @@ dependencies = [
  "wado-compiler",
  "wado-lsp",
  "wado-manifest",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -91,18 +91,18 @@ Keys the schema does not recognize — at the top level, in `[package]`, or in `
 
 The human-facing `[package]` fields are universal package metadata; on publish to OCI (see [Registry backend](#registry-backend)) each maps to a standard `org.opencontainers.image.*` annotation:
 
-| `[package]` field      | OCI annotation                                       | Notes                                                |
-| ---------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
-| `description`          | `org.opencontainers.image.description`               | Short human-readable summary                         |
-| `homepage`             | `org.opencontainers.image.url`                       |                                                      |
-| `repository`           | `org.opencontainers.image.source`                    | Bare repo URL — enables registry → repo auto-linking |
-| `documentation`        | `org.opencontainers.image.documentation`             |                                                      |
-| `license`              | `org.opencontainers.image.licenses`                  | SPDX License Expression                              |
-| `authors`              | `org.opencontainers.image.authors`                   | Array, serialized comma-separated                    |
-| `version`              | `org.opencontainers.image.version`                   | Set by the registry tool at publish time             |
-| (git commit SHA)       | `org.opencontainers.image.revision`                  | Auto-derived at build time                           |
-| `repository-directory` | `org.wado-lang.package.repository-directory`         | Wado-custom annotation (no OCI key); embedded, not promoted by `wkg`        |
-| `license-file`         | `org.opencontainers.image.licenses` = `LicenseRef-…` | License text embedded in the `org.wado-lang.license` custom section         |
+| `[package]` field      | OCI annotation                                       | Notes                                                                |
+| ---------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| `description`          | `org.opencontainers.image.description`               | Short human-readable summary                                         |
+| `homepage`             | `org.opencontainers.image.url`                       |                                                                      |
+| `repository`           | `org.opencontainers.image.source`                    | Bare repo URL — enables registry → repo auto-linking                 |
+| `documentation`        | `org.opencontainers.image.documentation`             |                                                                      |
+| `license`              | `org.opencontainers.image.licenses`                  | SPDX License Expression                                              |
+| `authors`              | `org.opencontainers.image.authors`                   | Array, serialized comma-separated                                    |
+| `version`              | `org.opencontainers.image.version`                   | Package semver                                                       |
+| (git commit SHA)       | `org.opencontainers.image.revision`                  | Auto-derived at build time; clean tree only                          |
+| `repository-directory` | `org.wado-lang.package.repository-directory`         | Wado-custom annotation (no OCI key); embedded, not promoted by `wkg` |
+| `license-file`         | `org.opencontainers.image.licenses` = `LicenseRef-…` | License text embedded in the `org.wado-lang.license` custom section  |
 
 `created` is not modeled (the registry tool owns publish timestamps);
 `keywords`/`categories` are omitted (no OCI key, so they would not reach the registry).

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -101,11 +101,16 @@ The human-facing `[package]` fields are universal package metadata; on publish t
 | `authors`              | `org.opencontainers.image.authors`                   | Array, serialized comma-separated                    |
 | `version`              | `org.opencontainers.image.version`                   | Set by the registry tool at publish time             |
 | (git commit SHA)       | `org.opencontainers.image.revision`                  | Auto-derived at build time                           |
-| `repository-directory` | — (Wado-custom)                                      | No OCI key exists; embedded in the component only    |
-| `license-file`         | `org.opencontainers.image.licenses` = `LicenseRef-…` | License text embedded as a custom section            |
+| `repository-directory` | `org.wado-lang.package.repository-directory`         | Wado-custom annotation (no OCI key); embedded, not promoted by `wkg`        |
+| `license-file`         | `org.opencontainers.image.licenses` = `LicenseRef-…` | License text embedded in the `org.wado-lang.license` custom section         |
 
 `created` is not modeled (the registry tool owns publish timestamps);
 `keywords`/`categories` are omitted (no OCI key, so they would not reach the registry).
+
+Metadata with no standard OCI key uses the Wado namespace
+`org.wado-lang.package.*`, keyed by the `wado.toml` field name (e.g.
+`org.wado-lang.package.repository-directory`). Wado-proprietary binary custom
+sections use the same `org.wado-lang.*` namespace.
 
 #### License
 
@@ -117,7 +122,19 @@ Neither OCI nor git addresses a repository subdirectory, so `repository` stays a
 
 #### Metadata embedding and the publish backend
 
-`wado publish` embeds the metadata into the component in the `wasm-metadata` custom-section format and shells out to `wkg` (wasm-pkg-tools), which derives the OCI annotations. There is no `wkg.toml` — `wado.toml` is the only source of truth, and `wkg` is an implementation detail (a missing `wkg` errors with install guidance). Authentication is delegated to the ambient OCI credential store (`docker login`), with an env-var token override for CI; Wado stores no credentials. `revision` is the git commit SHA, derived at build time and omitted (with a warning) on a dirty tree.
+`wado compile` embeds the metadata into the component in the `wasm-metadata`
+custom-section format. Embedding happens only in manifest-driven mode — `wado
+compile` with no argument (the cwd `wado.toml`) or a directory argument
+(`<dir>/wado.toml`); an explicit `.wado` file argument compiles that file as a
+standalone target and embeds nothing. `--no-embed-metadata` opts out.
+
+`wado publish` builds through the same compile path and shells out to `wkg`
+(wasm-pkg-tools), which derives the OCI annotations. There is no `wkg.toml` —
+`wado.toml` is the only source of truth, and `wkg` is an implementation detail
+(a missing `wkg` errors with install guidance). Authentication is delegated to
+the ambient OCI credential store (`docker login`), with an env-var token
+override for CI; Wado stores no credentials. `revision` is the git commit SHA,
+derived at build time; a dirty tree omits it, warned only at publish.
 
 ### Entry Points and Worlds
 

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -126,7 +126,9 @@ Neither OCI nor git addresses a repository subdirectory, so `repository` stays a
 custom-section format. Embedding happens only in manifest-driven mode — `wado
 compile` with no argument (the cwd `wado.toml`) or a directory argument
 (`<dir>/wado.toml`); an explicit `.wado` file argument compiles that file as a
-standalone target and embeds nothing. `--no-embed-metadata` opts out.
+standalone target and embeds nothing. `--no-embed-metadata` opts out, and `-Os`
+(strip symbols for minimal frontend delivery) drops the metadata too, matching
+the WIT section.
 
 `wado publish` builds through the same compile path and shells out to `wkg`
 (wasm-pkg-tools), which derives the OCI annotations. There is no `wkg.toml` —

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -128,7 +128,8 @@ compile` with no argument (the cwd `wado.toml`) or a directory argument
 (`<dir>/wado.toml`); an explicit `.wado` file argument compiles that file as a
 standalone target and embeds nothing. `--no-embed-metadata` opts out, and `-Os`
 (strip symbols for minimal frontend delivery) drops the metadata too, matching
-the WIT section.
+the WIT section; `--embed-metadata` forces it back on under `-Os` (mirroring
+`--embed-wit`).
 
 `wado publish` builds through the same compile path and shells out to `wkg`
 (wasm-pkg-tools), which derives the OCI annotations. There is no `wkg.toml` —

--- a/docs/wep-2026-02-22-cli-subcommands.md
+++ b/docs/wep-2026-02-22-cli-subcommands.md
@@ -268,6 +268,16 @@ wado compile -o out.wasm           # compiles the command entry point
 
 When a file argument is provided, it overrides the entry point from `wado.toml`.
 
+#### Default output path
+
+Without `-o`, a manifest-driven build (no argument or a directory argument)
+writes `<manifest_root>/build/<world>.wasm`, keeping artifacts out of the source
+tree and giving each world its own file (mirroring kiln's `build/` layout).
+`<world>` is the target Component Model world FQ sanitized to a path segment
+(`@version` dropped, `:`/`/` → `-`), e.g. `build/wasi-cli-command.wasm`;
+`--lib` writes `build/lib.wasm`. A standalone file argument keeps the old
+`<input>.wasm` beside the source.
+
 #### `--lib` — pending
 
 `wado compile --lib` (compile the `[package].lib` entry as a library) is

--- a/wado-cli/Cargo.toml
+++ b/wado-cli/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["net", "time", "signal"] }
+wasm-encoder = { workspace = true }
 wasmprinter = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
@@ -53,6 +54,7 @@ jsonschema = { workspace = true }
 predicates = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
+wasmparser = { workspace = true }
 
 [lints]
 workspace = true

--- a/wado-cli/src/check.rs
+++ b/wado-cli/src/check.rs
@@ -130,7 +130,7 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
 
     let manifest_root = manifest_pair
         .as_ref()
-        .map(|(_, root)| root.clone())
+        .map(|p| p.root.clone())
         .unwrap_or_else(|| {
             path.parent()
                 .map(std::path::Path::to_path_buf)
@@ -156,7 +156,7 @@ pub async fn run(opts: CheckOptions) -> Result<(), CliExit> {
         CheckOutcome::default()
     } else {
         let manifest = manifest_pair
-            .map(|(m, _)| m)
+            .map(|p| p.manifest)
             .unwrap_or_else(crate::compile::empty_manifest);
         crate::compile::rewrite_build_dep_modules(&mut inline, &manifest, &manifest_root);
         crate::compile::rewrite_local_dir_modules(&mut inline, &manifest_root);

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -102,6 +102,9 @@ pub struct CompileOptions {
     pub embed_wit: bool,
     /// `--no-embed-metadata`: opt out of embedding the `[package]` metadata.
     pub no_embed_metadata: bool,
+    /// `--embed-metadata`: force embedding on, overriding the `-Os` default-off.
+    /// Mutually exclusive with `--no-embed-metadata`.
+    pub embed_metadata: bool,
     /// True when the entry was resolved from a manifest (no path argument, or a
     /// directory argument), so the build represents the package's declared
     /// artifact. An explicit `.wado` file argument sets this false and embeds no
@@ -220,6 +223,7 @@ enum Opt {
     NoEmbedWit,
     EmbedWit,
     NoEmbedMetadata,
+    EmbedMetadata,
     Help,
 }
 
@@ -241,6 +245,7 @@ impl Opt {
         Self::NoEmbedWit,
         Self::EmbedWit,
         Self::NoEmbedMetadata,
+        Self::EmbedMetadata,
         Self::Help,
     ];
 
@@ -297,6 +302,12 @@ impl Opt {
                 value: None,
                 desc: "Do not embed the [package] metadata sections in the output",
             },
+            Self::EmbedMetadata => args::OptSpec {
+                long: Some("embed-metadata"),
+                short: None,
+                value: None,
+                desc: "Force embedding the [package] metadata on (e.g. under -Os, where it is off by default)",
+            },
             Self::Help => args::HELP_SPEC,
         }
     }
@@ -342,6 +353,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     let mut no_embed_wit = false;
     let mut embed_wit = false;
     let mut no_embed_metadata = false;
+    let mut embed_metadata = false;
     let mut param_args = args::ParamArgs::default();
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(p) = args::match_opt(&arg, args::ParamOpt::ALL, |p| p.spec()) {
@@ -381,6 +393,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
                 Opt::NoEmbedWit => no_embed_wit = true,
                 Opt::EmbedWit => embed_wit = true,
                 Opt::NoEmbedMetadata => no_embed_metadata = true,
+                Opt::EmbedMetadata => embed_metadata = true,
                 Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
@@ -400,6 +413,12 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     if no_embed_wit && embed_wit {
         return Err(CliExit::error(
             "`--no-embed-wit` and `--embed-wit` are mutually exclusive",
+        ));
+    }
+
+    if no_embed_metadata && embed_metadata {
+        return Err(CliExit::error(
+            "`--no-embed-metadata` and `--embed-metadata` are mutually exclusive",
         ));
     }
 
@@ -442,6 +461,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
         no_embed_wit,
         embed_wit,
         no_embed_metadata,
+        embed_metadata,
         manifest_driven,
     })
 }
@@ -1032,10 +1052,11 @@ async fn embed_wit_section(
 /// Embed the `[package]` metadata into the component when building the package's
 /// declared artifact (manifest-driven mode) and `--no-embed-metadata` was not
 /// given. Returns `wasm` unchanged otherwise — an explicit file argument, no
-/// `wado.toml`, a manifest without `[package]`, or `-Os` (which strips symbols
-/// for minimal frontend delivery, where the metadata is dead weight — matching
-/// the WIT section being dropped). The git `revision` is included only on a
-/// clean tree (omitted silently here; `wado publish` warns).
+/// `wado.toml`, or a manifest without `[package]`. Under `-Os` (strip symbols
+/// for minimal frontend delivery) the metadata is dropped as dead weight unless
+/// `--embed-metadata` forces it on, matching the WIT section's policy. The git
+/// `revision` is included only on a clean tree (omitted silently here; `wado
+/// publish` warns).
 ///
 /// `project` is the manifest already discovered by [`run`], reused here rather
 /// than re-parsed.
@@ -1044,7 +1065,10 @@ fn embed_package_metadata(
     project: Option<&manifest::ProjectManifest>,
     wasm: Vec<u8>,
 ) -> Vec<u8> {
-    if opts.no_embed_metadata || !opts.manifest_driven || opts.opt_level == OptLevel::Os {
+    if opts.no_embed_metadata || !opts.manifest_driven {
+        return wasm;
+    }
+    if opts.opt_level == OptLevel::Os && !opts.embed_metadata {
         return wasm;
     }
     let Some(project) = project else {

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -100,6 +100,13 @@ pub struct CompileOptions {
     /// closure (a `local`, registry-referencing section is not encodable; see
     /// WEP §"Phase 2 finding"). Mutually exclusive with `--no-embed-wit`.
     pub embed_wit: bool,
+    /// `--no-embed-metadata`: opt out of embedding the `[package]` metadata.
+    pub no_embed_metadata: bool,
+    /// True when the entry was resolved from a manifest (no path argument, or a
+    /// directory argument), so the build represents the package's declared
+    /// artifact. An explicit `.wado` file argument sets this false and embeds no
+    /// metadata. See WEP `wep-2026-02-14-package-manifest.md`.
+    pub manifest_driven: bool,
 }
 
 impl CompileOptions {
@@ -212,6 +219,7 @@ enum Opt {
     Feature,
     NoEmbedWit,
     EmbedWit,
+    NoEmbedMetadata,
     Help,
 }
 
@@ -232,6 +240,7 @@ impl Opt {
         Self::Feature,
         Self::NoEmbedWit,
         Self::EmbedWit,
+        Self::NoEmbedMetadata,
         Self::Help,
     ];
 
@@ -282,6 +291,12 @@ impl Opt {
                 value: None,
                 desc: "Force embedding the WIT section on (e.g. under -Os, where it is off by default)",
             },
+            Self::NoEmbedMetadata => args::OptSpec {
+                long: Some("no-embed-metadata"),
+                short: None,
+                value: None,
+                desc: "Do not embed the [package] metadata sections in the output",
+            },
             Self::Help => args::HELP_SPEC,
         }
     }
@@ -326,6 +341,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     let mut lib = false;
     let mut no_embed_wit = false;
     let mut embed_wit = false;
+    let mut no_embed_metadata = false;
     let mut param_args = args::ParamArgs::default();
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(p) = args::match_opt(&arg, args::ParamOpt::ALL, |p| p.spec()) {
@@ -364,6 +380,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
                 Opt::Feature => codegen_flags.push(args::require_string(&mut parser)?),
                 Opt::NoEmbedWit => no_embed_wit = true,
                 Opt::EmbedWit => embed_wit = true,
+                Opt::NoEmbedMetadata => no_embed_metadata = true,
                 Opt::Help => return Err(CliExit::help(usage)),
             }
         } else if let Value(val) = arg {
@@ -385,6 +402,12 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
             "`--no-embed-wit` and `--embed-wit` are mutually exclusive",
         ));
     }
+
+    // Manifest-driven mode: no path argument, or a directory argument. An
+    // explicit `.wado` file argument is a standalone target — `resolve_input`
+    // returns it verbatim without consulting a manifest for the entry, and
+    // metadata is not embedded (WEP `wep-2026-02-14-package-manifest.md`).
+    let manifest_driven = input.as_deref().is_none_or(|s| Path::new(s).is_dir());
 
     let (input, lib_world) = if lib {
         let (entry, world_fq) = manifest::resolve_lib_input(input, &usage)?;
@@ -418,6 +441,8 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
         param_policy: param_args.policy,
         no_embed_wit,
         embed_wit,
+        no_embed_metadata,
+        manifest_driven,
     })
 }
 
@@ -1005,6 +1030,26 @@ async fn embed_wit_section(
     }
 }
 
+/// Embed the `[package]` metadata into the component when building the package's
+/// declared artifact (manifest-driven mode) and `--no-embed-metadata` was not
+/// given. Returns `wasm` unchanged otherwise — an explicit file argument, no
+/// `wado.toml`, or a manifest without `[package]`. The git `revision` is
+/// included only on a clean tree (omitted silently here; `wado publish` warns).
+fn embed_package_metadata(opts: &CompileOptions, wasm: Vec<u8>) -> Vec<u8> {
+    if opts.no_embed_metadata || !opts.manifest_driven {
+        return wasm;
+    }
+    let Some((manifest, root)) = load_nearest_manifest(Path::new(&opts.input)) else {
+        return wasm;
+    };
+    let Some(pkg) = manifest.package.as_ref() else {
+        return wasm;
+    };
+    let revision = crate::metadata_embed::clean_git_revision(&root);
+    let sections = wado_manifest::metadata_sections(pkg, revision.as_deref());
+    crate::metadata_embed::embed_metadata_sections(wasm, &sections)
+}
+
 pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
     // Output format is independent of the compiled bytes; resolve it first so we
     // know whether to retain WIR (only the wasm-output embedding path needs it).
@@ -1050,9 +1095,10 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
                 .wir_package
                 .map(|p| p.imported_cm_interfaces)
                 .unwrap_or_default();
-            embed_wit_section(&opts, wasm, world_imports, explicit).await?
+            let embedded = embed_wit_section(&opts, wasm, world_imports, explicit).await?;
+            embed_package_metadata(&opts, embedded)
         }
-        (OutputFormat::Wasm, None) => wasm,
+        (OutputFormat::Wasm, None) => embed_package_metadata(&opts, wasm),
         (OutputFormat::Wat, _) => wasm_to_wat(&wasm)?.into_bytes(),
     };
     fs::write(&output_path, &bytes)

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -121,7 +121,24 @@ impl CompileOptions {
     fn embed_decision(&self) -> Option<bool> {
         resolve_embed_decision(self.no_embed_wit, self.embed_wit, self.opt_level)
     }
+
+    /// The Component Model world FQ this build targets: the `--lib` world, then
+    /// `--world`, then the CLI default. Single source of truth for the WIT
+    /// embed and the default output path.
+    fn target_world_fq(&self) -> &str {
+        self.lib_world
+            .as_deref()
+            .or(self.target_world.as_deref())
+            .unwrap_or(DEFAULT_WORLD)
+    }
 }
+
+/// The world `wado compile` targets when neither `--world` nor `--lib` is given.
+const DEFAULT_WORLD: &str = "wasi:cli/command";
+
+/// The build-output directory at the manifest root, shared with kiln's
+/// `build/kiln/...` layout (see `kiln_provider`).
+const BUILD_DIR: &str = "build";
 
 /// Pure embedding-policy resolution, factored out of [`CompileOptions`] for
 /// testing. See [`CompileOptions::embed_decision`].
@@ -425,6 +442,15 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
     // manifest; an explicit `.wado` file is a standalone target. Gates metadata
     // embedding (WEP `wep-2026-02-14-package-manifest.md`).
     let manifest_driven = input.as_deref().is_none_or(|s| Path::new(s).is_dir());
+
+    // Metadata embedding only happens for manifest-driven builds, so these flags
+    // would be silently ignored on a standalone file — reject the combination.
+    if (no_embed_metadata || embed_metadata) && !manifest_driven {
+        return Err(CliExit::error(
+            "`--embed-metadata` / `--no-embed-metadata` apply only to manifest-driven builds \
+             (no argument or a directory argument), not an explicit file",
+        ));
+    }
 
     let (input, lib_world) = if lib {
         let (entry, world_fq) = manifest::resolve_lib_input(input, &usage)?;
@@ -1003,13 +1029,7 @@ async fn embed_wit_section(
         return Ok(wasm);
     };
 
-    // The embedded world FQ mirrors what was compiled: the `--lib` world, then
-    // `--world`, then the CLI default.
-    let world = opts
-        .lib_world
-        .clone()
-        .or_else(|| opts.target_world.clone())
-        .unwrap_or_else(|| "wasi:cli/command".to_string());
+    let world = opts.target_world_fq().to_string();
 
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
     // Attach the manifest `[dependencies]` so a multi-package project's
@@ -1122,18 +1142,22 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
         default_output_path(&opts, project.as_ref(), format)
     };
 
-    let bytes = match (format, embed) {
-        (OutputFormat::Wasm, Some(explicit)) => {
-            let world_imports = result
-                .wir_package
-                .map(|p| p.imported_cm_interfaces)
-                .unwrap_or_default();
-            let embedded =
-                embed_wit_section(&opts, project.as_ref(), wasm, world_imports, explicit).await?;
-            embed_package_metadata(&opts, project.as_ref(), embedded)
+    let bytes = match format {
+        OutputFormat::Wat => wasm_to_wat(&wasm)?.into_bytes(),
+        OutputFormat::Wasm => {
+            // WIT first (if enabled), then the package metadata — both additive
+            // custom sections on the component.
+            let wasm = if let Some(explicit) = embed {
+                let world_imports = result
+                    .wir_package
+                    .map(|p| p.imported_cm_interfaces)
+                    .unwrap_or_default();
+                embed_wit_section(&opts, project.as_ref(), wasm, world_imports, explicit).await?
+            } else {
+                wasm
+            };
+            embed_package_metadata(&opts, project.as_ref(), wasm)
         }
-        (OutputFormat::Wasm, None) => embed_package_metadata(&opts, project.as_ref(), wasm),
-        (OutputFormat::Wat, _) => wasm_to_wat(&wasm)?.into_bytes(),
     };
     if let Some(parent) = output_path.parent().filter(|p| !p.as_os_str().is_empty()) {
         fs::create_dir_all(parent)
@@ -1164,9 +1188,9 @@ fn default_output_path(
             let world = if opts.lib_world.is_some() {
                 "lib".to_string()
             } else {
-                world_path_segment(opts.target_world.as_deref().unwrap_or("wasi:cli/command"))
+                world_path_segment(opts.target_world_fq())
             };
-            project.root.join("build").join(format!("{world}.{ext}"))
+            project.root.join(BUILD_DIR).join(format!("{world}.{ext}"))
         }
         None => Path::new(&opts.input).with_extension(ext),
     }

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1109,21 +1109,18 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
         return Ok(());
     }
 
+    // Discover the package manifest once, reused for the default output path and
+    // the wasm-output embedding paths (WIT + metadata) so nothing re-parses it.
+    let project = opts
+        .manifest_driven
+        .then(|| load_nearest_manifest(Path::new(&opts.input)))
+        .flatten();
+
     let output_path = if let Some(path) = &opts.output {
         Path::new(path).to_path_buf()
     } else {
-        let ext = match format {
-            OutputFormat::Wasm => "wasm",
-            OutputFormat::Wat => "wat",
-        };
-        Path::new(&opts.input).with_extension(ext)
+        default_output_path(&opts, project.as_ref(), format)
     };
-
-    // Discover the package manifest once for the wasm-output embedding paths
-    // (WIT + metadata), so neither step re-parses it.
-    let manifest_pair = (format == OutputFormat::Wasm)
-        .then(|| load_nearest_manifest(Path::new(&opts.input)))
-        .flatten();
 
     let bytes = match (format, embed) {
         (OutputFormat::Wasm, Some(explicit)) => {
@@ -1132,19 +1129,75 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
                 .map(|p| p.imported_cm_interfaces)
                 .unwrap_or_default();
             let embedded =
-                embed_wit_section(&opts, manifest_pair.as_ref(), wasm, world_imports, explicit)
-                    .await?;
-            embed_package_metadata(&opts, manifest_pair.as_ref(), embedded)
+                embed_wit_section(&opts, project.as_ref(), wasm, world_imports, explicit).await?;
+            embed_package_metadata(&opts, project.as_ref(), embedded)
         }
-        (OutputFormat::Wasm, None) => {
-            embed_package_metadata(&opts, manifest_pair.as_ref(), wasm)
-        }
+        (OutputFormat::Wasm, None) => embed_package_metadata(&opts, project.as_ref(), wasm),
         (OutputFormat::Wat, _) => wasm_to_wat(&wasm)?.into_bytes(),
     };
+    if let Some(parent) = output_path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        fs::create_dir_all(parent)
+            .map_err(|e| CliExit::error(format!("creating output directory: {e}")))?;
+    }
     fs::write(&output_path, &bytes)
         .map_err(|e| CliExit::error(format!("writing output file: {e}")))?;
     eprintln!("Generated: {}", output_path.display());
     Ok(())
+}
+
+/// The default output path when `-o` is absent. A manifest-driven build writes
+/// `<manifest_root>/build/<world>.<ext>` — keeping artifacts out of the source
+/// tree and giving each world its own file, mirroring kiln's `build/` layout.
+/// A standalone file argument writes `<input>.<ext>` beside the source.
+fn default_output_path(
+    opts: &CompileOptions,
+    project: Option<&manifest::ProjectManifest>,
+    format: OutputFormat,
+) -> std::path::PathBuf {
+    let ext = match format {
+        OutputFormat::Wasm => "wasm",
+        OutputFormat::Wat => "wat",
+    };
+    match project {
+        Some(project) => {
+            // `--lib` builds the library world, which has no external FQ name.
+            let world = if opts.lib_world.is_some() {
+                "lib".to_string()
+            } else {
+                world_path_segment(opts.target_world.as_deref().unwrap_or("wasi:cli/command"))
+            };
+            project.root.join("build").join(format!("{world}.{ext}"))
+        }
+        None => Path::new(&opts.input).with_extension(ext),
+    }
+}
+
+/// Sanitize a Component Model world FQ name into a single path segment: drop the
+/// `@version`, then replace every character outside `[A-Za-z0-9._-]` with `-`
+/// (e.g. `wasi:cli/command` → `wasi-cli-command`).
+fn world_path_segment(world_fq: &str) -> String {
+    let base = world_fq.split('@').next().unwrap_or(world_fq);
+    base.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod world_segment_tests {
+    use super::world_path_segment;
+
+    #[test]
+    fn sanitizes_and_drops_version() {
+        assert_eq!(world_path_segment("wasi:cli/command"), "wasi-cli-command");
+        assert_eq!(world_path_segment("wasi:http/service"), "wasi-http-service");
+        assert_eq!(world_path_segment("foo:bar/baz@1.2.3"), "foo-bar-baz");
+    }
 }
 
 #[cfg(test)]

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -105,10 +105,9 @@ pub struct CompileOptions {
     /// `--embed-metadata`: force embedding on, overriding the `-Os` default-off.
     /// Mutually exclusive with `--no-embed-metadata`.
     pub embed_metadata: bool,
-    /// True when the entry was resolved from a manifest (no path argument, or a
-    /// directory argument), so the build represents the package's declared
-    /// artifact. An explicit `.wado` file argument sets this false and embeds no
-    /// metadata. See WEP `wep-2026-02-14-package-manifest.md`.
+    /// The entry came from a manifest (no path argument, or a directory
+    /// argument), so the build is the package's declared artifact and carries
+    /// its metadata. False for an explicit `.wado` file argument.
     pub manifest_driven: bool,
 }
 
@@ -422,10 +421,9 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<CompileOptions, CliExit>
         ));
     }
 
-    // Manifest-driven mode: no path argument, or a directory argument. An
-    // explicit `.wado` file argument is a standalone target — `resolve_input`
-    // returns it verbatim without consulting a manifest for the entry, and
-    // metadata is not embedded (WEP `wep-2026-02-14-package-manifest.md`).
+    // No path argument or a directory argument resolves the entry through a
+    // manifest; an explicit `.wado` file is a standalone target. Gates metadata
+    // embedding (WEP `wep-2026-02-14-package-manifest.md`).
     let manifest_driven = input.as_deref().is_none_or(|s| Path::new(s).is_dir());
 
     let (input, lib_world) = if lib {

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1032,8 +1032,10 @@ async fn embed_wit_section(
 /// Embed the `[package]` metadata into the component when building the package's
 /// declared artifact (manifest-driven mode) and `--no-embed-metadata` was not
 /// given. Returns `wasm` unchanged otherwise — an explicit file argument, no
-/// `wado.toml`, or a manifest without `[package]`. The git `revision` is
-/// included only on a clean tree (omitted silently here; `wado publish` warns).
+/// `wado.toml`, a manifest without `[package]`, or `-Os` (which strips symbols
+/// for minimal frontend delivery, where the metadata is dead weight — matching
+/// the WIT section being dropped). The git `revision` is included only on a
+/// clean tree (omitted silently here; `wado publish` warns).
 ///
 /// `project` is the manifest already discovered by [`run`], reused here rather
 /// than re-parsed.
@@ -1042,7 +1044,7 @@ fn embed_package_metadata(
     project: Option<&manifest::ProjectManifest>,
     wasm: Vec<u8>,
 ) -> Vec<u8> {
-    if opts.no_embed_metadata || !opts.manifest_driven {
+    if opts.no_embed_metadata || !opts.manifest_driven || opts.opt_level == OptLevel::Os {
         return wasm;
     }
     let Some(project) = project else {

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -568,13 +568,15 @@ pub async fn compile(filename: &str, flags: &CompileFlags) -> Result<Vec<u8>, Cl
 /// entry point attaches dependency resolution identically.
 pub(crate) fn attach_manifest_deps(
     host: FilesystemCompilerHost,
-    manifest_pair: Option<&(wado_manifest::Manifest, std::path::PathBuf)>,
+    project: Option<&manifest::ProjectManifest>,
     base_path: &Path,
 ) -> FilesystemCompilerHost {
-    match manifest_pair {
-        Some((manifest, root)) => host.with_dependency_index(
-            wado_lsp::host::dependency_index_from(manifest, root, base_path),
-        ),
+    match project {
+        Some(project) => host.with_dependency_index(wado_lsp::host::dependency_index_from(
+            &project.manifest,
+            &project.root,
+            base_path,
+        )),
         None => host,
     }
 }
@@ -591,9 +593,9 @@ pub(crate) async fn maybe_run_pipeline(
     entry_file: &Path,
     host: &FilesystemCompilerHost,
     no_cache: bool,
-    manifest_pair: Option<(wado_manifest::Manifest, std::path::PathBuf)>,
+    project: Option<manifest::ProjectManifest>,
 ) -> Result<PipelineOutcome, PipelineError> {
-    let manifest_root_for_inline = manifest_pair.as_ref().map(|(_, root)| root.clone());
+    let manifest_root_for_inline = project.as_ref().map(|p| p.root.clone());
     let probe_manifest_root = manifest_root_for_inline.clone().unwrap_or_else(|| {
         entry_file
             .parent()
@@ -619,8 +621,8 @@ pub(crate) async fn maybe_run_pipeline(
         ));
     }
 
-    let (manifest, manifest_root) = match manifest_pair {
-        Some(pair) => pair,
+    let (manifest, manifest_root) = match project {
+        Some(p) => (p.manifest, p.root),
         None if inline.is_empty() => return Ok(PipelineOutcome::default()),
         None => (empty_manifest(), probe_manifest_root),
     };
@@ -943,9 +945,7 @@ pub(crate) fn remap_and_report_conflicts(
 
 /// Walk up from `entry_file` looking for the nearest `wado.toml`. Returns
 /// `None` (treated as "no Kiln config") on missing or malformed manifest.
-pub fn load_nearest_manifest(
-    entry_file: &Path,
-) -> Option<(wado_manifest::Manifest, std::path::PathBuf)> {
+pub fn load_nearest_manifest(entry_file: &Path) -> Option<manifest::ProjectManifest> {
     let mut dir = entry_file
         .parent()
         .map(std::path::Path::to_path_buf)
@@ -953,8 +953,7 @@ pub fn load_nearest_manifest(
     if dir.as_os_str().is_empty() {
         dir = std::path::PathBuf::from(".");
     }
-    let project = crate::manifest::discover(&dir).ok().flatten()?;
-    Some((project.manifest, project.root))
+    crate::manifest::discover(&dir).ok().flatten()
 }
 
 fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
@@ -974,6 +973,7 @@ fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
 /// (still valid, self-describing) component.
 async fn embed_wit_section(
     opts: &CompileOptions,
+    project: Option<&manifest::ProjectManifest>,
     wasm: Vec<u8>,
     world_imports: Vec<String>,
     explicit: bool,
@@ -997,10 +997,9 @@ async fn embed_wit_section(
     // Attach the manifest `[dependencies]` so a multi-package project's
     // re-analysis resolves the same imports the main compile did; a quiet host
     // avoids re-emitting diagnostics.
-    let manifest_pair = load_nearest_manifest(path);
     let host = attach_manifest_deps(
         FilesystemCompilerHost::silent(base_path.clone()),
-        manifest_pair.as_ref(),
+        project,
         &base_path,
     );
     let sem = wado_compiler::semantics(&source, &host, Some(input)).await;
@@ -1035,17 +1034,24 @@ async fn embed_wit_section(
 /// given. Returns `wasm` unchanged otherwise — an explicit file argument, no
 /// `wado.toml`, or a manifest without `[package]`. The git `revision` is
 /// included only on a clean tree (omitted silently here; `wado publish` warns).
-fn embed_package_metadata(opts: &CompileOptions, wasm: Vec<u8>) -> Vec<u8> {
+///
+/// `project` is the manifest already discovered by [`run`], reused here rather
+/// than re-parsed.
+fn embed_package_metadata(
+    opts: &CompileOptions,
+    project: Option<&manifest::ProjectManifest>,
+    wasm: Vec<u8>,
+) -> Vec<u8> {
     if opts.no_embed_metadata || !opts.manifest_driven {
         return wasm;
     }
-    let Some((manifest, root)) = load_nearest_manifest(Path::new(&opts.input)) else {
+    let Some(project) = project else {
         return wasm;
     };
-    let Some(pkg) = manifest.package.as_ref() else {
+    let Some(pkg) = project.manifest.package.as_ref() else {
         return wasm;
     };
-    let revision = crate::metadata_embed::clean_git_revision(&root);
+    let revision = crate::metadata_embed::clean_git_revision(&project.root);
     let sections = wado_manifest::metadata_sections(pkg, revision.as_deref());
     crate::metadata_embed::embed_metadata_sections(wasm, &sections)
 }
@@ -1089,16 +1095,26 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
         Path::new(&opts.input).with_extension(ext)
     };
 
+    // Discover the package manifest once for the wasm-output embedding paths
+    // (WIT + metadata), so neither step re-parses it.
+    let manifest_pair = (format == OutputFormat::Wasm)
+        .then(|| load_nearest_manifest(Path::new(&opts.input)))
+        .flatten();
+
     let bytes = match (format, embed) {
         (OutputFormat::Wasm, Some(explicit)) => {
             let world_imports = result
                 .wir_package
                 .map(|p| p.imported_cm_interfaces)
                 .unwrap_or_default();
-            let embedded = embed_wit_section(&opts, wasm, world_imports, explicit).await?;
-            embed_package_metadata(&opts, embedded)
+            let embedded =
+                embed_wit_section(&opts, manifest_pair.as_ref(), wasm, world_imports, explicit)
+                    .await?;
+            embed_package_metadata(&opts, manifest_pair.as_ref(), embedded)
         }
-        (OutputFormat::Wasm, None) => embed_package_metadata(&opts, wasm),
+        (OutputFormat::Wasm, None) => {
+            embed_package_metadata(&opts, manifest_pair.as_ref(), wasm)
+        }
         (OutputFormat::Wat, _) => wasm_to_wat(&wasm)?.into_bytes(),
     };
     fs::write(&output_path, &bytes)

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -22,6 +22,7 @@ pub mod kiln_provider;
 pub mod kiln_runtime;
 pub mod lsp;
 pub mod manifest;
+pub mod metadata_embed;
 pub mod publish;
 pub mod query;
 pub mod query_adapter;

--- a/wado-cli/src/metadata_embed.rs
+++ b/wado-cli/src/metadata_embed.rs
@@ -1,0 +1,113 @@
+//! Embed `[package]` metadata into a compiled component.
+//!
+//! The mapping from manifest fields to `(section name, payload)` pairs lives in
+//! [`wado_manifest::metadata_sections`] (pure data). This module appends those
+//! pairs to the component as custom sections — the `wasm-metadata` custom-section
+//! format `wkg` reads — mirroring the additive WIT `component-type` embed.
+
+use std::borrow::Cow;
+use std::path::Path;
+use std::process::Command;
+
+use wasm_encoder::{Encode, Section};
+use wado_manifest::MetadataSection;
+
+/// Append each metadata section to `component` as a custom section. Returns the
+/// component unchanged when there is nothing to embed.
+#[must_use]
+pub fn embed_metadata_sections(mut component: Vec<u8>, sections: &[MetadataSection]) -> Vec<u8> {
+    for s in sections {
+        let section = wasm_encoder::CustomSection {
+            name: Cow::Borrowed(&s.name),
+            data: Cow::Borrowed(s.value.as_bytes()),
+        };
+        component.push(section.id());
+        section.encode(&mut component);
+    }
+    component
+}
+
+/// The git commit SHA at `dir` (`HEAD`), but only when the working tree is
+/// clean. Returns `None` when `dir` is not a git repo, git is unavailable, or
+/// the tree has uncommitted tracked changes — so a dirty build silently omits
+/// the `revision` field (a warning is the `wado publish` path's job). Untracked
+/// files are ignored, matching what the commit actually captures.
+#[must_use]
+pub fn clean_git_revision(dir: &Path) -> Option<String> {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .output()
+        .ok()?;
+    if !status.status.success() || !status.stdout.is_empty() {
+        return None;
+    }
+    let rev = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !rev.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(rev.stdout).ok()?.trim().to_string();
+    (!sha.is_empty()).then_some(sha)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal valid empty component: the 8-byte component preamble.
+    fn empty_component() -> Vec<u8> {
+        let mut c = b"\0asm".to_vec();
+        // Component layer: version 0x0d, layer 0x01.
+        c.extend_from_slice(&[0x0d, 0x00, 0x01, 0x00]);
+        c
+    }
+
+    fn sections_of(bytes: &[u8]) -> Vec<(String, Vec<u8>)> {
+        let mut out = Vec::new();
+        for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+            if let Ok(wasmparser::Payload::CustomSection(reader)) = payload {
+                out.push((reader.name().to_string(), reader.data().to_vec()));
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn embeds_each_section_with_utf8_payload() {
+        let sections = vec![
+            MetadataSection {
+                name: "description".to_string(),
+                value: "A toolkit".to_string(),
+            },
+            MetadataSection {
+                name: "org.wado-lang.package.repository-directory".to_string(),
+                value: "packages/app".to_string(),
+            },
+        ];
+        let out = embed_metadata_sections(empty_component(), &sections);
+        let found = sections_of(&out);
+        assert_eq!(
+            found,
+            vec![
+                ("description".to_string(), b"A toolkit".to_vec()),
+                (
+                    "org.wado-lang.package.repository-directory".to_string(),
+                    b"packages/app".to_vec()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_sections_leave_component_unchanged() {
+        let component = empty_component();
+        let out = embed_metadata_sections(component.clone(), &[]);
+        assert_eq!(out, component);
+    }
+}

--- a/wado-cli/src/metadata_embed.rs
+++ b/wado-cli/src/metadata_embed.rs
@@ -9,8 +9,8 @@ use std::borrow::Cow;
 use std::path::Path;
 use std::process::Command;
 
-use wasm_encoder::{Encode, Section};
 use wado_manifest::MetadataSection;
+use wasm_encoder::{Encode, Section};
 
 /// Append each metadata section to `component` as a custom section. Returns the
 /// component unchanged when there is nothing to embed.

--- a/wado-cli/src/metadata_embed.rs
+++ b/wado-cli/src/metadata_embed.rs
@@ -60,12 +60,9 @@ pub fn clean_git_revision(dir: &Path) -> Option<String> {
 mod tests {
     use super::*;
 
-    /// A minimal valid empty component: the 8-byte component preamble.
+    /// A minimal valid empty component (just the preamble).
     fn empty_component() -> Vec<u8> {
-        let mut c = b"\0asm".to_vec();
-        // Component layer: version 0x0d, layer 0x01.
-        c.extend_from_slice(&[0x0d, 0x00, 0x01, 0x00]);
-        c
+        wasm_encoder::Component::new().finish()
     }
 
     fn sections_of(bytes: &[u8]) -> Vec<(String, Vec<u8>)> {

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -49,7 +49,10 @@ async fn prepare_query(filename: &str) -> Result<PreparedQuery, CliExit> {
 /// identically on the query path. `manifest_pair` must be the one
 /// [`run_generators_for`] is given, so the host's dependency index and the
 /// pipeline share a single manifest root.
-fn entry_host(entry_file: &Path, manifest_pair: Option<&ProjectManifest>) -> FilesystemCompilerHost {
+fn entry_host(
+    entry_file: &Path,
+    manifest_pair: Option<&ProjectManifest>,
+) -> FilesystemCompilerHost {
     let base = entry_file
         .parent()
         .map(std::path::Path::to_path_buf)

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -10,14 +10,13 @@ use wado_compiler::kiln::InvocationIndex;
 
 use crate::args::CliExit;
 use crate::compiler_host::FilesystemCompilerHost;
+use crate::manifest::ProjectManifest;
 
 struct PreparedQuery {
     uri: String,
     engine: wado_lsp::Engine,
     host: FilesystemCompilerHost,
 }
-
-type ManifestPair = (wado_manifest::Manifest, std::path::PathBuf);
 
 async fn prepare_query(filename: &str) -> Result<PreparedQuery, CliExit> {
     let path = Path::new(filename);
@@ -50,7 +49,7 @@ async fn prepare_query(filename: &str) -> Result<PreparedQuery, CliExit> {
 /// identically on the query path. `manifest_pair` must be the one
 /// [`run_generators_for`] is given, so the host's dependency index and the
 /// pipeline share a single manifest root.
-fn entry_host(entry_file: &Path, manifest_pair: Option<&ManifestPair>) -> FilesystemCompilerHost {
+fn entry_host(entry_file: &Path, manifest_pair: Option<&ProjectManifest>) -> FilesystemCompilerHost {
     let base = entry_file
         .parent()
         .map(std::path::Path::to_path_buf)
@@ -73,7 +72,7 @@ fn entry_host(entry_file: &Path, manifest_pair: Option<&ManifestPair>) -> Filesy
 async fn run_generators_for(
     entry_file: &Path,
     host: &FilesystemCompilerHost,
-    manifest_pair: Option<ManifestPair>,
+    manifest_pair: Option<ProjectManifest>,
 ) -> Option<InvocationIndex> {
     match crate::compile::maybe_run_pipeline(entry_file, host, false, manifest_pair).await {
         Ok(outcome) => Some(outcome.invocations),

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -746,7 +746,7 @@ enum LoadOutcome {
 struct ParsedTest {
     export_name: String,
     parsed: TestExportName,
-    /// Original `test "name"` string recovered from the `wado:test-names`
+    /// Original `test "name"` string recovered from the `org.wado-lang.test-names`
     /// custom section (`None` for unnamed tests). Preferred over
     /// `parsed.display` for output because it is lossless.
     original_name: Option<String>,

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -196,8 +196,8 @@ async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<St
 /// The default interface name: the manifest `[package].name` when the input
 /// resolves through a project, otherwise the entry file stem.
 pub(crate) fn default_interface_name(input: &str) -> String {
-    if let Some((manifest, _root)) = crate::compile::load_nearest_manifest(Path::new(input))
-        && let Some(package) = manifest.package
+    if let Some(project) = crate::compile::load_nearest_manifest(Path::new(input))
+        && let Some(package) = project.manifest.package
     {
         return package.name;
     }

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -100,6 +100,26 @@ fn test_compile_embeds_package_metadata_in_manifest_mode() {
 }
 
 #[test]
+fn test_compile_manifest_mode_default_output_to_build_dir() {
+    // Without -o, a manifest-driven build writes build/<world>.wasm at the
+    // manifest root, not into the source tree.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_metadata_project(dir);
+
+    wado_in(dir).arg("compile").assert().success();
+
+    assert!(
+        dir.join("build").join("wasi-cli-command.wasm").exists(),
+        "expected build/wasi-cli-command.wasm"
+    );
+    assert!(
+        !dir.join("src").join("main.wasm").exists(),
+        "must not write into the source tree"
+    );
+}
+
+#[test]
 fn test_compile_file_arg_does_not_embed_metadata() {
     // The same project, but the entry passed as an explicit file: a standalone
     // target, so no package metadata is embedded.

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -148,6 +148,30 @@ fn test_compile_os_skips_metadata() {
 }
 
 #[test]
+fn test_compile_os_embed_metadata_forces_on() {
+    // --embed-metadata overrides the -Os default-off, mirroring --embed-wit.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_metadata_project(dir);
+    let out = dir.join("out.wasm");
+
+    wado_in(dir)
+        .arg("compile")
+        .arg("-Os")
+        .arg("--embed-metadata")
+        .arg("-o")
+        .arg(&out)
+        .assert()
+        .success();
+
+    let sections = custom_sections(&out);
+    assert!(
+        sections.iter().any(|(n, _)| n == "description"),
+        "--embed-metadata must force metadata on under -Os, got {sections:?}"
+    );
+}
+
+#[test]
 fn test_compile_no_embed_metadata_opts_out() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path();

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -6,7 +6,7 @@
 use predicates::prelude::*;
 
 mod common;
-use common::{wado, wado_in};
+use common::{custom_sections, wado, wado_in};
 
 /// A project under a directory whose name contains a space must compile. The
 /// entry is passed by ABSOLUTE path so the Kiln harvest uses an absolute
@@ -40,18 +40,6 @@ fn test_compile_project_under_path_with_space() {
         .assert()
         .success();
     assert!(out.exists(), "expected out.wasm to be written");
-}
-
-/// Read the custom sections (name, payload) from a compiled component.
-fn read_custom_sections(wasm_path: &std::path::Path) -> Vec<(String, Vec<u8>)> {
-    let bytes = std::fs::read(wasm_path).unwrap();
-    let mut out = Vec::new();
-    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
-        if let Ok(wasmparser::Payload::CustomSection(reader)) = payload {
-            out.push((reader.name().to_string(), reader.data().to_vec()));
-        }
-    }
-    out
 }
 
 /// Write a minimal manifest-driven CLI package under `dir` and return the
@@ -90,7 +78,7 @@ fn test_compile_embeds_package_metadata_in_manifest_mode() {
         .assert()
         .success();
 
-    let sections = read_custom_sections(&out);
+    let sections = custom_sections(&out);
     let value = |name: &str| {
         sections
             .iter()
@@ -128,7 +116,7 @@ fn test_compile_file_arg_does_not_embed_metadata() {
         .assert()
         .success();
 
-    let sections = read_custom_sections(&out);
+    let sections = custom_sections(&out);
     assert!(
         !sections.iter().any(|(n, _)| n == "description"),
         "file-arg compile must not embed metadata, got {sections:?}"
@@ -150,7 +138,7 @@ fn test_compile_no_embed_metadata_opts_out() {
         .assert()
         .success();
 
-    let sections = read_custom_sections(&out);
+    let sections = custom_sections(&out);
     assert!(
         !sections.iter().any(|(n, _)| n == "description"),
         "--no-embed-metadata must opt out, got {sections:?}"

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -6,7 +6,7 @@
 use predicates::prelude::*;
 
 mod common;
-use common::wado;
+use common::{wado, wado_in};
 
 /// A project under a directory whose name contains a space must compile. The
 /// entry is passed by ABSOLUTE path so the Kiln harvest uses an absolute
@@ -40,6 +40,121 @@ fn test_compile_project_under_path_with_space() {
         .assert()
         .success();
     assert!(out.exists(), "expected out.wasm to be written");
+}
+
+/// Read the custom sections (name, payload) from a compiled component.
+fn read_custom_sections(wasm_path: &std::path::Path) -> Vec<(String, Vec<u8>)> {
+    let bytes = std::fs::read(wasm_path).unwrap();
+    let mut out = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+        if let Ok(wasmparser::Payload::CustomSection(reader)) = payload {
+            out.push((reader.name().to_string(), reader.data().to_vec()));
+        }
+    }
+    out
+}
+
+/// Write a minimal manifest-driven CLI package under `dir` and return the
+/// output path to compile to.
+fn write_metadata_project(dir: &std::path::Path) {
+    std::fs::write(
+        dir.join("wado.toml"),
+        "[package]\n\
+         namespace = \"acme\"\n\
+         name = \"app\"\n\
+         version = \"0.3.0\"\n\
+         description = \"A demo\"\n\
+         repository = \"https://github.com/acme/app\"\n\
+         license = \"MIT\"\n\
+         authors = [\"Alice\"]\n\
+         repository-directory = \"sub/app\"\n\n\
+         [world]\n\
+         \"wasi:cli/command\" = \"src/main.wado\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src").join("main.wado"), "export fn run() {}\n").unwrap();
+}
+
+#[test]
+fn test_compile_embeds_package_metadata_in_manifest_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_metadata_project(dir);
+    let out = dir.join("out.wasm");
+
+    wado_in(dir)
+        .arg("compile")
+        .arg("-o")
+        .arg(&out)
+        .assert()
+        .success();
+
+    let sections = read_custom_sections(&out);
+    let value = |name: &str| {
+        sections
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, d)| String::from_utf8_lossy(d).into_owned())
+    };
+    assert_eq!(value("description").as_deref(), Some("A demo"));
+    assert_eq!(value("version").as_deref(), Some("0.3.0"));
+    assert_eq!(
+        value("source").as_deref(),
+        Some("https://github.com/acme/app")
+    );
+    assert_eq!(value("licenses").as_deref(), Some("MIT"));
+    assert_eq!(value("authors").as_deref(), Some("Alice"));
+    assert_eq!(
+        value("org.wado-lang.package.repository-directory").as_deref(),
+        Some("sub/app")
+    );
+}
+
+#[test]
+fn test_compile_file_arg_does_not_embed_metadata() {
+    // The same project, but the entry passed as an explicit file: a standalone
+    // target, so no package metadata is embedded.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_metadata_project(dir);
+    let out = dir.join("out.wasm");
+
+    wado_in(dir)
+        .arg("compile")
+        .arg("-o")
+        .arg(&out)
+        .arg("src/main.wado")
+        .assert()
+        .success();
+
+    let sections = read_custom_sections(&out);
+    assert!(
+        !sections.iter().any(|(n, _)| n == "description"),
+        "file-arg compile must not embed metadata, got {sections:?}"
+    );
+}
+
+#[test]
+fn test_compile_no_embed_metadata_opts_out() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_metadata_project(dir);
+    let out = dir.join("out.wasm");
+
+    wado_in(dir)
+        .arg("compile")
+        .arg("--no-embed-metadata")
+        .arg("-o")
+        .arg(&out)
+        .assert()
+        .success();
+
+    let sections = read_custom_sections(&out);
+    assert!(
+        !sections.iter().any(|(n, _)| n == "description"),
+        "--no-embed-metadata must opt out, got {sections:?}"
+    );
 }
 
 #[test]
@@ -97,7 +212,7 @@ fn test_compile_wat_to_stdout() {
 fn test_compile_world_test_exports_tests() {
     // `--world test` targets the synthetic test world: the entry module's
     // `test` blocks become component exports (kebab-cased, plus a
-    // `wado:test-names` custom section), and no `run` entry point is required.
+    // `org.wado-lang.test-names` custom section), and no `run` entry point is required.
     wado()
         .args([
             "compile",
@@ -109,7 +224,7 @@ fn test_compile_world_test_exports_tests() {
         .assert()
         .success()
         .stdout(predicate::str::contains("test-0-simple"))
-        .stdout(predicate::str::contains("wado:test-names"));
+        .stdout(predicate::str::contains("org.wado-lang.test-names"));
 }
 
 #[test]

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -124,6 +124,30 @@ fn test_compile_file_arg_does_not_embed_metadata() {
 }
 
 #[test]
+fn test_compile_os_skips_metadata() {
+    // -Os strips symbols for minimal frontend delivery; package metadata is
+    // dropped too, matching the WIT section.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    write_metadata_project(dir);
+    let out = dir.join("out.wasm");
+
+    wado_in(dir)
+        .arg("compile")
+        .arg("-Os")
+        .arg("-o")
+        .arg(&out)
+        .assert()
+        .success();
+
+    let sections = custom_sections(&out);
+    assert!(
+        !sections.iter().any(|(n, _)| n == "description"),
+        "-Os must not embed metadata, got {sections:?}"
+    );
+}
+
+#[test]
 fn test_compile_no_embed_metadata_opts_out() {
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path();

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -143,8 +143,15 @@ fn compile_lib_and_world_mutually_exclusive() {
 
 #[test]
 fn compile_embed_metadata_flags_mutually_exclusive() {
-    let parser = Parser::from_args(&["--no-embed-metadata", "--embed-metadata", "input.wado"]);
+    let parser = Parser::from_args(&["--no-embed-metadata", "--embed-metadata", "pkgdir"]);
     assert_err(compile::parse_args(parser), "mutually exclusive");
+}
+
+#[test]
+fn compile_embed_metadata_requires_manifest_mode() {
+    // A metadata flag on an explicit file would be silently ignored — reject it.
+    let parser = Parser::from_args(&["--embed-metadata", "input.wado"]);
+    assert_err(compile::parse_args(parser), "manifest-driven");
 }
 
 #[test]

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -142,6 +142,12 @@ fn compile_lib_and_world_mutually_exclusive() {
 }
 
 #[test]
+fn compile_embed_metadata_flags_mutually_exclusive() {
+    let parser = Parser::from_args(&["--no-embed-metadata", "--embed-metadata", "input.wado"]);
+    assert_err(compile::parse_args(parser), "mutually exclusive");
+}
+
+#[test]
 fn compile_lib_rejects_single_file() {
     // `--lib` requires a package directory (for the [package] namespace), not a
     // bare .wado file.

--- a/wado-cli/tests/common.rs
+++ b/wado-cli/tests/common.rs
@@ -46,3 +46,15 @@ pub fn runtime() -> tokio::runtime::Runtime {
         .build()
         .unwrap()
 }
+
+/// The custom sections `(name, payload)` of a compiled component at `wasm_path`.
+pub fn custom_sections(wasm_path: &Path) -> Vec<(String, Vec<u8>)> {
+    let bytes = std::fs::read(wasm_path).unwrap();
+    let mut out = Vec::new();
+    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+        if let Ok(wasmparser::Payload::CustomSection(reader)) = payload {
+            out.push((reader.name().to_string(), reader.data().to_vec()));
+        }
+    }
+    out
+}

--- a/wado-cli/tests/run_inprocess.rs
+++ b/wado-cli/tests/run_inprocess.rs
@@ -107,6 +107,9 @@ fn hello_compile_opts(output_path: &Path, format: Option<OutputFormat>) -> Compi
         param_policy: wado_compiler::param_resolution::ParamPolicy::default(),
         no_embed_wit: false,
         embed_wit: false,
+        no_embed_metadata: false,
+        // Input is an explicit `.wado` file, so this is not manifest-driven.
+        manifest_driven: false,
     }
 }
 

--- a/wado-cli/tests/run_inprocess.rs
+++ b/wado-cli/tests/run_inprocess.rs
@@ -108,6 +108,7 @@ fn hello_compile_opts(output_path: &Path, format: Option<OutputFormat>) -> Compi
         no_embed_wit: false,
         embed_wit: false,
         no_embed_metadata: false,
+        embed_metadata: false,
         // Input is an explicit `.wado` file, so this is not manifest-driven.
         manifest_driven: false,
     }

--- a/wado-compiler/src/test_names.rs
+++ b/wado-compiler/src/test_names.rs
@@ -1,4 +1,4 @@
-//! Encoding of the `wado:test-names` custom section.
+//! Encoding of the `org.wado-lang.test-names` custom section.
 //!
 //! Component Model export names must be ASCII kebab-case, so the test export
 //! name (`test-0-hello-world`) is an ASCII-folded, lowercased rendering of the
@@ -23,7 +23,7 @@
 //! ```
 
 /// Name of the custom section embedded in test-world components.
-pub const SECTION_NAME: &str = "wado:test-names";
+pub const SECTION_NAME: &str = "org.wado-lang.test-names";
 
 /// Encode `(export_name, original_name)` pairs into the section payload.
 pub fn encode<'a>(entries: impl IntoIterator<Item = (&'a str, Option<&'a str>)>) -> Vec<u8> {
@@ -62,7 +62,7 @@ pub fn decode(data: &[u8]) -> Option<Vec<(String, Option<String>)>> {
     Some(entries)
 }
 
-/// Find and decode the `wado:test-names` custom section in a component binary.
+/// Find and decode the `org.wado-lang.test-names` custom section in a component binary.
 ///
 /// Returns `None` when the section is absent or malformed. Callers that expect
 /// the section (test-world components) should treat `None` as "no name

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -135,7 +135,7 @@ pub struct TestExportPlan {
     pub export_name: String,
     /// Original, lossless `test "name"` string (`None` for unnamed tests).
     /// `export_name` is ASCII-folded and lowercased, so this is the only
-    /// faithful record of the name. Emitted into the `wado:test-names` custom
+    /// faithful record of the name. Emitted into the `org.wado-lang.test-names` custom
     /// section so the runner can display what the user actually wrote.
     pub original_name: Option<String>,
     /// Whether this test is expected to trap (derived from the `#[expect_trap]` attribute)

--- a/wado-compiler/tests/test_name_filter.rs
+++ b/wado-compiler/tests/test_name_filter.rs
@@ -1,11 +1,11 @@
-//! `--test-name` compile-time filtering and the `wado:test-names` section.
+//! `--test-name` compile-time filtering and the `org.wado-lang.test-names` section.
 //!
 //! `wado test --test-name <pattern>` is implemented by passing the substring
 //! filters into `CompilerOptions::test_name_filters`. Only `test "name"` blocks
 //! whose name contains a filter are exported from the test-world component; the
 //! rest lose their `is_cm_export` adapter and are removed by early DCE, so they
 //! are never present in the output. The compiler also writes a
-//! `wado:test-names` custom section mapping each surviving export to its
+//! `org.wado-lang.test-names` custom section mapping each surviving export to its
 //! original (lossless) name for the runner to display.
 //!
 //! These tests inspect the compiled component bytes to hold both contracts
@@ -35,7 +35,7 @@ test "日本語 ok" {
 
 /// Compile `SOURCE` to the test world with the given `--test-name` filters and
 /// return the `(export_name, original_name)` pairs recorded in the
-/// `wado:test-names` custom section. The section enumerates exactly the test
+/// `org.wado-lang.test-names` custom section. The section enumerates exactly the test
 /// exports that survived DCE, so it doubles as the surviving-export set.
 fn compiled_test_names(filters: &[&str]) -> Vec<(String, Option<String>)> {
     let options = wado_compiler::CompilerOptions {

--- a/wado-manifest/src/lib.rs
+++ b/wado-manifest/src/lib.rs
@@ -1,5 +1,6 @@
 mod lockfile;
 mod manifest;
+mod metadata;
 mod provider;
 mod resolve;
 mod validate;
@@ -9,6 +10,9 @@ pub use lockfile::{LockFile, LockFileError, LockedPackage};
 pub use manifest::{
     Dependency, DependencySource, FormatSettings, GitPin, Manifest, ManifestError, ManifestWarning,
     Package, TestSettings, Workspace, WorkspacePackage, resolve_member,
+};
+pub use metadata::{
+    MetadataSection, REPOSITORY_DIRECTORY_SECTION, license_ref_id, metadata_sections,
 };
 pub use provider::{
     DependencyProvider, GitTagInfo, InMemoryDependencyProvider, ProviderError, RegistryPackageInfo,

--- a/wado-manifest/src/metadata.rs
+++ b/wado-manifest/src/metadata.rs
@@ -17,12 +17,11 @@ use crate::manifest::Package;
 /// Custom section name for the Wado-custom monorepo subdirectory field.
 pub const REPOSITORY_DIRECTORY_SECTION: &str = "org.wado-lang.package.repository-directory";
 
-/// A custom section carrying one metadata field.
+/// A custom section carrying one metadata field: the section name and its
+/// UTF-8 payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetadataSection {
-    /// Custom section name.
     pub name: String,
-    /// UTF-8 payload.
     pub value: String,
 }
 
@@ -150,7 +149,6 @@ authors = ["Alice <alice@example.com>", "Bob"]
             Some("Alice <alice@example.com>, Bob")
         );
         assert_eq!(value_of(&sections, "version"), Some("0.1.0"));
-        // No git SHA passed.
         assert!(value_of(&sections, "revision").is_none());
     }
 
@@ -182,7 +180,7 @@ repository = "https://github.com/myorg/app"
         assert!(value_of(&sections, "description").is_none());
         assert!(value_of(&sections, "homepage").is_none());
         assert!(value_of(&sections, "licenses").is_none());
-        // version is always present.
+        // version is unconditional, unlike the optional fields above.
         assert_eq!(value_of(&sections, "version"), Some("0.1.0"));
     }
 

--- a/wado-manifest/src/metadata.rs
+++ b/wado-manifest/src/metadata.rs
@@ -134,7 +134,10 @@ authors = ["Alice <alice@example.com>", "Bob"]
             value_of(&sections, "description"),
             Some("A fast widget toolkit")
         );
-        assert_eq!(value_of(&sections, "homepage"), Some("https://wado-lang.org"));
+        assert_eq!(
+            value_of(&sections, "homepage"),
+            Some("https://wado-lang.org")
+        );
         assert_eq!(
             value_of(&sections, "source"),
             Some("https://github.com/myorg/app")

--- a/wado-manifest/src/metadata.rs
+++ b/wado-manifest/src/metadata.rs
@@ -1,0 +1,235 @@
+//! Mapping from `[package]` metadata to embedded component metadata sections.
+//!
+//! Pure data: produces the `(section name, payload)` pairs the CLI appends to
+//! the component as custom sections. The encoding is the `wasm-metadata`
+//! custom-section format — one custom section per field, the section name being
+//! the field's bare name and the payload its UTF-8 value — so `wkg` can promote
+//! the standard fields to OCI annotations on publish. No wasm or IO
+//! dependencies, so it builds for `wasm32-unknown-unknown` like the rest of this
+//! crate.
+//!
+//! Standard fields use the bare `wasm-metadata` section names (`description`,
+//! `authors`, …); metadata with no standard OCI key uses the Wado namespace
+//! `org.wado-lang.package.*`.
+
+use crate::manifest::Package;
+
+/// Custom section name for the Wado-custom monorepo subdirectory field.
+pub const REPOSITORY_DIRECTORY_SECTION: &str = "org.wado-lang.package.repository-directory";
+
+/// A custom section carrying one metadata field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetadataSection {
+    /// Custom section name.
+    pub name: String,
+    /// UTF-8 payload.
+    pub value: String,
+}
+
+impl MetadataSection {
+    fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value: value.into(),
+        }
+    }
+}
+
+/// The metadata sections to embed, in deterministic order. `revision` (the git
+/// commit SHA) is supplied by the caller since it is derived at build time;
+/// pass `None` to omit it. Absent optional fields are skipped.
+#[must_use]
+pub fn metadata_sections(pkg: &Package, revision: Option<&str>) -> Vec<MetadataSection> {
+    let mut out = Vec::new();
+    if let Some(description) = &pkg.description {
+        out.push(MetadataSection::new("description", description));
+    }
+    if !pkg.authors.is_empty() {
+        out.push(MetadataSection::new("authors", pkg.authors.join(", ")));
+    }
+    if let Some(homepage) = pkg.effective_homepage() {
+        out.push(MetadataSection::new("homepage", homepage));
+    }
+    if let Some(source) = &pkg.repository {
+        out.push(MetadataSection::new("source", source));
+    }
+    if let Some(documentation) = pkg.effective_documentation() {
+        out.push(MetadataSection::new("documentation", documentation));
+    }
+    if let Some(licenses) = license_expression(pkg) {
+        out.push(MetadataSection::new("licenses", licenses));
+    }
+    out.push(MetadataSection::new("version", &pkg.version));
+    if let Some(revision) = revision {
+        out.push(MetadataSection::new("revision", revision));
+    }
+    if let Some(dir) = &pkg.repository_directory {
+        out.push(MetadataSection::new(REPOSITORY_DIRECTORY_SECTION, dir));
+    }
+    out
+}
+
+/// The `licenses` value: the SPDX expression when `license` is set, otherwise a
+/// `LicenseRef-<id>` reference for a `license-file`. `None` when neither is set.
+fn license_expression(pkg: &Package) -> Option<String> {
+    if let Some(license) = &pkg.license {
+        return Some(license.clone());
+    }
+    pkg.license_file
+        .as_deref()
+        .map(|file| format!("LicenseRef-{}", license_ref_id(file)))
+}
+
+/// Derive an SPDX `LicenseRef` idstring from a license-file path: the file's
+/// base name with any character outside `[A-Za-z0-9.-]` replaced by `-`.
+#[must_use]
+pub fn license_ref_id(license_file: &str) -> String {
+    let base = license_file
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(license_file);
+    base.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn package(toml: &str) -> Package {
+        toml.parse::<crate::Manifest>().unwrap().package.unwrap()
+    }
+
+    fn value_of<'a>(sections: &'a [MetadataSection], name: &str) -> Option<&'a str> {
+        sections
+            .iter()
+            .find(|s| s.name == name)
+            .map(|s| s.value.as_str())
+    }
+
+    #[test]
+    fn maps_standard_fields_to_bare_section_names() {
+        let pkg = package(
+            r#"
+[package]
+namespace = "myorg"
+name = "app"
+version = "0.1.0"
+description = "A fast widget toolkit"
+homepage = "https://wado-lang.org"
+repository = "https://github.com/myorg/app"
+documentation = "https://docs.wado-lang.org"
+license = "MIT OR Apache-2.0"
+authors = ["Alice <alice@example.com>", "Bob"]
+"#,
+        );
+        let sections = metadata_sections(&pkg, None);
+        assert_eq!(
+            value_of(&sections, "description"),
+            Some("A fast widget toolkit")
+        );
+        assert_eq!(value_of(&sections, "homepage"), Some("https://wado-lang.org"));
+        assert_eq!(
+            value_of(&sections, "source"),
+            Some("https://github.com/myorg/app")
+        );
+        assert_eq!(
+            value_of(&sections, "documentation"),
+            Some("https://docs.wado-lang.org")
+        );
+        assert_eq!(value_of(&sections, "licenses"), Some("MIT OR Apache-2.0"));
+        assert_eq!(
+            value_of(&sections, "authors"),
+            Some("Alice <alice@example.com>, Bob")
+        );
+        assert_eq!(value_of(&sections, "version"), Some("0.1.0"));
+        // No git SHA passed.
+        assert!(value_of(&sections, "revision").is_none());
+    }
+
+    #[test]
+    fn homepage_and_documentation_fall_back_to_repository() {
+        let pkg = package(
+            r#"
+[package]
+name = "app"
+version = "0.1.0"
+repository = "https://github.com/myorg/app"
+"#,
+        );
+        let sections = metadata_sections(&pkg, None);
+        assert_eq!(
+            value_of(&sections, "homepage"),
+            Some("https://github.com/myorg/app")
+        );
+        assert_eq!(
+            value_of(&sections, "documentation"),
+            Some("https://github.com/myorg/app")
+        );
+    }
+
+    #[test]
+    fn absent_optional_fields_are_skipped() {
+        let pkg = package("[package]\nname = \"app\"\nversion = \"0.1.0\"\n");
+        let sections = metadata_sections(&pkg, None);
+        assert!(value_of(&sections, "description").is_none());
+        assert!(value_of(&sections, "homepage").is_none());
+        assert!(value_of(&sections, "licenses").is_none());
+        // version is always present.
+        assert_eq!(value_of(&sections, "version"), Some("0.1.0"));
+    }
+
+    #[test]
+    fn revision_is_included_when_supplied() {
+        let pkg = package("[package]\nname = \"app\"\nversion = \"0.1.0\"\n");
+        let sections = metadata_sections(&pkg, Some("abc1234def5678"));
+        assert_eq!(value_of(&sections, "revision"), Some("abc1234def5678"));
+    }
+
+    #[test]
+    fn repository_directory_uses_wado_namespace() {
+        let pkg = package(
+            r#"
+[package]
+name = "app"
+version = "0.1.0"
+repository-directory = "packages/app"
+"#,
+        );
+        let sections = metadata_sections(&pkg, None);
+        assert_eq!(
+            value_of(&sections, "org.wado-lang.package.repository-directory"),
+            Some("packages/app")
+        );
+    }
+
+    #[test]
+    fn license_file_becomes_license_ref() {
+        let pkg = package(
+            r#"
+[package]
+name = "app"
+version = "0.1.0"
+license-file = "licenses/LICENSE-COMMERCIAL.txt"
+"#,
+        );
+        let sections = metadata_sections(&pkg, None);
+        assert_eq!(
+            value_of(&sections, "licenses"),
+            Some("LicenseRef-LICENSE-COMMERCIAL.txt")
+        );
+    }
+
+    #[test]
+    fn license_ref_id_sanitizes_invalid_chars() {
+        assert_eq!(license_ref_id("LICENSE-COMMERCIAL"), "LICENSE-COMMERCIAL");
+        assert_eq!(license_ref_id("dir/My License.md"), "My-License.md");
+    }
+}


### PR DESCRIPTION
## Summary

`wado compile` now embeds the `[package]` metadata into the compiled component as `wasm-metadata` custom sections, so a later `wado publish` can hand the bytes to `wkg` to derive OCI annotations. The field→section mapping lives in `wado-manifest` as pure, `wasm32`-safe data; `wado-cli` appends the sections to the component (mirroring the additive WIT `component-type` embed).

## What changed

### Metadata embedding
- New `wado_manifest::metadata_sections(pkg, revision)` maps `[package]` fields to `(section name, payload)` pairs. Standard fields use the bare `wasm-metadata` section names (`description`, `authors`, `homepage`, `source`, `documentation`, `licenses`, `version`, `revision`); a `license-file` maps to `licenses = LicenseRef-<id>`.
- Metadata with no standard OCI key uses the Wado namespace `org.wado-lang.package.*` (e.g. `org.wado-lang.package.repository-directory`).
- `wado-cli` appends these as custom sections on the component; the git `revision` is included only on a clean tree (omitted silently at compile time).

### When embedding happens
- Only in manifest-driven mode — `wado compile` with no argument (cwd `wado.toml`) or a directory argument. An explicit `.wado` file is a standalone target and embeds nothing.
- `--no-embed-metadata` opts out; `-Os` (strip symbols for minimal frontend delivery) drops the metadata too, and `--embed-metadata` forces it back on under `-Os` (mirroring `--embed-wit`).
- The metadata flags are rejected with an error when given outside manifest-driven mode, instead of being silently ignored.

### Default output path
- A manifest-driven `wado compile` without `-o` now writes `<manifest_root>/build/<world>.wasm` instead of dropping `<entry>.wasm` into the source tree. `<world>` is the target Component Model world FQ sanitized to a path segment (`wasi:cli/command` → `wasi-cli-command`); `--lib` writes `build/lib.wasm`. Standalone file builds keep `<input>.wasm`.

### Namespace consolidation
- The test-name custom section `wado:test-names` is renamed to `org.wado-lang.test-names`, so all Wado-proprietary custom sections share the `org.wado-lang.*` namespace. (The Component Model package namespace `wado:` is unrelated and unchanged.)

### Internal
- `load_nearest_manifest` and its consumers now use the existing `ProjectManifest { manifest, root }` struct instead of an ad-hoc `(Manifest, PathBuf)` tuple; the manifest is discovered once per `wado compile` and reused for the WIT and metadata embedding.

### Docs
- Records these decisions in the package-manifest and CLI-subcommands WEPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4zMw7KEqg5BXhXBgsoBG3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4zMw7KEqg5BXhXBgsoBG3)_