### PR TITLE
feat(cli): implement `wado publish` to build and push components via wkg

### DIFF
--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -131,8 +131,8 @@ standalone target and embeds nothing. `--no-embed-metadata` opts out, and `-Os`
 the WIT section; `--embed-metadata` forces it back on under `-Os` (mirroring
 `--embed-wit`).
 
-`wado publish` builds through the same compile path and shells out to `wkg`
-(wasm-pkg-tools), which derives the OCI annotations. There is no `wkg.toml` —
+`wado publish` builds each publishable world through the same compile path and
+shells out to `wkg` (wasm-pkg-tools), which derives the OCI annotations. There is no `wkg.toml` —
 `wado.toml` is the only source of truth, and `wkg` is an implementation detail
 (a missing `wkg` errors with install guidance). Authentication is delegated to
 the ambient OCI credential store (`docker login`), with an env-var token
@@ -242,7 +242,7 @@ A registry dependency with no `registry` field requires `default` to be set. If 
 
 ### Registry backend
 
-Registry resolution and publishing use OCI (the OCI Distribution Spec): a component is an OCI artifact in a container registry (e.g. `ghcr.io`), and the content digest provides integrity. A registry URL takes the form `oci://<host>/<prefix>`; an open coordinate `ns:pkg` resolves to the repository `<host>/<prefix>/<ns>/<pkg>`, with the version as an image tag.
+Registry resolution and publishing use OCI (the OCI Distribution Spec): a component is an OCI artifact in a container registry (e.g. `ghcr.io`), and the content digest provides integrity. A registry URL takes the form `oci://<host>/<prefix>`; an open coordinate `ns:pkg` resolves to the repository `<host>/<prefix>/<ns>/<pkg>`, with the version as an image tag. That repository holds the library world; a package's other worlds get a `/<world>` sub-path (see [Publishable Worlds and OCI Layout](#publishable-worlds-and-oci-layout)).
 
 The earlier warg protocol is dropped. Its registry (`bytecodealliance/registry`) is archived and the ecosystem (`wasm-pkg-tools`) defaults to OCI. A warg-only registry such as wa.dev is reachable only through the external `wkg` tool, not natively; Wado neither implements nor wraps warg. Publishing is likewise done with `wkg`, not a Wado subcommand.
 
