### PR TITLE
fix: reject `&mut` to an enum-typed struct field

### DIFF
--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -959,11 +959,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             });
         }
 
-        // Reject &mut on struct field access when the field is a primitive type.
-        // In Wasm GC, struct.get returns a value copy for primitives, so &mut field
-        // creates a disconnected Box — mutations don't propagate back to the struct.
-        // For GC reference types (struct, String, List, etc.), struct.get returns
-        // the shared reference, so &mut field works correctly.
+        // Reject &mut on struct field access when the field is a scalar type.
+        // In Wasm GC, struct.get returns a value copy for scalars (primitives,
+        // enums, flags), so &mut field creates a disconnected Box — mutations
+        // don't propagate back to the struct. For GC reference types (struct,
+        // String, List, etc.), struct.get returns the shared reference, so
+        // &mut field works correctly. Flags reduce to a primitive base, so the
+        // base-type check catches them; enums keep their own base type and need
+        // an explicit match.
         // Detect the field-access shape from the AST: `resolve_field_access`
         // returns a placeholder, so its resolved `kind` is no longer
         // `FieldAccess`; the operand's `type_id` still carries the field type
@@ -981,9 +984,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .get_ultimate_base_type(expr_type),
                 )
                 .clone();
-            if matches!(field_type, ResolvedType::Primitive(_))
-                || matches!(base_type, ResolvedType::Primitive(_))
-            {
+            let is_scalar_field = |ty: &ResolvedType| {
+                matches!(ty, ResolvedType::Primitive(_) | ResolvedType::Enum { .. })
+            };
+            if is_scalar_field(&field_type) || is_scalar_field(&base_type) {
                 let _ = self.logger.error(TypeError::CannotAssign {
                     message: "cannot take mutable reference to primitive struct field; use the struct reference directly".to_string(),
                     span: unary.span,

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -922,11 +922,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ctx: &mut FunctionContext,
         expected_type: Option<TypeId>,
     ) -> TypeId {
-        // For `&x` / `&mut x`, peel one layer of the expected type so the
-        // operand sees the underlying expected shape. This lets a generic
-        // function reference taken by `&identity` (expected `&fn(i32) -> i32`)
-        // pin its type arguments from the inner `fn(i32) -> i32` the same
-        // way a bare `identity` to a `fn(...)` parameter would.
         let inner_expected = if matches!(unary.op, UnaryOp::Ref | UnaryOp::MutRef) {
             expected_type.and_then(|expected| {
                 let table = self.tysys.type_table.borrow();
@@ -940,14 +935,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
         let expr_type = self.resolve_expr(&unary.expr, ctx, inner_expected);
 
-        // Address-taken-local tracking for `&x` / `&mut x` is owned by reify
-        // (`reify.rs` unary arm), which marks `TirFunction::address_taken_locals`
-        // on the TIR it actually emits; the combined walk's marking was dead.
-        // The `&mut`-on-immutable-local diagnostic stays here (annotate emits
-        // diagnostics once) and reads the target off the AST now that
-        // `resolve_ident` returns a placeholder: `&mut x` is an immutable-local
-        // error only when `x` is a function-frame local (a `Local` `kind`
-        // before 7-B), so classify it via a read-only `ctx.lookup`.
         if unary.op == UnaryOp::MutRef
             && let ast::Expr::Ident(id) = &unary.expr
             && let Some(local) = ctx.lookup(&id.name)
@@ -959,18 +946,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             });
         }
 
-        // Reject &mut on struct field access when the field is a scalar type.
-        // In Wasm GC, struct.get returns a value copy for scalars (primitives,
-        // enums, flags), so &mut field creates a disconnected Box — mutations
-        // don't propagate back to the struct. For GC reference types (struct,
-        // String, List, etc.), struct.get returns the shared reference, so
-        // &mut field works correctly. Flags reduce to a primitive base, so the
-        // base-type check catches them; enums keep their own base type and need
-        // an explicit match.
-        // Detect the field-access shape from the AST: `resolve_field_access`
-        // returns a placeholder, so its resolved `kind` is no longer
-        // `FieldAccess`; the operand's `type_id` still carries the field type
-        // via the placeholder.
         if unary.op == UnaryOp::MutRef && matches!(&unary.expr, ast::Expr::FieldAccess(_)) {
             let field_type = self.tysys.type_table.borrow().get(expr_type).clone();
             let base_type = self

--- a/wado-compiler/tests/fixtures/ref_field_ref_enum.wado
+++ b/wado-compiler/tests/fixtures/ref_field_ref_enum.wado
@@ -1,0 +1,26 @@
+// Taking &mut to an enum-typed struct field is prohibited.
+// Enums are scalar (i32 discriminant), so struct.get returns a copy —
+// &mut field would create a disconnected Box whose writes never reach
+// the struct. Rejected like a primitive field (#1473).
+
+enum E {
+    A,
+    B,
+}
+
+fn setb(p: &mut E) {
+    *p = E::B;
+}
+
+struct H {
+    x: E,
+    tag: i32,
+}
+
+export fn run() {
+    let mut h = H { x: E::A, tag: 7 };
+    setb(&mut h.x);
+}
+
+__DATA__
+{"compile_error": "cannot take mutable reference to primitive struct field"}


### PR DESCRIPTION
## Summary

`&mut self.field` on a **primitive** field is correctly rejected, but the same on an **enum**-typed field compiled and then silently behaved as a copy: mutations through the reference never reached the field. A loop guarded on the field therefore never terminated — an opt-independent infinite loop (hangs at `-O0` too). Fixes #1473.

## Root cause

Enums are scalar (i32 discriminant), so `struct.get` returns a value copy. Taking `&mut` of such a field boxes a disconnected copy whose writes never propagate back.

The forbid in `resolve_unary` only matched `ResolvedType::Primitive`. `flags` reduce to a `u32` primitive base (via `get_ultimate_base_type`) and were already caught; `enum` keeps its own base type, so it slipped through.

## Change

- Add an explicit `ResolvedType::Enum` arm to the scalar-field check, so `&mut` to an enum struct field is rejected with the same message used for primitive fields. This matches the forbid rule in `wep-2026-06-13-reference-representation.md` (D1) and Option 1 of the issue.
- Add fixture `tests/fixtures/ref_field_ref_enum.wado` asserting the compile error.

The broader single-predicate refactor and the `stores`-gated write-back carve-out remain the WEP's separate tracked work; this is the minimal fix scoped to the enum struct-field gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxKeRL8hFvhL4pR8kbVQM4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxKeRL8hFvhL4pR8kbVQM4)_