### PR TITLE
chore(deps): drop flate2/crc32fast/adler; validate zlib interop against zlib-rs alone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,18 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,9 +220,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cap-fs-ext"
@@ -918,16 +906,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "miniz_oxide",
- "zlib-rs",
-]
-
-[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,8 +1218,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -1253,6 +1229,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -1682,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.10"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1711,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.46.10"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
 dependencies = [
  "regex-syntax",
 ]
@@ -1841,9 +1819,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
@@ -1867,16 +1845,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -1946,11 +1914,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2379,14 +2346,14 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.10"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
 dependencies = [
  "ahash",
  "fluent-uri",
  "getrandom 0.3.4",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "micromap",
  "parking_lot",
@@ -2411,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2423,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2497,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -2817,12 +2784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3393,13 +3354,10 @@ dependencies = [
 name = "wado-compiler"
 version = "0.0.10"
 dependencies = [
- "adler",
  "anyhow",
  "bytes",
  "cranelift-entity",
- "crc32fast",
  "datatest-mini",
- "flate2",
  "fluent-uri",
  "futures",
  "heck",
@@ -4423,18 +4381,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4517,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,11 +85,8 @@ lexopt = { version = "0.3.2" }
 predicates = { version = "3" }
 regex = { version = "1" }
 tempfile = { version = "3" }
-jsonschema = { version = "0.46" }
+jsonschema = { version = "0.47" }
 zlib-rs = { version = "0.6" }
-flate2 = { version = "1", default-features = false, features = ["zlib-rs"] }
-crc32fast = { version = "1" }
-adler = { version = "1" }
 toml = { version = "1", default-features = false, features = ["parse", "display", "serde", "preserve_order"] }
 libc = { version = "0.2" }
 mimalloc = { version = "0.1" }

--- a/wado-compiler/Cargo.toml
+++ b/wado-compiler/Cargo.toml
@@ -44,10 +44,7 @@ futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 zlib-rs = { workspace = true }
-flate2 = { workspace = true }
-crc32fast = { workspace = true }
 sha2 = { workspace = true }
-adler = { workspace = true }
 serde_json = { workspace = true }
 iana-time-zone = { workspace = true }
 libc = { workspace = true }

--- a/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
@@ -100,7 +100,7 @@ type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref Array<u8>
 
 type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(39)
 
-type "functype//local_item_newtype_definition.wado/UserId@AstId(2012:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
+type "functype//local_item_newtype_definition.wado/UserId@AstId(2011:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
 
 type "functype//core:prelude/format.wado/Formatter::new" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/format.wado//Formatter";  // TypeId(41)
 
@@ -136,7 +136,7 @@ global global:local_item_newtype_definition.wado::__const_obj_0: ref null "core:
 global global:local_item_newtype_definition.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(108, 111, 99, 97, 108, 95, 105, 116, 101, 109, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110, 46, 119, 97, 100, 111)), used: 34 };
 global global:local_item_newtype_definition.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(95, 95, 116, 101, 115, 116, 95, 48, 95, 108, 111, 99, 97, 108, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110)), used: 33 };
 global global:local_item_newtype_definition.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(65, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 32, 105, 110, 32)), used: 20 };
-global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 50, 58, 49, 57, 41)), used: 25 };
+global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 49, 58, 49, 57, 41)), used: 25 };
 global global:core:prelude/format.wado::__const_obj_10: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(46, 46, 46)), used: 3 };
 global global:core:prelude/format.wado::__const_obj_11: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(92, 117, 123)), used: 3 };
 
@@ -199,7 +199,7 @@ fn "local_item_newtype_definition.wado/__cm_export____test_1_sibling_test_blocks
         cold_path;
         "core:rt/panic"(__local_3 = "core:prelude/string.wado/String::with_capacity"(118); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_sibling_test_blocks_may_declare_same_named_local_newtypes_with_different_base_types"), used: 92 }); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push"(__local_3, 97); "core:prelude/string.wado/String::push"(__local_3, 116); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("local_item_newtype_definition.wado"), used: 34 }); "core:prelude/string.wado/String::push"(__local_3, 58); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 17 }, __local_4); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: id == \"abc\"
