### PR TITLE
fix(vscode): restore extension name `wado`

### DIFF
--- a/wado-vscode/package-lock.json
+++ b/wado-vscode/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "wado-vscode",
+  "name": "wado",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wado-vscode",
+      "name": "wado",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/wado-vscode/package.json
+++ b/wado-vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wado-vscode",
+  "name": "wado",
   "displayName": "VS Code Extension for Wado",
   "description": "Language support for the Wado programming language",
   "version": "0.0.1",


### PR DESCRIPTION
Follow-up to #1528.

## Problem

#1528 renamed the extension's `name` in `wado-vscode/package.json` from `wado` to `wado-vscode`. Since a VS Code extension's identifier is `publisher.name`, this changed the ID from `wado-lang.wado` to `wado-lang.wado-vscode`.

The test suite, `mise.toml`, and the marketplace publish target all rely on `wado-lang.wado`:

- Every test calls `vscode.extensions.getExtension('wado-lang.wado')`, which now returns `undefined` → all extension/LSP tests fail with `AssertionError: Extension should be present`.
- `mise.toml` symlinks `~/.vscode/extensions/wado-lang.wado-0.0.1`.
- `docs/wep-2026-04-18-lsp-architecture.md` documents the marketplace ID as `wado-lang.wado`.

This broke the `ubuntu-latest` / `macos-latest` / `windows-latest` extension-test jobs on `main`.

## Fix

Restore `name` to `wado` in `package.json` and `package-lock.json`. The dependency update and the improved `displayName` ("VS Code Extension for Wado") from #1528 are kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)