@@ -785,10 +785,11 @@ See [WEP: CLI Subcommands for Package Management](./wep-2026-02-22-cli-subcomman
 
 ### Publishing
 
-`wado publish` builds the component, embeds the `[package]` metadata, and
-delegates the OCI upload to `wkg` (see [Metadata embedding and the publish
-backend](#metadata-embedding-and-the-publish-backend)). The following
-validations apply:
+`wado publish` builds each publishable world's component, embeds the
+`[package]` metadata, and delegates the OCI upload to `wkg` (see [Metadata
+embedding and the publish backend](#metadata-embedding-and-the-publish-backend)
+and [Publishable Worlds and OCI Layout](#publishable-worlds-and-oci-layout)).
+The following validations apply:
 
 - `namespace` and `name` must be present
 - `version` must be present and valid semver
@@ -800,12 +801,55 @@ validations apply:
 The descriptive fields are required because a published package must carry its metadata. The rest stay optional: `homepage`/`documentation` default to `repository`, `repository-directory` is monorepo-only, and `wado-version` is a build constraint.
 
 `wado publish --dry-run` runs these checks and reports every problem at once
-(it does not build or upload). A bare `wado publish` builds the package's
-library-world component (`build/lib.wasm`, metadata embedded), resolves the OCI
-reference from `[registries].default` — the only supported publish destination;
-a missing or non-`oci://` default is an error — and uploads it via `wkg oci
-push`. A package without `[package].lib` has no library contract to publish and
-is rejected.
+(it does not build or upload). A bare `wado publish` builds each publishable
+world's component (metadata embedded), resolves the OCI reference from
+`[registries].default` — the only supported publish destination; a missing or
+non-`oci://` default is an error — and uploads each via `wkg oci push`. A
+package with no publishable world has nothing to publish and is rejected.
+
+#### Publishable Worlds and OCI Layout
+
+A package can target several worlds (`[package].lib` plus the `[world]` table),
+and each is a distinct behavior — a library, a Kiln generator, a CLI tool — so
+each is published as its own OCI artifact. A world is not selectable inside a
+component (it is the component's whole import/export signature) and one OCI tag
+holds one component, so multi-world packages cannot collapse into a single
+artifact.
+
+The world is encoded as an OCI repository **path segment**, keeping the
+`namespace:name` coordinate clean (the `use` / `module:` reference never carries
+a world) and leaving the version as the sole image tag:
+
+| World                     | OCI repository                        |
+| ------------------------- | ------------------------------------- |
+| `[package].lib` (library) | `<host>/<prefix>/<ns>/<name>`         |
+| any `[world]` entry       | `<host>/<prefix>/<ns>/<name>/<world>` |
+
+`<world>` is the world FQ sanitized to one path segment (`wasi:cli/command` →
+`wasi-cli-command`, `core:kiln/generator` → `core-kiln-generator`). The library
+world stays at the bare repository so the common library case matches the
+[Registry backend](#registry-backend) mapping; other worlds get a sub-path. The
+resolver derives the same path from the world it needs — a `use` import resolves
+the bare repository, a `module:` generator reference appends
+`core-kiln-generator` — so push and pull share one `world → repository` rule.
+
+Example: `wado-lang:gale@0.1.0` (a CLI tool and a Kiln generator) publishes two
+artifacts, `…/wado-lang/gale/wasi-cli-command:0.1.0` and
+`…/wado-lang/gale/core-kiln-generator:0.1.0`; `wado-lang:cm-catalog@0.1.0` (a
+library) publishes one at `…/wado-lang/cm-catalog:0.1.0`.
+
+By default every declared world is published. A single world opts out with
+`publish = false` on its `[world]` entry, which then takes the table form:
+
+```toml
+[world]
+"wasi:cli/command" = "src/main.wado"                                 # published
+"core:kiln/generator" = "src/generator.wado"                         # published
+"wasi:http/service" = { entry = "src/server.wado", publish = false } # not published
+```
+
+`[package].publish = false` still opts the whole package out, overriding any
+per-world setting.
 
 In a workspace, `wado publish` is gated to the workspace root: it publishes every
 publishable member (and the root's own `[package]`, if any) together at the

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -853,10 +853,12 @@ per-world setting.
 
 In a workspace, `wado publish` is gated to the workspace root: it publishes every
 publishable member (and the root's own `[package]`, if any) together at the
-shared version. Members that are not publishable (`publish = false` or no
-`namespace`) are skipped, and any member with unmet requirements aborts the whole
-publish. Running `wado publish` from a member directory is an error pointing at
-the root. This is the registry half of the [Lockstep Contract](#lockstep-contract).
+shared version, all against the root's `[registries]` (a member's own
+`[registries]` is not consulted, since publish is a root-only operation).
+Members that are not publishable (`publish = false` or no `namespace`) are
+skipped, and any member with unmet requirements aborts the whole publish.
+Running `wado publish` from a member directory is an error pointing at the root.
+This is the registry half of the [Lockstep Contract](#lockstep-contract).
 
 #### Path Dependency Replacement
 

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -800,8 +800,12 @@ validations apply:
 The descriptive fields are required because a published package must carry its metadata. The rest stay optional: `homepage`/`documentation` default to `repository`, `repository-directory` is monorepo-only, and `wado-version` is a build constraint.
 
 `wado publish --dry-run` runs these checks and reports every problem at once
-(it does not upload). The OCI upload itself is not yet implemented, so a bare
-`wado publish` errors rather than pretending to publish.
+(it does not build or upload). A bare `wado publish` builds the package's
+library-world component (`build/lib.wasm`, metadata embedded), resolves the OCI
+reference from `[registries].default` — the only supported publish destination;
+a missing or non-`oci://` default is an error — and uploads it via `wkg oci
+push`. A package without `[package].lib` has no library contract to publish and
+is rejected.
 
 In a workspace, `wado publish` is gated to the workspace root: it publishes every
 publishable member (and the root's own `[package]`, if any) together at the

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1169,6 +1169,56 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
     Ok(())
 }
 
+/// Build a package's library-world component for publishing.
+///
+/// Compiles `[package].lib` against the library world and embeds the WIT and
+/// `[package]` metadata exactly like a default `wado compile`, writing the
+/// component to `<root>/build/lib.wasm`. Returns the output path. The library
+/// world is the registry artifact other packages depend on; a package without
+/// `[package].lib` has no such contract and is rejected.
+pub async fn build_lib_component(
+    project: &manifest::ProjectManifest,
+) -> Result<std::path::PathBuf, CliExit> {
+    let pkg = project
+        .manifest
+        .package
+        .as_ref()
+        .ok_or_else(|| CliExit::error("no [package] to build"))?;
+    let lib_rel = pkg.lib.as_deref().ok_or_else(|| {
+        CliExit::error(
+            "publishing requires `[package].lib`: the library world is the registry artifact",
+        )
+    })?;
+    let world_fq = manifest::lib_world_fq(pkg)?;
+    let entry = project.root.join(lib_rel);
+    let output = project.root.join(BUILD_DIR).join("lib.wasm");
+    let opts = CompileOptions {
+        input: entry.to_string_lossy().into_owned(),
+        output: Some(output.to_string_lossy().into_owned()),
+        format: Some(OutputFormat::Wasm),
+        opt_level: OptLevel::default(),
+        wat_to_stdout: false,
+        log_level: LogLevel::default(),
+        target_world: None,
+        skip_validation: false,
+        inline_threshold: None,
+        opt_iterations: None,
+        allocator: None,
+        no_cache: false,
+        codegen_flags: Vec::new(),
+        lib_world: Some(world_fq),
+        param_overrides: wado_compiler::hashmap::IndexMap::default(),
+        param_policy: wado_compiler::param_resolution::ParamPolicy::default(),
+        no_embed_wit: false,
+        embed_wit: false,
+        no_embed_metadata: false,
+        embed_metadata: false,
+        manifest_driven: true,
+    };
+    run(opts).await?;
+    Ok(output)
+}
+
 /// The default output path when `-o` is absent. A manifest-driven build writes
 /// `<manifest_root>/build/<world>.<ext>` — keeping artifacts out of the source
 /// tree and giving each world its own file, mirroring kiln's `build/` layout.

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1169,29 +1169,25 @@ pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {
     Ok(())
 }
 
-/// Build a package's library-world component for publishing.
+/// The `<root>/build/<segment>.wasm` artifact path for a publish build, where
+/// `<segment>` is `"lib"` or a [`world_path_segment`].
+#[must_use]
+pub fn build_output_path(root: &Path, segment: &str) -> std::path::PathBuf {
+    root.join(BUILD_DIR).join(format!("{segment}.wasm"))
+}
+
+/// Build one of a package's worlds for publishing.
 ///
-/// Compiles `[package].lib` against the library world and embeds the WIT and
-/// `[package]` metadata exactly like a default `wado compile`, writing the
-/// component to `<root>/build/lib.wasm`. Returns the output path. The library
-/// world is the registry artifact other packages depend on; a package without
-/// `[package].lib` has no such contract and is rejected.
-pub async fn build_lib_component(
-    project: &manifest::ProjectManifest,
-) -> Result<std::path::PathBuf, CliExit> {
-    let pkg = project
-        .manifest
-        .package
-        .as_ref()
-        .ok_or_else(|| CliExit::error("no [package] to build"))?;
-    let lib_rel = pkg.lib.as_deref().ok_or_else(|| {
-        CliExit::error(
-            "publishing requires `[package].lib`: the library world is the registry artifact",
-        )
-    })?;
-    let world_fq = manifest::lib_world_fq(pkg)?;
-    let entry = project.root.join(lib_rel);
-    let output = project.root.join(BUILD_DIR).join("lib.wasm");
+/// Compiles `entry` for the selected world and embeds the WIT and `[package]`
+/// metadata exactly like a default `wado compile`, writing the component to
+/// `output`. Exactly one of `lib_world` / `target_world` is `Some`, selecting
+/// the world as `--lib` / `--world` do.
+pub async fn build_publish_world(
+    entry: &Path,
+    output: &Path,
+    lib_world: Option<String>,
+    target_world: Option<String>,
+) -> Result<(), CliExit> {
     let opts = CompileOptions {
         input: entry.to_string_lossy().into_owned(),
         output: Some(output.to_string_lossy().into_owned()),
@@ -1199,14 +1195,14 @@ pub async fn build_lib_component(
         opt_level: OptLevel::default(),
         wat_to_stdout: false,
         log_level: LogLevel::default(),
-        target_world: None,
+        target_world,
         skip_validation: false,
         inline_threshold: None,
         opt_iterations: None,
         allocator: None,
         no_cache: false,
         codegen_flags: Vec::new(),
-        lib_world: Some(world_fq),
+        lib_world,
         param_overrides: wado_compiler::hashmap::IndexMap::default(),
         param_policy: wado_compiler::param_resolution::ParamPolicy::default(),
         no_embed_wit: false,
@@ -1215,8 +1211,7 @@ pub async fn build_lib_component(
         embed_metadata: false,
         manifest_driven: true,
     };
-    run(opts).await?;
-    Ok(output)
+    run(opts).await
 }
 
 /// The default output path when `-o` is absent. A manifest-driven build writes
@@ -1249,7 +1244,7 @@ fn default_output_path(
 /// Sanitize a Component Model world FQ name into a single path segment: drop the
 /// `@version`, then replace every character outside `[A-Za-z0-9._-]` with `-`
 /// (e.g. `wasi:cli/command` → `wasi-cli-command`).
-fn world_path_segment(world_fq: &str) -> String {
+pub fn world_path_segment(world_fq: &str) -> String {
     let base = world_fq.split('@').next().unwrap_or(world_fq);
     base.chars()
         .map(|c| {

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -248,7 +248,7 @@ async fn dispatch() -> Result<(), CliExit> {
                 }
                 Cmd::Publish => {
                     let opts = wado_cli::publish::parse_args(parser)?;
-                    wado_cli::publish::run(opts)
+                    Box::pin(wado_cli::publish::run(opts)).await
                 }
             }
         }

--- a/wado-cli/src/metadata_embed.rs
+++ b/wado-cli/src/metadata_embed.rs
@@ -27,6 +27,24 @@ pub fn embed_metadata_sections(mut component: Vec<u8>, sections: &[MetadataSecti
     component
 }
 
+/// Whether `dir` is a git repo with uncommitted tracked changes. `None` when
+/// `dir` is not a git repo or git is unavailable, so the caller can tell "clean"
+/// (`Some(false)`) from "no signal" (`None`). Untracked files are ignored,
+/// matching what a commit actually captures.
+#[must_use]
+pub fn working_tree_dirty(dir: &Path) -> Option<bool> {
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["status", "--porcelain", "--untracked-files=no"])
+        .output()
+        .ok()?;
+    if !status.status.success() {
+        return None;
+    }
+    Some(!status.stdout.is_empty())
+}
+
 /// The git commit SHA at `dir` (`HEAD`), but only when the working tree is
 /// clean. Returns `None` when `dir` is not a git repo, git is unavailable, or
 /// the tree has uncommitted tracked changes — so a dirty build silently omits
@@ -34,13 +52,7 @@ pub fn embed_metadata_sections(mut component: Vec<u8>, sections: &[MetadataSecti
 /// files are ignored, matching what the commit actually captures.
 #[must_use]
 pub fn clean_git_revision(dir: &Path) -> Option<String> {
-    let status = Command::new("git")
-        .arg("-C")
-        .arg(dir)
-        .args(["status", "--porcelain", "--untracked-files=no"])
-        .output()
-        .ok()?;
-    if !status.status.success() || !status.stdout.is_empty() {
+    if working_tree_dirty(dir)? {
         return None;
     }
     let rev = Command::new("git")

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -126,7 +126,7 @@ async fn publish_single(project: &ProjectManifest, dry_run: bool) -> Result<(), 
                 eprintln!("{coord} is ready to publish");
                 Ok(())
             } else {
-                publish_ready(project, &coord).await
+                publish_package(project, &coord).await
             }
         }
         Verdict::Failed(problems) => Err(problems_error(
@@ -212,39 +212,105 @@ async fn publish_workspace(root: &ProjectManifest, dry_run: bool) -> Result<(), 
     }
 
     for (coord, project) in &ready {
-        publish_ready(project, coord).await?;
+        publish_package(project, coord).await?;
     }
     Ok(())
 }
 
-/// Build and push one ready package: resolve the OCI reference, build the
-/// library-world component, then `wkg oci push` it.
-async fn publish_ready(project: &ProjectManifest, coord: &str) -> Result<(), CliExit> {
+/// One world to publish: where its component is built and the OCI sub-path it
+/// targets (`None` for the library world, which lives at the bare repository).
+struct PublishTarget {
+    subpath: Option<String>,
+    entry: std::path::PathBuf,
+    output: std::path::PathBuf,
+    lib_world: Option<String>,
+    target_world: Option<String>,
+}
+
+/// Every world a package publishes: the library world (bare repository) plus
+/// each `[world]` entry not opted out with `publish = false`.
+fn publishable_worlds(project: &ProjectManifest) -> Result<Vec<PublishTarget>, CliExit> {
     let pkg = project
         .manifest
         .package
         .as_ref()
         .ok_or_else(|| CliExit::error("no [package] to publish"))?;
-    let reference = resolve_push_target(&project.manifest, pkg)?;
+    let root = &project.root;
+    let mut targets = Vec::new();
+    if let Some(lib_rel) = pkg.lib.as_deref() {
+        targets.push(PublishTarget {
+            subpath: None,
+            entry: root.join(lib_rel),
+            output: crate::compile::build_output_path(root, "lib"),
+            lib_world: Some(crate::manifest::lib_world_fq(pkg)?),
+            target_world: None,
+        });
+    }
+    for (world_fq, entry) in &project.manifest.world {
+        if !entry.publish {
+            continue;
+        }
+        let segment = crate::compile::world_path_segment(world_fq);
+        targets.push(PublishTarget {
+            entry: root.join(&entry.entry),
+            output: crate::compile::build_output_path(root, &segment),
+            subpath: Some(segment),
+            lib_world: None,
+            target_world: Some(world_fq.clone()),
+        });
+    }
+    Ok(targets)
+}
+
+/// Build and push every publishable world of one ready package: build each
+/// world's component, resolve its OCI reference, then `wkg oci push` it.
+async fn publish_package(project: &ProjectManifest, coord: &str) -> Result<(), CliExit> {
+    let pkg = project
+        .manifest
+        .package
+        .as_ref()
+        .ok_or_else(|| CliExit::error("no [package] to publish"))?;
+    let targets = publishable_worlds(project)?;
+    if targets.is_empty() {
+        return Err(CliExit::error(format!(
+            "{coord} declares no publishable world; add `[package].lib` or a `[world]` entry"
+        )));
+    }
     if crate::metadata_embed::working_tree_dirty(&project.root) == Some(true) {
         eprintln!(
             "warning: working tree has uncommitted changes; publishing {coord} \
              without a `revision` annotation"
         );
     }
-    let component = crate::compile::build_lib_component(project).await?;
-    eprintln!("Publishing {coord} -> {reference}");
-    wkg_oci_push(&reference, &component)?;
-    eprintln!("Published {coord}");
+    for target in &targets {
+        let reference = resolve_push_target(&project.manifest, pkg, target.subpath.as_deref())?;
+        crate::compile::build_publish_world(
+            &target.entry,
+            &target.output,
+            target.lib_world.clone(),
+            target.target_world.clone(),
+        )
+        .await?;
+        eprintln!(
+            "Publishing {coord} ({}) -> {reference}",
+            target.subpath.as_deref().unwrap_or("lib")
+        );
+        wkg_oci_push(&reference, &target.output)?;
+    }
+    eprintln!("Published {coord} ({} artifact(s))", targets.len());
     Ok(())
 }
 
 /// The OCI reference `wkg oci push` targets:
-/// `<host>/<prefix>/<namespace>/<name>:<version>`, derived from
+/// `<host>/<prefix>/<namespace>/<name>[/<world>]:<version>`, derived from
 /// `[registries].default` (the only supported publish destination) and the
-/// package coordinate. Errors when no default registry is set or it is not an
-/// `oci://` URL.
-fn resolve_push_target(manifest: &Manifest, pkg: &Package) -> Result<String, CliExit> {
+/// package coordinate. `subpath` is the world segment for a non-library world.
+/// Errors when no default registry is set or it is not an `oci://` URL.
+fn resolve_push_target(
+    manifest: &Manifest,
+    pkg: &Package,
+    subpath: Option<&str>,
+) -> Result<String, CliExit> {
     let registry = manifest.registries.get("default").ok_or_else(|| {
         CliExit::error(
             "publishing requires a default registry; set it in wado.toml:\n  \
@@ -262,11 +328,12 @@ fn resolve_push_target(manifest: &Manifest, pkg: &Package) -> Result<String, Cli
         .namespace
         .as_deref()
         .ok_or_else(|| CliExit::error("[package].namespace is required to publish"))?;
-    Ok(format!(
-        "{base}/{namespace}/{name}:{version}",
-        name = pkg.name,
-        version = pkg.version
-    ))
+    let mut repo = format!("{base}/{namespace}/{name}", name = pkg.name);
+    if let Some(segment) = subpath {
+        repo.push('/');
+        repo.push_str(segment);
+    }
+    Ok(format!("{repo}:{version}", version = pkg.version))
 }
 
 const WKG_INSTALL_HINT: &str = "install wasm-pkg-tools: `cargo install wkg` (https://github.com/bytecodealliance/wasm-pkg-tools)";
@@ -373,23 +440,32 @@ mod tests {
     }
 
     #[test]
-    fn resolve_push_target_builds_oci_reference() {
+    fn resolve_push_target_library_uses_bare_repository() {
         let m = ready_manifest_with_registry("oci://ghcr.io/acme");
-        let target = resolve_push_target(&m, m.package.as_ref().unwrap()).unwrap();
+        let target = resolve_push_target(&m, m.package.as_ref().unwrap(), None).unwrap();
         assert_eq!(target, "ghcr.io/acme/org/app:0.1.0");
+    }
+
+    #[test]
+    fn resolve_push_target_world_appends_subpath() {
+        let m = ready_manifest_with_registry("oci://ghcr.io/acme");
+        let target =
+            resolve_push_target(&m, m.package.as_ref().unwrap(), Some("core-kiln-generator"))
+                .unwrap();
+        assert_eq!(target, "ghcr.io/acme/org/app/core-kiln-generator:0.1.0");
     }
 
     #[test]
     fn resolve_push_target_trims_trailing_slash() {
         let m = ready_manifest_with_registry("oci://ghcr.io/acme/");
-        let target = resolve_push_target(&m, m.package.as_ref().unwrap()).unwrap();
+        let target = resolve_push_target(&m, m.package.as_ref().unwrap(), None).unwrap();
         assert_eq!(target, "ghcr.io/acme/org/app:0.1.0");
     }
 
     #[test]
     fn resolve_push_target_errors_without_default_registry() {
         let m = manifest("[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"0.1.0\"\n");
-        let err = resolve_push_target(&m, m.package.as_ref().unwrap()).unwrap_err();
+        let err = resolve_push_target(&m, m.package.as_ref().unwrap(), None).unwrap_err();
         assert!(
             err.message.contains("default registry"),
             "{:?}",
@@ -400,7 +476,7 @@ mod tests {
     #[test]
     fn resolve_push_target_rejects_non_oci_registry() {
         let m = ready_manifest_with_registry("https://wa.dev");
-        let err = resolve_push_target(&m, m.package.as_ref().unwrap()).unwrap_err();
+        let err = resolve_push_target(&m, m.package.as_ref().unwrap(), None).unwrap_err();
         assert!(err.message.contains("oci://"), "{:?}", err.message);
     }
 

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -1,10 +1,15 @@
 //! `wado publish` — publish the package to a registry.
 //!
-//! Only `--dry-run` is implemented: it runs the publish-readiness checks
-//! ([`wado_manifest::validate_for_publish`]) and reports any problems. The
-//! actual OCI upload (via `wkg`, with metadata embedded into the component) is
-//! not wired yet, so a non-dry-run invocation errors instead of pretending to
-//! publish.
+//! A facade over the build path and `wkg`: it runs the publish-readiness checks
+//! ([`wado_manifest::validate_for_publish`]), builds the package's library-world
+//! component with `[package]` metadata embedded, then shells out to `wkg oci
+//! push` to upload it as an OCI artifact. `--dry-run` stops after the checks and
+//! reports any problems without building or uploading.
+//!
+//! The push target is `[registries].default` (the only supported publish
+//! destination); a missing or non-`oci://` default registry is an error.
+//! Authentication is delegated to `wkg` and the ambient OCI credential store
+//! (`docker login`); Wado stores no credentials.
 //!
 //! In a workspace, publishing is gated to the workspace root: it publishes every
 //! publishable member together at the shared (force-inherited) version, so the
@@ -12,8 +17,10 @@
 //! from a member directory is an error pointing at the root.
 
 use std::fmt::Write as _;
+use std::path::Path;
+use std::process::Command;
 
-use wado_manifest::{Manifest, PublishError, validate_for_publish};
+use wado_manifest::{Manifest, Package, PublishError, validate_for_publish};
 
 use crate::args::{self, CliExit};
 use crate::manifest::{ProjectManifest, discover, emit_manifest_warnings};
@@ -27,12 +34,16 @@ fn format_usage() -> String {
     let mut buf = String::new();
     writeln!(buf, "Usage: wado publish [options]").unwrap();
     writeln!(buf).unwrap();
-    writeln!(buf, "Check whether the package can be published.").unwrap();
+    writeln!(
+        buf,
+        "Build the package and publish it to a registry via wkg."
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Options:").unwrap();
     writeln!(
         buf,
-        "      --dry-run  Run publish-readiness checks without uploading"
+        "      --dry-run  Run publish-readiness checks without building or uploading"
     )
     .unwrap();
     writeln!(buf, "  -h, --help     Show this help message").unwrap();
@@ -54,14 +65,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<PublishOptions, CliExit>
     Ok(PublishOptions { dry_run })
 }
 
-pub fn run(opts: PublishOptions) -> Result<(), CliExit> {
-    if !opts.dry_run {
-        return Err(CliExit::error(
-            "wado publish: only --dry-run is supported for now \
-             (OCI upload via wkg is not yet implemented)",
-        ));
-    }
-
+pub async fn run(opts: PublishOptions) -> Result<(), CliExit> {
     let cwd = std::env::current_dir()
         .map_err(|e| CliExit::error(format!("cannot get current directory: {e}")))?;
     let project = discover(&cwd)
@@ -69,7 +73,7 @@ pub fn run(opts: PublishOptions) -> Result<(), CliExit> {
         .ok_or_else(|| CliExit::error("no wado.toml found"))?;
 
     if project.manifest.workspace.is_some() {
-        return publish_workspace_dry_run(&project);
+        return publish_workspace(&project, opts.dry_run).await;
     }
     if let Some(root) =
         crate::manifest::governing_workspace_root_dir(&project.root).map_err(CliExit::error)?
@@ -82,7 +86,7 @@ pub fn run(opts: PublishOptions) -> Result<(), CliExit> {
     }
 
     emit_manifest_warnings(&project);
-    publish_single_dry_run(&project.manifest)
+    publish_single(&project, opts.dry_run).await
 }
 
 /// One package's publish-readiness verdict.
@@ -115,11 +119,15 @@ fn classify(manifest: &Manifest) -> Verdict {
     }
 }
 
-fn publish_single_dry_run(manifest: &Manifest) -> Result<(), CliExit> {
-    match classify(manifest) {
+async fn publish_single(project: &ProjectManifest, dry_run: bool) -> Result<(), CliExit> {
+    match classify(&project.manifest) {
         Verdict::Ready(coord) => {
-            eprintln!("{coord} is ready to publish");
-            Ok(())
+            if dry_run {
+                eprintln!("{coord} is ready to publish");
+                Ok(())
+            } else {
+                publish_ready(project, &coord).await
+            }
         }
         Verdict::Failed(problems) => Err(problems_error(
             "package is not ready to publish:",
@@ -132,7 +140,7 @@ fn publish_single_dry_run(manifest: &Manifest) -> Result<(), CliExit> {
     }
 }
 
-fn publish_workspace_dry_run(root: &ProjectManifest) -> Result<(), CliExit> {
+async fn publish_workspace(root: &ProjectManifest, dry_run: bool) -> Result<(), CliExit> {
     emit_manifest_warnings(root);
     let members = root
         .manifest
@@ -142,11 +150,15 @@ fn publish_workspace_dry_run(root: &ProjectManifest) -> Result<(), CliExit> {
         .unwrap_or_default();
     let member_dirs = crate::manifest::workspace_member_dirs(&root.root, members);
 
-    let mut ready: Vec<String> = Vec::new();
-    let mut skipped: Vec<(String, String)> = Vec::new();
-    let mut failed: Vec<(String, Vec<PublishError>)> = Vec::new();
-
-    let mut candidates: Vec<(String, Manifest)> = vec![(".".to_string(), root.manifest.clone())];
+    // Keep each candidate's `ProjectManifest` so a non-dry-run publish can build
+    // it; the root's own `[package]` (if any) publishes alongside the members.
+    let mut candidates: Vec<(String, ProjectManifest)> = vec![(
+        ".".to_string(),
+        ProjectManifest {
+            manifest: root.manifest.clone(),
+            root: root.root.clone(),
+        },
+    )];
     for dir in member_dirs {
         let project = discover(&dir)
             .map_err(CliExit::error)?
@@ -157,14 +169,17 @@ fn publish_workspace_dry_run(root: &ProjectManifest) -> Result<(), CliExit> {
             .unwrap_or(&dir)
             .display()
             .to_string();
-        candidates.push((label, project.manifest));
+        candidates.push((label, project));
     }
 
-    for (label, manifest) in &candidates {
-        match classify(manifest) {
+    let mut ready: Vec<(String, &ProjectManifest)> = Vec::new();
+    let mut skipped: Vec<(String, String)> = Vec::new();
+    let mut failed: Vec<(String, Vec<PublishError>)> = Vec::new();
+    for (label, project) in &candidates {
+        match classify(&project.manifest) {
             Verdict::NotAPackage => {}
             Verdict::Skipped(reason) => skipped.push((label.clone(), reason)),
-            Verdict::Ready(coord) => ready.push(coord),
+            Verdict::Ready(coord) => ready.push((coord, project)),
             Verdict::Failed(problems) => failed.push((label.clone(), problems)),
         }
     }
@@ -185,11 +200,101 @@ fn publish_workspace_dry_run(root: &ProjectManifest) -> Result<(), CliExit> {
     if ready.is_empty() {
         return Err(CliExit::error("no publishable packages in this workspace"));
     }
-    eprintln!(
-        "{} package(s) ready to publish: {}",
-        ready.len(),
-        ready.join(", ")
-    );
+
+    if dry_run {
+        let coords: Vec<&str> = ready.iter().map(|(c, _)| c.as_str()).collect();
+        eprintln!(
+            "{} package(s) ready to publish: {}",
+            coords.len(),
+            coords.join(", ")
+        );
+        return Ok(());
+    }
+
+    for (coord, project) in &ready {
+        publish_ready(project, coord).await?;
+    }
+    Ok(())
+}
+
+/// Build and push one ready package: resolve the OCI reference, build the
+/// library-world component, then `wkg oci push` it.
+async fn publish_ready(project: &ProjectManifest, coord: &str) -> Result<(), CliExit> {
+    let pkg = project
+        .manifest
+        .package
+        .as_ref()
+        .ok_or_else(|| CliExit::error("no [package] to publish"))?;
+    let reference = resolve_push_target(&project.manifest, pkg)?;
+    if crate::metadata_embed::working_tree_dirty(&project.root) == Some(true) {
+        eprintln!(
+            "warning: working tree has uncommitted changes; publishing {coord} \
+             without a `revision` annotation"
+        );
+    }
+    let component = crate::compile::build_lib_component(project).await?;
+    eprintln!("Publishing {coord} -> {reference}");
+    wkg_oci_push(&reference, &component)?;
+    eprintln!("Published {coord}");
+    Ok(())
+}
+
+/// The OCI reference `wkg oci push` targets:
+/// `<host>/<prefix>/<namespace>/<name>:<version>`, derived from
+/// `[registries].default` (the only supported publish destination) and the
+/// package coordinate. Errors when no default registry is set or it is not an
+/// `oci://` URL.
+fn resolve_push_target(manifest: &Manifest, pkg: &Package) -> Result<String, CliExit> {
+    let registry = manifest.registries.get("default").ok_or_else(|| {
+        CliExit::error(
+            "publishing requires a default registry; set it in wado.toml:\n  \
+             [registries]\n  default = \"oci://ghcr.io/yourorg\"",
+        )
+    })?;
+    let base = registry.strip_prefix("oci://").ok_or_else(|| {
+        CliExit::error(format!(
+            "default registry {registry:?} is not an oci:// URL; \
+             only OCI registries are supported for publish"
+        ))
+    })?;
+    let base = base.trim_end_matches('/');
+    let namespace = pkg
+        .namespace
+        .as_deref()
+        .ok_or_else(|| CliExit::error("[package].namespace is required to publish"))?;
+    Ok(format!(
+        "{base}/{namespace}/{name}:{version}",
+        name = pkg.name,
+        version = pkg.version
+    ))
+}
+
+const WKG_INSTALL_HINT: &str = "install wasm-pkg-tools: `cargo install wkg` (https://github.com/bytecodealliance/wasm-pkg-tools)";
+
+fn wkg_oci_push(reference: &str, component: &Path) -> Result<(), CliExit> {
+    run_wkg_push("wkg", reference, component)
+}
+
+/// Run `<program> oci push <reference> <component>`, mapping a missing binary to
+/// install guidance. `program` is injectable so the missing-binary path is
+/// testable without depending on `wkg` being absent.
+fn run_wkg_push(program: &str, reference: &str, component: &Path) -> Result<(), CliExit> {
+    let status = Command::new(program)
+        .args(["oci", "push", reference])
+        .arg(component)
+        .status()
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                CliExit::error(format!("`{program}` not found on PATH; {WKG_INSTALL_HINT}"))
+            } else {
+                CliExit::error(format!("failed to run `{program}`: {e}"))
+            }
+        })?;
+    if !status.success() {
+        return Err(CliExit::error(format!(
+            "`{program} oci push` failed for {reference}"
+        )));
+    }
     Ok(())
 }
 
@@ -258,5 +363,59 @@ mod tests {
     fn classify_not_a_package_for_workspace_only_manifest() {
         let m = manifest("[workspace]\nmembers = [\"packages/*\"]\n");
         assert!(matches!(classify(&m), Verdict::NotAPackage));
+    }
+
+    fn ready_manifest_with_registry(registry: &str) -> Manifest {
+        manifest(&format!(
+            "[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"0.1.0\"\n\
+             [registries]\ndefault = \"{registry}\"\n"
+        ))
+    }
+
+    #[test]
+    fn resolve_push_target_builds_oci_reference() {
+        let m = ready_manifest_with_registry("oci://ghcr.io/acme");
+        let target = resolve_push_target(&m, m.package.as_ref().unwrap()).unwrap();
+        assert_eq!(target, "ghcr.io/acme/org/app:0.1.0");
+    }
+
+    #[test]
+    fn resolve_push_target_trims_trailing_slash() {
+        let m = ready_manifest_with_registry("oci://ghcr.io/acme/");
+        let target = resolve_push_target(&m, m.package.as_ref().unwrap()).unwrap();
+        assert_eq!(target, "ghcr.io/acme/org/app:0.1.0");
+    }
+
+    #[test]
+    fn resolve_push_target_errors_without_default_registry() {
+        let m = manifest("[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"0.1.0\"\n");
+        let err = resolve_push_target(&m, m.package.as_ref().unwrap()).unwrap_err();
+        assert!(
+            err.message.contains("default registry"),
+            "{:?}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn resolve_push_target_rejects_non_oci_registry() {
+        let m = ready_manifest_with_registry("https://wa.dev");
+        let err = resolve_push_target(&m, m.package.as_ref().unwrap()).unwrap_err();
+        assert!(err.message.contains("oci://"), "{:?}", err.message);
+    }
+
+    #[test]
+    fn run_wkg_push_missing_binary_reports_install_hint() {
+        let err = run_wkg_push(
+            "wkg-definitely-not-on-path-xyz",
+            "ghcr.io/acme/org/app:0.1.0",
+            Path::new("/tmp/does-not-matter.wasm"),
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("cargo install wkg"),
+            "{:?}",
+            err.message
+        );
     }
 }

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -1,20 +1,24 @@
 //! `wado publish` — publish the package to a registry.
 //!
 //! A facade over the build path and `wkg`: it runs the publish-readiness checks
-//! ([`wado_manifest::validate_for_publish`]), builds the package's library-world
+//! ([`wado_manifest::validate_for_publish`]), builds each publishable world's
 //! component with `[package]` metadata embedded, then shells out to `wkg oci
-//! push` to upload it as an OCI artifact. `--dry-run` stops after the checks and
-//! reports any problems without building or uploading.
+//! push` to upload each as an OCI artifact. `--dry-run` stops after the checks
+//! and reports any problems without building or uploading.
 //!
-//! The push target is `[registries].default` (the only supported publish
-//! destination); a missing or non-`oci://` default registry is an error.
-//! Authentication is delegated to `wkg` and the ambient OCI credential store
-//! (`docker login`); Wado stores no credentials.
+//! Each world is a distinct artifact: the library world publishes to the bare
+//! repository `<prefix>/<ns>/<name>`, and every other `[world]` entry (unless
+//! `publish = false`) to a `/<world>` sub-path. The push target is the `default`
+//! registry; a missing or non-`oci://` default is an error. Authentication is
+//! delegated to `wkg` and the ambient OCI credential store (`docker login`) or
+//! its `WKG_OCI_USERNAME` / `WKG_OCI_PASSWORD` override; Wado stores no
+//! credentials.
 //!
 //! In a workspace, publishing is gated to the workspace root: it publishes every
-//! publishable member together at the shared (force-inherited) version, so the
-//! registry can never end up with members at mismatched versions. Running it
-//! from a member directory is an error pointing at the root.
+//! publishable member together at the shared (force-inherited) version against
+//! the root's `[registries]`, so the registry can never end up with members at
+//! mismatched versions. Running it from a member directory is an error pointing
+//! at the root.
 
 use std::fmt::Write as _;
 use std::path::Path;
@@ -126,7 +130,7 @@ async fn publish_single(project: &ProjectManifest, dry_run: bool) -> Result<(), 
                 eprintln!("{coord} is ready to publish");
                 Ok(())
             } else {
-                publish_package(project, &coord).await
+                publish_package(project, &coord, &project.manifest.registries).await
             }
         }
         Verdict::Failed(problems) => Err(problems_error(
@@ -211,8 +215,10 @@ async fn publish_workspace(root: &ProjectManifest, dry_run: bool) -> Result<(), 
         return Ok(());
     }
 
+    // Publish is a root-only operation, so every member resolves against the
+    // workspace root's `[registries]`, not its own.
     for (coord, project) in &ready {
-        publish_package(project, coord).await?;
+        publish_package(project, coord, &root.manifest.registries).await?;
     }
     Ok(())
 }
@@ -264,7 +270,13 @@ fn publishable_worlds(project: &ProjectManifest) -> Result<Vec<PublishTarget>, C
 
 /// Build and push every publishable world of one ready package: build each
 /// world's component, resolve its OCI reference, then `wkg oci push` it.
-async fn publish_package(project: &ProjectManifest, coord: &str) -> Result<(), CliExit> {
+/// `registries` is the workspace root's (or the package's own, when standalone)
+/// `[registries]`, since publish is a root-only operation.
+async fn publish_package(
+    project: &ProjectManifest,
+    coord: &str,
+    registries: &indexmap::IndexMap<String, String>,
+) -> Result<(), CliExit> {
     let pkg = project
         .manifest
         .package
@@ -283,7 +295,7 @@ async fn publish_package(project: &ProjectManifest, coord: &str) -> Result<(), C
         );
     }
     for target in &targets {
-        let reference = resolve_push_target(&project.manifest, pkg, target.subpath.as_deref())?;
+        let reference = resolve_push_target(registries, pkg, target.subpath.as_deref())?;
         crate::compile::build_publish_world(
             &target.entry,
             &target.output,
@@ -302,16 +314,18 @@ async fn publish_package(project: &ProjectManifest, coord: &str) -> Result<(), C
 }
 
 /// The OCI reference `wkg oci push` targets:
-/// `<host>/<prefix>/<namespace>/<name>[/<world>]:<version>`, derived from
-/// `[registries].default` (the only supported publish destination) and the
-/// package coordinate. `subpath` is the world segment for a non-library world.
-/// Errors when no default registry is set or it is not an `oci://` URL.
+/// `<host>/<prefix>/<namespace>/<name>[/<world>]:<version>`, derived from the
+/// `default` registry (the only supported publish destination) and the package
+/// coordinate. `registries` comes from the workspace root when publishing a
+/// workspace, since `wado publish` is a root-only operation. `subpath` is the
+/// world segment for a non-library world. Errors when no default registry is
+/// set or it is not an `oci://` URL.
 fn resolve_push_target(
-    manifest: &Manifest,
+    registries: &indexmap::IndexMap<String, String>,
     pkg: &Package,
     subpath: Option<&str>,
 ) -> Result<String, CliExit> {
-    let registry = manifest.registries.get("default").ok_or_else(|| {
+    let registry = registries.get("default").ok_or_else(|| {
         CliExit::error(
             "publishing requires a default registry; set it in wado.toml:\n  \
              [registries]\n  default = \"oci://ghcr.io/yourorg\"",
@@ -442,30 +456,34 @@ mod tests {
     #[test]
     fn resolve_push_target_library_uses_bare_repository() {
         let m = ready_manifest_with_registry("oci://ghcr.io/acme");
-        let target = resolve_push_target(&m, m.package.as_ref().unwrap(), None).unwrap();
+        let target = resolve_push_target(&m.registries, m.package.as_ref().unwrap(), None).unwrap();
         assert_eq!(target, "ghcr.io/acme/org/app:0.1.0");
     }
 
     #[test]
     fn resolve_push_target_world_appends_subpath() {
         let m = ready_manifest_with_registry("oci://ghcr.io/acme");
-        let target =
-            resolve_push_target(&m, m.package.as_ref().unwrap(), Some("core-kiln-generator"))
-                .unwrap();
+        let target = resolve_push_target(
+            &m.registries,
+            m.package.as_ref().unwrap(),
+            Some("core-kiln-generator"),
+        )
+        .unwrap();
         assert_eq!(target, "ghcr.io/acme/org/app/core-kiln-generator:0.1.0");
     }
 
     #[test]
     fn resolve_push_target_trims_trailing_slash() {
         let m = ready_manifest_with_registry("oci://ghcr.io/acme/");
-        let target = resolve_push_target(&m, m.package.as_ref().unwrap(), None).unwrap();
+        let target = resolve_push_target(&m.registries, m.package.as_ref().unwrap(), None).unwrap();
         assert_eq!(target, "ghcr.io/acme/org/app:0.1.0");
     }
 
     #[test]
     fn resolve_push_target_errors_without_default_registry() {
         let m = manifest("[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"0.1.0\"\n");
-        let err = resolve_push_target(&m, m.package.as_ref().unwrap(), None).unwrap_err();
+        let err =
+            resolve_push_target(&m.registries, m.package.as_ref().unwrap(), None).unwrap_err();
         assert!(
             err.message.contains("default registry"),
             "{:?}",
@@ -476,7 +494,8 @@ mod tests {
     #[test]
     fn resolve_push_target_rejects_non_oci_registry() {
         let m = ready_manifest_with_registry("https://wa.dev");
-        let err = resolve_push_target(&m, m.package.as_ref().unwrap(), None).unwrap_err();
+        let err =
+            resolve_push_target(&m.registries, m.package.as_ref().unwrap(), None).unwrap_err();
         assert!(err.message.contains("oci://"), "{:?}", err.message);
     }
 

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -223,14 +223,24 @@ async fn publish_workspace(root: &ProjectManifest, dry_run: bool) -> Result<(), 
     Ok(())
 }
 
+/// Which world a publish target builds. The library world lives at the bare
+/// repository; a hosted world gets the `/<segment>` sub-path. Modeling it as an
+/// enum keeps "exactly one world kind" structural instead of a pair of
+/// `Option`s with an implicit invariant.
+enum BuildWorld {
+    /// Library world; the value is its FQ name (passed as `--lib`).
+    Lib(String),
+    /// Hosted `[world]` entry; the value is its FQ name (passed as `--world`).
+    Hosted(String),
+}
+
 /// One world to publish: where its component is built and the OCI sub-path it
 /// targets (`None` for the library world, which lives at the bare repository).
 struct PublishTarget {
     subpath: Option<String>,
     entry: std::path::PathBuf,
     output: std::path::PathBuf,
-    lib_world: Option<String>,
-    target_world: Option<String>,
+    world: BuildWorld,
 }
 
 /// Every world a package publishes: the library world (bare repository) plus
@@ -248,8 +258,7 @@ fn publishable_worlds(project: &ProjectManifest) -> Result<Vec<PublishTarget>, C
             subpath: None,
             entry: root.join(lib_rel),
             output: crate::compile::build_output_path(root, "lib"),
-            lib_world: Some(crate::manifest::lib_world_fq(pkg)?),
-            target_world: None,
+            world: BuildWorld::Lib(crate::manifest::lib_world_fq(pkg)?),
         });
     }
     for (world_fq, entry) in &project.manifest.world {
@@ -261,8 +270,7 @@ fn publishable_worlds(project: &ProjectManifest) -> Result<Vec<PublishTarget>, C
             entry: root.join(&entry.entry),
             output: crate::compile::build_output_path(root, &segment),
             subpath: Some(segment),
-            lib_world: None,
-            target_world: Some(world_fq.clone()),
+            world: BuildWorld::Hosted(world_fq.clone()),
         });
     }
     Ok(targets)
@@ -296,13 +304,12 @@ async fn publish_package(
     }
     for target in &targets {
         let reference = resolve_push_target(registries, pkg, target.subpath.as_deref())?;
-        crate::compile::build_publish_world(
-            &target.entry,
-            &target.output,
-            target.lib_world.clone(),
-            target.target_world.clone(),
-        )
-        .await?;
+        let (lib_world, target_world) = match &target.world {
+            BuildWorld::Lib(fq) => (Some(fq.clone()), None),
+            BuildWorld::Hosted(fq) => (None, Some(fq.clone())),
+        };
+        crate::compile::build_publish_world(&target.entry, &target.output, lib_world, target_world)
+            .await?;
         eprintln!(
             "Publishing {coord} ({}) -> {reference}",
             target.subpath.as_deref().unwrap_or("lib")
@@ -342,12 +349,63 @@ fn resolve_push_target(
         .namespace
         .as_deref()
         .ok_or_else(|| CliExit::error("[package].namespace is required to publish"))?;
+    // OCI repository components must be lowercase; Wado names allow uppercase, so
+    // catch a non-pushable coordinate here with a clear message rather than a
+    // cryptic `wkg` failure.
+    check_oci_path_component("[package].namespace", namespace)?;
+    check_oci_path_component("[package].name", &pkg.name)?;
+    if let Some(segment) = subpath {
+        check_oci_path_component("world", segment)?;
+    }
+    check_oci_tag(&pkg.version)?;
     let mut repo = format!("{base}/{namespace}/{name}", name = pkg.name);
     if let Some(segment) = subpath {
         repo.push('/');
         repo.push_str(segment);
     }
     Ok(format!("{repo}:{version}", version = pkg.version))
+}
+
+/// Reject an OCI repository path component that isn't pushable: components must
+/// be lowercase `[a-z0-9]` with single `.`/`_`/`-` separators (no leading or
+/// trailing separator).
+fn check_oci_path_component(field: &str, value: &str) -> Result<(), CliExit> {
+    let alnum = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit();
+    let valid = !value.is_empty()
+        && value
+            .bytes()
+            .all(|b| alnum(b) || matches!(b, b'.' | b'_' | b'-'))
+        && value.bytes().next().is_some_and(alnum)
+        && value.bytes().next_back().is_some_and(alnum);
+    if valid {
+        Ok(())
+    } else {
+        Err(CliExit::error(format!(
+            "{field} {value:?} cannot be published to an OCI registry: \
+             repository names must be lowercase letters, digits, and `.`/`_`/`-`"
+        )))
+    }
+}
+
+/// Reject a version that isn't a valid OCI image tag — notably a semver build
+/// metadata `+`, which OCI tags disallow.
+fn check_oci_tag(version: &str) -> Result<(), CliExit> {
+    let valid = (1..=128).contains(&version.len())
+        && version
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'-'))
+        && version
+            .bytes()
+            .next()
+            .is_some_and(|b| b.is_ascii_alphanumeric() || b == b'_');
+    if valid {
+        Ok(())
+    } else {
+        Err(CliExit::error(format!(
+            "version {version:?} cannot be an OCI image tag: \
+             tags allow letters, digits, and `_`/`.`/`-` (no `+` build metadata)"
+        )))
+    }
 }
 
 const WKG_INSTALL_HINT: &str = "install wasm-pkg-tools: `cargo install wkg` (https://github.com/bytecodealliance/wasm-pkg-tools)";
@@ -497,6 +555,36 @@ mod tests {
         let err =
             resolve_push_target(&m.registries, m.package.as_ref().unwrap(), None).unwrap_err();
         assert!(err.message.contains("oci://"), "{:?}", err.message);
+    }
+
+    #[test]
+    fn resolve_push_target_rejects_uppercase_coordinate() {
+        let m = manifest(
+            "[package]\nnamespace = \"MyOrg\"\nname = \"app\"\nversion = \"0.1.0\"\n\
+             [registries]\ndefault = \"oci://ghcr.io\"\n",
+        );
+        let err =
+            resolve_push_target(&m.registries, m.package.as_ref().unwrap(), None).unwrap_err();
+        assert!(err.message.contains("lowercase"), "{:?}", err.message);
+    }
+
+    #[test]
+    fn resolve_push_target_rejects_uppercase_world_segment() {
+        let m = ready_manifest_with_registry("oci://ghcr.io/acme");
+        let err = resolve_push_target(&m.registries, m.package.as_ref().unwrap(), Some("Foo-Bar"))
+            .unwrap_err();
+        assert!(err.message.contains("lowercase"), "{:?}", err.message);
+    }
+
+    #[test]
+    fn resolve_push_target_rejects_build_metadata_version() {
+        let m = manifest(
+            "[package]\nnamespace = \"org\"\nname = \"app\"\nversion = \"1.0.0+build.5\"\n\
+             [registries]\ndefault = \"oci://ghcr.io\"\n",
+        );
+        let err =
+            resolve_push_target(&m.registries, m.package.as_ref().unwrap(), None).unwrap_err();
+        assert!(err.message.contains("tag"), "{:?}", err.message);
     }
 
     #[test]

--- a/wado-manifest/src/lib.rs
+++ b/wado-manifest/src/lib.rs
@@ -9,7 +9,7 @@ mod version;
 pub use lockfile::{LockFile, LockFileError, LockedPackage};
 pub use manifest::{
     Dependency, DependencySource, FormatSettings, GitPin, Manifest, ManifestError, ManifestWarning,
-    Package, TestSettings, Workspace, WorkspacePackage, resolve_member,
+    Package, TestSettings, Workspace, WorkspacePackage, WorldEntry, resolve_member,
 };
 pub use metadata::{
     MetadataSection, REPOSITORY_DIRECTORY_SECTION, license_ref_id, metadata_sections,

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -41,6 +41,10 @@ pub struct Manifest {
 pub struct WorldEntry {
     pub entry: String,
     pub publish: bool,
+    /// Unknown keys in the table form (typos, unsupported). Reported as
+    /// warnings so an opt-out typo like `publsh = false` is not silently
+    /// ignored.
+    pub unknown_fields: Vec<String>,
 }
 
 impl Manifest {
@@ -120,6 +124,14 @@ impl Manifest {
                 section: Some("workspace.package".to_string()),
                 field: field.clone(),
             });
+        }
+        for (fq, entry) in &self.world {
+            for field in &entry.unknown_fields {
+                warnings.push(ManifestWarning::UnknownField {
+                    section: Some(format!("world.{fq:?}")),
+                    field: field.clone(),
+                });
+            }
         }
         warnings
     }
@@ -367,6 +379,8 @@ pub enum ManifestError {
     WorkspaceConflictingLicense,
     /// `[workspace.package].license` is not a valid SPDX expression.
     WorkspaceInvalidLicense { value: String, reason: String },
+    /// A `[world]` value is neither an entry-path string nor a valid table.
+    InvalidWorldEntry { world: String, reason: String },
 }
 
 impl fmt::Display for ManifestError {
@@ -431,6 +445,9 @@ impl fmt::Display for ManifestError {
                 f,
                 "[workspace.package].license {value:?} is not a valid SPDX expression: {reason}"
             ),
+            ManifestError::InvalidWorldEntry { world, reason } => {
+                write!(f, "[world].{world:?}: {reason}")
+            }
         }
     }
 }
@@ -439,39 +456,48 @@ impl std::error::Error for ManifestError {}
 
 // --- Raw serde types for TOML deserialization ---
 
-/// A `[world]` value: either a bare entry path or a table with `entry` and an
-/// optional `publish` flag (default `true`).
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum RawWorldEntry {
-    Path(String),
-    Table {
-        entry: String,
-        #[serde(default = "default_true")]
-        publish: bool,
-    },
-}
-
-fn default_true() -> bool {
-    true
-}
-
-impl RawWorldEntry {
-    fn convert(self) -> WorldEntry {
-        match self {
-            RawWorldEntry::Path(entry) => WorldEntry {
-                entry,
-                publish: true,
-            },
-            RawWorldEntry::Table { entry, publish } => WorldEntry { entry, publish },
+/// Convert one `[world]` value — a bare entry-path string, or a table with
+/// `entry` and an optional `publish` flag (default `true`) — into a
+/// [`WorldEntry`]. A table's unknown keys are collected (not dropped) so a typo
+/// like `publsh = false` surfaces as a warning instead of silently leaving the
+/// world published. Done by hand rather than via an untagged enum so type
+/// mismatches give a clear error and extra keys are recoverable.
+fn convert_world_entry(world: &str, value: toml::Value) -> Result<WorldEntry, ManifestError> {
+    let invalid = |reason: &str| ManifestError::InvalidWorldEntry {
+        world: world.to_string(),
+        reason: reason.to_string(),
+    };
+    let (entry, publish, unknown_fields) = match value {
+        toml::Value::String(entry) => (entry, true, Vec::new()),
+        toml::Value::Table(mut table) => {
+            let entry = match table.remove("entry") {
+                Some(toml::Value::String(s)) => s,
+                Some(_) => return Err(invalid("`entry` must be a string")),
+                None => return Err(invalid("table form requires an `entry` path")),
+            };
+            let publish = match table.remove("publish") {
+                Some(toml::Value::Boolean(b)) => b,
+                Some(_) => return Err(invalid("`publish` must be a boolean")),
+                None => true,
+            };
+            (entry, publish, table.keys().cloned().collect())
         }
+        _ => return Err(invalid("must be an entry-path string or a table")),
+    };
+    if entry.is_empty() {
+        return Err(invalid("entry path must not be empty"));
     }
+    Ok(WorldEntry {
+        entry,
+        publish,
+        unknown_fields,
+    })
 }
 
 #[derive(Deserialize)]
 struct RawManifest {
     package: Option<RawPackage>,
-    world: Option<IndexMap<String, RawWorldEntry>>,
+    world: Option<IndexMap<String, toml::Value>>,
     registries: Option<IndexMap<String, String>>,
     dependencies: Option<IndexMap<String, RawDependency>>,
     #[serde(rename = "dev-dependencies")]
@@ -565,12 +591,11 @@ struct RawDependency {
 fn convert_raw(raw: RawManifest) -> Result<Manifest, ManifestError> {
     let unknown_sections = unknown_keys(&raw.unknown);
     let package = raw.package.map(convert_package).transpose()?;
-    let world = raw
-        .world
-        .unwrap_or_default()
-        .into_iter()
-        .map(|(fq, entry)| (fq, entry.convert()))
-        .collect();
+    let mut world = IndexMap::new();
+    for (fq, value) in raw.world.unwrap_or_default() {
+        let entry = convert_world_entry(&fq, value)?;
+        world.insert(fq, entry);
+    }
     let registries = raw.registries.unwrap_or_default();
     let dependencies = convert_deps(raw.dependencies.unwrap_or_default())?;
     let dev_dependencies = convert_deps(raw.dev_dependencies.unwrap_or_default())?;
@@ -971,6 +996,46 @@ version = "0.1.0"
         // Explicit publish = false opts the single world out.
         assert!(!m.world["wasi:http/service"].publish);
         assert_eq!(m.world_entry("wasi:http/service"), Some("src/server.wado"));
+    }
+
+    #[test]
+    fn unknown_key_in_world_table_warns_instead_of_silently_dropping() {
+        let toml = r#"
+[package]
+name = "app"
+version = "0.1.0"
+
+[world]
+"wasi:http/service" = { entry = "src/server.wado", publsh = false }
+"#;
+        let m = toml.parse::<Manifest>().unwrap();
+        // The typo'd key must not silently opt the world out.
+        assert!(m.world["wasi:http/service"].publish);
+        let warnings = m.warnings();
+        assert!(
+            warnings.iter().any(|w| matches!(w,
+                ManifestWarning::UnknownField { section: Some(s), field }
+                if s == "world.\"wasi:http/service\"" && field == "publsh")),
+            "expected an unknown-field warning for the typo, got {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn world_table_with_non_string_entry_is_a_clear_error() {
+        let toml = "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\n[world]\n\"wasi:cli/command\" = { entry = 123 }\n";
+        let err = toml.parse::<Manifest>().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("wasi:cli/command") && msg.contains("entry"),
+            "expected a clear [world] error, got {msg:?}"
+        );
+    }
+
+    #[test]
+    fn world_entry_with_empty_path_is_rejected() {
+        let toml = "[package]\nname = \"a\"\nversion = \"0.1.0\"\n\n[world]\n\"wasi:cli/command\" = \"\"\n";
+        let err = toml.parse::<Manifest>().unwrap_err();
+        assert!(err.to_string().contains("empty"), "{err}");
     }
 
     #[test]

--- a/wado-manifest/src/manifest.rs
+++ b/wado-manifest/src/manifest.rs
@@ -13,10 +13,10 @@ use crate::version::VersionSpecifier;
 pub struct Manifest {
     pub package: Option<Package>,
     /// The `[world]` table: CM world FQ name (e.g. `"wasi:cli/command"`,
-    /// `"core:kiln/generator"`) → entry-point path, one entry per hosted
-    /// world the package targets. The library world is declared separately by
-    /// `[package].lib` (its world name is the package name).
-    pub world: IndexMap<String, String>,
+    /// `"core:kiln/generator"`) → entry, one entry per hosted world the package
+    /// targets. The library world is declared separately by `[package].lib`
+    /// (its world name is the package name).
+    pub world: IndexMap<String, WorldEntry>,
     pub registries: IndexMap<String, String>,
     pub dependencies: IndexMap<String, Dependency>,
     pub dev_dependencies: IndexMap<String, Dependency>,
@@ -33,12 +33,22 @@ pub struct Manifest {
     pub inherited_unknown_fields: Vec<String>,
 }
 
+/// A `[world]` table entry: the world's entry-point path and whether it is
+/// published. A bare string value (`"world" = "src/x.wado"`) means `publish =
+/// true`; the table form (`{ entry = "…", publish = false }`) opts the single
+/// world out of `wado publish`.
+#[derive(Debug, Clone)]
+pub struct WorldEntry {
+    pub entry: String,
+    pub publish: bool,
+}
+
 impl Manifest {
     /// Entry-point source path for the given CM world FQ name, if declared in
     /// the `[world]` table.
     #[must_use]
     pub fn world_entry(&self, world_fq: &str) -> Option<&str> {
-        self.world.get(world_fq).map(String::as_str)
+        self.world.get(world_fq).map(|w| w.entry.as_str())
     }
 
     /// Deterministic `sha256:` hash of `[dependencies]` + `[dev-dependencies]`
@@ -429,10 +439,39 @@ impl std::error::Error for ManifestError {}
 
 // --- Raw serde types for TOML deserialization ---
 
+/// A `[world]` value: either a bare entry path or a table with `entry` and an
+/// optional `publish` flag (default `true`).
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawWorldEntry {
+    Path(String),
+    Table {
+        entry: String,
+        #[serde(default = "default_true")]
+        publish: bool,
+    },
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl RawWorldEntry {
+    fn convert(self) -> WorldEntry {
+        match self {
+            RawWorldEntry::Path(entry) => WorldEntry {
+                entry,
+                publish: true,
+            },
+            RawWorldEntry::Table { entry, publish } => WorldEntry { entry, publish },
+        }
+    }
+}
+
 #[derive(Deserialize)]
 struct RawManifest {
     package: Option<RawPackage>,
-    world: Option<IndexMap<String, String>>,
+    world: Option<IndexMap<String, RawWorldEntry>>,
     registries: Option<IndexMap<String, String>>,
     dependencies: Option<IndexMap<String, RawDependency>>,
     #[serde(rename = "dev-dependencies")]
@@ -526,7 +565,12 @@ struct RawDependency {
 fn convert_raw(raw: RawManifest) -> Result<Manifest, ManifestError> {
     let unknown_sections = unknown_keys(&raw.unknown);
     let package = raw.package.map(convert_package).transpose()?;
-    let world = raw.world.unwrap_or_default();
+    let world = raw
+        .world
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(fq, entry)| (fq, entry.convert()))
+        .collect();
     let registries = raw.registries.unwrap_or_default();
     let dependencies = convert_deps(raw.dependencies.unwrap_or_default())?;
     let dev_dependencies = convert_deps(raw.dev_dependencies.unwrap_or_default())?;
@@ -905,6 +949,28 @@ version = "0.1.0"
         assert_eq!(pkg.version, "0.1.0");
         assert_eq!(m.world_entry("wasi:cli/command"), Some("src/main.wado"));
         assert!(pkg.namespace.is_none());
+    }
+
+    #[test]
+    fn world_entry_publish_defaults_true_and_opts_out_via_table() {
+        let toml = r#"
+[package]
+name = "tool"
+version = "0.1.0"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
+"core:kiln/generator" = { entry = "src/gen.wado" }
+"wasi:http/service" = { entry = "src/server.wado", publish = false }
+"#;
+        let m = toml.parse::<Manifest>().unwrap();
+        // Bare string and table-without-publish both default to published.
+        assert!(m.world["wasi:cli/command"].publish);
+        assert_eq!(m.world["core:kiln/generator"].entry, "src/gen.wado");
+        assert!(m.world["core:kiln/generator"].publish);
+        // Explicit publish = false opts the single world out.
+        assert!(!m.world["wasi:http/service"].publish);
+        assert_eq!(m.world_entry("wasi:http/service"), Some("src/server.wado"));
     }
 
     #[test]

--- a/wado-manifest/src/resolve.rs
+++ b/wado-manifest/src/resolve.rs
@@ -210,7 +210,12 @@ pub async fn resolve(
                 resolved_ref: None,
                 integrity: Some(info.integrity.clone()),
                 dev: frame.dev,
-                world: info.manifest.world.clone(),
+                world: info
+                    .manifest
+                    .world
+                    .iter()
+                    .map(|(fq, w)| (fq.clone(), w.entry.clone()))
+                    .collect(),
                 deps: Vec::new(),
             },
         );


### PR DESCRIPTION
## Summary

Completes `wado publish` as a facade over the build path and `wkg`: it runs the publish-readiness checks, builds each publishable world's component (with `[package]` metadata embedded), and uploads each to an OCI registry via `wkg oci push`. Previously only `--dry-run` was implemented.

## What it does

- **Build + push.** A bare `wado publish` builds each publishable world's component and pushes it. `--dry-run` still stops after the readiness checks.
- **Multiple artifacts per package.** A package can target several worlds (a library, a Kiln generator, a CLI tool), each a distinct component. The library world publishes to the bare repository `<prefix>/<ns>/<name>`; every other `[world]` entry gets a `/<world>` sub-path (e.g. `…/gale/core-kiln-generator`), keeping the `namespace:name` coordinate clean and the version as the sole tag. Push and pull share one `world → repository` rule.
- **Per-world publish opt-out.** `[world]` entries default to published; the table form `{ entry = "…", publish = false }` opts a single world out. `[package].publish = false` still opts the whole package out.
- **Registry resolution.** The push target is `[registries].default` (the only supported destination); a missing or non-`oci://` default is a clear error. In a workspace, publishing is gated to the root and every member resolves against the root's `[registries]`, since publish is a root-only operation.
- **Auth & revision.** Authentication is delegated to `wkg` and the ambient OCI credential store (or its `WKG_OCI_USERNAME` / `WKG_OCI_PASSWORD` env override); Wado stores no credentials. A missing `wkg` errors with install guidance. The git commit SHA is embedded as `revision` for a clean tree; a dirty tree omits it with a warning at publish time.

## Manifest changes

- `[world]` values gain a table form carrying the per-world `publish` flag. The value is parsed by hand (not via an untagged enum) so a typo'd key (e.g. `publsh = false`) surfaces as a warning instead of being silently dropped — which would otherwise publish a world the author meant to exclude. Non-string `entry`, non-bool `publish`, and empty entry paths give clear `[world]` errors.

## Validation

- Reject coordinates/versions that can't form a valid OCI reference with a clear message rather than a cryptic `wkg` failure: uppercase namespace / name / world-segment (OCI repository names must be lowercase) and a version with semver build metadata `+` (illegal in an OCI tag).

## Docs

- Records the decision in the package-manifest WEP, resolving the prior "one or more worlds" vs "one OCI artifact per coordinate" gap (world → OCI repository path segment; library at the bare path).

## Notes / follow-ups

- The pull-side resolver (registry fetch) is still a stub; it should adopt the same `world → repository` rule when wired.
- Path-dependency source replacement on publish is validated but not yet rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G28vwmmVDXMy1jV1nsy2tC)_