-"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2012:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
+"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2011:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
         unreachable;
     }
     "wasi/task-return"(0);
@@ -588,7 +588,7 @@ fn "core:prelude/string.wado/String::push"(self, c) {
     }
 }
 
-fn "local_item_newtype_definition.wado/UserId@AstId(2012:19)^Inspect::inspect"(self, f) {
+fn "local_item_newtype_definition.wado/UserId@AstId(2011:19)^Inspect::inspect"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     "core:prelude/format.wado/String^Inspect::inspect"(self, f);
     s = global:local_item_newtype_definition.wado::__const_obj_9;

--- a/wado-compiler/tests/zlib_interop.rs
+++ b/wado-compiler/tests/zlib_interop.rs
@@ -1,5 +1,5 @@
 //! Cross-validation tests comparing Wado's core:zlib implementation against
-//! zlib-rs and flate2 (backed by zlib-rs).
+//! zlib-rs.
 //!
 //! Architecture: Two Wado driver programs are compiled once and reused across
 //! all tests. Each test only performs cheap Wasm instantiation (no compilation).
@@ -12,9 +12,6 @@
 
 mod common;
 
-use flate2::Compression;
-use flate2::write::{DeflateDecoder, DeflateEncoder, GzDecoder, GzEncoder};
-use std::io::Write;
 use std::path::Path;
 use std::sync::OnceLock;
 use wasmtime::Store;
@@ -287,28 +284,48 @@ fn zlib_rs_decompress(input: &[u8], max_output: usize) -> Vec<u8> {
     decompressed.to_vec()
 }
 
-fn flate2_deflate_raw(input: &[u8], level: u32) -> Vec<u8> {
-    let mut encoder = DeflateEncoder::new(Vec::new(), Compression::new(level));
-    encoder.write_all(input).unwrap();
-    encoder.finish().unwrap()
+const RAW_WINDOW_BITS: i32 = -15;
+const GZIP_WINDOW_BITS: i32 = 15 + 16;
+
+fn zlib_rs_compress_with(input: &[u8], level: u32, window_bits: i32) -> Vec<u8> {
+    let mut output = vec![0u8; zlib_rs::compress_bound(input.len()) + 32];
+    let config = DeflateConfig {
+        window_bits,
+        ..DeflateConfig::new(level as i32)
+    };
+    let (compressed, rc) = zlib_rs::compress_slice(&mut output, input, config);
+    assert_eq!(rc, ReturnCode::Ok, "zlib-rs compress failed");
+    compressed.to_vec()
 }
 
-fn flate2_inflate_raw(input: &[u8]) -> Vec<u8> {
-    let mut decoder = DeflateDecoder::new(Vec::new());
-    decoder.write_all(input).unwrap();
-    decoder.finish().unwrap()
+fn zlib_rs_decompress_with(input: &[u8], window_bits: i32) -> Vec<u8> {
+    let mut size = input.len().max(64) * 4;
+    loop {
+        let mut output = vec![0u8; size];
+        let (decompressed, rc) =
+            zlib_rs::decompress_slice(&mut output, input, InflateConfig { window_bits });
+        match rc {
+            ReturnCode::Ok => return decompressed.to_vec(),
+            ReturnCode::BufError => size *= 2,
+            other => panic!("zlib-rs decompress failed: {other:?}"),
+        }
+    }
 }
 
-fn flate2_gzip_compress(input: &[u8], level: u32) -> Vec<u8> {
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::new(level));
-    encoder.write_all(input).unwrap();
-    encoder.finish().unwrap()
+fn zlib_rs_deflate_raw(input: &[u8], level: u32) -> Vec<u8> {
+    zlib_rs_compress_with(input, level, RAW_WINDOW_BITS)
 }
 
-fn flate2_gzip_decompress(input: &[u8]) -> Vec<u8> {
-    let mut decoder = GzDecoder::new(Vec::new());
-    decoder.write_all(input).unwrap();
-    decoder.finish().unwrap()
+fn zlib_rs_inflate_raw(input: &[u8]) -> Vec<u8> {
+    zlib_rs_decompress_with(input, RAW_WINDOW_BITS)
+}
+
+fn zlib_rs_gzip_compress(input: &[u8], level: u32) -> Vec<u8> {
+    zlib_rs_compress_with(input, level, GZIP_WINDOW_BITS)
+}
+
+fn zlib_rs_gzip_decompress(input: &[u8]) -> Vec<u8> {
+    zlib_rs_decompress_with(input, GZIP_WINDOW_BITS)
 }
 
 fn test_data_sequential(size: usize) -> Vec<u8> {
@@ -457,36 +474,36 @@ fn zlib_rs_pseudorandom_data_inflated_by_wado() {
 // ============================================================================
 
 #[test]
-fn wado_raw_deflate_decompressed_by_flate2() {
+fn wado_raw_deflate_decompressed_by_zlib_rs() {
     let input = test_data_text(5);
     let compressed = wado_deflate_raw(&input, 6);
-    let decompressed = flate2_inflate_raw(&compressed);
+    let decompressed = zlib_rs_inflate_raw(&compressed);
     assert_eq!(
         decompressed, input,
-        "flate2 failed to inflate Wado raw deflate"
+        "zlib-rs failed to inflate Wado raw deflate"
     );
 }
 
 #[test]
-fn flate2_raw_deflate_inflated_by_wado() {
+fn zlib_rs_raw_deflate_inflated_by_wado() {
     let input = test_data_sequential(300);
-    let compressed = flate2_deflate_raw(&input, 6);
+    let compressed = zlib_rs_deflate_raw(&input, 6);
     let decompressed = wado_inflate_raw(&compressed);
     assert_eq!(
         decompressed, input,
-        "Wado failed to inflate flate2 raw deflate"
+        "Wado failed to inflate zlib-rs raw deflate"
     );
 }
 
 #[test]
-fn flate2_raw_deflate_all_levels_inflated_by_wado() {
+fn zlib_rs_raw_deflate_all_levels_inflated_by_wado() {
     let input = test_data_text(5);
     for level in 0..=9 {
-        let compressed = flate2_deflate_raw(&input, level);
+        let compressed = zlib_rs_deflate_raw(&input, level);
         let decompressed = wado_inflate_raw(&compressed);
         assert_eq!(
             decompressed, input,
-            "Wado inflate_raw failed for flate2 level {level}"
+            "Wado inflate_raw failed for zlib-rs level {level}"
         );
     }
 }
@@ -496,36 +513,36 @@ fn flate2_raw_deflate_all_levels_inflated_by_wado() {
 // ============================================================================
 
 #[test]
-fn wado_gzip_compress_decompressed_by_flate2() {
+fn wado_gzip_compress_decompressed_by_zlib_rs() {
     let input = test_data_text(5);
     let compressed = wado_gzip_compress(&input, 6);
-    let decompressed = flate2_gzip_decompress(&compressed);
+    let decompressed = zlib_rs_gzip_decompress(&compressed);
     assert_eq!(
         decompressed, input,
-        "flate2 failed to decompress Wado gzip output"
+        "zlib-rs failed to decompress Wado gzip output"
     );
 }
 
 #[test]
-fn flate2_gzip_inflated_by_wado() {
+fn zlib_rs_gzip_inflated_by_wado() {
     let input = test_data_sequential(300);
-    let compressed = flate2_gzip_compress(&input, 6);
+    let compressed = zlib_rs_gzip_compress(&input, 6);
     let decompressed = wado_inflate_gzip(&compressed);
     assert_eq!(
         decompressed, input,
-        "Wado failed to inflate flate2 gzip data"
+        "Wado failed to inflate zlib-rs gzip data"
     );
 }
 
 #[test]
-fn flate2_gzip_all_levels_inflated_by_wado() {
+fn zlib_rs_gzip_all_levels_inflated_by_wado() {
     let input = test_data_text(3);
     for level in 0..=9 {
-        let compressed = flate2_gzip_compress(&input, level);
+        let compressed = zlib_rs_gzip_compress(&input, level);
         let decompressed = wado_inflate_gzip(&compressed);
         assert_eq!(
             decompressed, input,
-            "Wado inflate_gzip failed for flate2 level {level}"
+            "Wado inflate_gzip failed for zlib-rs level {level}"
         );
     }
 }
@@ -725,10 +742,10 @@ fn cross_validate_large_repetitive() {
 // ============================================================================
 
 #[test]
-fn wado_deflate_stream_raw_decompressed_by_flate2() {
+fn wado_deflate_stream_raw_decompressed_by_zlib_rs() {
     let input = b"Raw deflate test data";
     let compressed = wado_deflate_stream_raw(input, 6);
-    let decompressed = flate2_inflate_raw(&compressed);
+    let decompressed = zlib_rs_inflate_raw(&compressed);
     assert_eq!(
         decompressed, input,
         "DeflateStream RAW_FORMAT cross-inflate failed"
@@ -736,10 +753,10 @@ fn wado_deflate_stream_raw_decompressed_by_flate2() {
 }
 
 #[test]
-fn wado_deflate_stream_gzip_decompressed_by_flate2() {
+fn wado_deflate_stream_gzip_decompressed_by_zlib_rs() {
     let input = b"Gzip format test data";
     let compressed = wado_deflate_stream_gzip(input, 6);
-    let decompressed = flate2_gzip_decompress(&compressed);
+    let decompressed = zlib_rs_gzip_decompress(&compressed);
     assert_eq!(
         decompressed, input,
         "DeflateStream GZIP_FORMAT cross-inflate failed"
@@ -747,24 +764,24 @@ fn wado_deflate_stream_gzip_decompressed_by_flate2() {
 }
 
 #[test]
-fn wado_inflate_stream_raw_from_flate2() {
-    let input = b"Inflate raw from flate2";
-    let compressed = flate2_deflate_raw(input, 6);
+fn wado_inflate_stream_raw_from_zlib_rs() {
+    let input = b"Inflate raw from zlib-rs";
+    let compressed = zlib_rs_deflate_raw(input, 6);
     let decompressed = wado_inflate_stream_raw(&compressed);
     assert_eq!(
         decompressed, input,
-        "InflateStream RAW_FORMAT from flate2 failed"
+        "InflateStream RAW_FORMAT from zlib-rs failed"
     );
 }
 
 #[test]
-fn wado_inflate_stream_gzip_from_flate2() {
-    let input = b"Inflate gzip from flate2";
-    let compressed = flate2_gzip_compress(input, 6);
+fn wado_inflate_stream_gzip_from_zlib_rs() {
+    let input = b"Inflate gzip from zlib-rs";
+    let compressed = zlib_rs_gzip_compress(input, 6);
     let decompressed = wado_inflate_stream_gzip(&compressed);
     assert_eq!(
         decompressed, input,
-        "InflateStream GZIP_FORMAT from flate2 failed"
+        "InflateStream GZIP_FORMAT from zlib-rs failed"
     );
 }
 
@@ -782,7 +799,7 @@ fn wado_inflate_stream_auto_format_zlib() {
 #[test]
 fn wado_inflate_stream_auto_format_gzip() {
     let input = b"Auto detect gzip";
-    let compressed = flate2_gzip_compress(input, 6);
+    let compressed = zlib_rs_gzip_compress(input, 6);
     let decompressed = wado_inflate_stream_auto(&compressed);
     assert_eq!(
         decompressed, input,
@@ -944,20 +961,20 @@ fn fuzz_raw_deflate_round_trip() {
         let level = (next() % 10) as i32;
         let data: Vec<u8> = (0..size).map(|_| next() as u8).collect();
 
-        // Wado deflate → flate2 inflate
+        // Wado deflate → zlib-rs inflate
         let compressed = wado_deflate_raw(&data, level);
-        let decompressed = flate2_inflate_raw(&compressed);
+        let decompressed = zlib_rs_inflate_raw(&compressed);
         assert_eq!(
             decompressed, data,
             "fuzz #{i}: Wado raw deflate level {level}, size {size}"
         );
 
-        // flate2 deflate → Wado inflate
-        let compressed2 = flate2_deflate_raw(&data, level as u32);
+        // zlib-rs deflate → Wado inflate
+        let compressed2 = zlib_rs_deflate_raw(&data, level as u32);
         let decompressed2 = wado_inflate_raw(&compressed2);
         assert_eq!(
             decompressed2, data,
-            "fuzz #{i}: flate2 raw deflate level {level}, size {size}"
+            "fuzz #{i}: zlib-rs raw deflate level {level}, size {size}"
         );
     }
 }
@@ -975,20 +992,20 @@ fn fuzz_gzip_round_trip() {
         let level = (next() % 10) as i32;
         let data: Vec<u8> = (0..size).map(|_| next() as u8).collect();
 
-        // Wado gzip → flate2 decompress
+        // Wado gzip → zlib-rs decompress
         let compressed = wado_gzip_compress(&data, level);
-        let decompressed = flate2_gzip_decompress(&compressed);
+        let decompressed = zlib_rs_gzip_decompress(&compressed);
         assert_eq!(
             decompressed, data,
             "fuzz #{i}: Wado gzip level {level}, size {size}"
         );
 
-        // flate2 gzip → Wado decompress
-        let compressed2 = flate2_gzip_compress(&data, level as u32);
+        // zlib-rs gzip → Wado decompress
+        let compressed2 = zlib_rs_gzip_compress(&data, level as u32);
         let decompressed2 = wado_inflate_gzip(&compressed2);
         assert_eq!(
             decompressed2, data,
-            "fuzz #{i}: flate2 gzip level {level}, size {size}"
+            "fuzz #{i}: zlib-rs gzip level {level}, size {size}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Remove `flate2`, `crc32fast`, and `adler` from the workspace; `zlib_interop.rs` now cross-validates Wado's `core:zlib` against zlib-rs alone.
- `flate2` was configured with the `zlib-rs` backend, so it was an API wrapper over the same implementation, not an independent reference — no cross-validation coverage is lost. The four whole-buffer helpers (raw deflate / gzip, compress / decompress) are rewritten with `zlib_rs::compress_slice` / `decompress_slice` using `window_bits` (-15 = raw, 31 = gzip); decompression retries with a doubled buffer on `BufError`, keeping call sites unchanged.
- `crc32fast` and `adler` were added for checksum cross-validation (93b66dc836) but never referenced — the tests already use `zlib_rs::crc32` / `zlib_rs::adler32`.
- Also includes the pending `jsonschema` 0.46 → 0.47 bump.

`Cargo.lock` drops five packages (`flate2`, `adler`, `adler2`, `miniz_oxide`, `simd-adler32`). `crc32fast` remains only as a transitive dependency of wasmtime (via `object`).

## Test plan

- [x] `cargo test -p wado-compiler --test zlib_interop` — 49 passed, 0 failed
- [x] `cargo fmt -p wado-compiler -- --check`
- [x] `mise run check-deps` — wasm-tools pins still deduped on wasmtime's generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)