### PR TITLE
refactor(nir): make value-graph CSE order-independent and drop the dormant e-graph machinery

### DIFF
--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -455,17 +455,6 @@ impl<'a> Engine<'a> {
         out
     }
 
-    /// The class representative of `id` in the session's value graph. Two ids
-    /// with the same representative denote the same value. See
-    /// [`crate::nir_value_graph::ValuePool::find`].
-    pub fn value_find(
-        &mut self,
-        id: crate::nir_value_graph::ValueId,
-    ) -> crate::nir_value_graph::ValueId {
-        self.ensure_value_graph();
-        self.body.values.find(id)
-    }
-
     /// Drop the session's `&local` address-taken scan so the next
     /// [`Engine::body_address_taken`] recomputes it. The value graph is
     /// **never** dropped — it is built once and maintained in place (build-once

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -208,16 +208,11 @@ pub struct ValuePool {
     /// Next `OpaqueId` to allocate.
     next_opaque: u32,
     /// Union-find parent pointers, indexed by raw `ValueId`. `parent[i] == i`
-    /// for a class representative. [`ValuePool::union`] merges classes;
-    /// [`ValuePool::find`] resolves the representative with path halving.
+    /// for a class representative; [`ValuePool::find`] resolves the
+    /// representative with path halving. No merges happen today (CSE is pure
+    /// hash-consing), so every id is its own representative and `find` is the
+    /// identity — the field is the seam a future union-based rewrite would use.
     parent: Vec<u32>,
-    /// For each class representative (by raw id), the ids of the nodes that
-    /// reference it as a child. [`ValuePool::rebuild`] re-canonicalizes these
-    /// after a union so structurally-equal parents re-merge (congruence).
-    class_parents: IndexMap<u32, Vec<ValueId>>,
-    /// Classes merged since the last [`ValuePool::rebuild`], pending congruence
-    /// repair.
-    pending: Vec<ValueId>,
     /// Per-`ValueId` source type, indexed by raw id. `ValueKind` is type-erased
     /// (an `Int(u64)` carries no width), so extraction — which materialises a
     /// promoted `Operand::Value` back to WIR once the typed `ExprNode` is gone —
@@ -235,9 +230,6 @@ pub struct ValuePool {
     /// dropped them) share a single identity — the precondition for matching the
     /// guard's and check's copies of an induction variable or a hoisted bound.
     canonical_locals: IndexMap<u32, ValueId>,
-    /// Same, for a global receiver (keyed by module + name); see
-    /// [`ValuePool::canonical_global`].
-    canonical_globals: IndexMap<String, ValueId>,
 }
 
 /// How the extractor re-emits an [`OpaqueId`]'s value (see
@@ -271,8 +263,7 @@ impl ValuePool {
 
     /// Hash-cons: return the `ValueId` for `kind`, allocating a fresh one if no
     /// structurally-equal value exists. Children are canonicalized to their
-    /// class representatives first, so a node whose children were unioned dedups
-    /// against the congruent existing node.
+    /// class representatives first (a no-op today — see [`ValuePool::find`]).
     ///
     /// `kind` is cloned only on a fresh allocation (the clone goes into the
     /// `values` vector); a repeat lookup hits the index and returns the
@@ -296,7 +287,6 @@ impl ValuePool {
         };
         self.values.push(kind.clone());
         self.types.push(carried_type);
-        self.register_parent_links(id, &kind);
         self.interned.insert(kind, id);
         id
     }
@@ -359,87 +349,8 @@ impl ValuePool {
         ValueId(x)
     }
 
-    /// Merge the classes of `a` and `b`, returning the surviving representative
-    /// (the smaller raw id, for determinism). The merge is recorded for the
-    /// next [`ValuePool::rebuild`], which restores congruence. A no-op (and
-    /// nothing pending) when they already share a class.
-    pub fn union(&mut self, a: ValueId, b: ValueId) -> ValueId {
-        let ra = self.find(a);
-        let rb = self.find(b);
-        if ra == rb {
-            return ra;
-        }
-        // Prefer a constant representative: a class containing a literal should
-        // resolve to it, so extraction materializes the constant. Among equal
-        // ranks, the smaller raw id wins, for determinism.
-        let (ra_rank, rb_rank) = (self.rep_rank(ra), self.rep_rank(rb));
-        let ra_wins = ra_rank < rb_rank || (ra_rank == rb_rank && ra.0 <= rb.0);
-        let (win, lose) = if ra_wins { (ra, rb) } else { (rb, ra) };
-        self.parent[lose.0 as usize] = win.0;
-        // Keep a known type on the surviving representative.
-        if self.types[win.0 as usize].is_none() {
-            self.types[win.0 as usize] = self.types[lose.0 as usize];
-        }
-        if let Some(losers) = self.class_parents.swap_remove(&lose.0) {
-            self.class_parents.entry(win.0).or_default().extend(losers);
-        }
-        self.pending.push(win);
-        win
-    }
-
-    /// Restore congruence after a batch of unions: re-canonicalize the parents
-    /// of every merged class and re-merge any that became structurally equal,
-    /// to a fixed point. Cheap when nothing was unioned (empty `pending`).
-    pub fn rebuild(&mut self) {
-        while let Some(c) = self.pending.pop() {
-            let c = self.find(c);
-            self.repair(c);
-        }
-    }
-
-    /// Re-canonicalize and re-hash-cons the parents of class `c`, unioning any
-    /// pair that now denotes the same node. See [`ValuePool::rebuild`].
-    fn repair(&mut self, c: ValueId) {
-        let parents = self.class_parents.get(&c.0).cloned().unwrap_or_default();
-        // Drop every parent's stale memo entry before re-inserting, so a
-        // canonical kind that now collides with another parent is detected.
-        for &p in &parents {
-            let old = self.values[p.0 as usize].clone();
-            self.interned.swap_remove(&old);
-        }
-        for &p in &parents {
-            let canon = self.canonicalize(self.values[p.0 as usize].clone());
-            self.values[p.0 as usize] = canon.clone();
-            match self.interned.get(&canon).copied() {
-                Some(q) if self.find(q) != self.find(p) => {
-                    self.union(p, q);
-                    let r = self.find(p);
-                    self.interned.insert(canon, r);
-                }
-                _ => {
-                    let r = self.find(p);
-                    self.interned.insert(canon, r);
-                }
-            }
-        }
-    }
-
-    /// Representative-preference rank for `id`: a constant kind ranks 0 (most
-    /// preferred), everything else 1. [`ValuePool::union`] keeps the
-    /// lower-ranked side, so a class containing a literal resolves to it.
-    fn rep_rank(&self, id: ValueId) -> u8 {
-        match self.values[id.0 as usize] {
-            ValueKind::Int(_, _)
-            | ValueKind::Float(_, _)
-            | ValueKind::Bool(_)
-            | ValueKind::Char(_)
-            | ValueKind::Null
-            | ValueKind::Unit => 0,
-            _ => 1,
-        }
-    }
-
-    /// Replace each child of `kind` with its class representative.
+    /// Replace each child of `kind` with its class representative (the identity
+    /// today — [`ValuePool::find`] never merges).
     fn canonicalize(&mut self, kind: ValueKind) -> ValueKind {
         match kind {
             ValueKind::Binary { op, lhs, rhs, ty } => ValueKind::Binary {
@@ -479,27 +390,6 @@ impl ValuePool {
         }
     }
 
-    /// Register `id` as a parent of each of its (already-canonical) children's
-    /// classes, so a later union of a child re-canonicalizes `id`.
-    fn register_parent_links(&mut self, id: ValueId, kind: &ValueKind) {
-        for child in Self::child_values(kind) {
-            self.class_parents.entry(child.0).or_default().push(id);
-        }
-    }
-
-    /// The child `ValueId`s referenced by `kind` (empty for literals / opaque).
-    fn child_values(kind: &ValueKind) -> Vec<ValueId> {
-        match *kind {
-            ValueKind::Binary { lhs, rhs, .. } => vec![lhs, rhs],
-            ValueKind::Unary { operand, .. } => vec![operand],
-            ValueKind::Cast { operand, .. } => vec![operand],
-            ValueKind::Select { cond, then, else_ } => vec![cond, then, else_],
-            ValueKind::LoopPhi { entry, body_iter } => vec![entry, body_iter],
-            ValueKind::FieldAccess { receiver, .. } => vec![receiver],
-            _ => Vec::new(),
-        }
-    }
-
     /// Allocate a fresh `Opaque` value. Each call returns a `ValueId`
     /// distinct from every prior call to `fresh_opaque` on this pool.
     pub fn fresh_opaque(&mut self) -> ValueId {
@@ -533,33 +423,6 @@ impl ValuePool {
         let v = self.fresh_opaque_with_source(OpaqueSource::Local(idx));
         self.set_type(v, ty);
         self.canonical_locals.insert(idx, v);
-        v
-    }
-
-    /// The build's existing `Opaque(Local idx)` value if one was minted (a
-    /// parameter's `seed_params` opaque). Reusing it — rather than a fresh
-    /// `canonical_local` — lets a re-seeded leaf read match a *promoted* operand
-    /// that survived carrying the same build value (`pos + k` over the param's
-    /// `pos`). `None` when no such opaque exists (a non-param leaf).
-    pub fn existing_local_opaque(&mut self, idx: u32) -> Option<ValueId> {
-        let oid = self.opaque_sources.iter().find_map(|(&oid, src)| {
-            matches!(src, OpaqueSource::Local(i) if *i == idx).then_some(oid)
-        })?;
-        Some(self.intern(ValueKind::Opaque(oid)))
-    }
-
-    /// A stable opaque for a global, keyed by `key` (module + name). Like
-    /// [`ValuePool::canonical_local`] but for a `GlobalVarGet` receiver, so two
-    /// field copies of the same `global.field` share a receiver identity. The
-    /// opaque has no extraction source — it appears only as a re-seed receiver,
-    /// never promoted into an operand slot.
-    pub fn canonical_global(&mut self, key: &str, ty: TypeId) -> ValueId {
-        if let Some(&v) = self.canonical_globals.get(key) {
-            return v;
-        }
-        let v = self.fresh_opaque();
-        self.set_type(v, ty);
-        self.canonical_globals.insert(key.to_string(), v);
         v
     }
 
@@ -847,17 +710,13 @@ impl ValuePool {
 
     /// Patch the `body_iter` of a phi made by [`ValuePool::alloc_loop_phi`] to the
     /// loop body's exit value (which may reference `phi` itself — a sound
-    /// self-reference, traversals are visited-set/stop-at-phi guarded). Registers
-    /// the (now final) child links so a later union of `entry` / `body_iter`
-    /// re-canonicalizes the phi.
+    /// self-reference, traversals are visited-set/stop-at-phi guarded).
     pub fn set_loop_phi_body_iter(&mut self, phi: ValueId, body_iter: ValueId) {
         let entry = match self.values[phi.0 as usize] {
             ValueKind::LoopPhi { entry, .. } => entry,
             ref k => panic!("set_loop_phi_body_iter on non-phi {k:?}"),
         };
-        let kind = ValueKind::LoopPhi { entry, body_iter };
-        self.register_parent_links(phi, &kind);
-        self.values[phi.0 as usize] = kind;
+        self.values[phi.0 as usize] = ValueKind::LoopPhi { entry, body_iter };
     }
 
     #[inline]
@@ -1222,100 +1081,5 @@ mod tests {
         let b = pool.fresh_opaque();
         assert_eq!(pool.find(a), a);
         assert_eq!(pool.find(b), b);
-    }
-
-    #[test]
-    fn union_makes_find_agree() {
-        let mut pool = ValuePool::new();
-        let a = pool.fresh_opaque();
-        let b = pool.fresh_opaque();
-        assert_ne!(pool.find(a), pool.find(b));
-        let rep = pool.union(a, b);
-        assert_eq!(pool.find(a), rep);
-        assert_eq!(pool.find(b), rep);
-    }
-
-    #[test]
-    fn union_is_idempotent_and_keeps_smaller_id() {
-        let mut pool = ValuePool::new();
-        let a = pool.fresh_opaque();
-        let b = pool.fresh_opaque();
-        let rep1 = pool.union(a, b);
-        let rep2 = pool.union(b, a);
-        assert_eq!(rep1, rep2);
-        // The smaller raw id is the representative.
-        assert_eq!(rep1, if a.index() <= b.index() { a } else { b });
-    }
-
-    #[test]
-    fn rebuild_propagates_congruence_to_parents() {
-        // f = Add(a, c), g = Add(b, c). After union(a, b) + rebuild, the two
-        // sums denote the same value and must share a representative.
-        let mut pool = ValuePool::new();
-        let a = pool.fresh_opaque();
-        let b = pool.fresh_opaque();
-        let c = pool.fresh_opaque();
-        let f = pool.binary(NirBinaryOp::Add, a, c, crate::tir::TypeTable::I32);
-        let g = pool.binary(NirBinaryOp::Add, b, c, crate::tir::TypeTable::I32);
-        assert_ne!(pool.find(f), pool.find(g));
-        pool.union(a, b);
-        pool.rebuild();
-        assert_eq!(pool.find(f), pool.find(g));
-    }
-
-    #[test]
-    fn congruence_propagates_through_two_levels() {
-        // Neg(Add(a,c)) ≡ Neg(Add(b,c)) once a ≡ b.
-        let mut pool = ValuePool::new();
-        let a = pool.fresh_opaque();
-        let b = pool.fresh_opaque();
-        let c = pool.fresh_opaque();
-        let f = pool.binary(NirBinaryOp::Add, a, c, crate::tir::TypeTable::I32);
-        let g = pool.binary(NirBinaryOp::Add, b, c, crate::tir::TypeTable::I32);
-        let nf = pool.unary(NirUnaryOp::Neg, f, crate::tir::TypeTable::I32);
-        let ng = pool.unary(NirUnaryOp::Neg, g, crate::tir::TypeTable::I32);
-        pool.union(a, b);
-        pool.rebuild();
-        assert_eq!(pool.find(nf), pool.find(ng));
-    }
-
-    #[test]
-    fn interning_after_union_dedups_against_congruent_node() {
-        // Build Add(a,c); union a≡b; a fresh Add(b,c) interns to the same id.
-        let mut pool = ValuePool::new();
-        let a = pool.fresh_opaque();
-        let b = pool.fresh_opaque();
-        let c = pool.fresh_opaque();
-        let f = pool.binary(NirBinaryOp::Add, a, c, crate::tir::TypeTable::I32);
-        pool.union(a, b);
-        pool.rebuild();
-        let g = pool.binary(NirBinaryOp::Add, b, c, crate::tir::TypeTable::I32);
-        assert_eq!(pool.find(f), pool.find(g));
-    }
-
-    #[test]
-    fn unrelated_values_stay_distinct_after_union() {
-        let mut pool = ValuePool::new();
-        let a = pool.fresh_opaque();
-        let b = pool.fresh_opaque();
-        let c = pool.fresh_opaque();
-        let d = pool.fresh_opaque();
-        let f = pool.binary(NirBinaryOp::Add, a, c, crate::tir::TypeTable::I32);
-        let h = pool.binary(NirBinaryOp::Add, c, d, crate::tir::TypeTable::I32);
-        pool.union(a, b);
-        pool.rebuild();
-        // `h` shares no unioned operand with `f`, so it stays its own class.
-        assert_ne!(pool.find(f), pool.find(h));
-    }
-
-    #[test]
-    fn rebuild_without_union_is_noop() {
-        let mut pool = ValuePool::new();
-        let a = pool.fresh_opaque();
-        let c = pool.fresh_opaque();
-        let f = pool.binary(NirBinaryOp::Add, a, c, crate::tir::TypeTable::I32);
-        pool.rebuild();
-        assert_eq!(pool.find(f), f);
-        assert_eq!(pool.find(a), a);
     }
 }

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -1,7 +1,9 @@
-//! NIR Value Graph (Layer 2 — pure-value e-graph).
+//! NIR Value Graph (Layer 2 — hash-consed pure-value DAG).
 //!
 //! Hash-consed DAG of pure values. Each value has a [`ValueId`] (newtype
-//! over `u32`); two structurally-equivalent values share one `ValueId`. The
+//! over `u32`); two structurally-equivalent values share one `ValueId`. CSE is
+//! pure hash-consing — there are no e-class merges, so a `ValueId` is stable
+//! once allocated. The
 //! `SkelTree` (Layer 1 — see [`crate::nir_arena`]) references pure operands by
 //! `ValueId`; pure values live exclusively here.
 //!
@@ -198,21 +200,13 @@ pub enum ValueKind {
 #[derive(Debug, Default, Clone)]
 pub struct ValuePool {
     /// Allocated values, in `ValueId` order. `values[id.index() as usize]`
-    /// is the kind for `id`, with its children canonicalized to their class
-    /// representatives. A non-representative id's entry is read only via
-    /// [`ValuePool::find`].
+    /// is the kind for `id`. CSE is pure hash-consing (no e-class merges), so a
+    /// `ValueId` is stable once allocated and needs no representative lookup.
     values: Vec<ValueKind>,
-    /// Reverse index: canonical kind → `ValueId`. The hash-cons (e-graph memo).
-    /// Keyed by a kind whose children are class representatives.
+    /// Reverse index: kind → `ValueId`. The hash-cons memo.
     interned: IndexMap<ValueKind, ValueId>,
     /// Next `OpaqueId` to allocate.
     next_opaque: u32,
-    /// Union-find parent pointers, indexed by raw `ValueId`. `parent[i] == i`
-    /// for a class representative; [`ValuePool::find`] resolves the
-    /// representative with path halving. No merges happen today (CSE is pure
-    /// hash-consing), so every id is its own representative and `find` is the
-    /// identity — the field is the seam a future union-based rewrite would use.
-    parent: Vec<u32>,
     /// Per-`ValueId` source type, indexed by raw id. `ValueKind` is type-erased
     /// (an `Int(u64)` carries no width), so extraction — which materialises a
     /// promoted `Operand::Value` back to WIR once the typed `ExprNode` is gone —
@@ -262,19 +256,16 @@ impl ValuePool {
     }
 
     /// Hash-cons: return the `ValueId` for `kind`, allocating a fresh one if no
-    /// structurally-equal value exists. Children are canonicalized to their
-    /// class representatives first (a no-op today — see [`ValuePool::find`]).
+    /// structurally-equal value exists.
     ///
     /// `kind` is cloned only on a fresh allocation (the clone goes into the
     /// `values` vector); a repeat lookup hits the index and returns the
     /// existing id without copying.
     pub fn intern(&mut self, kind: ValueKind) -> ValueId {
-        let kind = self.canonicalize(kind);
         if let Some(&id) = self.interned.get(&kind) {
-            return self.find(id);
+            return id;
         }
         let id = ValueId(self.values.len() as u32);
-        self.parent.push(id.0);
         // A typed literal carries its width in the kind; record it so extraction
         // (which reads `type_of`) sees it without a separate `set_type` call.
         let carried_type = match kind {
@@ -292,16 +283,13 @@ impl ValuePool {
     }
 
     /// Record the source type of a value (its NIR `ExprNode` type before
-    /// promotion). Idempotent; a later call overwrites. Stored on `id`'s own raw
-    /// slot — resolve the representative with [`ValuePool::find`] before reading
-    /// if the class may have been unioned.
+    /// promotion). Idempotent; a later call overwrites.
     #[inline]
     pub fn set_type(&mut self, id: ValueId, type_id: TypeId) {
         self.types[id.0 as usize] = Some(type_id);
     }
 
-    /// The recorded source type of `id`, if any. Prefer passing a representative
-    /// (`find(id)`); a non-representative slot may be unset.
+    /// The recorded source type of `id`, if any.
     #[inline]
     pub fn type_of(&self, id: ValueId) -> Option<TypeId> {
         self.types[id.0 as usize]
@@ -323,71 +311,8 @@ impl ValuePool {
     pub fn alloc_unshared(&mut self, kind: ValueKind, type_id: TypeId) -> ValueId {
         let id = ValueId(self.values.len() as u32);
         self.values.push(kind);
-        self.parent.push(id.0);
         self.types.push(Some(type_id));
         id
-    }
-
-    /// The class representative of `id`, with path halving.
-    pub fn find(&mut self, id: ValueId) -> ValueId {
-        let mut x = id.0;
-        while self.parent[x as usize] != x {
-            let gp = self.parent[self.parent[x as usize] as usize];
-            self.parent[x as usize] = gp;
-            x = gp;
-        }
-        ValueId(x)
-    }
-
-    /// Class representative without path compression — the `&self` form of
-    /// [`ValuePool::find`], for read-only walks that cannot take `&mut`.
-    pub fn find_imm(&self, id: ValueId) -> ValueId {
-        let mut x = id.0;
-        while self.parent[x as usize] != x {
-            x = self.parent[x as usize];
-        }
-        ValueId(x)
-    }
-
-    /// Replace each child of `kind` with its class representative (the identity
-    /// today — [`ValuePool::find`] never merges).
-    fn canonicalize(&mut self, kind: ValueKind) -> ValueKind {
-        match kind {
-            ValueKind::Binary { op, lhs, rhs, ty } => ValueKind::Binary {
-                op,
-                lhs: self.find(lhs),
-                rhs: self.find(rhs),
-                ty,
-            },
-            ValueKind::Unary { op, operand, ty } => ValueKind::Unary {
-                op,
-                operand: self.find(operand),
-                ty,
-            },
-            ValueKind::Cast { operand, target } => ValueKind::Cast {
-                operand: self.find(operand),
-                target,
-            },
-            ValueKind::Select { cond, then, else_ } => ValueKind::Select {
-                cond: self.find(cond),
-                then: self.find(then),
-                else_: self.find(else_),
-            },
-            ValueKind::LoopPhi { entry, body_iter } => ValueKind::LoopPhi {
-                entry: self.find(entry),
-                body_iter: self.find(body_iter),
-            },
-            ValueKind::FieldAccess {
-                receiver,
-                field_index,
-                heap_ver,
-            } => ValueKind::FieldAccess {
-                receiver: self.find(receiver),
-                field_index,
-                heap_ver,
-            },
-            leaf => leaf,
-        }
     }
 
     /// Allocate a fresh `Opaque` value. Each call returns a `ValueId`
@@ -448,11 +373,10 @@ impl ValuePool {
         let mut stack = vec![v];
         let mut seen: IndexSet<ValueId> = IndexSet::default();
         while let Some(v) = stack.pop() {
-            let rep = self.find_imm(v);
-            if !seen.insert(rep) {
+            if !seen.insert(v) {
                 continue;
             }
-            match self.kind(rep).clone() {
+            match self.kind(v).clone() {
                 ValueKind::Opaque(oid) => {
                     if let Some(OpaqueSource::Local(idx)) = self.opaque_source(oid) {
                         out.insert(idx);
@@ -512,8 +436,7 @@ impl ValuePool {
         id: ValueId,
         mut_locals: &IndexSet<u32>,
     ) -> bool {
-        let rep = self.find(id);
-        match self.kind(rep).clone() {
+        match self.kind(id).clone() {
             ValueKind::Int(_, _)
             | ValueKind::Float(_, _)
             | ValueKind::Bool(_)
@@ -566,22 +489,21 @@ impl ValuePool {
     }
 
     fn dup_work_walk(&mut self, v: ValueId, seen: &mut IndexSet<ValueId>) -> bool {
-        let rep = self.find(v);
-        match self.kind(rep).clone() {
+        match self.kind(v).clone() {
             ValueKind::Binary { lhs, rhs, .. } => {
-                if !seen.insert(rep) {
+                if !seen.insert(v) {
                     return true;
                 }
                 self.dup_work_walk(lhs, seen) || self.dup_work_walk(rhs, seen)
             }
             ValueKind::Unary { operand, .. } => {
-                if !seen.insert(rep) {
+                if !seen.insert(v) {
                     return true;
                 }
                 self.dup_work_walk(operand, seen)
             }
             ValueKind::Select { cond, then, else_ } => {
-                if !seen.insert(rep) {
+                if !seen.insert(v) {
                     return true;
                 }
                 self.dup_work_walk(cond, seen)
@@ -660,9 +582,7 @@ impl ValuePool {
     }
 
     pub fn select(&mut self, cond: ValueId, then: ValueId, else_: ValueId) -> ValueId {
-        let t = self.find(then);
-        let e = self.find(else_);
-        let c = self.find(cond);
+        let (t, e, c) = (then, else_, cond);
         // A constant condition selects one arm: `Select(true, a, _) → a`,
         // `Select(false, _, b) → b`. Recovers `false || x` / `true && x` → `x`,
         // which lower to a const-condition merge under operand promotion.
@@ -1070,16 +990,5 @@ mod tests {
         assert_eq!(_t, t2);
         // 4 originals + 1 new opaque = 5 entries.
         assert_eq!(pool.len(), 5);
-    }
-
-    // ---- Union-find / congruence ----
-
-    #[test]
-    fn fresh_value_is_its_own_representative() {
-        let mut pool = ValuePool::new();
-        let a = pool.int_typed(1, crate::tir::TypeTable::I32);
-        let b = pool.fresh_opaque();
-        assert_eq!(pool.find(a), a);
-        assert_eq!(pool.find(b), b);
     }
 }

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -730,11 +730,10 @@ impl<'a> Builder<'a> {
         } else {
             self.mut_escaped.iter().copied().collect()
         };
-        // Mint the fresh opaques in a canonical order (ascending local index),
-        // not `mut_escaped`'s alias-set insertion order. Opaque `ValueId`s are
-        // allocated in mint order, so this keeps the whole value graph — and the
-        // CSE / extraction it feeds — a deterministic function of the program,
-        // independent of how the alias sets were built (issue #1440).
+        // Mint the opaques by ascending local index, not `mut_escaped`'s
+        // insertion order: opaque `ValueId`s are handed out in mint order, so
+        // this keeps the value graph a deterministic function of the program
+        // regardless of how the alias sets were built (#1440).
         targets.sort_unstable();
         for l in targets {
             self.heap_state.bump_local(l);
@@ -2204,8 +2203,6 @@ mod tests {
         assert_eq!(body.values.type_of(v), Some(TypeTable::I32));
     }
 
-    // ----- Order-independent CSE (issue #1440) -----
-
     /// `f(); a + b`, where locals `a` (0) and `b` (1) are both mutably escaped:
     /// the call re-mints an opaque for each, and the `a + b` that follows reads
     /// those post-call opaques. Opaque `ValueId`s are handed out in mint order,
@@ -2291,7 +2288,6 @@ mod tests {
             body.values.values
         };
 
-        // Same set, opposite insertion order: the graph must be byte-identical.
         assert_eq!(build_with(&escaped([0, 1])), build_with(&escaped([1, 0])));
     }
 }

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -343,11 +343,11 @@ pub(crate) fn build_scoped(
     out
 }
 
-/// Whether `id`'s value (resolved through its e-class) is a constant literal — a
-/// build-context-free value safe to freeze into an operand at the early freeze
-/// (see `extract::freeze_pure_arith`'s constant-leaf promotion).
+/// Whether `id`'s value is a constant literal — a build-context-free value safe
+/// to freeze into an operand at the early freeze (see
+/// `extract::freeze_pure_arith`'s constant-leaf promotion).
 pub(crate) fn is_const_value(pool: &ValuePool, id: ValueId) -> bool {
-    is_const_kind(pool.kind(pool.find_imm(id)))
+    is_const_kind(pool.kind(id))
 }
 
 /// Whether a `ValueKind` is a constant literal (carries no build-local context).
@@ -721,7 +721,7 @@ impl<'a> Builder<'a> {
     /// `mut_escaped` receiver's field version stable across it.
     fn bump_call_effects(&mut self, call: ExprId) {
         let pure = self.pure_calls.contains(&call);
-        let targets: Vec<u32> = if pure {
+        let mut targets: Vec<u32> = if pure {
             self.mut_escaped
                 .iter()
                 .filter(|l| self.untrackable.contains(*l))
@@ -730,6 +730,12 @@ impl<'a> Builder<'a> {
         } else {
             self.mut_escaped.iter().copied().collect()
         };
+        // Mint the fresh opaques in a canonical order (ascending local index),
+        // not `mut_escaped`'s alias-set insertion order. Opaque `ValueId`s are
+        // allocated in mint order, so this keeps the whole value graph — and the
+        // CSE / extraction it feeds — a deterministic function of the program,
+        // independent of how the alias sets were built (issue #1440).
+        targets.sort_unstable();
         for l in targets {
             self.heap_state.bump_local(l);
             // A `&mut`-escaped local's *scalar* value can also be overwritten by
@@ -856,11 +862,11 @@ impl<'a> Builder<'a> {
         id
     }
 
-    /// Walk an operand: a promoted pure value resolves through the pool; an
-    /// effectful subtree walks its skeleton.
+    /// Walk an operand: a promoted pure value is its own id; an effectful
+    /// subtree walks its skeleton.
     fn walk_operand(&mut self, op: Operand) -> Option<ValueId> {
         match op {
-            Operand::Value(v) => Some(self.pool.find(v)),
+            Operand::Value(v) => Some(v),
             Operand::Expr(e) => self.walk_expr(e),
         }
     }
@@ -1797,8 +1803,7 @@ impl<'a> Builder<'a> {
             let Some(&entry) = self.current_value.get(idx) else {
                 continue;
             };
-            let rep = self.pool.find(entry);
-            let phi = match self.pool.type_of(rep) {
+            let phi = match self.pool.type_of(entry) {
                 Some(ty) => {
                     let phi = self.pool.alloc_loop_phi(entry, ty);
                     phis.push((*idx, phi));
@@ -2197,5 +2202,96 @@ mod tests {
             unreachable!("int_lit yields a pool value")
         };
         assert_eq!(body.values.type_of(v), Some(TypeTable::I32));
+    }
+
+    // ----- Order-independent CSE (issue #1440) -----
+
+    /// `f(); a + b`, where locals `a` (0) and `b` (1) are both mutably escaped:
+    /// the call re-mints an opaque for each, and the `a + b` that follows reads
+    /// those post-call opaques. Opaque `ValueId`s are handed out in mint order,
+    /// so a build that minted them in `mut_escaped`'s iteration order would
+    /// produce a differently-shaped graph under a permuted set.
+    fn call_then_add_body() -> Body {
+        use crate::nir::{FuncId, NirLocal};
+        use crate::nir_arena::{BlockNode, ExprNode, StmtNode};
+        use crate::token::Span;
+        let span = Span::new(0, 0, 0, 0);
+        let mut b = Body::empty();
+        let mut_local = |name: &str| NirLocal {
+            name: name.to_string(),
+            type_id: TypeTable::I32,
+            is_mut: true,
+        };
+        b.locals = vec![mut_local("a"), mut_local("b")];
+        let call = b.exprs.push(ExprNode {
+            kind: ExprKind::Call {
+                func_id: FuncId::from_u32(0),
+                type_args: vec![],
+                args: vec![],
+            },
+            type_id: TypeTable::I32,
+            span,
+        });
+        let read = |b: &mut Body, index: u32, name: &str| {
+            Operand::Expr(b.exprs.push(ExprNode {
+                kind: ExprKind::Local {
+                    index,
+                    name: name.to_string(),
+                },
+                type_id: TypeTable::I32,
+                span,
+            }))
+        };
+        let left = read(&mut b, 0, "a");
+        let right = read(&mut b, 1, "b");
+        let add = b.exprs.push(ExprNode {
+            kind: ExprKind::Binary {
+                left,
+                op: NirBinaryOp::Add,
+                right,
+            },
+            type_id: TypeTable::I32,
+            span,
+        });
+        let s_call = b.stmts.push(StmtNode {
+            kind: StmtKind::Expr(Operand::Expr(call)),
+            span,
+        });
+        let s_add = b.stmts.push(StmtNode {
+            kind: StmtKind::Expr(Operand::Expr(add)),
+            span,
+        });
+        b.root = b.blocks.push(BlockNode {
+            stmts: vec![s_call, s_add],
+            span,
+        });
+        b
+    }
+
+    #[test]
+    fn cse_independent_of_mut_escaped_iteration_order() {
+        use crate::hashmap::IndexSet;
+        let empty = IndexSet::default();
+        let no_calls = IndexSet::default();
+        let no_callees = IndexSet::default();
+        let escaped = |order: [u32; 2]| order.into_iter().collect::<IndexSet<u32>>();
+
+        let build_with = |mut_escaped: &IndexSet<u32>| {
+            let mut body = call_then_add_body();
+            build(
+                &mut body,
+                &[],
+                &empty,
+                &empty,
+                mut_escaped,
+                &no_calls,
+                &no_callees,
+                None,
+            );
+            body.values.values
+        };
+
+        // Same set, opposite insertion order: the graph must be byte-identical.
+        assert_eq!(build_with(&escaped([0, 1])), build_with(&escaped([1, 0])));
     }
 }

--- a/wado-compiler/src/optimize/extract.rs
+++ b/wado-compiler/src/optimize/extract.rs
@@ -2,22 +2,19 @@
 //! `SkelTree`.
 //!
 //! In the live-ValueGraph design (see
-//! `docs/wep-2026-06-15-live-value-graph.md`) pure-value rewrites prove
-//! equivalences by unioning e-classes rather than editing the skeleton. A read
-//! of an expression's value therefore goes through the class representative
-//! ([`Engine::value_find`]); the extractor walks the skeleton and lowers each
-//! pure operand to the representative's chosen concrete form.
+//! `docs/wep-2026-06-15-live-value-graph.md`) an expression's value is a
+//! hash-consed [`ValueId`]; the extractor walks the skeleton and lowers each
+//! pure operand to that value's concrete form.
 //!
-//! This is the literal case — the keystone every union-based pure-value rule
-//! reuses: an expression whose representative is a constant (`Int` / `Float` /
-//! `Bool` / `Char`) is replaced by that literal. The share-vs-duplicate cost
-//! model for non-literal multi-use values is a later step; constants are always
-//! cheaper to rematerialize than to share, so they need no cost decision.
+//! This is the literal case: an expression whose value is a constant (`Int` /
+//! `Float` / `Bool` / `Char`) is replaced by that literal. The share-vs-duplicate
+//! cost model for non-literal multi-use values is a later step; constants are
+//! always cheaper to rematerialize than to share, so they need no cost decision.
 //!
 //! [`extract_const`] is the shared materialization primitive, used in
 //! production by `store_load_forward`. [`ExtractLiteralRule`] (the worklist
-//! rule form) is exercised by unit tests until the first union-producing
-//! pure-value pass wires it into a combined session.
+//! rule form) is exercised by unit tests until the first value-rewrite pass
+//! wires it into a combined session.
 #![allow(dead_code)]
 
 use crate::nir_arena::{ExprId, ExprKind, NodeRef, StmtKind};
@@ -38,8 +35,7 @@ impl Rule for ExtractLiteralRule {
         let Some(vid) = e.value(id) else {
             return false;
         };
-        let rep = e.value_find(vid);
-        let Some(value) = extract_const(e, rep, id) else {
+        let Some(value) = extract_const(e, vid, id) else {
             return false;
         };
         // Promote the node to the pooled constant in its parent slot (WEP: The
@@ -250,13 +246,12 @@ fn receiver_available_at(
 #[must_use]
 fn record_value_tree_types(e: &mut Engine, v: ValueId, type_id: crate::tir::TypeId) -> bool {
     use crate::nir_value_graph::ValueKind;
-    let rep = e.body.values.find(v);
-    match e.body.values.type_of(rep) {
+    match e.body.values.type_of(v) {
         Some(existing) if existing != type_id => return false,
         Some(_) => {}
-        None => e.body.values.set_type(rep, type_id),
+        None => e.body.values.set_type(v, type_id),
     }
-    match e.body.values.kind(rep).clone() {
+    match e.body.values.kind(v).clone() {
         ValueKind::Binary { lhs, rhs, .. } => {
             record_value_tree_types(e, lhs, type_id) && record_value_tree_types(e, rhs, type_id)
         }
@@ -385,18 +380,15 @@ pub(super) fn freeze_pure_arith(
                 && leaf_root_stable
                 && !is_place_read(&engine, id)
                 && let Some(vid) = engine.value(id)
+                && crate::nir_value_graph::builder::is_const_value(&engine.body.values, vid)
             {
-                let rep = engine.value_find(vid);
-                if crate::nir_value_graph::builder::is_const_value(&engine.body.values, rep) {
-                    to_freeze.push((id, rep));
-                    continue;
-                }
+                to_freeze.push((id, vid));
+                continue;
             }
             if !is_pure_arith(&engine, id, include_fields) {
                 continue;
             }
-            if let Some(vid) = engine.value(id) {
-                let rep = engine.value_find(vid);
+            if let Some(rep) = engine.value(id) {
                 // A standalone `FieldAccess` is reemittable when its receiver is
                 // (it materialises via the source-point path). For every other
                 // value, `FieldAccess` is non-reemittable (it cannot be inlined),

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -1789,9 +1789,8 @@ fn cse_operand_in_scope(
     match op {
         Operand::Expr(e) => cse_clone_in_scope(engine, e, min_i, toplevel_lets, loop_body),
         Operand::Value(v) => {
-            let rep = engine.body.values.find_imm(v);
             let mut leaves: IndexSet<u32> = IndexSet::default();
-            engine.body.values.collect_opaque_locals(rep, &mut leaves);
+            engine.body.values.collect_opaque_locals(v, &mut leaves);
             leaves
                 .iter()
                 .all(|&idx| cse_local_available(engine, idx, min_i, toplevel_lets, loop_body))
@@ -2140,11 +2139,10 @@ fn hoist_invariant_value_operands(
     let mut leaf_locals: IndexSet<u32> = IndexSet::default();
     for op in &ops {
         if let Operand::Value(v) = *op {
-            let rep = engine.body.values.find_imm(v);
             engine
                 .body
                 .values
-                .collect_opaque_locals(rep, &mut leaf_locals);
+                .collect_opaque_locals(v, &mut leaf_locals);
         }
     }
     let mut entry_locals: IndexSet<u32> = IndexSet::default();
@@ -2158,8 +2156,7 @@ fn hoist_invariant_value_operands(
     // order, and materialise a pre-header temp + read value for each.
     let mut rep_read: IndexMap<ValueId, ValueId> = IndexMap::default();
     for op in &ops {
-        let Operand::Value(v) = *op else { continue };
-        let rep = engine.body.values.find_imm(v);
+        let Operand::Value(rep) = *op else { continue };
         if rep_read.contains_key(&rep)
             || !is_hoistable_value(&engine.body.values, rep, &entry_locals)
         {
@@ -2200,7 +2197,7 @@ fn hoist_invariant_value_operands(
     let new_ops: Vec<Operand> = ops
         .iter()
         .map(|op| match *op {
-            Operand::Value(v) => match rep_read.get(&engine.body.values.find_imm(v)) {
+            Operand::Value(v) => match rep_read.get(&v) {
                 Some(&read) => Operand::Value(read),
                 None => *op,
             },

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -171,11 +171,8 @@ pub(super) fn forward_at_root(
         let Some(vid) = consts.get(&expr).copied() else {
             continue;
         };
-        // Resolve through the e-class representative so a value proven equal to
-        // a constant by a union (not only by build-time hash-consing) forwards
-        // too. With no unions this is the identity. The constant promotes into
-        // `expr`'s parent operand slot (WEP: The Live ValueGraph).
-        let vid = engine.value_find(vid);
+        // The constant promotes into `expr`'s parent operand slot (WEP: The Live
+        // ValueGraph).
         let Some(value) = super::extract::extract_const(engine, vid, expr) else {
             continue;
         };


### PR DESCRIPTION
Closes #1440.

## Background

Investigating #1440 surfaced that the value graph's union / congruence machinery (`union`, `rebuild`, `repair`, the `parent` union-find, `class_parents`, `pending`) was reachable only from unit tests — no optimize pass ever unions or rebuilds. CSE in the live pipeline is pure hash-consing. The order-dependence #1440 describes therefore does not come from a union representative tie-break (as the issue hypothesised) but from **opaque leaf identity**: `bump_call_effects` minted the post-call opaques for `mut_escaped` locals in the alias set's insertion order, and opaque `ValueId`s are handed out in mint order, so the alias-set build order leaked into the whole graph (the #1439 perturbation).

## Changes

**1. Remove the dormant e-graph machinery.** Delete the test-only `union` / `rebuild` / `repair` / `rep_rank` / `register_parent_links` / `child_values` cluster and the `class_parents` / `pending` fields, plus the fully-dead `existing_local_opaque` / `canonical_global` helpers.

**2. Collapse the now-identity union-find.** With no merges, `find` / `find_imm` always returned their argument and `canonicalize` never rewrote a child. Remove `parent`, `find`, `find_imm`, `canonicalize`, and `Engine::value_find`, rewriting every caller (builder, licm, extract, store_load_forward) to use the `ValueId` directly. CSE is now plainly a hash-consed DAG.

**3. Fix #1440 at the root.** Sort `bump_call_effects`'s targets by local index before minting, so opaque allocation — and the CSE / extraction it feeds — is a deterministic function of the program, independent of how the alias sets were built. A red/green builder test (`cse_independent_of_mut_escaped_iteration_order`) permutes `mut_escaped` and asserts a byte-identical pool.

No correctness or codegen change: the golden WIR fixtures (including the serde ones #1440 flagged) are unchanged; the sort is a determinism guard, and the union-find removal is a pure identity collapse. Net ~300 lines removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_016wdEt1E9mjbvnv3xYsgNk7)_