### PR TITLE
feat(wit): emit the library world via `wado wit --lib`

### DIFF
--- a/docs/wep-2026-05-02-wit-interoperability.md
+++ b/docs/wep-2026-05-02-wit-interoperability.md
@@ -663,6 +663,9 @@ splits two previously-conflated values: the world's emit name (`root`, textual
 only) and the default-interface FQ (`ns:name/name`, the codegen identity and
 the component's real export). The anonymous component binary is unaffected.
 
+`wado wit --lib` renders this same shape (`world root` exporting the default
+interface), so the human-readable text and the embedded `component-type` agree.
+
 Export grouping follows the same A/B rule the WIT producer applies
 (`wit_emit`, mirroring WEP: WIT and Wado Mapping → "Default Interface"):
 

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1029,7 +1029,7 @@ async fn embed_wit_section(
         return Ok(wasm);
     };
 
-    let world = if opts.lib_world.is_some() {
+    let (world, default_interface) = if opts.lib_world.is_some() {
         let Some(pkg) = project.and_then(|p| p.manifest.package.as_ref()) else {
             let msg = "--lib build has no resolvable [package] to name the library world";
             if explicit {
@@ -1038,9 +1038,12 @@ async fn embed_wit_section(
             eprintln!("warning: skipped embedding WIT component-type section: {msg}");
             return Ok(wasm);
         };
-        crate::manifest::lib_emit_world_fq(pkg)?
+        crate::manifest::lib_emit_target(pkg)?
     } else {
-        opts.target_world_fq().to_string()
+        (
+            opts.target_world_fq().to_string(),
+            crate::wit::default_interface_name(input),
+        )
     };
 
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
@@ -1071,7 +1074,7 @@ async fn embed_wit_section(
     let emit_opts = WitEmitOptions {
         scope: WitScope::Full,
         world_fq: world,
-        default_interface_name: crate::wit::default_interface_name(input),
+        default_interface_name: default_interface,
         world_imports,
     };
 

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -9,7 +9,6 @@ use lexopt::Arg::Value;
 use lexopt::Parser;
 use wado_compiler::LogLevel;
 use wado_compiler::wit_bundle;
-use wado_compiler::wit_emit::{WitEmitOptions, WitScope};
 
 use crate::args::{self, CliExit};
 use crate::compiler_host::{FilesystemCompilerHost, KilnComponentCache};
@@ -1029,23 +1028,6 @@ async fn embed_wit_section(
         return Ok(wasm);
     };
 
-    let (world, default_interface) = if opts.lib_world.is_some() {
-        let Some(pkg) = project.and_then(|p| p.manifest.package.as_ref()) else {
-            let msg = "--lib build has no resolvable [package] to name the library world";
-            if explicit {
-                return Err(CliExit::error(format!("--embed-wit: {msg}")));
-            }
-            eprintln!("warning: skipped embedding WIT component-type section: {msg}");
-            return Ok(wasm);
-        };
-        crate::manifest::lib_emit_target(pkg)?
-    } else {
-        (
-            opts.target_world_fq().to_string(),
-            crate::wit::default_interface_name(input),
-        )
-    };
-
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
     // Attach the manifest `[dependencies]` so a multi-package project's
     // re-analysis resolves the same imports the main compile did; a quiet host
@@ -1055,7 +1037,7 @@ async fn embed_wit_section(
         project,
         &base_path,
     );
-    let sem = wado_compiler::semantics_for_world(
+    let mut sem = wado_compiler::semantics_for_world(
         &source,
         &host,
         Some(input),
@@ -1070,15 +1052,13 @@ async fn embed_wit_section(
         eprintln!("warning: skipped embedding WIT component-type section: {msg}");
         return Ok(wasm);
     }
+    sem.set_wit_contract(wado_compiler::wit_emit::wit_contract(
+        opts.target_world.as_deref(),
+        opts.lib_world.as_deref(),
+        Some(&crate::wit::default_interface_name(input)),
+    ));
 
-    let emit_opts = WitEmitOptions {
-        scope: WitScope::Full,
-        world_fq: world,
-        default_interface_name: default_interface,
-        world_imports,
-    };
-
-    match wit_bundle::embed_component_type(&wasm, &sem, &emit_opts) {
+    match wit_bundle::embed_component_type(&wasm, &sem, &world_imports) {
         Ok(embedded) => Ok(embedded),
         Err(e) if explicit => Err(CliExit::error(format!("--embed-wit: {e}"))),
         Err(e) => {

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -224,7 +224,8 @@ impl EntryPointKind {
 }
 
 /// The emitted name of a library's world — the component's anonymous root.
-pub const LIB_WORLD_NAME: &str = "root";
+/// Re-exported from [`wado_compiler::wit_emit`], the single source of truth.
+pub const LIB_WORLD_NAME: &str = wado_compiler::wit_emit::LIB_WORLD_NAME;
 
 /// A library FQ `namespace:name/<segment>@version`, rejecting a package name
 /// that (case-insensitively) equals the reserved [`LIB_WORLD_NAME`].
@@ -253,20 +254,6 @@ pub fn lib_world_fq(pkg: &wado_manifest::Package) -> Result<String, CliExit> {
     lib_fq(pkg, &pkg.name)
 }
 
-/// The FQ that names the world when emitting a library's WIT, using the
-/// reserved [`LIB_WORLD_NAME`] segment instead of the default-interface name.
-pub fn lib_emit_world_fq(pkg: &wado_manifest::Package) -> Result<String, CliExit> {
-    lib_fq(pkg, LIB_WORLD_NAME)
-}
-
-/// The `(world-emit FQ, default-interface name)` pair for emitting a library's
-/// WIT — the single source both `wado wit --lib` and the `wado compile --lib`
-/// embed path derive their `WitEmitOptions` from, so the text and the embedded
-/// `component-type` cannot disagree.
-pub fn lib_emit_target(pkg: &wado_manifest::Package) -> Result<(String, String), CliExit> {
-    Ok((lib_emit_world_fq(pkg)?, pkg.name.clone()))
-}
-
 /// A resolved `--lib` package: everything needed to build and emit its world.
 pub struct LibTarget {
     /// Entry-point source path (`[package].lib`).
@@ -274,10 +261,6 @@ pub struct LibTarget {
     /// Default-interface FQ `namespace:name/name@version` — the codegen key and
     /// the identity consumers import.
     pub interface_fq: String,
-    /// The emitted world-name FQ `namespace:name/root@version`.
-    pub world_emit_fq: String,
-    /// Default interface name (`[package].name`).
-    pub default_interface: String,
 }
 
 /// Resolve the `--lib` package: its `ProjectManifest` and [`LibTarget`].
@@ -325,7 +308,6 @@ pub fn resolve_lib_project(
         .package
         .as_ref()
         .ok_or_else(|| CliExit::error("`--lib` requires a `[package]` section in wado.toml"))?;
-    let (world_emit_fq, default_interface) = lib_emit_target(pkg)?;
     let interface_fq = lib_world_fq(pkg)?;
     let lib_rel = pkg
         .lib
@@ -334,8 +316,6 @@ pub fn resolve_lib_project(
     let target = LibTarget {
         entry: project.root.join(lib_rel),
         interface_fq,
-        world_emit_fq,
-        default_interface,
     };
     Ok((project, target))
 }
@@ -636,24 +616,6 @@ lib = "src/lib.wado"
     }
 
     #[test]
-    fn lib_emit_world_fq_uses_reserved_root_name() {
-        let toml = r#"
-[package]
-namespace = "wado"
-name = "cm-catalog-min"
-version = "0.1.0"
-lib = "src/lib.wado"
-"#;
-        let m = toml.parse::<Manifest>().unwrap();
-        let pkg = m.package.as_ref().unwrap();
-        let world = lib_emit_world_fq(pkg).unwrap();
-        let iface = lib_world_fq(pkg).unwrap();
-        assert_eq!(world, "wado:cm-catalog-min/root@0.1.0");
-        assert_eq!(iface, "wado:cm-catalog-min/cm-catalog-min@0.1.0");
-        assert_ne!(world, iface);
-    }
-
-    #[test]
     fn lib_fq_rejects_reserved_root_package_name_any_case() {
         for name in ["root", "Root", "ROOT"] {
             let toml = format!(
@@ -662,16 +624,10 @@ lib = "src/lib.wado"
             let m = toml.parse::<Manifest>().unwrap();
             let pkg = m.package.as_ref().unwrap();
             let iface_err = lib_world_fq(pkg).unwrap_err();
-            let world_err = lib_emit_world_fq(pkg).unwrap_err();
             assert!(
                 iface_err.message.contains("reserved"),
                 "{}",
                 iface_err.message
-            );
-            assert!(
-                world_err.message.contains("reserved"),
-                "{}",
-                world_err.message
             );
         }
     }

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -259,18 +259,16 @@ pub fn lib_emit_world_fq(pkg: &wado_manifest::Package) -> Result<String, CliExit
     lib_fq(pkg, LIB_WORLD_NAME)
 }
 
-/// Resolve the `--lib` entry point and library world FQ.
+/// Resolve the `--lib` package: its `ProjectManifest` and entry-point path.
 ///
 /// `--lib` requires a manifest (directory input or a `wado.toml` discovered
 /// from the cwd); a bare `.wado` file argument is rejected because the package
 /// namespace — required to form the world FQ — lives only in `[package]`. The
 /// entry comes from `[package].lib`, not the `[world]` table.
-///
-/// Returns `(entry_path, world_fq)`.
-pub fn resolve_lib_input(
+pub fn resolve_lib_project(
     explicit_input: Option<String>,
     usage: &str,
-) -> Result<(String, String), CliExit> {
+) -> Result<(ProjectManifest, PathBuf), CliExit> {
     let project = if let Some(input) = explicit_input {
         let path = Path::new(&input);
         if !path.is_dir() {
@@ -301,17 +299,32 @@ pub fn resolve_lib_input(
     };
     emit_manifest_warnings(&project);
 
-    let pkg = project
+    let lib_rel = project
         .manifest
         .package
         .as_ref()
-        .ok_or_else(|| CliExit::error("`--lib` requires a `[package]` section in wado.toml"))?;
-    let world_fq = lib_world_fq(pkg)?;
-    let lib_rel = pkg
+        .ok_or_else(|| CliExit::error("`--lib` requires a `[package]` section in wado.toml"))?
         .lib
         .as_deref()
         .ok_or_else(|| CliExit::error("`--lib` requires `[package].lib` in wado.toml"))?;
     let entry = project.root.join(lib_rel);
+    Ok((project, entry))
+}
+
+/// Resolve the `--lib` entry point and default-interface FQ.
+///
+/// Returns `(entry_path, world_fq)`.
+pub fn resolve_lib_input(
+    explicit_input: Option<String>,
+    usage: &str,
+) -> Result<(String, String), CliExit> {
+    let (project, entry) = resolve_lib_project(explicit_input, usage)?;
+    let pkg = project
+        .manifest
+        .package
+        .as_ref()
+        .expect("resolve_lib_project guarantees a [package]");
+    let world_fq = lib_world_fq(pkg)?;
     Ok((entry.to_string_lossy().into_owned(), world_fq))
 }
 

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -259,7 +259,28 @@ pub fn lib_emit_world_fq(pkg: &wado_manifest::Package) -> Result<String, CliExit
     lib_fq(pkg, LIB_WORLD_NAME)
 }
 
-/// Resolve the `--lib` package: its `ProjectManifest` and entry-point path.
+/// The `(world-emit FQ, default-interface name)` pair for emitting a library's
+/// WIT — the single source both `wado wit --lib` and the `wado compile --lib`
+/// embed path derive their `WitEmitOptions` from, so the text and the embedded
+/// `component-type` cannot disagree.
+pub fn lib_emit_target(pkg: &wado_manifest::Package) -> Result<(String, String), CliExit> {
+    Ok((lib_emit_world_fq(pkg)?, pkg.name.clone()))
+}
+
+/// A resolved `--lib` package: everything needed to build and emit its world.
+pub struct LibTarget {
+    /// Entry-point source path (`[package].lib`).
+    pub entry: PathBuf,
+    /// Default-interface FQ `namespace:name/name@version` — the codegen key and
+    /// the identity consumers import.
+    pub interface_fq: String,
+    /// The emitted world-name FQ `namespace:name/root@version`.
+    pub world_emit_fq: String,
+    /// Default interface name (`[package].name`).
+    pub default_interface: String,
+}
+
+/// Resolve the `--lib` package: its `ProjectManifest` and [`LibTarget`].
 ///
 /// `--lib` requires a manifest (directory input or a `wado.toml` discovered
 /// from the cwd); a bare `.wado` file argument is rejected because the package
@@ -268,7 +289,7 @@ pub fn lib_emit_world_fq(pkg: &wado_manifest::Package) -> Result<String, CliExit
 pub fn resolve_lib_project(
     explicit_input: Option<String>,
     usage: &str,
-) -> Result<(ProjectManifest, PathBuf), CliExit> {
+) -> Result<(ProjectManifest, LibTarget), CliExit> {
     let project = if let Some(input) = explicit_input {
         let path = Path::new(&input);
         if !path.is_dir() {
@@ -299,33 +320,38 @@ pub fn resolve_lib_project(
     };
     emit_manifest_warnings(&project);
 
-    let lib_rel = project
-        .manifest
-        .package
-        .as_ref()
-        .ok_or_else(|| CliExit::error("`--lib` requires a `[package]` section in wado.toml"))?
-        .lib
-        .as_deref()
-        .ok_or_else(|| CliExit::error("`--lib` requires `[package].lib` in wado.toml"))?;
-    let entry = project.root.join(lib_rel);
-    Ok((project, entry))
-}
-
-/// Resolve the `--lib` entry point and default-interface FQ.
-///
-/// Returns `(entry_path, world_fq)`.
-pub fn resolve_lib_input(
-    explicit_input: Option<String>,
-    usage: &str,
-) -> Result<(String, String), CliExit> {
-    let (project, entry) = resolve_lib_project(explicit_input, usage)?;
     let pkg = project
         .manifest
         .package
         .as_ref()
-        .expect("resolve_lib_project guarantees a [package]");
-    let world_fq = lib_world_fq(pkg)?;
-    Ok((entry.to_string_lossy().into_owned(), world_fq))
+        .ok_or_else(|| CliExit::error("`--lib` requires a `[package]` section in wado.toml"))?;
+    let (world_emit_fq, default_interface) = lib_emit_target(pkg)?;
+    let interface_fq = lib_world_fq(pkg)?;
+    let lib_rel = pkg
+        .lib
+        .as_deref()
+        .ok_or_else(|| CliExit::error("`--lib` requires `[package].lib` in wado.toml"))?;
+    let target = LibTarget {
+        entry: project.root.join(lib_rel),
+        interface_fq,
+        world_emit_fq,
+        default_interface,
+    };
+    Ok((project, target))
+}
+
+/// Resolve the `--lib` entry point and default-interface FQ.
+///
+/// Returns `(entry_path, interface_fq)`.
+pub fn resolve_lib_input(
+    explicit_input: Option<String>,
+    usage: &str,
+) -> Result<(String, String), CliExit> {
+    let (_, target) = resolve_lib_project(explicit_input, usage)?;
+    Ok((
+        target.entry.to_string_lossy().into_owned(),
+        target.interface_fq,
+    ))
 }
 
 /// Resolve an entry point path from a manifest.

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -12,6 +12,7 @@ use wado_compiler::semantics::Semantics;
 use wado_compiler::wit_emit::{self, WitEmitOptions, WitScope};
 
 use crate::args::{self, CliExit, OptSpec};
+use crate::compile::attach_manifest_deps;
 use crate::compiler_host::FilesystemCompilerHost;
 use crate::manifest::{self, EntryPointKind};
 
@@ -175,7 +176,7 @@ async fn world_semantics_and_opts(
     let source = fs::read_to_string(path)
         .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
-    let host = FilesystemCompilerHost::new(base_path);
+    let host = FilesystemCompilerHost::new(base_path.clone());
 
     let sem =
         wado_compiler::semantics_for_world(&source, &host, Some(&input), world.as_deref()).await;
@@ -184,7 +185,8 @@ async fn world_semantics_and_opts(
     }
 
     let world = world.unwrap_or_else(|| DEFAULT_WORLD.to_string());
-    let world_imports = resolve_world_imports(&source, &input, &world).await;
+    let import_host = FilesystemCompilerHost::silent(base_path);
+    let world_imports = resolve_world_imports(&import_host, &source, &input, &world).await;
     let emit_opts = WitEmitOptions {
         scope,
         world_fq: world,
@@ -202,50 +204,72 @@ async fn lib_semantics_and_opts(
     scope: WitScope,
     usage: &str,
 ) -> Result<(Semantics, WitEmitOptions), CliExit> {
-    let (project, entry) = manifest::resolve_lib_project(input, usage)?;
-    let pkg = project
-        .manifest
-        .package
-        .as_ref()
-        .expect("resolve_lib_project guarantees a [package]");
-    let world_fq = manifest::lib_emit_world_fq(pkg)?;
-    let interface_world = manifest::lib_world_fq(pkg)?;
-    let default_interface = pkg.name.clone();
+    let (project, target) = manifest::resolve_lib_project(input, usage)?;
 
-    let entry_str = entry.to_string_lossy().into_owned();
-    let source = fs::read_to_string(&entry)
-        .map_err(|e| CliExit::error(format!("reading '{}': {e}", entry.display())))?;
-    let base_path = entry.parent().map(Path::to_path_buf).unwrap_or_default();
-    let host = FilesystemCompilerHost::new(base_path);
+    let entry_str = target.entry.to_string_lossy().into_owned();
+    let source = fs::read_to_string(&target.entry)
+        .map_err(|e| CliExit::error(format!("reading '{}': {e}", target.entry.display())))?;
+    let base_path = target
+        .entry
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_default();
 
+    let host = attach_manifest_deps(
+        FilesystemCompilerHost::new(base_path.clone()),
+        Some(&project),
+        &base_path,
+    );
     let sem = wado_compiler::semantics_for_world(&source, &host, Some(&entry_str), None).await;
     if !sem.is_complete() {
         return Err(CliExit::silent_failure(1));
     }
 
-    let world_imports = resolve_lib_world_imports(&source, &entry_str, &interface_world).await;
+    let import_host = attach_manifest_deps(
+        FilesystemCompilerHost::silent(base_path.clone()),
+        Some(&project),
+        &base_path,
+    );
+    let world_imports =
+        resolve_lib_world_imports(&import_host, &source, &entry_str, &target.interface_fq).await;
     let emit_opts = WitEmitOptions {
         scope,
-        world_fq,
-        default_interface_name: default_interface,
+        world_fq: target.world_emit_fq,
+        default_interface_name: target.default_interface,
         world_imports,
     };
     Ok((sem, emit_opts))
 }
 
-/// Compile `source` through optimize (on a silent host, so diagnostics are not
-/// re-emitted) and read the faithful import set from the WIR-level plan
-/// (`NirPackage::imported_cm_interfaces`). Returns empty on any failure; the
-/// caller has already validated the program with `semantics`.
-async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<String> {
-    let base_path = Path::new(input)
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_default();
-    let host = FilesystemCompilerHost::silent(base_path);
-    match wado_compiler::dump_with_host_and_world(
+/// The faithful import set from a compiled WIR plan, empty when absent.
+fn wir_imports(wir_package: Option<wado_compiler::wir::WirPackage>) -> Vec<String> {
+    wir_package
+        .map(|pkg| pkg.imported_cm_interfaces)
+        .unwrap_or_default()
+}
+
+/// The imports the WIT should list, computed post-DCE. `Err` after a passing
+/// `semantics` is anomalous (a later-pass failure), so it warns rather than
+/// silently emitting import-less WIT.
+fn imports_or_warn<T, E>(result: Result<T, E>, wir: impl FnOnce(T) -> Vec<String>) -> Vec<String> {
+    let Ok(r) = result else {
+        eprintln!("warning: could not resolve world imports; WIT may omit import lines");
+        return Vec::new();
+    };
+    wir(r)
+}
+
+/// Analyze `source` against `world` (on the passed silent host, so diagnostics
+/// are not re-emitted) and read the faithful import set from the WIR plan.
+async fn resolve_world_imports(
+    host: &FilesystemCompilerHost,
+    source: &str,
+    input: &str,
+    world: &str,
+) -> Vec<String> {
+    let result = wado_compiler::dump_with_host_and_world(
         source,
-        &host,
+        host,
         Some(input),
         wado_compiler::OptLevel::O2,
         Some(world),
@@ -255,41 +279,29 @@ async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<St
         &wado_compiler::hashmap::IndexMap::default(),
         wado_compiler::param_resolution::ParamPolicy::default(),
     )
-    .await
-    {
-        Ok(result) => result
-            .wir_package
-            .map(|pkg| pkg.imported_cm_interfaces)
-            .unwrap_or_default(),
-        Err(_) => Vec::new(),
-    }
+    .await;
+    imports_or_warn(result, |r| wir_imports(r.wir_package))
 }
 
-/// Compile the library entry with its synthesized world (via `lib_world`) and
-/// read the faithful import set from the retained WIR plan. `lib_world` is the
-/// default-interface FQ the codegen keys on (`namespace:name/name`), not the
-/// emitted `root` world name. Returns empty on any failure; the caller has
-/// already validated the program with `semantics`.
-async fn resolve_lib_world_imports(source: &str, input: &str, lib_world: &str) -> Vec<String> {
-    let base_path = Path::new(input)
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_default();
-    let host = FilesystemCompilerHost::silent(base_path);
+/// Like [`resolve_world_imports`] but for the synthesized library world. Uses
+/// the same `compile_with_options` path (and allocator) as `wado compile --lib`
+/// so the import set matches what that build embeds. `lib_world` is the
+/// default-interface FQ the codegen keys on (`namespace:name/name`).
+async fn resolve_lib_world_imports(
+    host: &FilesystemCompilerHost,
+    source: &str,
+    input: &str,
+    lib_world: &str,
+) -> Vec<String> {
     let options = wado_compiler::CompilerOptions {
         opt_level: wado_compiler::OptLevel::O2,
         lib_world: Some(lib_world.to_string()),
+        allocator: Some("freelist".to_string()),
         retain_wir: true,
-        log_level: Some(wado_compiler::LogLevel::Error),
         ..Default::default()
     };
-    match wado_compiler::compile_with_options(source, &host, Some(input), options).await {
-        Ok(result) => result
-            .wir_package
-            .map(|pkg| pkg.imported_cm_interfaces)
-            .unwrap_or_default(),
-        Err(_) => Vec::new(),
-    }
+    let result = wado_compiler::compile_with_options(source, host, Some(input), options).await;
+    imports_or_warn(result, |r| wir_imports(r.wir_package))
 }
 
 /// The default interface name: the manifest `[package].name` when the input

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -143,13 +143,14 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<WitOptions, CliExit> {
 
 pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
     let usage = format_usage();
-    let (sem, emit_opts) = if opts.lib {
-        lib_semantics_and_opts(opts.input, opts.scope, &usage).await?
+    let scope = opts.scope;
+    let (sem, world_imports) = if opts.lib {
+        lib_semantics_and_opts(opts.input, &usage).await?
     } else {
-        world_semantics_and_opts(opts.input, opts.scope, opts.world, &usage).await?
+        world_semantics_and_opts(opts.input, opts.world, &usage).await?
     };
 
-    let text = wit_emit::emit_wit_text(&sem, &emit_opts)
+    let text = wit_emit::emit_wit_text(&sem, &WitEmitOptions { scope }, &world_imports)
         .map_err(|e| CliExit::error(format!("wado wit: {e}")))?;
 
     match opts.output {
@@ -167,10 +168,9 @@ pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
 /// emit options for it.
 async fn world_semantics_and_opts(
     input: Option<String>,
-    scope: WitScope,
     world: Option<String>,
     usage: &str,
-) -> Result<(Semantics, WitEmitOptions), CliExit> {
+) -> Result<(Semantics, Vec<String>), CliExit> {
     let input = manifest::resolve_input(input, EntryPointKind::Command, usage)?;
     let path = Path::new(&input);
     let source = fs::read_to_string(path)
@@ -178,22 +178,22 @@ async fn world_semantics_and_opts(
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
     let host = FilesystemCompilerHost::new(base_path.clone());
 
-    let sem =
+    let mut sem =
         wado_compiler::semantics_for_world(&source, &host, Some(&input), world.as_deref()).await;
     if !sem.is_complete() {
         return Err(CliExit::silent_failure(1));
     }
 
     let world = world.unwrap_or_else(|| DEFAULT_WORLD.to_string());
+    sem.set_wit_contract(wado_compiler::wit_emit::wit_contract(
+        Some(&world),
+        None,
+        Some(&default_interface_name(&input)),
+    ));
+
     let import_host = FilesystemCompilerHost::silent(base_path);
     let world_imports = resolve_world_imports(&import_host, &source, &input, &world).await;
-    let emit_opts = WitEmitOptions {
-        scope,
-        world_fq: world,
-        default_interface_name: default_interface_name(&input),
-        world_imports,
-    };
-    Ok((sem, emit_opts))
+    Ok((sem, world_imports))
 }
 
 /// Analyze the `[package].lib` entry and build the emit options for the library
@@ -201,9 +201,8 @@ async fn world_semantics_and_opts(
 /// `namespace:name/name` (see `manifest::LIB_WORLD_NAME`).
 async fn lib_semantics_and_opts(
     input: Option<String>,
-    scope: WitScope,
     usage: &str,
-) -> Result<(Semantics, WitEmitOptions), CliExit> {
+) -> Result<(Semantics, Vec<String>), CliExit> {
     let (project, target) = manifest::resolve_lib_project(input, usage)?;
 
     let entry_str = target.entry.to_string_lossy().into_owned();
@@ -220,10 +219,15 @@ async fn lib_semantics_and_opts(
         Some(&project),
         &base_path,
     );
-    let sem = wado_compiler::semantics_for_world(&source, &host, Some(&entry_str), None).await;
+    let mut sem = wado_compiler::semantics_for_world(&source, &host, Some(&entry_str), None).await;
     if !sem.is_complete() {
         return Err(CliExit::silent_failure(1));
     }
+    sem.set_wit_contract(wado_compiler::wit_emit::wit_contract(
+        None,
+        Some(&target.interface_fq),
+        None,
+    ));
 
     let import_host = attach_manifest_deps(
         FilesystemCompilerHost::silent(base_path.clone()),
@@ -232,13 +236,7 @@ async fn lib_semantics_and_opts(
     );
     let world_imports =
         resolve_lib_world_imports(&import_host, &source, &entry_str, &target.interface_fq).await;
-    let emit_opts = WitEmitOptions {
-        scope,
-        world_fq: target.world_emit_fq,
-        default_interface_name: target.default_interface,
-        world_imports,
-    };
-    Ok((sem, emit_opts))
+    Ok((sem, world_imports))
 }
 
 /// The faithful import set from a compiled WIR plan, empty when absent.

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use lexopt::Arg::Value;
+use wado_compiler::semantics::Semantics;
 use wado_compiler::wit_emit::{self, WitEmitOptions, WitScope};
 
 use crate::args::{self, CliExit, OptSpec};
@@ -20,6 +21,7 @@ pub struct WitOptions {
     pub input: Option<String>,
     pub scope: WitScope,
     pub world: Option<String>,
+    pub lib: bool,
     pub output: Option<String>,
 }
 
@@ -27,12 +29,19 @@ pub struct WitOptions {
 enum Opt {
     Scope,
     World,
+    Lib,
     Output,
     Help,
 }
 
 impl Opt {
-    const ALL: &[Self] = &[Self::Scope, Self::World, Self::Output, Self::Help];
+    const ALL: &[Self] = &[
+        Self::Scope,
+        Self::World,
+        Self::Lib,
+        Self::Output,
+        Self::Help,
+    ];
 
     const fn spec(self) -> OptSpec {
         match self {
@@ -43,6 +52,12 @@ impl Opt {
                 desc: "Inlining scope for referenced interfaces (default: full)",
             },
             Self::World => args::WORLD_SPEC,
+            Self::Lib => OptSpec {
+                long: Some("lib"),
+                short: None,
+                value: None,
+                desc: "Emit the library world (from [package].lib); excludes --world",
+            },
             Self::Output => OptSpec {
                 long: Some("output"),
                 short: Some('o'),
@@ -73,6 +88,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<WitOptions, CliExit> {
     let mut inputs: Vec<String> = Vec::new();
     let mut scope = WitScope::Full;
     let mut world: Option<String> = None;
+    let mut lib = false;
     let mut output: Option<String> = None;
 
     while let Some(arg) = args::next_arg(&mut parser)? {
@@ -91,6 +107,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<WitOptions, CliExit> {
                     };
                 }
                 Opt::World => world = Some(args::require_string(&mut parser)?),
+                Opt::Lib => lib = true,
                 Opt::Output => output = Some(args::require_string(&mut parser)?),
                 Opt::Help => return Err(CliExit::help(usage)),
             }
@@ -101,6 +118,12 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<WitOptions, CliExit> {
         }
     }
 
+    if lib && world.is_some() {
+        return Err(CliExit::error_with_usage(
+            "`--lib` and `--world` are mutually exclusive",
+            &usage,
+        ));
+    }
     if inputs.len() > 1 {
         return Err(CliExit::error_with_usage(
             "wado wit takes a single file or directory",
@@ -112,41 +135,17 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<WitOptions, CliExit> {
         input: inputs.into_iter().next(),
         scope,
         world,
+        lib,
         output,
     })
 }
 
 pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
     let usage = format_usage();
-    let input = manifest::resolve_input(opts.input, EntryPointKind::Command, &usage)?;
-    let path = Path::new(&input);
-
-    let source = fs::read_to_string(path)
-        .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
-
-    let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
-    let host = FilesystemCompilerHost::new(base_path);
-
-    let sem =
-        wado_compiler::semantics_for_world(&source, &host, Some(&input), opts.world.as_deref())
-            .await;
-    if !sem.is_complete() {
-        // Diagnostics are already emitted by the host; signal silently.
-        return Err(CliExit::silent_failure(1));
-    }
-
-    let world = opts.world.unwrap_or_else(|| DEFAULT_WORLD.to_string());
-
-    // The faithful world import set is the WIR-level plan, available only after
-    // DCE — so compile through optimize to read it. Diagnostics were already
-    // surfaced by the `semantics` pass above; a quiet host avoids duplicates.
-    let world_imports = resolve_world_imports(&source, &input, &world).await;
-
-    let emit_opts = WitEmitOptions {
-        scope: opts.scope,
-        world_fq: world,
-        default_interface_name: default_interface_name(&input),
-        world_imports,
+    let (sem, emit_opts) = if opts.lib {
+        lib_semantics_and_opts(opts.input, opts.scope, &usage).await?
+    } else {
+        world_semantics_and_opts(opts.input, opts.scope, opts.world, &usage).await?
     };
 
     let text = wit_emit::emit_wit_text(&sem, &emit_opts)
@@ -161,6 +160,77 @@ pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
         None => print!("{text}"),
     }
     Ok(())
+}
+
+/// Analyze `input` against a fixed WASI world (or the default) and build the
+/// emit options for it.
+async fn world_semantics_and_opts(
+    input: Option<String>,
+    scope: WitScope,
+    world: Option<String>,
+    usage: &str,
+) -> Result<(Semantics, WitEmitOptions), CliExit> {
+    let input = manifest::resolve_input(input, EntryPointKind::Command, usage)?;
+    let path = Path::new(&input);
+    let source = fs::read_to_string(path)
+        .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
+    let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
+    let host = FilesystemCompilerHost::new(base_path);
+
+    let sem =
+        wado_compiler::semantics_for_world(&source, &host, Some(&input), world.as_deref()).await;
+    if !sem.is_complete() {
+        return Err(CliExit::silent_failure(1));
+    }
+
+    let world = world.unwrap_or_else(|| DEFAULT_WORLD.to_string());
+    let world_imports = resolve_world_imports(&source, &input, &world).await;
+    let emit_opts = WitEmitOptions {
+        scope,
+        world_fq: world,
+        default_interface_name: default_interface_name(&input),
+        world_imports,
+    };
+    Ok((sem, emit_opts))
+}
+
+/// Analyze the `[package].lib` entry and build the emit options for the library
+/// world — emitted as the anonymous `root`, exporting the default interface
+/// `namespace:name/name` (see `manifest::LIB_WORLD_NAME`).
+async fn lib_semantics_and_opts(
+    input: Option<String>,
+    scope: WitScope,
+    usage: &str,
+) -> Result<(Semantics, WitEmitOptions), CliExit> {
+    let (project, entry) = manifest::resolve_lib_project(input, usage)?;
+    let pkg = project
+        .manifest
+        .package
+        .as_ref()
+        .expect("resolve_lib_project guarantees a [package]");
+    let world_fq = manifest::lib_emit_world_fq(pkg)?;
+    let interface_world = manifest::lib_world_fq(pkg)?;
+    let default_interface = pkg.name.clone();
+
+    let entry_str = entry.to_string_lossy().into_owned();
+    let source = fs::read_to_string(&entry)
+        .map_err(|e| CliExit::error(format!("reading '{}': {e}", entry.display())))?;
+    let base_path = entry.parent().map(Path::to_path_buf).unwrap_or_default();
+    let host = FilesystemCompilerHost::new(base_path);
+
+    let sem = wado_compiler::semantics_for_world(&source, &host, Some(&entry_str), None).await;
+    if !sem.is_complete() {
+        return Err(CliExit::silent_failure(1));
+    }
+
+    let world_imports = resolve_lib_world_imports(&source, &entry_str, &interface_world).await;
+    let emit_opts = WitEmitOptions {
+        scope,
+        world_fq,
+        default_interface_name: default_interface,
+        world_imports,
+    };
+    Ok((sem, emit_opts))
 }
 
 /// Compile `source` through optimize (on a silent host, so diagnostics are not
@@ -187,6 +257,33 @@ async fn resolve_world_imports(source: &str, input: &str, world: &str) -> Vec<St
     )
     .await
     {
+        Ok(result) => result
+            .wir_package
+            .map(|pkg| pkg.imported_cm_interfaces)
+            .unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Compile the library entry with its synthesized world (via `lib_world`) and
+/// read the faithful import set from the retained WIR plan. `lib_world` is the
+/// default-interface FQ the codegen keys on (`namespace:name/name`), not the
+/// emitted `root` world name. Returns empty on any failure; the caller has
+/// already validated the program with `semantics`.
+async fn resolve_lib_world_imports(source: &str, input: &str, lib_world: &str) -> Vec<String> {
+    let base_path = Path::new(input)
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_default();
+    let host = FilesystemCompilerHost::silent(base_path);
+    let options = wado_compiler::CompilerOptions {
+        opt_level: wado_compiler::OptLevel::O2,
+        lib_world: Some(lib_world.to_string()),
+        retain_wir: true,
+        log_level: Some(wado_compiler::LogLevel::Error),
+        ..Default::default()
+    };
+    match wado_compiler::compile_with_options(source, &host, Some(input), options).await {
         Ok(result) => result
             .wir_package
             .map(|pkg| pkg.imported_cm_interfaces)

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -176,6 +176,44 @@ fn test_compile_lib_embeds_component_type_without_interface_collision() {
 }
 
 #[test]
+fn test_wit_lib_emits_root_world() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"shapes\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "pub struct Point { x: f64, y: f64 }\nexport fn identity(p: Point) -> Point { return p; }\n",
+    )
+    .unwrap();
+
+    wado_in(dir)
+        .arg("wit")
+        .arg("--lib")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("world root {"))
+        .stdout(predicate::str::contains("interface shapes {"))
+        .stdout(predicate::str::contains("world shapes").not());
+}
+
+#[test]
+fn test_wit_lib_conflicts_with_world() {
+    wado()
+        .arg("wit")
+        .arg("--lib")
+        .arg("--world")
+        .arg("wasi:cli/command")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("mutually exclusive"));
+}
+
+#[test]
 fn test_compile_os_skips_metadata() {
     // -Os strips symbols for minimal frontend delivery; package metadata is
     // dropped too, matching the WIT section.

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -138,6 +138,10 @@ pub struct Semantics {
     /// Batch compilation refuses to continue when this is false; LSP queries
     /// proceed with whatever partial state the phases managed to produce.
     pub(crate) is_complete: bool,
+    /// Compiler-owned WIT emit facts (target world + default interface). Set by
+    /// the CLI before WIT emission so `wado wit` and the `wado compile` embed
+    /// path derive them identically. `None` until set.
+    pub(crate) wit_contract: Option<crate::wit_emit::WitContract>,
 }
 
 /// A definition location, assembled from a symbol.
@@ -182,6 +186,17 @@ impl Semantics {
     #[must_use]
     pub fn is_complete(&self) -> bool {
         self.is_complete
+    }
+
+    /// The compiler-owned WIT emit contract, if set by the CLI.
+    #[must_use]
+    pub fn wit_contract(&self) -> Option<&crate::wit_emit::WitContract> {
+        self.wit_contract.as_ref()
+    }
+
+    /// Set the WIT emit contract (target world + default interface).
+    pub fn set_wit_contract(&mut self, c: crate::wit_emit::WitContract) {
+        self.wit_contract = Some(c);
     }
 
     /// Component Model world registry produced during annotate.
@@ -266,6 +281,7 @@ impl Semantics {
             tir_modules,
             liveness: crate::elaborator::liveness::Liveness::default(),
             is_complete: false,
+            wit_contract: None,
         }
     }
 
@@ -1315,6 +1331,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         tir_modules,
         liveness,
         is_complete: lower_ok && no_syntax_errors,
+        wit_contract: None,
     }
 }
 

--- a/wado-compiler/src/wit_bundle.rs
+++ b/wado-compiler/src/wit_bundle.rs
@@ -38,9 +38,9 @@ use crate::wit_emit::{self, WitEmitError, WitEmitOptions, WitScope};
 pub fn embed_component_type(
     component_bytes: &[u8],
     sem: &Semantics,
-    opts: &WitEmitOptions,
+    world_imports: &[String],
 ) -> Result<Vec<u8>, WitEmitError> {
-    let payload = encode_component_type(sem, opts)?;
+    let payload = encode_component_type(sem, world_imports)?;
 
     let section = wasm_encoder::CustomSection {
         name: "component-type".into(),
@@ -59,15 +59,14 @@ pub fn embed_component_type(
 /// a standalone WIT package.
 pub fn encode_component_type(
     sem: &Semantics,
-    opts: &WitEmitOptions,
+    world_imports: &[String],
 ) -> Result<Vec<u8>, WitEmitError> {
     // Force full scope: the section must be a self-contained WIT package so
     // `metadata::encode` can type the world without an external registry.
     let opts = WitEmitOptions {
         scope: WitScope::Full,
-        ..opts.clone()
     };
-    let text = wit_emit::emit_wit_text(sem, &opts)?;
+    let text = wit_emit::emit_wit_text(sem, &opts, world_imports)?;
 
     let mut resolve = wit_parser::Resolve::new();
     let pkg = resolve
@@ -76,7 +75,7 @@ pub fn encode_component_type(
             description: format!("re-parsing emitted WIT failed: {e}"),
         })?;
 
-    let world_name = wit_emit::world_name(&opts);
+    let world_name = wit_emit::world_name(sem);
     let world = resolve
         .select_world(&[pkg], Some(world_name.as_str()))
         .map_err(|e| WitEmitError::Embed {

--- a/wado-compiler/src/wit_emit.rs
+++ b/wado-compiler/src/wit_emit.rs
@@ -37,20 +37,60 @@ pub enum WitScope {
 /// Options threaded from the CLI into the emitter. These are project-level
 /// configuration, not frontend-derived facts, so they live here rather than on
 /// [`Semantics`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct WitEmitOptions {
     /// Inlining scope for referenced interfaces.
     pub scope: WitScope,
-    /// Fully-qualified name of the target world (e.g. `wasi:cli/command`).
+}
+
+/// The emitted name of a library's world — the component's anonymous root.
+pub const LIB_WORLD_NAME: &str = "root";
+
+/// The compiler-owned facts that fix a target's emitted world name and default
+/// interface. Set on [`Semantics`] by the CLI (see
+/// [`Semantics::set_wit_contract`](crate::semantics::Semantics::set_wit_contract))
+/// so `wado wit` and the `wado compile` embed path derive them identically and
+/// cannot drift.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WitContract {
+    /// World whose local name is emitted, and the registry key for its exports.
     pub world_fq: String,
-    /// Name for the synthesized default interface that groups bare exports.
-    /// Sourced from `[package].name` or the entry-file stem.
-    pub default_interface_name: String,
-    /// The CM interface FQs the compiled component imports — the WIR-level
-    /// import plan (`NirPackage::imported_cm_interfaces`). The authoritative,
-    /// faithful world import set; injected by the caller because it is computed
-    /// post-DCE and is unavailable from `Semantics` alone.
-    pub world_imports: Vec<String>,
+    /// Name of the default interface grouping bare exports.
+    pub default_interface: String,
+}
+
+/// Single source of truth for a target's emitted world name + default interface.
+///
+/// Library (`lib_world = Some("ns:name/name@ver")`): the world is the anonymous
+/// root — `world_fq = "ns:name/root@ver"`, `default_interface` = the name
+/// segment. Non-lib: `world_fq = target_world` (default `wasi:cli/command`),
+/// `default_interface` = `default_interface` (fallback `"root"`).
+#[must_use]
+pub fn wit_contract(
+    target_world: Option<&str>,
+    lib_world: Option<&str>,
+    default_interface: Option<&str>,
+) -> WitContract {
+    if let Some(lib_fq) = lib_world
+        && let Some(parts) = FqParts::parse(lib_fq)
+    {
+        let version = if parts.version.is_empty() {
+            String::new()
+        } else {
+            format!("@{}", parts.version)
+        };
+        return WitContract {
+            world_fq: format!(
+                "{}:{}/{}{}",
+                parts.namespace, parts.package, LIB_WORLD_NAME, version
+            ),
+            default_interface: parts.interface,
+        };
+    }
+    WitContract {
+        world_fq: target_world.unwrap_or("wasi:cli/command").to_string(),
+        default_interface: default_interface.unwrap_or("root").to_string(),
+    }
 }
 
 /// A failure that prevents emitting valid WIT.
@@ -90,14 +130,20 @@ impl std::fmt::Display for WitEmitError {
 
 impl std::error::Error for WitEmitError {}
 
-/// Render the WIT text for `sem` under `opts`.
-pub fn emit_wit_text(sem: &Semantics, opts: &WitEmitOptions) -> Result<String, WitEmitError> {
+/// Render the WIT text for `sem` under `opts`. `world_imports` is the faithful
+/// import plan (`NirPackage::imported_cm_interfaces`) computed post-DCE by the
+/// caller, since it is unavailable from `Semantics` alone.
+pub fn emit_wit_text(
+    sem: &Semantics,
+    opts: &WitEmitOptions,
+    world_imports: &[String],
+) -> Result<String, WitEmitError> {
     if !sem.is_complete() {
         return Err(WitEmitError::IncompleteSemantics);
     }
 
     let mut emitter = Emitter::new(sem);
-    let package = emitter.build_package(opts)?;
+    let package = emitter.build_package(world_imports)?;
     let mut out = package.to_string();
 
     // `full` scope inlines every referenced CM interface as a nested package,
@@ -180,12 +226,17 @@ impl<'a> Emitter<'a> {
         }
     }
 
-    fn build_package(&mut self, opts: &WitEmitOptions) -> Result<Package, WitEmitError> {
+    fn build_package(&mut self, world_imports: &[String]) -> Result<Package, WitEmitError> {
+        let contract = self
+            .sem
+            .wit_contract()
+            .ok_or(WitEmitError::IncompleteSemantics)?
+            .clone();
         let exports = self.collect_exported_functions();
         let world_info = self
             .sem
             .world_registry()
-            .and_then(|registry| registry.get(&opts.world_fq));
+            .and_then(|registry| registry.get(&contract.world_fq));
 
         // World imports: the faithful set the compiled component imports,
         // computed post-DCE at the WIR layer and injected by the caller (WEP
@@ -193,7 +244,7 @@ impl<'a> Emitter<'a> {
         // includes implicit runtime imports (e.g. `wasi:cli/stderr` for assert)
         // and excludes type-alias-only interfaces — neither visible from the
         // effect rows alone.
-        let import_fqs: BTreeSet<String> = opts.world_imports.iter().cloned().collect();
+        let import_fqs: BTreeSet<String> = world_imports.iter().cloned().collect();
 
         // Partition exports into world-conformance entry points (`run` /
         // `handle`, which map to a standard export interface like
@@ -225,7 +276,7 @@ impl<'a> Emitter<'a> {
         let type_defs = self.drain_pending_type_defs()?;
 
         let mut package = Package::new(PackageName::new("root", "component", None));
-        let mut world = World::new(to_kebab(&world_local_name(&opts.world_fq)));
+        let mut world = World::new(to_kebab(&world_local_name(&contract.world_fq)));
 
         for fq in &import_fqs {
             world.named_interface_import(fq.clone());
@@ -243,7 +294,7 @@ impl<'a> Emitter<'a> {
             }
         } else {
             // Group user exports and their types into the default interface.
-            let iface_name = to_kebab(&opts.default_interface_name);
+            let iface_name = to_kebab(&contract.default_interface);
             let mut iface = Interface::new(iface_name.clone());
             for ty in type_defs {
                 iface.type_def(ty);
@@ -1086,12 +1137,17 @@ fn collect_named_type_sources(ty: &crate::ast::Type, out: &mut Vec<String>) {
     }
 }
 
-/// The WIT world name the emitter renders for `opts`, in kebab-case. This is
-/// the name to pass to `Resolve::select_world` when re-parsing the emitted text
-/// (see [`crate::wit_bundle`]).
+/// The WIT world name the emitter renders for `sem`, in kebab-case. This is the
+/// name to pass to `Resolve::select_world` when re-parsing the emitted text (see
+/// [`crate::wit_bundle`]). Reads the compiler-owned [`WitContract`]; falls back
+/// to the empty local name when unset (callers always set it before emitting).
 #[must_use]
-pub fn world_name(opts: &WitEmitOptions) -> String {
-    to_kebab(&world_local_name(&opts.world_fq))
+pub fn world_name(sem: &Semantics) -> String {
+    let world_fq = sem
+        .wit_contract()
+        .map(|c| c.world_fq.as_str())
+        .unwrap_or("");
+    to_kebab(&world_local_name(world_fq))
 }
 
 /// Extract the local name of a world FQ: `wasi:cli/command` -> `command`.

--- a/wado-compiler/tests/wit.rs
+++ b/wado-compiler/tests/wit.rs
@@ -10,7 +10,7 @@ mod common;
 
 use common::InMemoryHost;
 use wado_compiler::semantics::{semantics, semantics_for_world};
-use wado_compiler::wit_emit::{WitEmitOptions, WitScope, emit_wit_text};
+use wado_compiler::wit_emit::{self, WitEmitOptions, WitScope, emit_wit_text};
 use wado_compiler::{OptLevel, dump_with_host_and_world};
 
 fn block_on<F: std::future::Future>(future: F) -> F::Output {
@@ -48,15 +48,15 @@ fn import_plan(source: &str, world_fq: &str) -> Vec<String> {
 /// emitter the faithful import plan as the CLI does.
 fn emit_world(source: &str, scope: WitScope, world_fq: &str) -> String {
     let host = InMemoryHost::new();
-    let sem = block_on(semantics(source, &host, Some("entry.wado")));
+    let mut sem = block_on(semantics(source, &host, Some("entry.wado")));
     assert!(sem.is_complete(), "semantics did not complete for source");
-    let opts = WitEmitOptions {
-        scope,
-        world_fq: world_fq.to_string(),
-        default_interface_name: "entry".to_string(),
-        world_imports: import_plan(source, world_fq),
-    };
-    emit_wit_text(&sem, &opts).expect("emit_wit_text failed")
+    sem.set_wit_contract(wit_emit::wit_contract(Some(world_fq), None, Some("entry")));
+    emit_wit_text(
+        &sem,
+        &WitEmitOptions { scope },
+        &import_plan(source, world_fq),
+    )
+    .expect("emit_wit_text failed")
 }
 
 /// Emit WIT for `source` targeting the default CLI world, under `scope`.
@@ -104,21 +104,26 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
 }
 "#;
     let host = InMemoryHost::new();
-    let sem = block_on(semantics_for_world(
+    let mut sem = block_on(semantics_for_world(
         GENERATOR,
         &host,
         Some("entry.wado"),
         Some("core:kiln/generator"),
     ));
     assert!(sem.is_complete(), "generator semantics did not complete");
-    let opts = WitEmitOptions {
-        scope: WitScope::Local,
-        world_fq: "core:kiln/generator".to_string(),
-        default_interface_name: "entry".to_string(),
-        world_imports: Vec::new(),
-    };
-    let text = emit_wit_text(&sem, &opts)
-        .expect("emit_wit_text must succeed for the generator world (issue #1478)");
+    sem.set_wit_contract(wit_emit::wit_contract(
+        Some("core:kiln/generator"),
+        None,
+        Some("entry"),
+    ));
+    let text = emit_wit_text(
+        &sem,
+        &WitEmitOptions {
+            scope: WitScope::Local,
+        },
+        &[],
+    )
+    .expect("emit_wit_text must succeed for the generator world (issue #1478)");
     assert!(
         text.contains("req: raw-request"),
         "generate must export the representable raw-request param:\n{text}"
@@ -293,16 +298,22 @@ fn cm_catalog_matches_committed_wit() {
     let source = include_str!("../../package-cm-catalog/src/lib.wado");
     let expected = include_str!("../../package-cm-catalog/cm-catalog.wit");
     let host = InMemoryHost::new();
-    let sem = block_on(semantics(source, &host, Some("lib.wado")));
+    let mut sem = block_on(semantics(source, &host, Some("lib.wado")));
     assert!(sem.is_complete(), "catalog source did not analyze");
-    let opts = WitEmitOptions {
-        scope: WitScope::Full,
-        world_fq: "wasi:cli/command".to_string(),
-        default_interface_name: "cm-catalog".to_string(),
-        // Pure value types import no CM interface.
-        world_imports: Vec::new(),
-    };
-    let text = emit_wit_text(&sem, &opts).expect("emit_wit_text failed");
+    sem.set_wit_contract(wit_emit::wit_contract(
+        Some("wasi:cli/command"),
+        None,
+        Some("cm-catalog"),
+    ));
+    // Pure value types import no CM interface.
+    let text = emit_wit_text(
+        &sem,
+        &WitEmitOptions {
+            scope: WitScope::Full,
+        },
+        &[],
+    )
+    .expect("emit_wit_text failed");
     assert_eq!(
         text.trim_end(),
         expected.trim_end(),

--- a/wado-compiler/tests/wit_bundle.rs
+++ b/wado-compiler/tests/wit_bundle.rs
@@ -14,7 +14,7 @@ mod common;
 use common::InMemoryHost;
 use wado_compiler::semantics::semantics;
 use wado_compiler::wit_bundle::{embed_component_type, encode_component_type};
-use wado_compiler::wit_emit::{WitEmitOptions, WitScope};
+use wado_compiler::wit_emit;
 use wado_compiler::{OptLevel, dump_with_host_and_world};
 
 use wit_parser::decoding::{DecodedWasm, decode};
@@ -65,13 +65,13 @@ fn compile(source: &str, world_fq: &str) -> Vec<u8> {
     .unwrap_or_else(|_| panic!("compile failed:\n{:#?}", host.diagnostics()))
 }
 
-fn emit_opts(source: &str, world_fq: &str) -> WitEmitOptions {
-    WitEmitOptions {
-        scope: WitScope::Full,
-        world_fq: world_fq.to_string(),
-        default_interface_name: "entry".to_string(),
-        world_imports: import_plan(source, world_fq),
-    }
+/// Set the WIT contract on `sem` for `world_fq`, matching the CLI's setup.
+fn with_contract(
+    mut sem: wado_compiler::semantics::Semantics,
+    world_fq: &str,
+) -> wado_compiler::semantics::Semantics {
+    sem.set_wit_contract(wit_emit::wit_contract(Some(world_fq), None, Some("entry")));
+    sem
 }
 
 const CLI_WORLD: &str = "wasi:cli/command";
@@ -132,10 +132,13 @@ fn component_is_self_describing_without_embedding() {
 fn embedding_appends_section_and_preserves_component() {
     let wasm = compile(HELLO, CLI_WORLD);
     let host = InMemoryHost::new();
-    let sem = block_on(semantics(HELLO, &host, Some("entry.wado")));
+    let sem = with_contract(
+        block_on(semantics(HELLO, &host, Some("entry.wado"))),
+        CLI_WORLD,
+    );
     assert!(sem.is_complete());
 
-    let embedded = embed_component_type(&wasm, &sem, &emit_opts(HELLO, CLI_WORLD))
+    let embedded = embed_component_type(&wasm, &sem, &import_plan(HELLO, CLI_WORLD))
         .expect("embed_component_type");
 
     assert!(embedded.len() > wasm.len(), "section should add bytes");
@@ -165,9 +168,12 @@ fn embedding_appends_section_and_preserves_component() {
 #[test]
 fn encoded_payload_decodes_as_wit_package() {
     let host = InMemoryHost::new();
-    let sem = block_on(semantics(HELLO, &host, Some("entry.wado")));
+    let sem = with_contract(
+        block_on(semantics(HELLO, &host, Some("entry.wado"))),
+        CLI_WORLD,
+    );
     let payload =
-        encode_component_type(&sem, &emit_opts(HELLO, CLI_WORLD)).expect("encode_component_type");
+        encode_component_type(&sem, &import_plan(HELLO, CLI_WORLD)).expect("encode_component_type");
     assert!(
         matches!(decode(&payload), Ok(DecodedWasm::WitPackage(..))),
         "payload must decode as a standalone WIT package"
@@ -179,10 +185,13 @@ fn encoded_payload_decodes_as_wit_package() {
 fn pure_compute_world_embeds() {
     let wasm = compile(PURE, CLI_WORLD);
     let host = InMemoryHost::new();
-    let sem = block_on(semantics(PURE, &host, Some("entry.wado")));
-    let embedded = embed_component_type(&wasm, &sem, &emit_opts(PURE, CLI_WORLD)).expect("embed");
+    let sem = with_contract(
+        block_on(semantics(PURE, &host, Some("entry.wado"))),
+        CLI_WORLD,
+    );
+    let embedded = embed_component_type(&wasm, &sem, &import_plan(PURE, CLI_WORLD)).expect("embed");
     assert!(matches!(decode(&embedded), Ok(DecodedWasm::Component(..))));
 
-    let payload = encode_component_type(&sem, &emit_opts(PURE, CLI_WORLD)).expect("encode");
+    let payload = encode_component_type(&sem, &import_plan(PURE, CLI_WORLD)).expect("encode");
     assert!(matches!(decode(&payload), Ok(DecodedWasm::WitPackage(..))));
 }


### PR DESCRIPTION
Adds `wado wit --lib` so a library package's WIT is inspectable, and reworks the WIT-emit API so the human-readable text and the embedded `component-type` cannot drift.

## `wado wit --lib`

`wado wit` could only emit against a fixed WASI world; a library's WIT was uninspectable (coercing it via `--world <interface-fq>` printed the colliding pre-fix `world <name>`). `--lib` (mutually exclusive with `--world`) resolves `[package].lib` and emits the library world as the anonymous `root` exporting the default interface `namespace:name/name`, with the faithful import set read from a library compile — matching what `wado compile --lib` embeds and what `wasm-tools` decodes.

It attaches the manifest `[dependencies]` exactly as `wado compile --lib` does, so a library that imports a CM interface from a dependency resolves the same way in both commands.

## Compiler-owned WIT-emit contract (drift-proofing)

The two places that emit WIT — `wado wit` and the `wado compile` embed path — each hand-assembled a wide `WitEmitOptions { scope, world_fq, default_interface_name, world_imports }`. Three of those four fields are facts of the compilation, so the two sites kept diverging (world name, default interface, imports, allocator). An API that asks callers to assemble derivable facts will always drift.

The facts now flow from one place:

- `WitEmitOptions` shrinks to `{ scope }` — the one genuine user option.
- A new `wit_emit::WitContract { world_fq, default_interface }` and a single `wit_emit::wit_contract(target_world, lib_world, default_interface)` factory own the derivation. The decision that a library's world is the anonymous `root` (default interface = package name) moves out of the CLI — `manifest::lib_emit_world_fq` / `lib_emit_target` are deleted — and into the compiler, derived from the library world FQ.
- The contract is recorded on `Semantics`; `emit_wit_text(sem, opts, world_imports)` reads the world name and default interface from it. `world_imports` stays an argument sourced from a compile's WIR plan, never hand-built.
- Both emit paths now just call `wit_contract(..)` and set it on their `Semantics`, so there is no place left to assemble the options inconsistently. `encode_component_type` / `embed_component_type` also drop their now-meaningless `opts` parameter (the embedded section is always full-scope).

The committed `cm-catalog.wit` golden is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018khBaDrxawB4Lc2Brncafu

---
_Generated by [Claude Code](https://claude.ai/code/session_018khBaDrxawB4Lc2Brncafu)_