### PR TITLE
feat(manifest): publish to OCI and embed license-file text

### DIFF
--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1096,8 +1096,34 @@ fn embed_package_metadata(
         return wasm;
     };
     let revision = crate::metadata_embed::clean_git_revision(&project.root);
-    let sections = wado_manifest::metadata_sections(pkg, revision.as_deref());
+    let license_text = match read_license_text(project, pkg) {
+        Ok(text) => text,
+        Err(e) => {
+            eprintln!("warning: skipped embedding license text: {e}");
+            None
+        }
+    };
+    let sections =
+        wado_manifest::metadata_sections(pkg, revision.as_deref(), license_text.as_deref());
     crate::metadata_embed::embed_metadata_sections(wasm, &sections)
+}
+
+/// Read the `license-file` text to embed, resolving the path against the
+/// manifest that declared it (see [`manifest::license_file_base_dir`]). Returns
+/// `Ok(None)` when the package has no `license-file`; an `Err` when the declared
+/// file cannot be read (the caller downgrades this to a warning, matching the
+/// other embed steps).
+fn read_license_text(
+    project: &manifest::ProjectManifest,
+    pkg: &wado_manifest::Package,
+) -> Result<Option<String>, String> {
+    let Some(license_file) = pkg.license_file.as_deref() else {
+        return Ok(None);
+    };
+    let path = manifest::license_file_base_dir(&project.root).join(license_file);
+    fs::read_to_string(&path)
+        .map(Some)
+        .map_err(|e| format!("cannot read license-file {}: {e}", path.display()))
 }
 
 pub async fn run(opts: CompileOptions) -> Result<(), CliExit> {

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -116,6 +116,33 @@ pub(crate) fn governing_workspace_root_dir(
     Ok(governing_workspace(member_dir, &content).map(|(dir, _)| dir))
 }
 
+/// The directory a `license-file` path resolves against: the package's own root
+/// when the package declares its own license slot, or the governing workspace
+/// root when the `license-file` is inherited from `[workspace.package]` (per the
+/// package-manifest WEP). Falls back to `package_root` when the own manifest is
+/// unreadable or the package is standalone.
+pub(crate) fn license_file_base_dir(package_root: &Path) -> PathBuf {
+    let content = fs::read_to_string(package_root.join(MANIFEST_FILENAME)).unwrap_or_default();
+    if own_manifest_declares_license_slot(&content) {
+        return package_root.to_path_buf();
+    }
+    governing_workspace(package_root, &content)
+        .map(|(dir, _)| dir)
+        .unwrap_or_else(|| package_root.to_path_buf())
+}
+
+/// Whether a manifest's own `[package]` sets a license slot (`license` or
+/// `license-file`) — i.e. the license is the package's own, not inherited.
+fn own_manifest_declares_license_slot(content: &str) -> bool {
+    let Ok(table) = content.parse::<toml::Table>() else {
+        return false;
+    };
+    let Some(pkg) = table.get("package").and_then(toml::Value::as_table) else {
+        return false;
+    };
+    pkg.contains_key("license") || pkg.contains_key("license-file")
+}
+
 /// Member package directories of the workspace rooted at `root_dir`, expanded
 /// from its `members` globs (directories containing a `wado.toml`, excluding the
 /// root itself).
@@ -720,6 +747,55 @@ authors = ["Alice"]
             dirs,
             vec![tmp.path().join("packages/a"), tmp.path().join("packages/b")]
         );
