### PR TITLE
fix(benchmark): order runtime graphs by latest run, retire legacy json/* series

### DIFF
--- a/.github/pages/runtime-index.html
+++ b/.github/pages/runtime-index.html
@@ -201,10 +201,15 @@
             a.click();
           };
 
-          // Collect all bench results per benchmark name
+          // Collect all bench results per benchmark name, and track the most
+          // recent entry to derive the graph order from.
           const benchesByName = new Map();
+          let latestEntry = null;
           for (const entries of Object.values(data.entries)) {
             for (const entry of entries) {
+              if (!latestEntry || entry.date > latestEntry.date) {
+                latestEntry = entry;
+              }
               const {commit, date, tool, benches} = entry;
               for (const bench of benches) {
                 const result = { commit, date, tool, bench };
@@ -231,7 +236,25 @@
             // Skip entries without optimization level suffix (legacy data)
           }
 
-          return groups;
+          if (!latestEntry) {
+            return groups;
+          }
+
+          // Order graphs by the most recent run and drop retired series. The
+          // latest entry lists benches in the benchmark script's emission
+          // order, so following it places each series in its natural position
+          // (e.g. the `json/*/ser` and `json/*/de` series sit where the old
+          // suffix-less `json/*` ones used to). Series absent from the latest
+          // run — such as those retired `json/*` names — are omitted even
+          // though their historical data remains in data.js.
+          const ordered = new Map();
+          for (const bench of latestEntry.benches) {
+            const baseName = bench.name.replace(OPT_PATTERN, '');
+            if (groups.has(baseName) && !ordered.has(baseName)) {
+              ordered.set(baseName, groups.get(baseName));
+            }
+          }
+          return ordered;
         }
 
         // Every commit gets a fixed horizontal slot, so the chart grows as wide


### PR DESCRIPTION
## Summary

The runtime throughput trend report grouped graphs by first-appearance across all history. After the JSON benchmarks gained `/ser` and `/de` suffixes, the retired suffix-less `json/twitter`, `json/canada`, and `json/catalog` series kept their old slots while the new `json/*/ser` and `json/*/de` series piled up together at the bottom of the page.

This changes the report (`.github/pages/runtime-index.html`) to order graphs by the **most recent run's** bench list and drop any series absent from it. As a result:

- The `json/*/ser` and `json/*/de` graphs now sit where the legacy `json/*` graphs used to be (between `zlib/decompress` and `sqlite_parse`).
- The retired suffix-less `json/*` series are omitted from the report (their historical data remains in `data.js`).
- Graph order now follows the benchmark script's emission order automatically, so future series changes need no manual reordering.

Verified against the current gh-pages `data.js` (207 commits): the resulting order drops the three plain `json/*` graphs and places ser/de in their natural positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gHWKb5csqjwmihBwT251E

---
_Generated by [Claude Code](https://claude.ai/code/session_016gHWKb5csqjwmihBwT251E)_