### PR TITLE
feat(cli): redesign wado test's output format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,22 @@ wado compile --allocator debug file.wado     # debug allocator
 wado run file.wado  # run a CLI program with wasmtime
 ```
 
+### Test Command
+
+`wado test` discovers and runs `test` blocks (compiled against the `test` world, see Target World above).
+
+```sh
+wado test                    # discover and run every .wado test in the project
+wado test file.wado          # run tests in one file
+wado test --filter '**/json*.wado'  # run tests in files matching a wildcard
+```
+
+`--format <name>` selects how progress is rendered:
+
+- `compact` (default): a failure or resolved `#[TODO]` prints its own one-line notice immediately; otherwise a heartbeat digest (`N/Total files · tests, failed, todo, skip · ETA`) prints every 5s. A run always ends with a `compile:`/`load:`/`skip:`/`test:` summary. Tailing just the last line or two is enough to read the current state of a long run — this is the point of the format, so prefer it (over redirect-then-inspect) when watching `wado test` live.
+- `verbose`: per-file `Compiled`/`Loaded` lines streamed live, then every test result and the summary sections printed once the run drains.
+- `tap`: a [TAP version 14](https://testanything.org/tap-version-14-specification.html) document — one Test Point per file (a `# Subtest:` block for files with `test` blocks), for CI/tooling consumption.
+
 ### Serve Command
 
 Use `wado serve` to run a Wado HTTP service (wasi:http/service world):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,8 +166,6 @@ wado test file.wado          # run tests in one file
 wado test --filter '**/json*.wado'  # run tests in files matching a wildcard
 ```
 
-`--format <name>` selects how progress is rendered (default: `heartbeat`) — a failure or resolved `#[TODO]` prints its own one-line notice immediately, otherwise a digest (`N/Total files · tests, failed, todo, skip · ETA`) prints every 5s, ending in a `compile:`/`load:`/`skip:`/`test:` summary. See `wado test --help` for the other formats (`verbose`, `tap`).
-
 ### Serve Command
 
 Use `wado serve` to run a Wado HTTP service (wasi:http/service world):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,8 @@ wado test file.wado          # run tests in one file
 wado test --filter '**/json*.wado'  # run tests in files matching a wildcard
 ```
 
+A failure or resolved `#[TODO]` prints its own one-line notice immediately, otherwise a digest (`N/Total files · tests, failed, todo, skip · ETA`) prints every 5s, ending in a `compile:`/`load:`/`skip:`/`test:` summary. `tail`ing the last line or two is enough to read the current state of a long run.
+
 ### Serve Command
 
 Use `wado serve` to run a Wado HTTP service (wasi:http/service world):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,6 @@ mise run report-wasm-size  # hello_world, pi_approx, zlib, and so on
 - Perform red/green TDD.
 - A compiler bug is always P0 — no exceptions. The instant you suspect one, stop all other work, and as the top priority write a minimal reproducible e2e fixture, file the issue, and fix it. A workaround that lets the current task proceed is never a reason to skip or defer any of these.
 - A pre-existing issue — whether you find it or a reviewer points it out — must be fixed, with TDD when practical.
-- Don't pipe long-running commands (`mise run …`, `cargo test`, etc.) into `tail` or `head`. Redirect to a file and inspect it afterwards if you need to trim output. Exception: `wado test`'s default `heartbeat` format (see The CLI below) is designed to be tailed directly.
 - Use plain `cargo build` / `cargo run` / `cargo test` (the `dev` profile) for iteration. `Cargo.toml` raises `opt-level` on `wado-compiler`, `wado-dev-tools`, and `cranelift-codegen` so dev-build runtime is close to release for the parts that matter, while compile time stays much lower. `--release` is for distributing binaries, not for the inner dev loop.
 - Use the `rust` skill when writing Rust.
 - Use the `wado` skill when writing Wado code or designing Wado language features.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ mise run report-wasm-size  # hello_world, pi_approx, zlib, and so on
 - Perform red/green TDD.
 - A compiler bug is always P0 — no exceptions. The instant you suspect one, stop all other work, and as the top priority write a minimal reproducible e2e fixture, file the issue, and fix it. A workaround that lets the current task proceed is never a reason to skip or defer any of these.
 - A pre-existing issue — whether you find it or a reviewer points it out — must be fixed, with TDD when practical.
-- Don't pipe long-running commands (`mise run …`, `cargo test`, etc.) into `tail` or `head`. Redirect to a file and inspect it afterwards if you need to trim output.
+- Don't pipe long-running commands (`mise run …`, `cargo test`, etc.) into `tail` or `head`. Redirect to a file and inspect it afterwards if you need to trim output. Exception: `wado test`'s default `heartbeat` format (see The CLI below) is designed to be tailed directly.
 - Use plain `cargo build` / `cargo run` / `cargo test` (the `dev` profile) for iteration. `Cargo.toml` raises `opt-level` on `wado-compiler`, `wado-dev-tools`, and `cranelift-codegen` so dev-build runtime is close to release for the parts that matter, while compile time stays much lower. `--release` is for distributing binaries, not for the inner dev loop.
 - Use the `rust` skill when writing Rust.
 - Use the `wado` skill when writing Wado code or designing Wado language features.
@@ -167,11 +167,7 @@ wado test file.wado          # run tests in one file
 wado test --filter '**/json*.wado'  # run tests in files matching a wildcard
 ```
 
-`--format <name>` selects how progress is rendered:
-
-- `compact` (default): a failure or resolved `#[TODO]` prints its own one-line notice immediately; otherwise a heartbeat digest (`N/Total files · tests, failed, todo, skip · ETA`) prints every 5s. A run always ends with a `compile:`/`load:`/`skip:`/`test:` summary. Tailing just the last line or two is enough to read the current state of a long run — this is the point of the format, so prefer it (over redirect-then-inspect) when watching `wado test` live.
-- `verbose`: per-file `Compiled`/`Loaded` lines streamed live, then every test result and the summary sections printed once the run drains.
-- `tap`: a [TAP version 14](https://testanything.org/tap-version-14-specification.html) document — one Test Point per file (a `# Subtest:` block for files with `test` blocks), for CI/tooling consumption.
+`--format <name>` selects how progress is rendered (default: `heartbeat`) — a failure or resolved `#[TODO]` prints its own one-line notice immediately, otherwise a digest (`N/Total files · tests, failed, todo, skip · ETA`) prints every 5s, ending in a `compile:`/`load:`/`skip:`/`test:` summary. See `wado test --help` for the other formats (`verbose`, `tap`).
 
 ### Serve Command
 

--- a/mise.toml
+++ b/mise.toml
@@ -204,16 +204,17 @@ set -xe -o pipefail
 # nested package. In CI, package-gale runs in its own per-optlevel jobs
 # (test-gale-o1/o2/o3), so we exclude it here to keep this job fast.
 # Locally we include everything so a single `mise run test-wado` covers
-# it all.
+# it all. CI also switches to `--format tap` for its machine-readable
+# per-test output; the default `heartbeat` format is for local/agent use.
 #
 # benchmark/* test blocks use only inline data — the `Preopens`-driven
 # file reads sit in `export fn run()`, which the test world does not
 # invoke — so they need no `--dir` setup of their own.
-excludes=()
+extra_args=()
 if [ -n "${CI:-}" ]; then
-    excludes+=(--exclude 'package-gale/**')
+    extra_args+=(--exclude 'package-gale/**' --format tap)
 fi
-cargo run -p wado-cli -- test "${excludes[@]}"
+cargo run -p wado-cli -- test "${extra_args[@]}"
 """
 
 [tasks.test-gale-o1]
@@ -221,7 +222,11 @@ description = "Run package-gale tests with -O1"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-cargo run -p wado-cli -- test -O1 package-gale
+extra_args=()
+if [ -n "${CI:-}" ]; then
+    extra_args+=(--format tap)
+fi
+cargo run -p wado-cli -- test -O1 package-gale "${extra_args[@]}"
 """
 
 [tasks.test-gale-o2]
@@ -229,7 +234,11 @@ description = "Run package-gale tests with -O2"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-cargo run -p wado-cli -- test -O2 package-gale
+extra_args=()
+if [ -n "${CI:-}" ]; then
+    extra_args+=(--format tap)
+fi
+cargo run -p wado-cli -- test -O2 package-gale "${extra_args[@]}"
 """
 
 [tasks.test-gale-o3]
@@ -237,7 +246,11 @@ description = "Run package-gale tests with -O3"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-cargo run -p wado-cli -- test -O3 package-gale
+extra_args=()
+if [ -n "${CI:-}" ]; then
+    extra_args+=(--format tap)
+fi
+cargo run -p wado-cli -- test -O3 package-gale "${extra_args[@]}"
 """
 
 [tasks.test-cov]

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -32,6 +32,7 @@ pub mod runtime;
 pub mod serve;
 pub mod syntax;
 pub mod test;
+mod test_report;
 pub mod timezone_host;
 pub mod tls_trust;
 pub mod update;

--- a/wado-cli/src/runtime.rs
+++ b/wado-cli/src/runtime.rs
@@ -8,6 +8,7 @@ use wasmtime::{
     ProfilingStrategy, Store,
 };
 use wasmtime_wasi::filesystem::WasiFilesystemCtx;
+use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
 use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxView, WasiView};
 use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::p3::{WasiHttpCtxView, WasiHttpView};
@@ -73,6 +74,24 @@ pub struct WasiState {
     tls: WasiTlsCtx,
 }
 
+/// Per-guest stdout/stderr capacity for [`WasiState::new_capturing_stdio`].
+/// Overflow traps the guest (see that constructor's doc) rather than
+/// silently truncating, so this just needs to be generous enough that
+/// realistic test output (assertion diagnostics, a benchmark's own
+/// printed stats) never gets anywhere near it.
+const CAPTURED_STDIO_CAPACITY: usize = 1024 * 1024;
+
+/// Selects where a [`WasiState`]'s stdout/stderr go.
+enum Stdio {
+    /// Pass through to the host's real stdout/stderr.
+    Inherit,
+    /// Redirect into in-memory pipes a caller reads back later.
+    Captured {
+        stdout: MemoryOutputPipe,
+        stderr: MemoryOutputPipe,
+    },
+}
+
 impl WasiState {
     /// Create a new WASI state with preopened directories and program arguments.
     /// `preopened_dirs`: `(host_path, guest_path)` pairs.
@@ -89,7 +108,40 @@ impl WasiState {
     ///
     /// Returns an error if a preopened directory cannot be opened.
     pub fn new(preopened_dirs: &[(String, String)], args: &[String]) -> Result<Self> {
-        Self::build(preopened_dirs, args, true)
+        Self::build(preopened_dirs, args, true, Stdio::Inherit)
+    }
+
+    /// Like [`Self::new`], but captures the guest's stdout/stderr into
+    /// in-memory pipes instead of inheriting the host's, so a caller can
+    /// read back what the guest printed after it exits. Used by `wado
+    /// test` to attribute a test's own output to its result instead of
+    /// letting it race directly onto the host's real stdout/stderr
+    /// alongside every other concurrently-running test.
+    ///
+    /// Capacity-bounded (`CAPTURED_STDIO_CAPACITY`): a guest that writes
+    /// past the cap traps rather than blocking, so a runaway test can't
+    /// deadlock the caller, who only reads the pipes back after the
+    /// guest's `Store` is done with them.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a preopened directory cannot be opened.
+    pub fn new_capturing_stdio(
+        preopened_dirs: &[(String, String)],
+        args: &[String],
+    ) -> Result<(Self, MemoryOutputPipe, MemoryOutputPipe)> {
+        let stdout = MemoryOutputPipe::new(CAPTURED_STDIO_CAPACITY);
+        let stderr = MemoryOutputPipe::new(CAPTURED_STDIO_CAPACITY);
+        let state = Self::build(
+            preopened_dirs,
+            args,
+            true,
+            Stdio::Captured {
+                stdout: stdout.clone(),
+                stderr: stderr.clone(),
+            },
+        )?;
+        Ok((state, stdout, stderr))
     }
 
     /// Like [`Self::new`], but reuses pre-opened directories from
@@ -130,9 +182,18 @@ impl WasiState {
         preopened_dirs: &[(String, String)],
         args: &[String],
         inherit_env: bool,
+        stdio: Stdio,
     ) -> Result<Self> {
         let mut builder = WasiCtx::builder();
-        builder.inherit_stdio();
+        match stdio {
+            Stdio::Inherit => {
+                builder.inherit_stdio();
+            }
+            Stdio::Captured { stdout, stderr } => {
+                builder.stdout(stdout);
+                builder.stderr(stderr);
+            }
+        }
         if inherit_env {
             builder.inherit_env();
         }
@@ -404,6 +465,22 @@ pub fn create_store(
     args: &[String],
 ) -> Result<Store<WasiState>> {
     Ok(Store::new(engine, WasiState::new(preopened_dirs, args)?))
+}
+
+/// Like [`create_store`], but the guest's stdout/stderr are captured into
+/// in-memory pipes instead of inherited — used by `wado test` so a
+/// test's own prints can be attributed to its result instead of racing
+/// directly onto the host's real stdout/stderr.
+///
+/// # Errors
+///
+/// Returns an error if a preopened directory cannot be opened.
+pub fn create_test_store(
+    engine: &Engine,
+    preopened_dirs: &[(String, String)],
+) -> Result<(Store<WasiState>, MemoryOutputPipe, MemoryOutputPipe)> {
+    let (state, stdout, stderr) = WasiState::new_capturing_stdio(preopened_dirs, &[])?;
+    Ok((Store::new(engine, state), stdout, stderr))
 }
 
 /// Create a Linker with WASI P3 and HTTP bindings.

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -694,6 +694,11 @@ pub(crate) struct TestResult {
     pub(crate) outcome: TestOutcome,
     pub(crate) error: Option<String>,
     pub(crate) duration: Duration,
+    /// Captured guest stdout/stderr (see `runtime::create_test_store`).
+    /// Empty when nothing was printed, or when the test never got as far
+    /// as calling its test function (`fail_result`'s setup-time failures).
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -1606,6 +1611,8 @@ fn fail_result(job: &TestJob, error: String, start: Instant) -> TestResult {
         outcome: TestOutcome::Fail,
         error: Some(error),
         duration: start.elapsed(),
+        stdout: String::new(),
+        stderr: String::new(),
     }
 }
 
@@ -1628,10 +1635,11 @@ async fn run_single_test(job: &TestJob, preopened_dirs: &[(String, String)]) -> 
     let start = Instant::now();
     let module = job.module.as_ref();
 
-    let mut store = match runtime::create_store(&module.engine, preopened_dirs, &[]) {
-        Ok(s) => s,
-        Err(e) => return fail_result(job, format!("failed to set up store: {e}"), start),
-    };
+    let (mut store, stdout_pipe, stderr_pipe) =
+        match runtime::create_test_store(&module.engine, preopened_dirs) {
+            Ok(v) => v,
+            Err(e) => return fail_result(job, format!("failed to set up store: {e}"), start),
+        };
 
     let deadline_ticks = (job.timeout_ms / EPOCH_INTERVAL_MS).max(1);
     store.set_epoch_deadline(deadline_ticks);
@@ -1699,6 +1707,8 @@ async fn run_single_test(job: &TestJob, preopened_dirs: &[(String, String)]) -> 
         outcome,
         error,
         duration: start.elapsed(),
+        stdout: String::from_utf8_lossy(&stdout_pipe.contents()).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr_pipe.contents()).into_owned(),
     }
 }
 
@@ -1832,6 +1842,8 @@ pub(crate) struct FailEntry {
     pub(crate) file_path: String,
     pub(crate) display_name: String,
     pub(crate) error: Option<String>,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
 }
 
 /// Tally + per-entry detail produced by [`display_test_results`].
@@ -1843,6 +1855,37 @@ pub(crate) struct RunReport {
     pub(crate) todo_resolved: u32,
     pub(crate) todo_entries: Vec<TodoEntry>,
     pub(crate) fail_entries: Vec<FailEntry>,
+}
+
+/// Render a test's captured stdout/stderr (see `runtime::create_test_store`)
+/// as `stdout:`/`stderr:` labelled blocks, every line prefixed by `indent`.
+/// Empty for a stream that captured nothing; `None` if both are empty.
+pub(crate) fn format_captured_output(stdout: &str, stderr: &str, indent: &str) -> Option<String> {
+    if stdout.is_empty() && stderr.is_empty() {
+        return None;
+    }
+    let mut out = String::new();
+    if !stdout.is_empty() {
+        out.push_str(&format!("{indent}stdout:\n"));
+        for line in stdout.lines() {
+            out.push_str(&format!("{indent}  {line}\n"));
+        }
+    }
+    if !stderr.is_empty() {
+        out.push_str(&format!("{indent}stderr:\n"));
+        for line in stderr.lines() {
+            out.push_str(&format!("{indent}  {line}\n"));
+        }
+    }
+    out.pop(); // drop the trailing newline; callers print with println!
+    Some(out)
+}
+
+/// Print a test's captured stdout/stderr — see [`format_captured_output`].
+pub(crate) fn print_captured_output(stdout: &str, stderr: &str, indent: &str) {
+    if let Some(block) = format_captured_output(stdout, stderr, indent) {
+        println!("{block}");
+    }
 }
 
 /// Print per-file/per-test results in source order while accumulating
@@ -1876,6 +1919,7 @@ pub(crate) fn display_test_results(
             match result.outcome {
                 TestOutcome::Pass => {
                     println!("  ok   {} ({dur})", result.display_name);
+                    print_captured_output(&result.stdout, &result.stderr, "    ");
                     report.test_passed += 1;
                 }
                 TestOutcome::Fail => {
@@ -1884,6 +1928,8 @@ pub(crate) fn display_test_results(
                         file_path: result.file_path.clone(),
                         display_name: result.display_name.clone(),
                         error: result.error.clone(),
+                        stdout: result.stdout.clone(),
+                        stderr: result.stderr.clone(),
                     });
                     report.test_failed += 1;
                 }
@@ -1892,6 +1938,7 @@ pub(crate) fn display_test_results(
                         "  \x1b[33m·\x1b[0m {} \x1b[33m# TODO\x1b[0m ({dur})",
                         result.display_name
                     );
+                    print_captured_output(&result.stdout, &result.stderr, "    ");
                     report.todo_pending += 1;
                     report.todo_entries.push(TodoEntry {
                         file_path: result.file_path.clone(),
@@ -1907,6 +1954,7 @@ pub(crate) fn display_test_results(
                     if let Some(ref error) = result.error {
                         println!("    {error}");
                     }
+                    print_captured_output(&result.stdout, &result.stderr, "    ");
                     report.todo_resolved += 1;
                     report.todo_entries.push(TodoEntry {
                         file_path: result.file_path.clone(),
@@ -1931,6 +1979,7 @@ pub(crate) fn print_failure_section(fail_entries: &[FailEntry]) {
         if let Some(ref error) = entry.error {
             println!("---- {} ({}) ----", entry.display_name, entry.file_path);
             println!("{error}");
+            print_captured_output(&entry.stdout, &entry.stderr, "");
             println!();
         }
     }

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -1753,42 +1753,58 @@ impl PackageTotals {
     }
 }
 
-/// Print the per-stage tally lines (`compile:` / `load:` / `test:` /
-/// optionally `todo:`). The `load:` line is suppressed when the stage
-/// didn't run (e.g. `--no-run`) so the no-run output stays as concise
-/// as before.
-pub(crate) fn print_three_axis(totals: &PackageTotals, duration: Option<&str>) {
+/// Build the per-stage tally lines (`compile:` / `load:` / `test:` /
+/// optionally `skip:`/`todo:`/wall time), each including its `[cpu: …]`
+/// work-time tag. Shared by every reporter so the numbers — including
+/// the compile/load/execute timing — never drift between `verbose`,
+/// `heartbeat`, and `tap` (which renders each line as a `#` comment).
+/// The `load:` line is suppressed when the stage didn't run (e.g.
+/// `--no-run`) so the no-run output stays as concise as before.
+pub(crate) fn format_three_axis_lines(
+    totals: &PackageTotals,
+    duration: Option<&str>,
+) -> Vec<String> {
     let compile_dur = format_stage_duration(totals.timings.compile);
     let load_dur = format_stage_duration(totals.timings.load);
     let execute_dur = format_stage_duration(totals.timings.execute);
-    println!(
+    let mut lines = vec![format!(
         "compile: {} ok, {} failed{compile_dur}",
         totals.compile_ok, totals.compile_failed
-    );
+    )];
     let load_total = totals.load_ok + totals.load_failed;
     if load_total > 0 {
-        println!(
+        lines.push(format!(
             "load:    {} ok, {} failed{load_dur}",
             totals.load_ok, totals.load_failed
-        );
+        ));
     }
     if totals.skip_files > 0 {
-        println!("skip:    {} files (no test blocks)", totals.skip_files);
+        lines.push(format!(
+            "skip:    {} files (no test blocks)",
+            totals.skip_files
+        ));
     }
-    println!(
+    lines.push(format!(
         "test:    {} passed, {} failed{execute_dur}",
         totals.test_passed, totals.test_failed
-    );
+    ));
     let todo_total = totals.todo_pending + totals.todo_resolved;
     if todo_total > 0 {
         let mut todo_line = format!("todo:    {} pending", totals.todo_pending);
         if totals.todo_resolved > 0 {
             todo_line.push_str(&format!(", {} resolved", totals.todo_resolved));
         }
-        println!("{todo_line}");
+        lines.push(todo_line);
     }
     if let Some(d) = duration {
-        println!("(wall: {d})");
+        lines.push(format!("(wall: {d})"));
+    }
+    lines
+}
+
+pub(crate) fn print_three_axis(totals: &PackageTotals, duration: Option<&str>) {
+    for line in format_three_axis_lines(totals, duration) {
+        println!("{line}");
     }
 }
 

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -25,6 +25,10 @@ use crate::compiler_host::KilnComponentCache;
 use crate::discover;
 use crate::manifest as project_manifest;
 use crate::runtime::{self, WasiState};
+use crate::test_report::{
+    CompactReporter, CompileEvent, LoadEvent, PackageDoneArgs, TapReporter, TestReporter,
+    VerboseReporter,
+};
 use wado_compiler::LogLevel;
 
 const DEFAULT_TIMEOUT_MS: u64 = 5000;
@@ -56,6 +60,33 @@ pub struct TestOptions {
     pub test_name_filters: Vec<String>,
     pub param_overrides: wado_compiler::hashmap::IndexMap<String, String>,
     pub param_policy: wado_compiler::param_resolution::ParamPolicy,
+    pub format: TestFormat,
+}
+
+/// `--format` selects how a run's progress is rendered.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum TestFormat {
+    /// Per-file compile/load lines streamed live; per-test results and
+    /// summary sections printed as one batch per package.
+    Verbose,
+    /// Immediate one-line notices for failures/resolved TODOs, a 5s
+    /// heartbeat digest otherwise, and a final summary — meant to be
+    /// tailed. The default.
+    Compact,
+    /// TAP14 document: one Test Point per file (a `# Subtest:` block for
+    /// files with `test` blocks), for CI/tooling consumption.
+    Tap,
+}
+
+impl TestFormat {
+    fn parse(s: &str) -> Option<Self> {
+        match s {
+            "verbose" => Some(Self::Verbose),
+            "compact" => Some(Self::Compact),
+            "tap" => Some(Self::Tap),
+            _ => None,
+        }
+    }
 }
 
 impl TestOptions {
@@ -98,6 +129,7 @@ enum Opt {
     OptIterations,
     LogLevel,
     Allocator,
+    Format,
     Dir,
     NoDir,
     NoRun,
@@ -116,6 +148,7 @@ impl Opt {
         Self::OptIterations,
         Self::LogLevel,
         Self::Allocator,
+        Self::Format,
         Self::Dir,
         Self::NoDir,
         Self::NoRun,
@@ -154,6 +187,12 @@ impl Opt {
             Self::OptIterations => args::OPT_ITERATIONS_SPEC,
             Self::LogLevel => args::LOG_LEVEL_SPEC,
             Self::Allocator => args::ALLOCATOR_SPEC,
+            Self::Format => args::OptSpec {
+                long: Some("format"),
+                short: None,
+                value: Some("<name>"),
+                desc: "Output format: compact (default), verbose, tap",
+            },
             Self::Dir => args::DIR_SPEC,
             Self::NoDir => args::NO_DIR_SPEC,
             Self::NoRun => args::OptSpec {
@@ -372,6 +411,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     let mut no_dir = false;
     let mut no_run = false;
     let mut no_cache = false;
+    let mut format = TestFormat::Compact;
     let mut param_args = args::ParamArgs::default();
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(p) = args::match_opt(&arg, args::ParamOpt::ALL, |p| p.spec()) {
@@ -411,6 +451,14 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
                 }
                 Opt::LogLevel => log_level = args::parse_log_level_arg(&mut parser)?,
                 Opt::Allocator => allocator = Some(args::require_string(&mut parser)?),
+                Opt::Format => {
+                    let val = args::require_string(&mut parser)?;
+                    format = TestFormat::parse(&val).ok_or_else(|| {
+                        CliExit::error(format!(
+                            "--format requires compact, verbose, or tap, got '{val}'"
+                        ))
+                    })?;
+                }
                 Opt::Dir => {
                     preopened_dirs.push(args::parse_dir_arg(&mut parser)?);
                     explicit_dirs = true;
@@ -500,6 +548,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
         test_name_filters,
         param_overrides: param_args.overrides,
         param_policy: param_args.policy,
+        format,
     })
 }
 
@@ -531,8 +580,8 @@ struct LoadedModule {
 
 /// Non-TODO module that failed `Component::new`/`create_linker` or whose
 /// load worker panicked. Counted on the `load` axis; does not abort the run.
-struct LoadFailure {
-    path: String,
+pub(crate) struct LoadFailure {
+    pub(crate) path: String,
 }
 
 /// Pipeline-wide resource caps.
@@ -631,20 +680,20 @@ struct TestJob {
 /// `TodoPending` trapped as expected, `TodoResolved` passed unexpectedly
 /// (consider dropping the `#[TODO]`).
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum TestOutcome {
+pub(crate) enum TestOutcome {
     Pass,
     Fail,
     TodoPending,
     TodoResolved,
 }
 
-struct TestResult {
-    file_path: String,
-    test_name: String,
-    display_name: String,
-    outcome: TestOutcome,
-    error: Option<String>,
-    duration: Duration,
+pub(crate) struct TestResult {
+    pub(crate) file_path: String,
+    pub(crate) test_name: String,
+    pub(crate) display_name: String,
+    pub(crate) outcome: TestOutcome,
+    pub(crate) error: Option<String>,
+    pub(crate) duration: Duration,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -718,15 +767,15 @@ fn parse_timeout_segment(rest: &str) -> (Option<u64>, &str) {
 
 /// A `#![TODO]` module that failed to compile.
 /// Treated as a passing result since the module is expected to have errors.
-struct TodoCompileError {
-    path: String,
+pub(crate) struct TodoCompileError {
+    pub(crate) path: String,
 }
 
 /// A non-TODO module that failed to compile.
 /// Counted on the `compile` axis of the summary; does not abort the run so
 /// other files still get a chance to compile and report.
-struct CompileFailure {
-    path: String,
+pub(crate) struct CompileFailure {
+    pub(crate) path: String,
 }
 
 /// Per-file outcome from the **compile** stage.
@@ -777,9 +826,9 @@ impl ParsedTest {
 async fn compile_artifact(
     path: String,
     flags: Arc<CompileFlags>,
-    overall_start: Instant,
     observer: Arc<StageObserver>,
     kiln_cache: Arc<KilnComponentCache>,
+    reporter: Arc<dyn TestReporter>,
 ) -> CompileOutcome {
     let compile_start = Instant::now();
     let panic_or_result = AssertUnwindSafe(compile::try_compile_with_kiln_cache(
@@ -791,32 +840,40 @@ async fn compile_artifact(
     .await;
     let compile_duration = compile_start.elapsed();
     observer.add_work(compile_duration);
-    let elapsed = format_duration(overall_start.elapsed());
-    let dur = format_duration(compile_duration);
 
     let compile_result = match panic_or_result {
         Ok(r) => r,
         Err(payload) => {
             let cause = format_panic_payload(&payload);
-            eprintln!("[{elapsed}] FAILED to compile {path} ({dur}): panicked: {cause}");
+            reporter.on_compile(
+                &path,
+                CompileEvent::Failed {
+                    detail: Some(format!("panicked: {cause}")),
+                },
+                compile_duration,
+            );
             return CompileOutcome::CompileFailure(CompileFailure { path });
         }
     };
 
     match compile_result {
         Ok(result) => {
-            println!("[{elapsed}] Compiled {path} ({dur})");
+            reporter.on_compile(&path, CompileEvent::Ok, compile_duration);
             CompileOutcome::Compiled(CompiledArtifact {
                 path,
                 wasm: result.wasm,
             })
         }
         Err(failure) if failure.is_todo_module => {
-            println!("[{elapsed}] Compiled {path} (TODO module, compile error expected, {dur})");
+            reporter.on_compile(&path, CompileEvent::TodoModule, compile_duration);
             CompileOutcome::TodoCompileError(TodoCompileError { path })
         }
         Err(_) => {
-            eprintln!("[{elapsed}] FAILED to compile {path} ({dur})");
+            reporter.on_compile(
+                &path,
+                CompileEvent::Failed { detail: None },
+                compile_duration,
+            );
             CompileOutcome::CompileFailure(CompileFailure { path })
         }
     }
@@ -838,9 +895,9 @@ async fn compile_artifact(
 fn load_module(
     artifact: CompiledArtifact,
     opt_level: wasmtime::OptLevel,
-    overall_start: Instant,
     module_permit: OwnedSemaphorePermit,
     observer: Arc<StageObserver>,
+    reporter: &Arc<dyn TestReporter>,
 ) -> LoadOutcome {
     let load_start = Instant::now();
     let panic_or_result = std::panic::catch_unwind(AssertUnwindSafe(|| -> Result<_> {
@@ -851,16 +908,17 @@ fn load_module(
     }));
     let load_duration = load_start.elapsed();
     observer.add_work(load_duration);
-    let elapsed = format_duration(overall_start.elapsed());
-    let load_dur = format_duration(load_duration);
 
     let load_result = match panic_or_result {
         Ok(r) => r,
         Err(payload) => {
             let cause = format_panic_payload(&payload);
-            eprintln!(
-                "[{elapsed}] FAILED to load {} ({load_dur}): panicked: {cause}",
-                artifact.path
+            reporter.on_load(
+                &artifact.path,
+                LoadEvent::Failed {
+                    detail: Some(format!("panicked: {cause}")),
+                },
+                load_duration,
             );
             return LoadOutcome::LoadFailure(LoadFailure {
                 path: artifact.path,
@@ -870,8 +928,6 @@ fn load_module(
 
     match load_result {
         Ok((engine, component, linker)) => {
-            println!("[{elapsed}] Loaded {} ({load_dur})", artifact.path);
-
             // Recover original (lossless) test names from the custom section
             // the compiler embeds. Keyed by kebab export name. The compiler
             // emits an entry for every test export, so a discovered test
@@ -902,6 +958,13 @@ fn load_module(
                 }
             }
 
+            reporter.on_load(
+                &artifact.path,
+                LoadEvent::Ok {
+                    test_count: tests.len(),
+                },
+                load_duration,
+            );
             LoadOutcome::Loaded(LoadedModule {
                 path: artifact.path,
                 engine,
@@ -912,9 +975,12 @@ fn load_module(
             })
         }
         Err(e) => {
-            eprintln!(
-                "[{elapsed}] FAILED to load {} ({load_dur}): {e}",
-                artifact.path
+            reporter.on_load(
+                &artifact.path,
+                LoadEvent::Failed {
+                    detail: Some(format!("{e}")),
+                },
+                load_duration,
             );
             LoadOutcome::LoadFailure(LoadFailure {
                 path: artifact.path,
@@ -957,12 +1023,12 @@ async fn run_compile_stage(
     flags: Arc<CompileFlags>,
     parallelism: usize,
     cpu_budget: Arc<Semaphore>,
-    overall_start: Instant,
     observer: Arc<StageObserver>,
     artifact_tx: mpsc::Sender<CompiledArtifact>,
     todo_tx: mpsc::Sender<TodoCompileError>,
     cfail_tx: mpsc::Sender<CompileFailure>,
     kiln_cache: Arc<KilnComponentCache>,
+    reporter: Arc<dyn TestReporter>,
 ) -> usize {
     let mut compiled_count = 0_usize;
 
@@ -973,6 +1039,7 @@ async fn run_compile_stage(
             let observer_inner = Arc::clone(&observer);
             let cpu_budget = Arc::clone(&cpu_budget);
             let kiln_cache = Arc::clone(&kiln_cache);
+            let reporter = Arc::clone(&reporter);
             // Spawn each per-fixture worker as an independent task so
             // its progress is not gated by `buffer_unordered`'s outer
             // polling state. If the outer loop is briefly parked on
@@ -988,6 +1055,7 @@ async fn run_compile_stage(
                     .await
                     .expect("cpu semaphore closed");
                 let path_for_failure = path.clone();
+                let reporter_for_join_err = Arc::clone(&reporter);
                 tokio::task::spawn_blocking(move || {
                     let panic_or_runtime = std::panic::catch_unwind(AssertUnwindSafe(|| {
                         tokio::runtime::Builder::new_current_thread()
@@ -998,24 +1066,28 @@ async fn run_compile_stage(
                         Ok(Ok(rt)) => rt.block_on(compile_artifact(
                             path,
                             flags,
-                            overall_start,
                             observer_inner,
                             kiln_cache,
+                            reporter,
                         )),
                         Ok(Err(e)) => {
-                            let elapsed = format_duration(overall_start.elapsed());
-                            eprintln!(
-                                "[{elapsed}] FAILED to compile {path}: \
-                                 unable to create compile runtime: {e}"
+                            reporter.on_compile(
+                                &path,
+                                CompileEvent::Failed {
+                                    detail: Some(format!("unable to create compile runtime: {e}")),
+                                },
+                                Duration::ZERO,
                             );
                             CompileOutcome::CompileFailure(CompileFailure { path })
                         }
                         Err(payload) => {
                             let cause = format_panic_payload(&payload);
-                            let elapsed = format_duration(overall_start.elapsed());
-                            eprintln!(
-                                "[{elapsed}] FAILED to compile {path}: \
-                                 compile worker panicked: {cause}"
+                            reporter.on_compile(
+                                &path,
+                                CompileEvent::Failed {
+                                    detail: Some(format!("compile worker panicked: {cause}")),
+                                },
+                                Duration::ZERO,
                             );
                             CompileOutcome::CompileFailure(CompileFailure { path })
                         }
@@ -1023,10 +1095,12 @@ async fn run_compile_stage(
                 })
                 .await
                 .unwrap_or_else(|join_err| {
-                    let elapsed = format_duration(overall_start.elapsed());
-                    eprintln!(
-                        "[{elapsed}] FAILED to compile {path_for_failure}: \
-                         blocking-task join error: {join_err}"
+                    reporter_for_join_err.on_compile(
+                        &path_for_failure,
+                        CompileEvent::Failed {
+                            detail: Some(format!("blocking-task join error: {join_err}")),
+                        },
+                        Duration::ZERO,
                     );
                     CompileOutcome::CompileFailure(CompileFailure {
                         path: path_for_failure,
@@ -1078,13 +1152,14 @@ async fn run_load_stage(
     parallelism: usize,
     cpu_budget: Arc<Semaphore>,
     modules_budget: Arc<Semaphore>,
-    overall_start: Instant,
     observer: Arc<StageObserver>,
     loaded_tx: mpsc::Sender<Arc<LoadedModule>>,
     lfail_tx: mpsc::Sender<LoadFailure>,
     epoch_ticker: Arc<EpochTicker>,
-) -> usize {
+    reporter: Arc<dyn TestReporter>,
+) -> (usize, usize) {
     let mut ok_count = 0_usize;
+    let mut skip_count = 0_usize;
 
     let mut stream = receiver_stream(artifact_rx)
         .map(|artifact| {
@@ -1093,6 +1168,8 @@ async fn run_load_stage(
             let modules_budget = Arc::clone(&modules_budget);
             let observer_inner = Arc::clone(&observer);
             let path_for_failure = artifact.path.clone();
+            let reporter = Arc::clone(&reporter);
+            let reporter_for_join_err = Arc::clone(&reporter);
             // Each load worker is its own task so its progress is not
             // gated by `buffer_unordered`'s outer poll.
             tokio::spawn(async move {
@@ -1115,17 +1192,19 @@ async fn run_load_stage(
                     load_module(
                         artifact,
                         opt_level,
-                        overall_start,
                         module_permit,
                         observer_inner,
+                        &reporter,
                     )
                 })
                 .await
                 .unwrap_or_else(|join_err| {
-                    let elapsed = format_duration(overall_start.elapsed());
-                    eprintln!(
-                        "[{elapsed}] FAILED to load {path_for_failure}: \
-                         blocking-task join error: {join_err}"
+                    reporter_for_join_err.on_load(
+                        &path_for_failure,
+                        LoadEvent::Failed {
+                            detail: Some(format!("blocking-task join error: {join_err}")),
+                        },
+                        Duration::ZERO,
                     );
                     LoadOutcome::LoadFailure(LoadFailure {
                         path: path_for_failure,
@@ -1140,6 +1219,9 @@ async fn run_load_stage(
         match outcome {
             LoadOutcome::Loaded(module) => {
                 ok_count += 1;
+                if module.tests.is_empty() {
+                    skip_count += 1;
+                }
                 epoch_ticker.register(&module.engine);
                 if loaded_tx.send(Arc::new(module)).await.is_ok() {
                     observer.record_output();
@@ -1152,7 +1234,7 @@ async fn run_load_stage(
             }
         }
     }
-    ok_count
+    (ok_count, skip_count)
 }
 
 /// **Stage 3 driver** — consume `LoadedModule`s as they stream in,
@@ -1172,6 +1254,7 @@ async fn run_execute_stage(
     preopened_dirs: Arc<Vec<(String, String)>>,
     observer: Arc<StageObserver>,
     result_tx: mpsc::Sender<TestResult>,
+    reporter: Arc<dyn TestReporter>,
 ) {
     // Each loaded module fans out into 0+ test jobs. `flat_map` keeps
     // backpressure honest: as soon as one module's jobs are queued, the
@@ -1231,6 +1314,7 @@ async fn run_execute_stage(
     while let Some(join_result) = stream.next().await {
         let result = join_result.expect("test task panicked");
         observer.add_work(result.duration);
+        reporter.on_test_result(&result);
         if result_tx.send(result).await.is_ok() {
             observer.record_output();
         }
@@ -1242,10 +1326,10 @@ async fn run_execute_stage(
 /// streaming design, these overlap heavily — each duration is the wall
 /// time from the stage's first input to its last output.
 #[derive(Default, Clone, Copy)]
-struct StageTimings {
-    compile: Duration,
-    load: Duration,
-    execute: Duration,
+pub(crate) struct StageTimings {
+    pub(crate) compile: Duration,
+    pub(crate) load: Duration,
+    pub(crate) execute: Duration,
 }
 
 impl StageTimings {
@@ -1272,6 +1356,10 @@ impl StageTimings {
 struct PipelineOutcome {
     compiled_count: usize,
     load_ok: usize,
+    /// Files that loaded successfully but declared zero `test` blocks.
+    /// Already counted within `load_ok`; tracked separately so the
+    /// summary can call them out instead of silently absorbing them.
+    skip_files: usize,
     test_results: Vec<TestResult>,
     todo_compile_errors: Vec<TodoCompileError>,
     compile_failures: Vec<CompileFailure>,
@@ -1364,8 +1452,8 @@ async fn run_pipeline(
     load_jobs: usize,
     execute_jobs: usize,
     preopened_dirs: Arc<Vec<(String, String)>>,
-    overall_start: Instant,
     no_run: bool,
+    reporter: Arc<dyn TestReporter>,
 ) -> PipelineOutcome {
     let opt_level = flags.opt_level.to_wasmtime();
     let budget = Arc::new(PipelineBudget::new(
@@ -1407,15 +1495,15 @@ async fn run_pipeline(
         flags.clone(),
         compile_jobs,
         budget.cpu.clone(),
-        overall_start,
         compile_observer.clone(),
         artifact_tx,
         todo_tx,
         cfail_tx,
         kiln_cache,
+        reporter.clone(),
     );
 
-    let load_future: Pin<Box<dyn Future<Output = usize> + Send>> =
+    let load_future: Pin<Box<dyn Future<Output = (usize, usize)> + Send>> =
         if let Some(ticker) = epoch_ticker.as_ref() {
             Box::pin(run_load_stage(
                 artifact_rx,
@@ -1423,11 +1511,11 @@ async fn run_pipeline(
                 load_jobs,
                 budget.cpu.clone(),
                 budget.modules.clone(),
-                overall_start,
                 load_observer.clone(),
                 loaded_tx,
                 lfail_tx,
                 ticker.clone(),
+                reporter.clone(),
             ))
         } else {
             // Drain the artifact channel so compile-stage producers don't
@@ -1438,7 +1526,7 @@ async fn run_pipeline(
             Box::pin(async move {
                 let mut rx = artifact_rx;
                 while rx.recv().await.is_some() {}
-                0
+                (0, 0)
             })
         };
 
@@ -1450,6 +1538,7 @@ async fn run_pipeline(
             preopened_dirs,
             execute_observer.clone(),
             result_tx,
+            reporter.clone(),
         ))
     } else {
         drop(result_tx);
@@ -1475,7 +1564,7 @@ async fn run_pipeline(
     let result_task = tokio::spawn(collect_into_vec(result_rx));
 
     let compiled_count = compile_task.await.expect("compile stage panicked");
-    let load_ok = load_task.await.expect("load stage panicked");
+    let (load_ok, skip_files) = load_task.await.expect("load stage panicked");
     execute_task.await.expect("execute stage panicked");
     let todos = todo_task.await.expect("todo collector panicked");
     let cfails = cfail_task.await.expect("cfail collector panicked");
@@ -1487,6 +1576,7 @@ async fn run_pipeline(
     PipelineOutcome {
         compiled_count,
         load_ok,
+        skip_files,
         test_results: results,
         todo_compile_errors: todos,
         compile_failures: cfails,
@@ -1618,7 +1708,7 @@ fn is_epoch_deadline_error(err: &wasmtime::Error) -> bool {
 }
 
 /// Format a duration in human-readable form with appropriate units.
-fn format_duration(d: Duration) -> String {
+pub(crate) fn format_duration(d: Duration) -> String {
     let secs = d.as_secs_f64();
     if secs >= 1.0 {
         format!("{secs:.2}s")
@@ -1635,16 +1725,17 @@ fn format_duration(d: Duration) -> String {
 /// the summary line can show, e.g., a load-stage regression independent
 /// from a wado-side compile error.
 #[derive(Default)]
-struct PackageTotals {
-    compile_ok: usize,
-    compile_failed: usize,
-    load_ok: usize,
-    load_failed: usize,
-    test_passed: u32,
-    test_failed: u32,
-    todo_pending: u32,
-    todo_resolved: u32,
-    timings: StageTimings,
+pub(crate) struct PackageTotals {
+    pub(crate) compile_ok: usize,
+    pub(crate) compile_failed: usize,
+    pub(crate) load_ok: usize,
+    pub(crate) load_failed: usize,
+    pub(crate) skip_files: usize,
+    pub(crate) test_passed: u32,
+    pub(crate) test_failed: u32,
+    pub(crate) todo_pending: u32,
+    pub(crate) todo_resolved: u32,
+    pub(crate) timings: StageTimings,
 }
 
 impl PackageTotals {
@@ -1653,6 +1744,7 @@ impl PackageTotals {
         self.compile_failed += other.compile_failed;
         self.load_ok += other.load_ok;
         self.load_failed += other.load_failed;
+        self.skip_files += other.skip_files;
         self.test_passed += other.test_passed;
         self.test_failed += other.test_failed;
         self.todo_pending += other.todo_pending;
@@ -1665,7 +1757,7 @@ impl PackageTotals {
 /// optionally `todo:`). The `load:` line is suppressed when the stage
 /// didn't run (e.g. `--no-run`) so the no-run output stays as concise
 /// as before.
-fn print_three_axis(totals: &PackageTotals, duration: Option<&str>) {
+pub(crate) fn print_three_axis(totals: &PackageTotals, duration: Option<&str>) {
     let compile_dur = format_stage_duration(totals.timings.compile);
     let load_dur = format_stage_duration(totals.timings.load);
     let execute_dur = format_stage_duration(totals.timings.execute);
@@ -1679,6 +1771,9 @@ fn print_three_axis(totals: &PackageTotals, duration: Option<&str>) {
             "load:    {} ok, {} failed{load_dur}",
             totals.load_ok, totals.load_failed
         );
+    }
+    if totals.skip_files > 0 {
+        println!("skip:    {} files (no test blocks)", totals.skip_files);
     }
     println!(
         "test:    {} passed, {} failed{execute_dur}",
@@ -1710,33 +1805,33 @@ fn format_stage_duration(d: Duration) -> String {
 }
 
 /// One entry in the post-summary "TODO tests" section.
-struct TodoEntry {
-    file_path: String,
-    display_name: String,
-    resolved: bool,
+pub(crate) struct TodoEntry {
+    pub(crate) file_path: String,
+    pub(crate) display_name: String,
+    pub(crate) resolved: bool,
 }
 
 /// One entry in the post-summary "failures:" section.
-struct FailEntry {
-    file_path: String,
-    display_name: String,
-    error: Option<String>,
+pub(crate) struct FailEntry {
+    pub(crate) file_path: String,
+    pub(crate) display_name: String,
+    pub(crate) error: Option<String>,
 }
 
 /// Tally + per-entry detail produced by [`display_test_results`].
 #[derive(Default)]
-struct RunReport {
-    test_passed: u32,
-    test_failed: u32,
-    todo_pending: u32,
-    todo_resolved: u32,
-    todo_entries: Vec<TodoEntry>,
-    fail_entries: Vec<FailEntry>,
+pub(crate) struct RunReport {
+    pub(crate) test_passed: u32,
+    pub(crate) test_failed: u32,
+    pub(crate) todo_pending: u32,
+    pub(crate) todo_resolved: u32,
+    pub(crate) todo_entries: Vec<TodoEntry>,
+    pub(crate) fail_entries: Vec<FailEntry>,
 }
 
 /// Print per-file/per-test results in source order while accumulating
 /// totals and the entries needed for the post-run summary sections.
-fn display_test_results(
+pub(crate) fn display_test_results(
     pkg_paths: &[String],
     results_by_file: &IndexMap<&str, Vec<&TestResult>>,
     todo_error_by_path: &IndexMap<&str, &TodoCompileError>,
@@ -1809,7 +1904,7 @@ fn display_test_results(
     report
 }
 
-fn print_failure_section(fail_entries: &[FailEntry]) {
+pub(crate) fn print_failure_section(fail_entries: &[FailEntry]) {
     if fail_entries.is_empty() {
         return;
     }
@@ -1829,7 +1924,7 @@ fn print_failure_section(fail_entries: &[FailEntry]) {
     }
 }
 
-fn print_todo_section(todo_entries: &[TodoEntry], todo_resolved: u32) {
+pub(crate) fn print_todo_section(todo_entries: &[TodoEntry], todo_resolved: u32) {
     if todo_entries.is_empty() {
         return;
     }
@@ -1858,7 +1953,7 @@ fn print_todo_section(todo_entries: &[TodoEntry], todo_resolved: u32) {
     }
 }
 
-fn print_compile_failures_section(failures: &[CompileFailure]) {
+pub(crate) fn print_compile_failures_section(failures: &[CompileFailure]) {
     if failures.is_empty() {
         return;
     }
@@ -1869,7 +1964,7 @@ fn print_compile_failures_section(failures: &[CompileFailure]) {
     }
 }
 
-fn print_load_failures_section(failures: &[LoadFailure]) {
+pub(crate) fn print_load_failures_section(failures: &[LoadFailure]) {
     if failures.is_empty() {
         return;
     }
@@ -1878,6 +1973,22 @@ fn print_load_failures_section(failures: &[LoadFailure]) {
     for entry in failures {
         println!("    {}", entry.path);
     }
+}
+
+/// Tally test outcomes into the four counts `PackageTotals` needs. Pure
+/// and format-independent: every reporter displays a run differently, but
+/// they all must agree on what counts as a pass/fail for the exit code.
+fn tally_test_results(results: &[TestResult]) -> (u32, u32, u32, u32) {
+    let (mut passed, mut failed, mut todo_pending, mut todo_resolved) = (0u32, 0u32, 0u32, 0u32);
+    for r in results {
+        match r.outcome {
+            TestOutcome::Pass => passed += 1,
+            TestOutcome::Fail => failed += 1,
+            TestOutcome::TodoPending => todo_pending += 1,
+            TestOutcome::TodoResolved => todo_resolved += 1,
+        }
+    }
+    (passed, failed, todo_pending, todo_resolved)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1889,14 +2000,11 @@ async fn run_one_package(
     load_jobs: usize,
     execute_jobs: usize,
     preopened_dirs: Arc<Vec<(String, String)>>,
-    overall_start: Instant,
     show_banner: bool,
     no_run: bool,
+    reporter: Arc<dyn TestReporter>,
 ) -> PackageTotals {
-    if show_banner {
-        println!();
-        println!("=== package: {} ===", pkg_run.label);
-    }
+    reporter.on_package_start(pkg_run, show_banner);
 
     let outcome = run_pipeline(
         &pkg_run.paths,
@@ -1906,14 +2014,15 @@ async fn run_one_package(
         load_jobs,
         execute_jobs,
         preopened_dirs,
-        overall_start,
         no_run,
+        reporter.clone(),
     )
     .await;
 
     let PipelineOutcome {
         compiled_count,
         load_ok,
+        skip_files,
         test_results,
         todo_compile_errors,
         compile_failures,
@@ -1933,75 +2042,44 @@ async fn run_one_package(
     let compile_failed = compile_failures.len();
     let load_failed = load_failures.len();
 
-    // `--no-run`: stages 2 and 3 were short-circuited. The compile stage
-    // wrote each fixture's `<primary>.kiln.json` as a side effect, which
-    // is the whole point of the flag. We still surface compile failures
-    // (so a stale-cache run that fails to compile isn't silently
-    // swallowed) and `#![TODO]` modules whose expected compile-error
-    // fired (so the TODO surface stays visible in summary parity with
-    // the normal-run path — only test-level TODO resolution is
-    // unobservable here, since we never executed any tests).
-    if no_run {
-        let todo_entries: Vec<TodoEntry> = todo_compile_errors
-            .iter()
-            .map(|e| TodoEntry {
-                file_path: e.path.clone(),
-                display_name: "#![TODO] module".to_string(),
-                resolved: false,
-            })
-            .collect();
+    // `--no-run`: stages 2 and 3 were short-circuited, so there are no
+    // test results — only the TODO-module compile-error axis is
+    // observable here.
+    let totals = if no_run {
         let todo_pending = u32::try_from(todo_compile_errors.len()).unwrap_or(u32::MAX);
-
-        print_compile_failures_section(&compile_failures);
-        print_todo_section(&todo_entries, 0);
-        let totals = PackageTotals {
+        PackageTotals {
             compile_ok,
             compile_failed,
             todo_pending,
             timings,
             ..PackageTotals::default()
-        };
-        println!();
-        print_three_axis(&totals, None);
-        return totals;
-    }
-
-    // Group results by file for display. Iteration order doesn't matter —
-    // display walks `pkg_run.paths` and looks each one up here.
-    let mut results_by_file: IndexMap<&str, Vec<&TestResult>> = IndexMap::default();
-    for result in &test_results {
-        results_by_file
-            .entry(result.file_path.as_str())
-            .or_default()
-            .push(result);
-    }
-    let todo_error_by_path: IndexMap<&str, &TodoCompileError> = todo_compile_errors
-        .iter()
-        .map(|e| (e.path.as_str(), e))
-        .collect();
-
-    let report = display_test_results(&pkg_run.paths, &results_by_file, &todo_error_by_path);
-    print_failure_section(&report.fail_entries);
-    print_todo_section(&report.todo_entries, report.todo_resolved);
-    print_compile_failures_section(&compile_failures);
-    print_load_failures_section(&load_failures);
-
-    let totals = PackageTotals {
-        compile_ok,
-        compile_failed,
-        load_ok,
-        load_failed,
-        test_passed: report.test_passed,
-        test_failed: report.test_failed,
-        todo_pending: report.todo_pending,
-        todo_resolved: report.todo_resolved,
-        timings,
+        }
+    } else {
+        let (test_passed, test_failed, todo_pending, todo_resolved) =
+            tally_test_results(&test_results);
+        PackageTotals {
+            compile_ok,
+            compile_failed,
+            load_ok,
+            load_failed,
+            skip_files,
+            test_passed,
+            test_failed,
+            todo_pending,
+            todo_resolved,
+            timings,
+        }
     };
 
-    // Per-package summary (no duration; the aggregate or the run itself
-    // owns the elapsed-time line).
-    println!();
-    print_three_axis(&totals, None);
+    reporter.on_package_done(PackageDoneArgs {
+        pkg_run,
+        totals: &totals,
+        test_results: &test_results,
+        todo_compile_errors: &todo_compile_errors,
+        compile_failures: &compile_failures,
+        load_failures: &load_failures,
+        no_run,
+    });
 
     totals
 }
@@ -2054,6 +2132,7 @@ async fn prewarm_stdlib_snapshot_on_workers(parallelism: usize) {
 pub async fn run(opts: TestOptions) -> Result<(), CliExit> {
     let overall_start = Instant::now();
     let multi_pkg = opts.package_runs.len() > 1;
+    let format = opts.format;
     let flags = Arc::new(opts.compile_flags());
     let jobs = opts.jobs;
     let no_run = opts.no_run;
@@ -2086,6 +2165,13 @@ pub async fn run(opts: TestOptions) -> Result<(), CliExit> {
     // `spawn_blocking` tasks can re-use.
     prewarm_stdlib_snapshot_on_workers(compile_jobs).await;
 
+    let total_files: usize = package_runs.iter().map(|r| r.paths.len()).sum();
+    let reporter: Arc<dyn TestReporter> = match format {
+        TestFormat::Verbose => Arc::new(VerboseReporter::new(overall_start)),
+        TestFormat::Compact => Arc::new(CompactReporter::new(overall_start, total_files)),
+        TestFormat::Tap => Arc::new(TapReporter::new(overall_start, total_files)),
+    };
+
     let mut grand = PackageTotals::default();
     for pkg_run in &package_runs {
         let totals = run_one_package(
@@ -2096,22 +2182,15 @@ pub async fn run(opts: TestOptions) -> Result<(), CliExit> {
             load_jobs,
             execute_jobs,
             preopened_dirs.clone(),
-            overall_start,
             multi_pkg,
             no_run,
+            reporter.clone(),
         )
         .await;
         grand.merge(&totals);
     }
 
-    let total_dur = format_duration(overall_start.elapsed());
-    if multi_pkg {
-        println!();
-        println!("=== aggregate ===");
-        print_three_axis(&grand, Some(&total_dur));
-    } else {
-        println!("(wall: {total_dur})");
-    }
+    reporter.on_run_done(&grand, multi_pkg, overall_start.elapsed());
 
     if grand.compile_failed > 0
         || grand.load_failed > 0

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -26,7 +26,7 @@ use crate::discover;
 use crate::manifest as project_manifest;
 use crate::runtime::{self, WasiState};
 use crate::test_report::{
-    CompactReporter, CompileEvent, LoadEvent, PackageDoneArgs, TapReporter, TestReporter,
+    CompileEvent, HeartbeatReporter, LoadEvent, PackageDoneArgs, TapReporter, TestReporter,
     VerboseReporter,
 };
 use wado_compiler::LogLevel;
@@ -72,7 +72,7 @@ pub enum TestFormat {
     /// Immediate one-line notices for failures/resolved TODOs, a 5s
     /// heartbeat digest otherwise, and a final summary — meant to be
     /// tailed. The default.
-    Compact,
+    Heartbeat,
     /// TAP14 document: one Test Point per file (a `# Subtest:` block for
     /// files with `test` blocks), for CI/tooling consumption.
     Tap,
@@ -82,7 +82,7 @@ impl TestFormat {
     fn parse(s: &str) -> Option<Self> {
         match s {
             "verbose" => Some(Self::Verbose),
-            "compact" => Some(Self::Compact),
+            "heartbeat" => Some(Self::Heartbeat),
             "tap" => Some(Self::Tap),
             _ => None,
         }
@@ -191,7 +191,7 @@ impl Opt {
                 long: Some("format"),
                 short: None,
                 value: Some("<name>"),
-                desc: "Output format: compact (default), verbose, tap",
+                desc: "Output format: heartbeat (default), verbose, tap",
             },
             Self::Dir => args::DIR_SPEC,
             Self::NoDir => args::NO_DIR_SPEC,
@@ -411,7 +411,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     let mut no_dir = false;
     let mut no_run = false;
     let mut no_cache = false;
-    let mut format = TestFormat::Compact;
+    let mut format = TestFormat::Heartbeat;
     let mut param_args = args::ParamArgs::default();
     while let Some(arg) = args::next_arg(&mut parser)? {
         if let Some(p) = args::match_opt(&arg, args::ParamOpt::ALL, |p| p.spec()) {
@@ -455,7 +455,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
                     let val = args::require_string(&mut parser)?;
                     format = TestFormat::parse(&val).ok_or_else(|| {
                         CliExit::error(format!(
-                            "--format requires compact, verbose, or tap, got '{val}'"
+                            "--format requires heartbeat, verbose, or tap, got '{val}'"
                         ))
                     })?;
                 }
@@ -2168,7 +2168,7 @@ pub async fn run(opts: TestOptions) -> Result<(), CliExit> {
     let total_files: usize = package_runs.iter().map(|r| r.paths.len()).sum();
     let reporter: Arc<dyn TestReporter> = match format {
         TestFormat::Verbose => Arc::new(VerboseReporter::new(overall_start)),
-        TestFormat::Compact => Arc::new(CompactReporter::new(overall_start, total_files)),
+        TestFormat::Heartbeat => Arc::new(HeartbeatReporter::new(overall_start, total_files)),
         TestFormat::Tap => Arc::new(TapReporter::new(overall_start, total_files)),
     };
 

--- a/wado-cli/src/test_report.rs
+++ b/wado-cli/src/test_report.rs
@@ -381,11 +381,17 @@ impl TestReporter for HeartbeatReporter {
             TestOutcome::Fail => {
                 self.state.tests_failed.fetch_add(1, Ordering::Relaxed);
                 let dur = test::format_duration(result.duration);
-                let detail = result
+                let mut detail = result
                     .error
                     .as_ref()
                     .map(|e| format!("\n  {e}"))
                     .unwrap_or_default();
+                if let Some(captured) =
+                    test::format_captured_output(&result.stdout, &result.stderr, "  ")
+                {
+                    detail.push('\n');
+                    detail.push_str(&captured);
+                }
                 self.announce(&format!(
                     "not ok  {} :: {} ({dur}){detail}",
                     result.file_path, result.display_name
@@ -423,12 +429,31 @@ impl TestReporter for HeartbeatReporter {
 /// wasm backtraces) needs no escaping. `indent` is the Test Point's own
 /// indentation — the block markers sit at `indent` + 2 spaces, matching
 /// the spec's "YAML indented 2 spaces past its Test Point" rule.
-fn yaml_block(indent: &str, message: &str) -> Vec<String> {
-    let mut lines = vec![format!("{indent}  ---"), format!("{indent}  message: |")];
-    for line in message.lines() {
-        lines.push(format!("{indent}    {line}"));
+fn yaml_block(indent: &str, fields: &[(&str, &str)]) -> Vec<String> {
+    let mut lines = vec![format!("{indent}  ---")];
+    for (key, value) in fields {
+        lines.push(format!("{indent}  {key}: |"));
+        for line in value.lines() {
+            lines.push(format!("{indent}    {line}"));
+        }
     }
     lines.push(format!("{indent}  ..."));
+    lines
+}
+
+/// `# stdout:`/`# stderr:` comment lines for a test's captured output
+/// (see `runtime::create_test_store`) — used for outcomes that don't
+/// already carry a YAML diagnostic block (only a `not ok` Fail does).
+fn captured_output_comments(stdout: &str, stderr: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    if !stdout.is_empty() {
+        lines.push("# stdout:".to_string());
+        lines.extend(stdout.lines().map(|l| format!("# {l}")));
+    }
+    if !stderr.is_empty() {
+        lines.push("# stderr:".to_string());
+        lines.extend(stderr.lines().map(|l| format!("# {l}")));
+    }
     lines
 }
 
@@ -629,7 +654,7 @@ impl TestReporter for TapReporter {
                 self.comment(&format!("FAILED to compile {path} ({dur})"));
                 let mut block = vec![format!("not ok - {path} (compile failed)")];
                 if let Some(msg) = detail {
-                    block.extend(yaml_block("", &msg));
+                    block.extend(yaml_block("", &[("message", &msg)]));
                 }
                 self.doc().register_standalone(block.join("\n"));
             }
@@ -652,7 +677,7 @@ impl TestReporter for TapReporter {
                 self.comment(&format!("FAILED to load {path} ({dur})"));
                 let mut block = vec![format!("not ok - {path} (load failed)")];
                 if let Some(msg) = detail {
-                    block.extend(yaml_block("", &msg));
+                    block.extend(yaml_block("", &[("message", &msg)]));
                 }
                 self.doc().register_standalone(block.join("\n"));
             }
@@ -666,8 +691,18 @@ impl TestReporter for TapReporter {
             TestOutcome::Pass => (vec![format!("ok - {name} ({dur})")], false),
             TestOutcome::Fail => {
                 let mut l = vec![format!("not ok - {name} ({dur})")];
+                let mut fields: Vec<(&str, &str)> = Vec::new();
                 if let Some(ref msg) = result.error {
-                    l.extend(yaml_block("", msg));
+                    fields.push(("message", msg));
+                }
+                if !result.stdout.is_empty() {
+                    fields.push(("stdout", &result.stdout));
+                }
+                if !result.stderr.is_empty() {
+                    fields.push(("stderr", &result.stderr));
+                }
+                if !fields.is_empty() {
+                    l.extend(yaml_block("", &fields));
                 }
                 (l, true)
             }
@@ -679,6 +714,12 @@ impl TestReporter for TapReporter {
                 false,
             ),
         };
+        // Non-failing outcomes have no YAML block to carry captured output,
+        // so surface it as plain comments instead (Fail already folded it
+        // into the block above, alongside the failure message).
+        if !matches!(result.outcome, TestOutcome::Fail) {
+            lines.extend(captured_output_comments(&result.stdout, &result.stderr));
+        }
         // One subtest nesting level: 4-space indent on every body line,
         // diagnostic blocks included.
         for line in &mut lines {

--- a/wado-cli/src/test_report.rs
+++ b/wado-cli/src/test_report.rs
@@ -3,8 +3,8 @@
 //! The pipeline (`test.rs`) drives compile/load/execute purely on data; it
 //! reports progress through a [`TestReporter`] rather than printing
 //! directly, so different `--format` values can render the same event
-//! stream differently (a human-readable log, a compact tailable digest, a
-//! TAP document, ...).
+//! stream differently (a human-readable log, a tailable heartbeat digest,
+//! a TAP document, ...).
 //!
 //! Events fire live as the pipeline discovers them (per file compiled,
 //! per file loaded, per test executed). Totals used for the exit code are
@@ -25,9 +25,9 @@ use crate::test::{
     TodoCompileError,
 };
 
-/// How often the compact reporter's heartbeat re-prints progress while
+/// How often the heartbeat reporter re-prints progress while
 /// otherwise quiet. A failure/resolved-TODO notice resets this window
-/// (see `CompactState::notify`) so the next heartbeat doesn't immediately
+/// (see `HeartbeatState::notify`) so the next heartbeat doesn't immediately
 /// repeat what was just reported.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 
@@ -200,7 +200,7 @@ impl TestReporter for VerboseReporter {
 /// `#![TODO]` compile error, immediately on load with zero test blocks
 /// (a SKIP), or once its last test result arrives (tracked via
 /// `pending_tests`).
-struct CompactState {
+struct HeartbeatState {
     overall_start: Instant,
     total_files: usize,
     files_done: AtomicUsize,
@@ -217,13 +217,13 @@ struct CompactState {
     stop: AtomicBool,
 }
 
-impl CompactState {
+impl HeartbeatState {
     fn mark_file_done(&self) {
         self.files_done.fetch_add(1, Ordering::Relaxed);
     }
 }
 
-fn print_heartbeat(state: &CompactState) {
+fn print_heartbeat(state: &HeartbeatState) {
     let elapsed = state.overall_start.elapsed();
     let done = state.files_done.load(Ordering::Relaxed);
     let total = state.total_files;
@@ -267,13 +267,13 @@ fn print_heartbeat(state: &CompactState) {
 /// Tailable default: immediate one-line notices for anything that needs
 /// attention (failures, resolved TODOs), a periodic heartbeat digest
 /// otherwise, and a final three-axis summary.
-pub(crate) struct CompactReporter {
-    state: Arc<CompactState>,
+pub(crate) struct HeartbeatReporter {
+    state: Arc<HeartbeatState>,
 }
 
-impl CompactReporter {
+impl HeartbeatReporter {
     pub(crate) fn new(overall_start: Instant, total_files: usize) -> Self {
-        let state = Arc::new(CompactState {
+        let state = Arc::new(HeartbeatState {
             overall_start,
             total_files,
             files_done: AtomicUsize::new(0),
@@ -333,11 +333,11 @@ impl CompactReporter {
     }
 }
 
-impl TestReporter for CompactReporter {
+impl TestReporter for HeartbeatReporter {
     fn on_package_start(&self, _pkg_run: &PackageRun, _show_banner: bool) {
-        // Compact treats the whole invocation as one continuous run — no
+        // Heartbeat treats the whole invocation as one continuous run — no
         // per-package banners, consistent with the single running total
-        // the heartbeat reports.
+        // it reports.
     }
 
     fn on_compile(&self, path: &str, event: CompileEvent, _duration: Duration) {

--- a/wado-cli/src/test_report.rs
+++ b/wado-cli/src/test_report.rs
@@ -693,32 +693,9 @@ impl TestReporter for TapReporter {
     }
 
     fn on_run_done(&self, grand: &PackageTotals, _multi_pkg: bool, wall: Duration) {
-        self.comment(&format!(
-            "compile: {} ok, {} failed",
-            grand.compile_ok, grand.compile_failed
-        ));
-        if grand.load_ok + grand.load_failed > 0 {
-            self.comment(&format!(
-                "load: {} ok, {} failed",
-                grand.load_ok, grand.load_failed
-            ));
+        let wall_str = test::format_duration(wall);
+        for line in test::format_three_axis_lines(grand, Some(&wall_str)) {
+            self.comment(&line);
         }
-        if grand.skip_files > 0 {
-            self.comment(&format!(
-                "skip: {} files (no test blocks)",
-                grand.skip_files
-            ));
-        }
-        self.comment(&format!(
-            "test: {} passed, {} failed",
-            grand.test_passed, grand.test_failed
-        ));
-        if grand.todo_pending + grand.todo_resolved > 0 {
-            self.comment(&format!(
-                "todo: {} pending, {} resolved",
-                grand.todo_pending, grand.todo_resolved
-            ));
-        }
-        self.comment(&format!("wall: {}", test::format_duration(wall)));
     }
 }

--- a/wado-cli/src/test_report.rs
+++ b/wado-cli/src/test_report.rs
@@ -1,0 +1,724 @@
+//! Output-format abstraction for `wado test`.
+//!
+//! The pipeline (`test.rs`) drives compile/load/execute purely on data; it
+//! reports progress through a [`TestReporter`] rather than printing
+//! directly, so different `--format` values can render the same event
+//! stream differently (a human-readable log, a compact tailable digest, a
+//! TAP document, ...).
+//!
+//! Events fire live as the pipeline discovers them (per file compiled,
+//! per file loaded, per test executed). Totals used for the exit code are
+//! always computed by the pipeline itself, independent of which reporter
+//! is active — a reporter only decides how to *display* the run, never
+//! what counts as success or failure.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Notify;
+use wado_compiler::hashmap::IndexMap;
+
+use crate::test::{
+    self, CompileFailure, LoadFailure, PackageRun, PackageTotals, TestOutcome, TestResult,
+    TodoCompileError,
+};
+
+/// How often the compact reporter's heartbeat re-prints progress while
+/// otherwise quiet. A failure/resolved-TODO notice resets this window
+/// (see `CompactState::notify`) so the next heartbeat doesn't immediately
+/// repeat what was just reported.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Outcome of compiling one file, as seen by a reporter.
+pub(crate) enum CompileEvent {
+    Ok,
+    /// A `#![TODO]` module whose compile error fired as expected.
+    TodoModule,
+    /// `detail` carries a message for the rare host-side failures (worker
+    /// panic, blocking-task join error) that have no per-file compiler
+    /// diagnostic of their own.
+    Failed {
+        detail: Option<String>,
+    },
+}
+
+/// Outcome of loading one compiled file into wasmtime, as seen by a reporter.
+pub(crate) enum LoadEvent {
+    Ok { test_count: usize },
+    Failed { detail: Option<String> },
+}
+
+/// Everything a reporter needs to render one package's final result.
+/// `totals` is already-computed and authoritative (drives the exit code);
+/// the rest is the raw material a batch-style reporter needs to lay out
+/// per-file/per-test detail.
+pub(crate) struct PackageDoneArgs<'a> {
+    pub(crate) pkg_run: &'a PackageRun,
+    pub(crate) totals: &'a PackageTotals,
+    pub(crate) test_results: &'a [TestResult],
+    pub(crate) todo_compile_errors: &'a [TodoCompileError],
+    pub(crate) compile_failures: &'a [CompileFailure],
+    pub(crate) load_failures: &'a [LoadFailure],
+    pub(crate) no_run: bool,
+}
+
+/// Sink for the pipeline's progress events. One instance is constructed
+/// per `wado test` invocation and shared (via `Arc`) across every package
+/// run and every pipeline worker task.
+pub(crate) trait TestReporter: Send + Sync {
+    fn on_package_start(&self, pkg_run: &PackageRun, show_banner: bool);
+    fn on_compile(&self, path: &str, event: CompileEvent, duration: Duration);
+    fn on_load(&self, path: &str, event: LoadEvent, duration: Duration);
+    fn on_test_result(&self, result: &TestResult);
+    fn on_package_done(&self, args: PackageDoneArgs);
+    fn on_run_done(&self, grand: &PackageTotals, multi_pkg: bool, wall: Duration);
+}
+
+/// Reproduces `wado test`'s original output: per-file compile/load lines
+/// streamed live, per-test results and summary sections printed as one
+/// batch per package once its pipeline drains.
+pub(crate) struct VerboseReporter {
+    overall_start: Instant,
+}
+
+impl VerboseReporter {
+    pub(crate) fn new(overall_start: Instant) -> Self {
+        Self { overall_start }
+    }
+
+    fn elapsed(&self) -> String {
+        test::format_duration(self.overall_start.elapsed())
+    }
+}
+
+impl TestReporter for VerboseReporter {
+    fn on_package_start(&self, pkg_run: &PackageRun, show_banner: bool) {
+        if show_banner {
+            println!();
+            println!("=== package: {} ===", pkg_run.label);
+        }
+    }
+
+    fn on_compile(&self, path: &str, event: CompileEvent, duration: Duration) {
+        let elapsed = self.elapsed();
+        let dur = test::format_duration(duration);
+        match event {
+            CompileEvent::Ok => println!("[{elapsed}] Compiled {path} ({dur})"),
+            CompileEvent::TodoModule => {
+                println!(
+                    "[{elapsed}] Compiled {path} (TODO module, compile error expected, {dur})"
+                );
+            }
+            CompileEvent::Failed { detail: None } => {
+                eprintln!("[{elapsed}] FAILED to compile {path} ({dur})");
+            }
+            CompileEvent::Failed { detail: Some(msg) } => {
+                eprintln!("[{elapsed}] FAILED to compile {path} ({dur}): {msg}");
+            }
+        }
+    }
+
+    fn on_load(&self, path: &str, event: LoadEvent, duration: Duration) {
+        let elapsed = self.elapsed();
+        let dur = test::format_duration(duration);
+        match event {
+            LoadEvent::Ok { .. } => println!("[{elapsed}] Loaded {path} ({dur})"),
+            LoadEvent::Failed { detail: None } => {
+                eprintln!("[{elapsed}] FAILED to load {path} ({dur})");
+            }
+            LoadEvent::Failed { detail: Some(msg) } => {
+                eprintln!("[{elapsed}] FAILED to load {path} ({dur}): {msg}");
+            }
+        }
+    }
+
+    fn on_test_result(&self, _result: &TestResult) {
+        // Verbose prints test results in one batch per package, in
+        // `on_package_done` — see the module doc for why.
+    }
+
+    fn on_package_done(&self, args: PackageDoneArgs) {
+        if args.no_run {
+            let todo_entries: Vec<test::TodoEntry> = args
+                .todo_compile_errors
+                .iter()
+                .map(|e| test::TodoEntry {
+                    file_path: e.path.clone(),
+                    display_name: "#![TODO] module".to_string(),
+                    resolved: false,
+                })
+                .collect();
+            test::print_compile_failures_section(args.compile_failures);
+            test::print_todo_section(&todo_entries, 0);
+            println!();
+            test::print_three_axis(args.totals, None);
+            return;
+        }
+
+        let mut results_by_file: wado_compiler::hashmap::IndexMap<&str, Vec<&TestResult>> =
+            wado_compiler::hashmap::IndexMap::default();
+        for result in args.test_results {
+            results_by_file
+                .entry(result.file_path.as_str())
+                .or_default()
+                .push(result);
+        }
+        let todo_error_by_path: wado_compiler::hashmap::IndexMap<&str, &TodoCompileError> = args
+            .todo_compile_errors
+            .iter()
+            .map(|e| (e.path.as_str(), e))
+            .collect();
+
+        let report =
+            test::display_test_results(&args.pkg_run.paths, &results_by_file, &todo_error_by_path);
+        test::print_failure_section(&report.fail_entries);
+        test::print_todo_section(&report.todo_entries, report.todo_resolved);
+        test::print_compile_failures_section(args.compile_failures);
+        test::print_load_failures_section(args.load_failures);
+
+        println!();
+        test::print_three_axis(args.totals, None);
+    }
+
+    fn on_run_done(&self, grand: &PackageTotals, multi_pkg: bool, wall: Duration) {
+        let total_dur = test::format_duration(wall);
+        if multi_pkg {
+            println!();
+            println!("=== aggregate ===");
+            test::print_three_axis(grand, Some(&total_dur));
+        } else {
+            println!("(wall: {total_dur})");
+        }
+    }
+}
+
+/// Shared, atomically-updated counters the heartbeat ticker reads and
+/// every trait method writes to. A file counts as "done" the moment its
+/// outcome is fully known: immediately on a compile/load failure or a
+/// `#![TODO]` compile error, immediately on load with zero test blocks
+/// (a SKIP), or once its last test result arrives (tracked via
+/// `pending_tests`).
+struct CompactState {
+    overall_start: Instant,
+    total_files: usize,
+    files_done: AtomicUsize,
+    tests_seen: AtomicU32,
+    tests_failed: AtomicU32,
+    todo_pending: AtomicU32,
+    todo_resolved: AtomicU32,
+    skip_files: AtomicUsize,
+    pending_tests: Mutex<IndexMap<String, usize>>,
+    /// Signalled on every immediate failure/resolved-TODO notice so the
+    /// heartbeat loop can restart its wait — avoids printing a near-
+    /// duplicate heartbeat right after an event that already reported.
+    notify: Notify,
+    stop: AtomicBool,
+}
+
+impl CompactState {
+    fn mark_file_done(&self) {
+        self.files_done.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+fn print_heartbeat(state: &CompactState) {
+    let elapsed = state.overall_start.elapsed();
+    let done = state.files_done.load(Ordering::Relaxed);
+    let total = state.total_files;
+    let tests = state.tests_seen.load(Ordering::Relaxed);
+    let failed = state.tests_failed.load(Ordering::Relaxed);
+    let todo = state.todo_pending.load(Ordering::Relaxed);
+    let resolved = state.todo_resolved.load(Ordering::Relaxed);
+    let skip = state.skip_files.load(Ordering::Relaxed);
+
+    let pct = done
+        .checked_mul(100)
+        .and_then(|p| p.checked_div(total))
+        .map_or_else(String::new, |p| format!(" ({p}%)"));
+    // File-count-based ETA only: total test count isn't known upfront
+    // (a file's test blocks are discovered when it loads), so files are
+    // the only axis with a stable denominator to extrapolate from.
+    let eta = if done > 0 && done < total {
+        let remaining = elapsed.as_secs_f64() / done as f64 * (total - done) as f64;
+        format!(" · ETA ~{}s", remaining.round() as u64)
+    } else {
+        String::new()
+    };
+
+    let mut counts = format!("{tests} tests, {failed} failed");
+    if todo > 0 {
+        counts.push_str(&format!(", {todo} todo"));
+    }
+    if resolved > 0 {
+        counts.push_str(&format!(", {resolved} resolved"));
+    }
+    if skip > 0 {
+        counts.push_str(&format!(", {skip} skip"));
+    }
+
+    println!(
+        "[{}] {done}/{total} files{pct} · {counts}{eta}",
+        test::format_duration(elapsed)
+    );
+}
+
+/// Tailable default: immediate one-line notices for anything that needs
+/// attention (failures, resolved TODOs), a periodic heartbeat digest
+/// otherwise, and a final three-axis summary.
+pub(crate) struct CompactReporter {
+    state: Arc<CompactState>,
+}
+
+impl CompactReporter {
+    pub(crate) fn new(overall_start: Instant, total_files: usize) -> Self {
+        let state = Arc::new(CompactState {
+            overall_start,
+            total_files,
+            files_done: AtomicUsize::new(0),
+            tests_seen: AtomicU32::new(0),
+            tests_failed: AtomicU32::new(0),
+            todo_pending: AtomicU32::new(0),
+            todo_resolved: AtomicU32::new(0),
+            skip_files: AtomicUsize::new(0),
+            pending_tests: Mutex::new(IndexMap::default()),
+            notify: Notify::new(),
+            stop: AtomicBool::new(false),
+        });
+
+        print_heartbeat(&state);
+
+        let ticker_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            loop {
+                // Wait for the heartbeat interval, but bail out early (and
+                // restart the wait) if a failure/resolved-TODO notice fires
+                // in the meantime — avoids an immediate near-duplicate line.
+                let notified =
+                    tokio::time::timeout(HEARTBEAT_INTERVAL, ticker_state.notify.notified()).await;
+                if ticker_state.stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                if notified.is_err() {
+                    print_heartbeat(&ticker_state);
+                }
+            }
+        });
+
+        Self { state }
+    }
+
+    /// Print an immediate one-line notice and wake the heartbeat loop so
+    /// it doesn't immediately repeat the same information.
+    fn announce(&self, line: &str) {
+        println!("{line}");
+        self.state.notify.notify_one();
+    }
+
+    fn finish_file_if_done(&self, path: &str) {
+        let mut pending = self
+            .state
+            .pending_tests
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(remaining) = pending.get_mut(path) {
+            *remaining -= 1;
+            if *remaining == 0 {
+                pending.swap_remove(path);
+                drop(pending);
+                self.state.mark_file_done();
+            }
+        }
+    }
+}
+
+impl TestReporter for CompactReporter {
+    fn on_package_start(&self, _pkg_run: &PackageRun, _show_banner: bool) {
+        // Compact treats the whole invocation as one continuous run — no
+        // per-package banners, consistent with the single running total
+        // the heartbeat reports.
+    }
+
+    fn on_compile(&self, path: &str, event: CompileEvent, _duration: Duration) {
+        match event {
+            CompileEvent::Ok => {}
+            CompileEvent::TodoModule => self.state.mark_file_done(),
+            CompileEvent::Failed { detail } => {
+                self.state.mark_file_done();
+                let suffix = detail.map(|d| format!(": {d}")).unwrap_or_default();
+                self.announce(&format!("not ok  {path} (compile failed){suffix}"));
+            }
+        }
+    }
+
+    fn on_load(&self, path: &str, event: LoadEvent, _duration: Duration) {
+        match event {
+            LoadEvent::Ok { test_count: 0 } => {
+                self.state.mark_file_done();
+                self.state.skip_files.fetch_add(1, Ordering::Relaxed);
+            }
+            LoadEvent::Ok { test_count } => {
+                let mut pending = self
+                    .state
+                    .pending_tests
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                pending.insert(path.to_string(), test_count);
+            }
+            LoadEvent::Failed { detail } => {
+                self.state.mark_file_done();
+                let suffix = detail.map(|d| format!(": {d}")).unwrap_or_default();
+                self.announce(&format!("not ok  {path} (load failed){suffix}"));
+            }
+        }
+    }
+
+    fn on_test_result(&self, result: &TestResult) {
+        self.state.tests_seen.fetch_add(1, Ordering::Relaxed);
+        match result.outcome {
+            TestOutcome::Pass => {}
+            TestOutcome::Fail => {
+                self.state.tests_failed.fetch_add(1, Ordering::Relaxed);
+                let dur = test::format_duration(result.duration);
+                let detail = result
+                    .error
+                    .as_ref()
+                    .map(|e| format!("\n  {e}"))
+                    .unwrap_or_default();
+                self.announce(&format!(
+                    "not ok  {} :: {} ({dur}){detail}",
+                    result.file_path, result.display_name
+                ));
+            }
+            TestOutcome::TodoPending => {
+                self.state.todo_pending.fetch_add(1, Ordering::Relaxed);
+            }
+            TestOutcome::TodoResolved => {
+                self.state.todo_resolved.fetch_add(1, Ordering::Relaxed);
+                self.announce(&format!(
+                    "resolved  {} :: {} — remove the #[TODO] attribute",
+                    result.file_path, result.display_name
+                ));
+            }
+        }
+        self.finish_file_if_done(&result.file_path);
+    }
+
+    fn on_package_done(&self, _args: PackageDoneArgs) {
+        // Everything relevant already streamed live via the other hooks;
+        // the authoritative totals are rendered once in `on_run_done`.
+    }
+
+    fn on_run_done(&self, grand: &PackageTotals, _multi_pkg: bool, wall: Duration) {
+        self.state.stop.store(true, Ordering::Relaxed);
+        self.state.notify.notify_one();
+        println!();
+        test::print_three_axis(grand, Some(&test::format_duration(wall)));
+    }
+}
+
+/// One YAML diagnostic block (TAP13/14 `---` … `...`), rendered as a
+/// literal block scalar so multi-line error text (assertion diagnostics,
+/// wasm backtraces) needs no escaping. `indent` is the Test Point's own
+/// indentation — the block markers sit at `indent` + 2 spaces, matching
+/// the spec's "YAML indented 2 spaces past its Test Point" rule.
+fn yaml_block(indent: &str, message: &str) -> Vec<String> {
+    let mut lines = vec![format!("{indent}  ---"), format!("{indent}  message: |")];
+    for line in message.lines() {
+        lines.push(format!("{indent}    {line}"));
+    }
+    lines.push(format!("{indent}  ..."));
+    lines
+}
+
+/// One file's subtest bookkeeping: its declared test count (known once it
+/// loads, before any test runs), how many results have arrived, whether
+/// any counted as a failure, and its body lines — printed immediately if
+/// this file is the active subtest, buffered otherwise.
+struct TapFileState {
+    test_count: usize,
+    seen: usize,
+    any_failed: bool,
+    opened: bool,
+    lines: Vec<String>,
+}
+
+/// Serializes concurrent files into one valid nested TAP document.
+///
+/// TAP's subtest nesting is indentation-based, so only one subtest can be
+/// "open" in the output stream at a time — a top-level Test Point from a
+/// different, concurrently-finishing file can't be interleaved into the
+/// middle of another file's indented block without corrupting the
+/// structure. `active` names the file currently allowed to print; every
+/// other file's lines buffer in `entries`/`standalone` until their turn.
+/// This only serializes *printing* — compilation/loading/execution keep
+/// running fully concurrently underneath.
+struct TapDoc {
+    /// Subtest-bearing files, insertion-ordered. Order of *printing*
+    /// doesn't have to match registration order (TAP has no such
+    /// requirement) — `advance` just picks the first unopened entry.
+    entries: IndexMap<String, TapFileState>,
+    /// Fully-formed single-shot Test Points (compile/load failure, skip,
+    /// TODO-module) ready to print as soon as it's their turn.
+    standalone: VecDeque<String>,
+    active: Option<String>,
+}
+
+impl TapDoc {
+    fn new() -> Self {
+        Self {
+            entries: IndexMap::default(),
+            standalone: VecDeque::new(),
+            active: None,
+        }
+    }
+
+    /// Make as much progress as possible: flush queued standalone points,
+    /// then open the next unopened subtest, repeating while the document
+    /// is idle. Stops as soon as something is active (waiting on more
+    /// test results) or there's nothing left ready to print.
+    fn advance(&mut self) {
+        loop {
+            if self.active.is_some() {
+                return;
+            }
+            if let Some(block) = self.standalone.pop_front() {
+                println!("{block}");
+                continue;
+            }
+            let Some(path) = self
+                .entries
+                .iter()
+                .find(|(_, e)| !e.opened)
+                .map(|(k, _)| k.clone())
+            else {
+                return;
+            };
+            let entry = self.entries.get_mut(&path).expect("path was just found");
+            entry.opened = true;
+            println!("# Subtest: {path}");
+            println!("    1..{}", entry.test_count);
+            for line in &entry.lines {
+                println!("{line}");
+            }
+            let done = entry.seen >= entry.test_count;
+            self.active = Some(path);
+            if done {
+                self.close_active();
+            }
+        }
+    }
+
+    fn close_active(&mut self) {
+        let Some(path) = self.active.take() else {
+            return;
+        };
+        let entry = self
+            .entries
+            .swap_remove(&path)
+            .expect("active entry exists");
+        let point = if entry.any_failed { "not ok" } else { "ok" };
+        println!("{point} - {path}");
+    }
+
+    fn register_subtest(&mut self, path: String, test_count: usize) {
+        self.entries.insert(
+            path,
+            TapFileState {
+                test_count,
+                seen: 0,
+                any_failed: false,
+                opened: false,
+                lines: Vec::new(),
+            },
+        );
+        self.advance();
+    }
+
+    fn register_standalone(&mut self, block: String) {
+        self.standalone.push_back(block);
+        self.advance();
+    }
+
+    fn record_result(&mut self, path: &str, failed: bool, lines: Vec<String>) {
+        let is_active = self.active.as_deref() == Some(path);
+        let Some(entry) = self.entries.get_mut(path) else {
+            return;
+        };
+        entry.seen += 1;
+        if failed {
+            entry.any_failed = true;
+        }
+        let done = entry.seen >= entry.test_count;
+        if is_active {
+            for line in &lines {
+                println!("{line}");
+            }
+        } else {
+            entry.lines.extend(lines);
+        }
+        if is_active && done {
+            self.close_active();
+            self.advance();
+        }
+    }
+}
+
+/// TAP14 output: `TAP version 14` and a leading `1..{file count}` plan
+/// (the file count is known upfront from discovery, before anything
+/// compiles), one top-level Test Point per file, and — for files with
+/// `test` blocks — a `# Subtest:` block nesting each test's own Test
+/// Point. `#[TODO]` maps onto TAP's own `TODO` directive (the feature it
+/// was modeled on); a TODO test that unexpectedly passes is reported
+/// honestly as `ok … # TODO resolved` rather than forced to `not ok` —
+/// whether that counts as a failure is `wado test`'s own policy (see
+/// `on_run_done`/the exit code in `test::run`), not something the raw TAP
+/// text should misrepresent. Compile/load progress and the final summary
+/// are `#` comments, which TAP consumers ignore but a human or an agent
+/// tailing the stream can still read.
+pub(crate) struct TapReporter {
+    overall_start: Instant,
+    doc: Mutex<TapDoc>,
+}
+
+impl TapReporter {
+    pub(crate) fn new(overall_start: Instant, total_files: usize) -> Self {
+        println!("TAP version 14");
+        println!("1..{total_files}");
+        Self {
+            overall_start,
+            doc: Mutex::new(TapDoc::new()),
+        }
+    }
+
+    fn comment(&self, text: &str) {
+        println!(
+            "# [{}] {text}",
+            test::format_duration(self.overall_start.elapsed())
+        );
+    }
+
+    fn doc(&self) -> std::sync::MutexGuard<'_, TapDoc> {
+        self.doc
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl TestReporter for TapReporter {
+    fn on_package_start(&self, pkg_run: &PackageRun, show_banner: bool) {
+        if show_banner {
+            self.comment(&format!("package: {}", pkg_run.label));
+        }
+    }
+
+    fn on_compile(&self, path: &str, event: CompileEvent, duration: Duration) {
+        let dur = test::format_duration(duration);
+        match event {
+            CompileEvent::Ok => self.comment(&format!("Compiled {path} ({dur})")),
+            CompileEvent::TodoModule => {
+                self.comment(&format!(
+                    "Compiled {path} (TODO module, compile error expected, {dur})"
+                ));
+                self.doc().register_standalone(format!(
+                    "ok - {path} # TODO module compile error expected"
+                ));
+            }
+            CompileEvent::Failed { detail } => {
+                self.comment(&format!("FAILED to compile {path} ({dur})"));
+                let mut block = vec![format!("not ok - {path} (compile failed)")];
+                if let Some(msg) = detail {
+                    block.extend(yaml_block("", &msg));
+                }
+                self.doc().register_standalone(block.join("\n"));
+            }
+        }
+    }
+
+    fn on_load(&self, path: &str, event: LoadEvent, duration: Duration) {
+        let dur = test::format_duration(duration);
+        match event {
+            LoadEvent::Ok { test_count: 0 } => {
+                self.comment(&format!("Loaded {path} ({dur})"));
+                self.doc()
+                    .register_standalone(format!("ok - {path} # SKIP no test blocks"));
+            }
+            LoadEvent::Ok { test_count } => {
+                self.comment(&format!("Loaded {path} ({dur})"));
+                self.doc().register_subtest(path.to_string(), test_count);
+            }
+            LoadEvent::Failed { detail } => {
+                self.comment(&format!("FAILED to load {path} ({dur})"));
+                let mut block = vec![format!("not ok - {path} (load failed)")];
+                if let Some(msg) = detail {
+                    block.extend(yaml_block("", &msg));
+                }
+                self.doc().register_standalone(block.join("\n"));
+            }
+        }
+    }
+
+    fn on_test_result(&self, result: &TestResult) {
+        let dur = test::format_duration(result.duration);
+        let name = &result.display_name;
+        let (mut lines, failed) = match result.outcome {
+            TestOutcome::Pass => (vec![format!("ok - {name} ({dur})")], false),
+            TestOutcome::Fail => {
+                let mut l = vec![format!("not ok - {name} ({dur})")];
+                if let Some(ref msg) = result.error {
+                    l.extend(yaml_block("", msg));
+                }
+                (l, true)
+            }
+            TestOutcome::TodoPending => (vec![format!("not ok - {name} ({dur}) # TODO")], false),
+            TestOutcome::TodoResolved => (
+                vec![format!(
+                    "ok - {name} ({dur}) # TODO resolved — remove the #[TODO] attribute"
+                )],
+                false,
+            ),
+        };
+        // One subtest nesting level: 4-space indent on every body line,
+        // diagnostic blocks included.
+        for line in &mut lines {
+            *line = format!("    {line}");
+        }
+        self.doc().record_result(&result.file_path, failed, lines);
+    }
+
+    fn on_package_done(&self, _args: PackageDoneArgs) {
+        // Everything streams live through the other hooks; there's no
+        // per-package concept in a single TAP document.
+    }
+
+    fn on_run_done(&self, grand: &PackageTotals, _multi_pkg: bool, wall: Duration) {
+        self.comment(&format!(
+            "compile: {} ok, {} failed",
+            grand.compile_ok, grand.compile_failed
+        ));
+        if grand.load_ok + grand.load_failed > 0 {
+            self.comment(&format!(
+                "load: {} ok, {} failed",
+                grand.load_ok, grand.load_failed
+            ));
+        }
+        if grand.skip_files > 0 {
+            self.comment(&format!(
+                "skip: {} files (no test blocks)",
+                grand.skip_files
+            ));
+        }
+        self.comment(&format!(
+            "test: {} passed, {} failed",
+            grand.test_passed, grand.test_failed
+        ));
+        if grand.todo_pending + grand.todo_resolved > 0 {
+            self.comment(&format!(
+                "todo: {} pending, {} resolved",
+                grand.todo_pending, grand.todo_resolved
+            ));
+        }
+        self.comment(&format!("wall: {}", test::format_duration(wall)));
+    }
+}

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -419,7 +419,11 @@ fn test_test_tap_format_produces_a_tap14_document() {
             "not ok - wado-cli/tests/fixtures/test_fail.wado",
         ))
         .stdout(predicate::str::contains("      ---"))
-        .stdout(predicate::str::contains("      message: |"));
+        .stdout(predicate::str::contains("      message: |"))
+        // The final summary carries the same compile/load/execute [cpu: …]
+        // timing as `verbose`, as `#` comments (TAP allows arbitrary data
+        // there) — not just the pass/fail counts.
+        .stdout(predicate::str::contains("compile: 3 ok, 0 failed  [cpu:"));
 }
 
 #[test]

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -370,6 +370,71 @@ fn test_test_heartbeat_is_default_and_reports_failure_immediately() {
 }
 
 #[test]
+fn test_test_heartbeat_discards_output_from_passing_tests() {
+    // A passing test's own stdout is captured (not left to race directly
+    // onto the real stdout — see `runtime::create_test_store`); heartbeat
+    // discards it since there's nothing that needs attention.
+    wado()
+        .args(["test", "wado-cli/tests/fixtures/test_stdout.wado"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hello from the test body").not());
+}
+
+#[test]
+fn test_test_heartbeat_shows_captured_stderr_on_failure() {
+    // A failing test's captured stderr is attached to its immediate
+    // failure notice — not just discarded like a passing test's output.
+    wado()
+        .args(["test", "wado-cli/tests/fixtures/test_fail.wado"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("stderr:"))
+        .stdout(predicate::str::contains("this should fail"));
+}
+
+#[test]
+fn test_test_verbose_shows_captured_stdout_inline() {
+    // verbose is a full transcript: a passing test's own stdout prints
+    // right under its `ok` line, in order, instead of being discarded or
+    // racing directly onto the real stdout.
+    wado()
+        .args([
+            "test",
+            "--format",
+            "verbose",
+            "wado-cli/tests/fixtures/test_stdout.wado",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ok   prints and passes"))
+        .stdout(predicate::str::contains("stdout:"))
+        .stdout(predicate::str::contains("hello from the test body"));
+}
+
+#[test]
+fn test_test_tap_renders_captured_output_as_comments_or_yaml_fields() {
+    // TAP allows arbitrary `#` comments, so a passing test's captured
+    // stdout renders as one; a failing test's captured stderr instead
+    // becomes a `stderr:` field in the same YAML block as `message:`,
+    // since that's the one place TAP already gathers rich diagnostics.
+    wado()
+        .args([
+            "test",
+            "--format",
+            "tap",
+            "wado-cli/tests/fixtures/test_stdout.wado",
+            "wado-cli/tests/fixtures/test_fail.wado",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("# stdout:"))
+        .stdout(predicate::str::contains("# hello from the test body"))
+        .stdout(predicate::str::contains("stderr: |"))
+        .stdout(predicate::str::contains("this should fail"));
+}
+
+#[test]
 fn test_test_heartbeat_reports_skip_for_files_without_test_blocks() {
     // A file with zero `test` blocks still compiles and loads; the
     // `skip` axis (not silently folded into `load: N ok`) is how a

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -353,6 +353,76 @@ fn test_test_failing() {
 }
 
 #[test]
+fn test_test_compact_is_default_and_reports_failure_immediately() {
+    // `compact` is the default `--format`: no per-file `Compiled`/`Loaded`
+    // log lines and no per-test `ok`/`FAILED` lines (that's `verbose`
+    // territory) — but a failing test still gets its own `not ok` line,
+    // not just a buried count in the final summary.
+    wado()
+        .args(["test", "wado-cli/tests/fixtures/test_fail.wado"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("not ok"))
+        .stdout(predicate::str::contains("failing"))
+        .stdout(predicate::str::contains("1 passed, 1 failed"))
+        .stdout(predicate::str::contains("Compiled").not())
+        .stdout(predicate::str::contains("Running tests in").not());
+}
+
+#[test]
+fn test_test_compact_reports_skip_for_files_without_test_blocks() {
+    // A file with zero `test` blocks still compiles and loads; the
+    // `skip` axis (not silently folded into `load: N ok`) is how a
+    // developer notices "this file has no tests" rather than assuming
+    // it was covered.
+    wado()
+        .args([
+            "test",
+            "wado-cli/tests/fixtures/test_no_test_blocks.wado",
+            "wado-compiler/tests/fixtures/test_decl.wado",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "skip:    1 files (no test blocks)",
+        ))
+        .stdout(predicate::str::contains("2 passed, 0 failed"));
+}
+
+#[test]
+fn test_test_tap_format_produces_a_tap14_document() {
+    // `--format tap`: a leading version + plan (file count, known
+    // upfront), one top-level Test Point per file — `# SKIP` for a
+    // file with no `test` blocks, a `# Subtest:` block (with its own
+    // leading plan) for a file with tests, and diagnostics as a YAML
+    // block under a failing Test Point.
+    wado()
+        .args([
+            "test",
+            "--format",
+            "tap",
+            "wado-cli/tests/fixtures/test_no_test_blocks.wado",
+            "wado-compiler/tests/fixtures/test_decl.wado",
+            "wado-cli/tests/fixtures/test_fail.wado",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("TAP version 14"))
+        .stdout(predicate::str::contains("1..3"))
+        .stdout(predicate::str::contains(
+            "ok - wado-cli/tests/fixtures/test_no_test_blocks.wado # SKIP no test blocks",
+        ))
+        .stdout(predicate::str::contains(
+            "# Subtest: wado-compiler/tests/fixtures/test_decl.wado",
+        ))
+        .stdout(predicate::str::contains(
+            "not ok - wado-cli/tests/fixtures/test_fail.wado",
+        ))
+        .stdout(predicate::str::contains("      ---"))
+        .stdout(predicate::str::contains("      message: |"));
+}
+
+#[test]
 fn test_test_filter_keeps_matching_path() {
     // --filter is a path-based wildcard. `*` does not cross path
     // separators (consistent with shell glob and `.gitignore`); use `**`
@@ -394,6 +464,8 @@ fn test_test_compile_failure_reported_on_compile_axis() {
     wado()
         .args([
             "test",
+            "--format",
+            "verbose",
             "wado-cli/tests/fixtures/test_compile_error.wado",
             "wado-compiler/tests/fixtures/test_decl.wado",
         ])
@@ -438,6 +510,8 @@ fn test_test_no_run_surfaces_todo_compile_errors() {
         .args([
             "test",
             "--no-run",
+            "--format",
+            "verbose",
             "wado-compiler/tests/fixtures/module_attr_todo_compile_error.wado",
         ])
         .assert()

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -353,8 +353,8 @@ fn test_test_failing() {
 }
 
 #[test]
-fn test_test_compact_is_default_and_reports_failure_immediately() {
-    // `compact` is the default `--format`: no per-file `Compiled`/`Loaded`
+fn test_test_heartbeat_is_default_and_reports_failure_immediately() {
+    // `heartbeat` is the default `--format`: no per-file `Compiled`/`Loaded`
     // log lines and no per-test `ok`/`FAILED` lines (that's `verbose`
     // territory) — but a failing test still gets its own `not ok` line,
     // not just a buried count in the final summary.
@@ -370,7 +370,7 @@ fn test_test_compact_is_default_and_reports_failure_immediately() {
 }
 
 #[test]
-fn test_test_compact_reports_skip_for_files_without_test_blocks() {
+fn test_test_heartbeat_reports_skip_for_files_without_test_blocks() {
     // A file with zero `test` blocks still compiles and loads; the
     // `skip` axis (not silently folded into `load: N ok`) is how a
     // developer notices "this file has no tests" rather than assuming

--- a/wado-cli/tests/fixtures/test_no_test_blocks.wado
+++ b/wado-cli/tests/fixtures/test_no_test_blocks.wado
@@ -1,0 +1,7 @@
+// A file with no `test` blocks. Used to verify that `wado test` reports it
+// on the `skip` axis (loaded successfully, nothing to run) instead of
+// silently absorbing it into the load-ok count.
+
+fn answer() -> i32 {
+    return 42;
+}

--- a/wado-cli/tests/fixtures/test_stdout.wado
+++ b/wado-cli/tests/fixtures/test_stdout.wado
@@ -1,0 +1,11 @@
+// A passing test that prints. Used to verify that a test's own stdout is
+// captured (not left to race directly onto the host's stdout) and that
+// each `--format` decides for itself whether/how to show it.
+
+use { println } from "core:cli";
+
+test "prints and passes" {
+    println("hello from the test body");
+    let x = 1;
+    assert x == 1;
+}


### PR DESCRIPTION
## Summary

`wado test`'s output is now format-pluggable via `--format`, with a `TestReporter` abstraction (`wado-cli/src/test_report.rs`) decoupling the compile/load/execute pipeline from how progress gets rendered:

- **`heartbeat` (new default)**: immediate one-line notices for failures and resolved `#[TODO]`s, a periodic digest (`N/Total files · tests, failed, todo, skip · ETA`) every 5s otherwise, and a final `compile:`/`load:`/`skip:`/`test:` summary. Designed to be tailed — the last line or two is enough to read a long run's current state.
- **`verbose`**: the original behavior (per-file `Compiled`/`Loaded` lines streamed live, then every test result printed once the run drains), preserved byte-for-byte as the fallback.
- **`tap`**: a [TAP version 14](https://testanything.org/tap-version-14-specification.html) document — a leading `1..N` plan (file count, known upfront), one Test Point per file with a `# Subtest:` block for files with `test` blocks, `#[TODO]` mapped onto TAP's own `TODO` directive, and YAML diagnostic blocks for failures. Verified against Perl's `TAP::Parser`/`prove`. CI (`test-wado`, `test-gale-o1/o2/o3` in `mise.toml`) now runs with `--format tap`.

Also:

- Introduces a `skip` axis (files with zero `test` blocks), previously silently folded into `load: N ok`, surfaced in all three formats' final summary.
- A test's own stdout/stderr is now captured into an in-memory pipe (`runtime::create_test_store`) instead of inheriting the host's real stdio, so concurrently-running tests' prints no longer race directly onto the terminal. Each format decides what to do with the captured output: `verbose` shows it inline under each test, `heartbeat` discards it unless the test failed, `tap` renders it as `#` comments or folds it into the failing Test Point's YAML block.
- `AGENTS.md` documents the default's tailable behavior under a new `### Test Command` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzQuQxQeTQpQYwnGGhwmSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzQuQxQeTQpQYwnGGhwmSw)_