### PR TITLE
chore: drop dead vendor/wasmtime submodule checkout and document publish auth

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,8 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -90,8 +88,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -109,8 +105,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -128,8 +122,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -147,8 +139,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -166,8 +156,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -185,8 +173,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -211,8 +197,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -237,8 +221,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -263,8 +245,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ci
@@ -295,8 +275,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
 
       - uses: jdx/mise-action@v4
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,8 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
 
       # Fast linker — matches the CI setup
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,6 @@ jobs:
         with:
           ref: ${{ needs.validate.outputs.tag }}
 
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
-
       - name: Install Rust target
         # rust-toolchain.toml is honored automatically by rustup; we only
         # need to add the target triple when it differs from the runner's

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -26,11 +26,6 @@ jobs:
           fetch-depth: 0
           token: "${{ steps.app-token.outputs.token }}"
 
-      # postVersionCommand (cargo update, see .tagpr) needs the vendored
-      # wasmtime path dependency, or Cargo.lock is left stale on the release PR.
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
-
       - uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: "${{ steps.app-token.outputs.token }}"

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -45,10 +45,6 @@ jobs:
             echo "should-run=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Check out the vendored wasmtime fork (path dependency)
-        if: steps.precheck.outputs.should-run == 'true'
-        run: git submodule update --init --depth 1 vendor/wasmtime
-
       - uses: Swatinem/rust-cache@v2
         if: steps.precheck.outputs.should-run == 'true'
         with:

--- a/.github/workflows/wado-vscode.yml
+++ b/.github/workflows/wado-vscode.yml
@@ -22,8 +22,6 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
-      - name: Check out the vendored wasmtime fork (path dependency)
-        run: git submodule update --init --depth 1 vendor/wasmtime
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -135,9 +135,13 @@ the WIT section; `--embed-metadata` forces it back on under `-Os` (mirroring
 shells out to `wkg` (wasm-pkg-tools), which derives the OCI annotations. There is no `wkg.toml` —
 `wado.toml` is the only source of truth, and `wkg` is an implementation detail
 (a missing `wkg` errors with install guidance). Authentication is delegated to
-the ambient OCI credential store (`docker login`), with an env-var token
-override for CI; Wado stores no credentials. `revision` is the git commit SHA,
-derived at build time; a dirty tree omits it, warned only at publish.
+`wkg`: either the ambient OCI credential store (`docker login <registry>`, or
+docker/login-action in GitHub Actions) or the `WKG_OCI_USERNAME` /
+`WKG_OCI_PASSWORD` environment variables. For GHCR the username is the GitHub
+account (`github.actor` in Actions) and the password a token with the
+`write:packages` scope (e.g. `GITHUB_TOKEN`). Wado stores no credentials.
+`revision` is the git commit SHA, derived at build time; a dirty tree omits it,
+warned only at publish.
 
 ### Entry Points and Worlds
 

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -51,6 +51,36 @@ fn format_usage() -> String {
     )
     .unwrap();
     writeln!(buf, "  -h, --help     Show this help message").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Authentication:").unwrap();
+    writeln!(
+        buf,
+        "  Credentials are handled by wkg, not Wado. Authenticate to the target"
+    )
+    .unwrap();
+    writeln!(buf, "  registry before publishing, via either:").unwrap();
+    writeln!(
+        buf,
+        "    - the ambient OCI credential store: `docker login <registry>`"
+    )
+    .unwrap();
+    writeln!(buf, "      (in GitHub Actions, use docker/login-action)").unwrap();
+    writeln!(
+        buf,
+        "    - the WKG_OCI_USERNAME / WKG_OCI_PASSWORD environment variables"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "  For GHCR, the username is your GitHub account (github.actor in Actions)"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "  and the password a token with the `write:packages` scope"
+    )
+    .unwrap();
+    writeln!(buf, "  (e.g. GITHUB_TOKEN in Actions).").unwrap();
     buf
 }
 
@@ -448,6 +478,15 @@ fn problems_error(header: &str, problems: &[PublishError]) -> CliExit {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn usage_documents_authentication() {
+        let usage = format_usage();
+        assert!(usage.contains("Authentication:"), "{usage}");
+        assert!(usage.contains("docker login"), "{usage}");
+        assert!(usage.contains("WKG_OCI_USERNAME"), "{usage}");
+        assert!(usage.contains("write:packages"), "{usage}");
+    }
 
     #[test]
     fn parse_args_defaults_to_no_dry_run() {


### PR DESCRIPTION
Two independent cleanups that surfaced while investigating the failed v0.0.9 release run.

## Remove dead `vendor/wasmtime` submodule checkout from workflows

The workspace depends on `wasmtime = "=46.0.1"` from crates.io, not the vendored fork: every workspace member resolves it via the registry (`Cargo.lock` source is `registry+https://…`), and the only path dependency on `vendor/wasmtime` lives in `wado-bundled-icu`, which is excluded from the workspace (`exclude = ["vendor"]`). No CI job builds the vendored wasmtime CLI or runs a task that reads its WIT sources, so the `git submodule update --init vendor/wasmtime` step in every workflow was pure overhead (it only checked out source, never built anything).

Removes the step from all 7 workflows (17 occurrences) plus tagpr's now-moot justification comment. The submodule itself and the mise tasks that use it (`update-stdlib-wasi`, the wasmtime-CLI build, etc.) are unchanged.

## Document `wado publish` authentication

The publish auth story lived only in a source comment and a vague WEP line ("an env-var token override for CI"). Surface it where users look:

- `wado publish --help` gains an `Authentication` section covering ambient OCI credentials (`docker login` / docker-login-action) and the `WKG_OCI_USERNAME` / `WKG_OCI_PASSWORD` override, plus the concrete GHCR pattern (`github.actor` + a `write:packages` token such as `GITHUB_TOKEN`).
- The package-manifest WEP names the env vars and GHCR pattern instead of the vague CI reference.

Credential handling stays delegated to `wkg`; no code path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZjkZVM8gmu9WC7oPGpjRo

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZjkZVM8gmu9WC7oPGpjRo)_