+    }
+
+    const WS_ROOT_LICENSE_FILE: &str = r#"
+[workspace]
+members = ["packages/*"]
+
+[workspace.package]
+version = "0.1.0"
+repository = "https://github.com/org/monorepo"
+namespace = "org"
+license-file = "COMPANY-LICENSE.txt"
+authors = ["Alice"]
+"#;
+
+    #[test]
+    fn license_file_base_dir_standalone_uses_package_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(
+            &tmp.path().join("wado.toml"),
+            "[package]\nname = \"solo\"\nversion = \"0.1.0\"\nlicense-file = \"LICENSE\"\n",
+        );
+        assert_eq!(license_file_base_dir(tmp.path()), tmp.path());
+    }
+
+    #[test]
+    fn license_file_base_dir_inherited_uses_workspace_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("wado.toml"), WS_ROOT_LICENSE_FILE);
+        let member_dir = tmp.path().join("packages/core");
+        write(
+            &member_dir.join("wado.toml"),
+            "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n",
+        );
+        // The member declares no license slot, so it inherits `license-file`,
+        // which resolves against the workspace root, not the member directory.
+        assert_eq!(license_file_base_dir(&member_dir), tmp.path());
+    }
+
+    #[test]
+    fn license_file_base_dir_member_own_license_file_uses_member() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("wado.toml"), WS_ROOT_LICENSE_FILE);
+        let member_dir = tmp.path().join("packages/core");
+        write(
+            &member_dir.join("wado.toml"),
+            "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\nlicense-file = \"OWN-LICENSE\"\n",
+        );
+        // The member overrides with its own `license-file`, resolved locally.
+        assert_eq!(license_file_base_dir(&member_dir), member_dir);
     }
 
     #[test]

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -131,8 +131,7 @@ pub(crate) fn license_file_base_dir(package_root: &Path) -> PathBuf {
         .unwrap_or_else(|| package_root.to_path_buf())
 }
 
-/// Whether a manifest's own `[package]` sets a license slot (`license` or
-/// `license-file`) — i.e. the license is the package's own, not inherited.
+/// Whether `[package]` sets `license` or `license-file` directly.
 fn own_manifest_declares_license_slot(content: &str) -> bool {
     let Ok(table) = content.parse::<toml::Table>() else {
         return false;
@@ -780,8 +779,7 @@ authors = ["Alice"]
             &member_dir.join("wado.toml"),
             "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\n",
         );
-        // The member declares no license slot, so it inherits `license-file`,
-        // which resolves against the workspace root, not the member directory.
+        // No license slot of its own, so it inherits the workspace's.
         assert_eq!(license_file_base_dir(&member_dir), tmp.path());
     }
 
@@ -794,7 +792,6 @@ authors = ["Alice"]
             &member_dir.join("wado.toml"),
             "[package]\nname = \"core\"\nlib = \"src/lib.wado\"\nlicense-file = \"OWN-LICENSE\"\n",
         );
-        // The member overrides with its own `license-file`, resolved locally.
         assert_eq!(license_file_base_dir(&member_dir), member_dir);
     }
 

