### PR TITLE
docs: fix broken doc cross-links, drop the CLAUDE.md reference

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -4,7 +4,7 @@ The Wado compiler (`wado-compiler/`) translates `.wado` source into a Wasm compo
 
 - Optimization passes: [optimizer.md](./optimizer.md)
 - LSP architecture: [WEP 2026-04-18](./wep-2026-04-18-lsp-architecture.md)
-- Language features: [spec.md](./spec.md) and the [WEP index](./CLAUDE.md)
+- Language features: [spec.md](./spec.md)
 
 ## Pipeline
 

--- a/docs/jitdump-profiling.md
+++ b/docs/jitdump-profiling.md
@@ -90,4 +90,4 @@ rm -f jit-*.dump perf.data perf.jit.data
 
 ## Comparison with Other Wasmtime Profilers
 
-See [wasmtime-profiler-characteristics.md](./wasmtime-profiler-characteristics.md) for a detailed comparison of all three wasmtime profiling modes (guest, jitdump, perfmap).
+See [research-wasmtime-profiler-characteristics.md](./research-wasmtime-profiler-characteristics.md) for a detailed comparison of all three wasmtime profiling modes (guest, jitdump, perfmap).

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -12,7 +12,7 @@ Wado is a programming language targeting Wasm/WASI -- Wasm in plain sight.
 | Typing    | Static, Strong, Inferred  |
 | Target    | Wasm/WASI                 |
 
-See also: [Cheatsheet](docs/cheatsheet.md) for quick syntax reference.
+See also: [Cheatsheet](./cheatsheet.md) for quick syntax reference.
 
 ## Design Philosophy
 

--- a/docs/wep-2026-01-10-deterministic-libm.md
+++ b/docs/wep-2026-01-10-deterministic-libm.md
@@ -290,7 +290,7 @@ match import_source {
 - [ ] Generate `embedded/libm.wasm` and `embedded/libm.wit`
 - [ ] Embed `libm.wasm` in compiler binary
 
-### Phase 2: Compiler Integration (depends on ARD-2026-01-10-wasm-import)
+### Phase 2: Compiler Integration (depends on WEP-2026-01-10-wasm-import)
 
 - [ ] Implement `builtin:libm` namespace resolution
 - [ ] Link bundled `libm.wasm` into final component
@@ -338,4 +338,4 @@ match import_source {
 - [Floating-point portability issues (Japanese)](https://zenn.dev/mod_poppo/articles/floating-point-portability)
 - [IEEE 754-2019 Standard](https://ieeexplore.ieee.org/document/8766229)
 - [WebAssembly Floating-Point Semantics](https://webassembly.github.io/spec/core/exec/numerics.html#floating-point-operations)
-- Related ARD: [ARD-2026-01-10-wasm-import](./ard-2026-01-10-wasm-import.md)
+- Related WEP: [WEP-2026-01-10-wasm-import](./wep-2026-01-10-wasm-import.md)

--- a/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
@@ -100,7 +100,7 @@ type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref Array<u8>
 
 type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(39)
 
-type "functype//local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
+type "functype//local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
 
 type "functype//core:prelude/format.wado/Formatter::new" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/format.wado//Formatter";  // TypeId(41)
 
@@ -136,7 +136,7 @@ global global:local_item_newtype_definition.wado::__const_obj_0: ref null "core:
 global global:local_item_newtype_definition.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(108, 111, 99, 97, 108, 95, 105, 116, 101, 109, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110, 46, 119, 97, 100, 111)), used: 34 };
 global global:local_item_newtype_definition.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(95, 95, 116, 101, 115, 116, 95, 48, 95, 108, 111, 99, 97, 108, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110)), used: 33 };
 global global:local_item_newtype_definition.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(65, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 32, 105, 110, 32)), used: 20 };
-global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 55, 58, 49, 57, 41)), used: 25 };
+global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 56, 58, 49, 57, 41)), used: 25 };
 global global:core:prelude/format.wado::__const_obj_10: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(46, 46, 46)), used: 3 };
 global global:core:prelude/format.wado::__const_obj_11: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(92, 117, 123)), used: 3 };
 
@@ -199,7 +199,7 @@ fn "local_item_newtype_definition.wado/__cm_export____test_1_sibling_test_blocks
         cold_path;
         "core:rt/panic"(__local_3 = "core:prelude/string.wado/String::with_capacity"(118); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_sibling_test_blocks_may_declare_same_named_local_newtypes_with_different_base_types"), used: 92 }); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push"(__local_3, 97); "core:prelude/string.wado/String::push"(__local_3, 116); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("local_item_newtype_definition.wado"), used: 34 }); "core:prelude/string.wado/String::push"(__local_3, 58); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 17 }, __local_4); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: id == \"abc\"
-"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
+"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
         unreachable;
     }
     "wasi/task-return"(0);
@@ -588,7 +588,7 @@ fn "core:prelude/string.wado/String::push"(self, c) {
     }
 }
 
-fn "local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect"(self, f) {
+fn "local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     "core:prelude/format.wado/String^Inspect::inspect"(self, f);
     s = global:local_item_newtype_definition.wado::__const_obj_9;


### PR DESCRIPTION
Fixes broken relative links found while rendering `docs/` on the Wado site.

- `compiler.md`: remove the `[WEP index](./CLAUDE.md)` link.
- `spec.md`: `docs/cheatsheet.md` → `./cheatsheet.md` — it sits in the same directory, so the `docs/` prefix pointed a level too deep.
- `jitdump-profiling.md`: link `research-wasmtime-profiler-characteristics.md`, the file's actual name (the `research-` prefix was missing).
- `wep-2026-01-10-deterministic-libm.md`: the related proposal is a WEP, not an "ARD" — corrected the name and the `./wep-2026-01-10-wasm-import.md` link.

The remaining relative links the scan flags are not broken: `../vendor/component-model/design/mvp/*.md` resolve once the submodule is initialized, and the `Digest::update` / grammar-notation / Marl-syntax-example hits are inline code or prose, not links.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrNa2dR3XekiV3sE2xo9jd)_