--- a/wado-manifest/src/lib.rs
+++ b/wado-manifest/src/lib.rs
@@ -12,7 +12,8 @@ pub use manifest::{
     Package, TestSettings, Workspace, WorkspacePackage, WorldEntry, resolve_member,
 };
 pub use metadata::{
-    MetadataSection, REPOSITORY_DIRECTORY_SECTION, license_ref_id, metadata_sections,
+    LICENSE_SECTION, MetadataSection, REPOSITORY_DIRECTORY_SECTION, license_ref_id,
+    metadata_sections,
 };
 pub use provider::{
     DependencyProvider, GitTagInfo, InMemoryDependencyProvider, ProviderError, RegistryPackageInfo,

--- a/wado-manifest/src/metadata.rs
+++ b/wado-manifest/src/metadata.rs
@@ -70,9 +70,8 @@ pub fn metadata_sections(
     if let Some(licenses) = license_expression(pkg) {
         out.push(MetadataSection::new("licenses", licenses));
     }
-    // Ship the verbatim text only for a `license-file` (LicenseRef); an SPDX
-    // `license` is looked up by id and carries no text. `license`/`license-file`
-    // are mutually exclusive, so gating on `license_file` also excludes SPDX.
+    // Gate on `license_file`, not just `license_text`: an SPDX `license` has no
+    // text to ship, and the two fields are mutually exclusive.
     if let (Some(_), Some(text)) = (&pkg.license_file, license_text) {
         out.push(MetadataSection::new(LICENSE_SECTION, text));
     }

--- a/wado-manifest/src/metadata.rs
+++ b/wado-manifest/src/metadata.rs
@@ -17,6 +17,11 @@ use crate::manifest::Package;
 /// Custom section name for the Wado-custom monorepo subdirectory field.
 pub const REPOSITORY_DIRECTORY_SECTION: &str = "org.wado-lang.package.repository-directory";
 
+/// Custom section carrying the verbatim text of a non-standard `license-file`.
+/// The `licenses` annotation is a `LicenseRef-<id>`; the referenced text ships
+/// here since a `LicenseRef` has no canonical SPDX text to look up.
+pub const LICENSE_SECTION: &str = "org.wado-lang.license";
+
 /// A custom section carrying one metadata field: the section name and its
 /// UTF-8 payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,10 +40,17 @@ impl MetadataSection {
 }
 
 /// The metadata sections to embed, in deterministic order. `revision` (the git
-/// commit SHA) is supplied by the caller since it is derived at build time;
-/// pass `None` to omit it. Absent optional fields are skipped.
+/// commit SHA) and `license_text` (the `license-file` contents) are supplied by
+/// the caller since both need build-time IO this pure crate avoids; pass `None`
+/// to omit them. `license_text` is embedded only when the package uses
+/// `license-file` (a `LicenseRef` licenses annotation). Absent optional fields
+/// are skipped.
 #[must_use]
-pub fn metadata_sections(pkg: &Package, revision: Option<&str>) -> Vec<MetadataSection> {
+pub fn metadata_sections(
+    pkg: &Package,
+    revision: Option<&str>,
+    license_text: Option<&str>,
+) -> Vec<MetadataSection> {
     let mut out = Vec::new();
     if let Some(description) = &pkg.description {
         out.push(MetadataSection::new("description", description));
@@ -57,6 +69,12 @@ pub fn metadata_sections(pkg: &Package, revision: Option<&str>) -> Vec<MetadataS
     }
     if let Some(licenses) = license_expression(pkg) {
         out.push(MetadataSection::new("licenses", licenses));
+    }
+    // Ship the verbatim text only for a `license-file` (LicenseRef); an SPDX
+    // `license` is looked up by id and carries no text. `license`/`license-file`
+    // are mutually exclusive, so gating on `license_file` also excludes SPDX.
+    if let (Some(_), Some(text)) = (&pkg.license_file, license_text) {
+        out.push(MetadataSection::new(LICENSE_SECTION, text));
     }
     out.push(MetadataSection::new("version", &pkg.version));
     if let Some(revision) = revision {
@@ -129,7 +147,7 @@ license = "MIT OR Apache-2.0"
 authors = ["Alice <alice@example.com>", "Bob"]
 "#,
         );
-        let sections = metadata_sections(&pkg, None);
+        let sections = metadata_sections(&pkg, None, None);
         assert_eq!(
             value_of(&sections, "description"),
             Some("A fast widget toolkit")
@@ -165,7 +183,7 @@ version = "0.1.0"
 repository = "https://github.com/myorg/app"
 "#,
         );
-        let sections = metadata_sections(&pkg, None);
+        let sections = metadata_sections(&pkg, None, None);
         assert_eq!(
             value_of(&sections, "homepage"),
             Some("https://github.com/myorg/app")
@@ -179,7 +197,7 @@ repository = "https://github.com/myorg/app"
     #[test]
     fn absent_optional_fields_are_skipped() {
         let pkg = package("[package]\nname = \"app\"\nversion = \"0.1.0\"\n");
-        let sections = metadata_sections(&pkg, None);
+        let sections = metadata_sections(&pkg, None, None);
         assert!(value_of(&sections, "description").is_none());
         assert!(value_of(&sections, "homepage").is_none());
         assert!(value_of(&sections, "licenses").is_none());
@@ -190,7 +208,7 @@ repository = "https://github.com/myorg/app"
     #[test]
     fn revision_is_included_when_supplied() {
         let pkg = package("[package]\nname = \"app\"\nversion = \"0.1.0\"\n");
-        let sections = metadata_sections(&pkg, Some("abc1234def5678"));
+        let sections = metadata_sections(&pkg, Some("abc1234def5678"), None);
         assert_eq!(value_of(&sections, "revision"), Some("abc1234def5678"));
     }
 
@@ -204,7 +222,7 @@ version = "0.1.0"
 repository-directory = "packages/app"
 "#,
         );
-        let sections = metadata_sections(&pkg, None);
+        let sections = metadata_sections(&pkg, None, None);
         assert_eq!(
             value_of(&sections, "org.wado-lang.package.repository-directory"),
             Some("packages/app")
@@ -221,11 +239,41 @@ version = "0.1.0"
 license-file = "licenses/LICENSE-COMMERCIAL.txt"
 "#,
         );
-        let sections = metadata_sections(&pkg, None);
+        let sections = metadata_sections(&pkg, None, None);
         assert_eq!(
             value_of(&sections, "licenses"),
             Some("LicenseRef-LICENSE-COMMERCIAL.txt")
         );
+    }
+
+    #[test]
+    fn license_file_text_embedded_when_supplied() {
+        let pkg = package(
+            r#"
+[package]
+name = "app"
+version = "0.1.0"
+license-file = "LICENSE-COMMERCIAL"
+"#,
+        );
+        let sections = metadata_sections(&pkg, None, Some("Commercial license terms.\n"));
+        assert_eq!(
+            value_of(&sections, "licenses"),
+            Some("LicenseRef-LICENSE-COMMERCIAL")
+        );
+        assert_eq!(
+            value_of(&sections, LICENSE_SECTION),
+            Some("Commercial license terms.\n")
+        );
+    }
+
+    #[test]
+    fn spdx_license_has_no_license_text_section() {
+        let pkg = package("[package]\nname = \"app\"\nversion = \"0.1.0\"\nlicense = \"MIT\"\n");
+        // Even if text is (spuriously) supplied, an SPDX license embeds no text.
+        let sections = metadata_sections(&pkg, None, Some("should be ignored"));
+        assert_eq!(value_of(&sections, "licenses"), Some("MIT"));
+        assert!(value_of(&sections, LICENSE_SECTION).is_none());
     }
 
     #[test]

--- a/wado.toml
+++ b/wado.toml
@@ -7,3 +7,6 @@ repository = "https://github.com/wado-lang/wado"
 namespace = "wado-lang"
 license = "MIT"
 authors = ["FUJI Goro <g.psy.va@gmail.com>"]
+
+[registries]
+default = "oci://ghcr.io"


### PR DESCRIPTION
## Summary

- Set `[registries].default = "oci://ghcr.io"` in the workspace root `wado.toml`, so `wado publish` resolves the GitHub Container Registry for `package-cm-catalog` and `package-gale` (namespace `wado-lang`), matching the OCI layout documented in the package-manifest WEP.
- Embed the verbatim `license-file` text in the `org.wado-lang.license` custom section when a package uses `license-file` instead of an SPDX `license` expression. Previously only the `LicenseRef-<id>` OCI annotation was emitted, with no way for a consumer to retrieve the referenced license text — a gap against the package-manifest WEP's publish-metadata spec.
  - `wado_manifest::metadata_sections` gained a `license_text` parameter (mirroring the existing build-time `revision` parameter).
  - The CLI resolves the `license-file` path against the manifest that declared it: the package's own root, or the governing workspace root when the value is inherited from `[workspace.package]`.

## Verification

`wado publish` was run end-to-end against the real workspace (`package-cm-catalog`, `package-gale`) and pushed to `ghcr.io/wado-lang/...`; all three published artifacts were pulled back and confirmed intact. License-text embedding was verified with a standalone `license-file` package, confirming the text lands in the `org.wado-lang.license` custom section of the compiled component.

Filed separately (out of scope here): #1477 and #1478, two pre-existing WIT component-type embedding gaps surfaced during the publish dry run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhzWJpbBT54jxp7GMUkYMf)_