### PR TITLE
feat(marl)!: GFM heading ids and rendered outline with a value-only API

### DIFF
--- a/docs/wep-2026-07-05-marl.md
+++ b/docs/wep-2026-07-05-marl.md
@@ -59,17 +59,56 @@ than merely echo it. Two backends walk the same tree:
 - `fmt_html.wado` — AST to HTML (`render`).
 - `fmt_print.wado` — AST to canonical Markdown (`format`).
 
-`lib.wado` re-exports `render`, `format`, and the `escape_text` /
-`escape_attr` helpers for HTML-templating consumers.
+`lib.wado` re-exports `render`, `RenderResult` / `HeadingInfo`, `format`, and
+the `escape_text` / `escape_attr` helpers for HTML-templating consumers.
+
+### Public API: WIT-representable, no references
+
+The public surface takes and returns values only — no `&T` — so it maps
+directly onto a WIT interface (`string`, `list`, records) should Marl ever be
+exposed as a Component Model component. Reference-taking workhorses stay
+`internal` behind the value-based facade, so the hot path avoids copies.
 
 ### Rendering: the HTML backend
 
 The renderer has no I/O — a single pure entry point over strings, which keeps
-it trivially testable and reusable by any consumer.
+it trivially testable and reusable by any consumer. It returns the HTML plus
+the heading outline collected during rendering, so a consumer (e.g. a CMS) can
+opt into a table of contents by walking `headings`, or ignore it for plain
+HTML.
 
 ```wado
-pub fn render(source: &String) -> String { ... }
+pub struct RenderResult {
+    pub html: String,
+    pub headings: List<HeadingInfo>,
+}
+
+pub struct HeadingInfo {
+    pub level: u8,     // 1..=6
+    pub id: String,    // GFM slug, unique in the document; also the `id` attr
+    pub text: String,  // plain-text content: slug source and TOC label
+}
+
+pub fn render(source: String) -> RenderResult { ... }
 ```
+
+### Heading ids (GFM slugs)
+
+Every heading is emitted as `<hN id="slug">…</hN>` and recorded in
+`RenderResult.headings` in document order (headings nested in blockquotes and
+list items included). The slug follows github-slugger:
+
+- lowercase ASCII letters; keep ASCII alphanumerics, `-`, and `_`;
+- turn each space into `-`; drop other ASCII punctuation;
+- keep non-ASCII characters verbatim as UTF-8, so `## 日本語` yields
+  `id="日本語"`;
+- deduplicate within the document by appending `-1`, `-2`, … to a repeated
+  base, skipping any suffix that collides with an explicit slug.
+
+Fidelity is exact for ASCII and for caseless scripts (CJK). The one accepted
+divergence from GitHub: non-ASCII letters are not case-folded (an uppercase
+`Ü` stays `Ü`), since the guest has ASCII-only case tables and full Unicode
+case folding is out of scope for this iteration.
 
 Supported blocks (v0.1):
 
@@ -212,7 +251,9 @@ tool for context-free DSLs, not for Markdown.
 - [x] Inline parsing: emphasis, strong, code, links, images, strikethrough,
       autolinks, hard breaks, backslash escapes
 - [x] CommonMark fence-length rules
-- [x] `pub fn render(source: &String) -> String`
+- [x] `pub fn render(source: String) -> RenderResult` — HTML plus the heading
+      outline; every heading carries a GFM slug `id`
+- [x] Value-only public API (no references), so the surface maps onto WIT
 
 Within the implemented subset, rendering follows CommonMark: emphasis uses
 the delimiter-stack procedure (flanking, rule of three, nested `***`), ATX

--- a/package-marl/src/fmt_html.wado
+++ b/package-marl/src/fmt_html.wado
@@ -5,6 +5,10 @@
 //! HTML. Output is safe by construction: text and raw HTML are escaped, and
 //! link/image/autolink destinations are scheme-filtered (see
 //! `docs/wep-2026-07-05-marl.md`, "HTML safety").
+//!
+//! `render` returns both the HTML and the heading outline it collected, so a
+//! consumer (e.g. a CMS) can opt into a table of contents. Every heading gets
+//! a GFM-compatible `id` (see `fmt_slug.wado`).
 
 use {
     Node,
@@ -18,76 +22,192 @@ use {
     ReferenceLinkNode,
     ReferenceImageNode,
 } from "./fmt_ast.wado";
-use { escape_text, escape_attr, sanitize_url } from "./html.wado";
+use { escape_text_ref, escape_attr_ref } from "./html.wado";
 use { RefTable, ref_table_get } from "./fmt_links.wado";
 use { parse } from "./fmt_parse_block.wado";
 use { is_ascii_punct } from "./fmt_parse_inline.wado";
 use { chars_of } from "./str_cursor.wado";
+use { slugify, Slugger } from "./fmt_slug.wado";
 
-pub fn render(source: &String) -> String {
-    let parsed = parse(source);
-    return match &parsed.document {
-        Node::Document(children) => render_blocks(children, &parsed.refs),
+/// A rendered Markdown document: the HTML plus the heading outline collected
+/// while rendering. Consuming `headings` is opt-in — ignore it for plain HTML,
+/// or walk it to build a table of contents.
+pub struct RenderResult {
+    pub html: String,
+    pub headings: List<HeadingInfo>,
+}
+
+/// One heading in the document outline, in document order.
+pub struct HeadingInfo {
+    /// Heading level, 1..=6.
+    pub level: u8,
+    /// GFM-compatible slug, unique within the document; also the heading's
+    /// `id` attribute.
+    pub id: String,
+    /// Plain-text content of the heading, used both as the slug source and as
+    /// a ready-made table-of-contents label.
+    pub text: String,
+}
+
+pub fn render(source: String) -> RenderResult {
+    let parsed = parse(&source);
+    let mut r = Renderer {
+        refs: parsed.refs,
+        slugger: Slugger::new(),
+        headings: [],
+    };
+    let html = match &parsed.document {
+        Node::Document(children) => r.render_blocks(children),
         _ => panic("marl-html: render expects a Document node"),
     };
+    return RenderResult { html, headings: r.headings };
 }
 
-// --- blocks ---
+/// Rendering state threaded through the block walk: the document's reference
+/// definitions plus the slug deduplicator and the heading outline being built.
+struct Renderer {
+    refs: RefTable,
+    slugger: Slugger,
+    headings: List<HeadingInfo>,
+}
 
-/// Blocks join with a single newline, and front matter / reference
-/// definitions contribute no output — they are metadata, not content.
-fn render_blocks(nodes: &List<Node>, refs: &RefTable) -> String {
-    let mut parts: List<String> = [];
-    for let node of nodes {
-        if node matches { Node::FrontMatter(_) | Node::LinkReferenceDef(_) } {
-            continue;
+impl Renderer {
+    // --- blocks ---
+
+    /// Blocks join with a single newline, and front matter / reference
+    /// definitions contribute no output — they are metadata, not content.
+    fn render_blocks(&mut self, nodes: &List<Node>) -> String {
+        let mut parts: List<String> = [];
+        for let node of nodes {
+            if node matches { Node::FrontMatter(_) | Node::LinkReferenceDef(_) } {
+                continue;
+            }
+            parts.push(self.render_block(node));
         }
-        parts.push(render_block(node, refs));
+        return parts.join("\n");
     }
-    return parts.join("\n");
+
+    fn render_block(&mut self, node: &Node) -> String {
+        return match node {
+            Node::Heading(h) => self.render_heading(h),
+            Node::Paragraph(p) => `<p>{render_inline_seq(&p.children, &self.refs)}</p>`,
+            Node::BlockQuote(children) => `<blockquote>\n{self.render_blocks(children)}\n</blockquote>`,
+            Node::CodeBlock(cb) => render_code_block(cb),
+            Node::List(list) => self.render_list(list),
+            Node::Table(t) => render_table(t, &self.refs),
+            Node::ThematicBreak => "<hr />",
+            Node::Html(s) => escape_text_ref(s),
+            _ => panic("marl-html: unexpected node in block position"),
+        };
+    }
+
+    fn render_heading(&mut self, h: &Heading) -> String {
+        let text = heading_text(&h.children);
+        let id = self.slugger.slug(slugify(&text));
+        let inner = render_inline_seq(&h.children, &self.refs);
+        self.headings.push(HeadingInfo { level: h.level as u8, id, text });
+        return `<h{h.level} id="{escape_attr_ref(&id)}">{inner}</h{h.level}>`;
+    }
+
+    // --- lists ---
+
+    fn render_list(&mut self, list: &MdList) -> String {
+        let loose = list_is_loose(list);
+        let mut parts: List<String> = [];
+        for let item of list.items {
+            parts.push(self.render_item(&item, loose));
+        }
+        let inner = parts.join("\n");
+        let [open, close] = list_tags(list);
+        return `{open}\n{inner}\n{close}`;
+    }
+
+    fn render_item(&mut self, item: &MdItem, loose: bool) -> String {
+        let marker = match item.marker {
+            Some(m) => if m.checked { "[x] " } else { "[ ] " },
+            None => "",
+        };
+        let content = self.render_item_children(&item.children, loose, marker);
+        if loose {
+            return `<li>\n{content}\n</li>`;
+        }
+        return `<li>{content}</li>`;
+    }
+
+    /// In a tight list a paragraph item contributes its inline content
+    /// directly; in a loose list it is wrapped in `<p>`. Nested blocks render
+    /// normally. A task-list marker (`[ ] ` / `[x] `) leads the first child's
+    /// content, so it lands inside the `<p>` of a loose item without
+    /// inspecting the output.
+    fn render_item_children(&mut self, children: &List<Node>, loose: bool, marker: String) -> String {
+        let mut parts: List<String> = [];
+        let mut first = true;
+        for let child of children {
+            let lead = if first { marker } else { "" };
+            parts.push(self.render_item_child(child, loose, &lead));
+            first = false;
+        }
+        return parts.join("\n");
+    }
+
+    fn render_item_child(&mut self, child: &Node, loose: bool, lead: &String) -> String {
+        match child {
+            Node::Paragraph(p) => {
+                let inline = render_inline_seq(&p.children, &self.refs);
+                if loose {
+                    return `<p>{lead}{inline}</p>`;
+                }
+                return `{lead}{inline}`;
+            },
+            _ => {
+                return `{lead}{self.render_block(child)}`;
+            },
+        }
+    }
 }
 
-fn render_block(node: &Node, refs: &RefTable) -> String {
-    return match node {
-        Node::Heading(h) => render_heading(h, refs),
-        Node::Paragraph(p) => `<p>{render_inline_seq(&p.children, refs)}</p>`,
-        Node::BlockQuote(children) => `<blockquote>\n{render_blocks(children, refs)}\n</blockquote>`,
-        Node::CodeBlock(cb) => render_code_block(cb),
-        Node::List(list) => render_list(list, refs),
-        Node::Table(t) => render_table(t, refs),
-        Node::ThematicBreak => "<hr />",
-        Node::Html(s) => escape_text(s),
-        _ => panic("marl-html: unexpected node in block position"),
-    };
+// --- heading text extraction ---
+
+/// The plain-text content of a heading's inline children — the slug source and
+/// TOC label. Mirrors GFM's `textContent`: code-span text is included, link
+/// and emphasis text is flattened, autolinks contribute their URL, and image
+/// alt text is excluded.
+fn heading_text(children: &List<Node>) -> String {
+    let mut out = String::new();
+    collect_heading_text(children, &mut out);
+    return out;
 }
 
-fn render_heading(h: &Heading, refs: &RefTable) -> String {
-    return `<h{h.level}>{render_inline_seq(&h.children, refs)}</h{h.level}>`;
+fn collect_heading_text(children: &List<Node>, out: &mut String) {
+    for let node of children {
+        match node {
+            Node::Text(s) => out.push_str(&unescape_backslashes(s)),
+            Node::Code(s) => out.push_str(s),
+            Node::Emphasis(em) => collect_heading_text(&em.children, out),
+            Node::Strong(ch) => collect_heading_text(ch, out),
+            Node::Strikethrough(ch) => collect_heading_text(ch, out),
+            Node::InlineLink(link) => collect_heading_text(&link.children, out),
+            Node::ReferenceLink(link) => collect_heading_text(&link.children, out),
+            Node::ShortcutLink(link) => collect_heading_text(&link.children, out),
+            Node::AutoLink(link) => out.push_str(&link.url),
+            Node::Html(s) => out.push_str(s),
+            _ => {},
+        }
+    }
 }
+
+// --- blocks (reference-only) ---
 
 fn render_code_block(cb: &CodeBlock) -> String {
     let mut out = String::new();
     out.push_str(&"<pre><code");
     if cb.tag.len() > 0 {
-        out.push_str(&` class="language-{escape_attr(&cb.tag)}"`);
+        out.push_str(&` class="language-{escape_attr_ref(&cb.tag)}"`);
     }
     out.push('>');
-    out.push_str(&escape_text(&cb.code));
+    out.push_str(&escape_text_ref(&cb.code));
     out.push_str(&"</code></pre>");
     return out;
-}
-
-// --- lists ---
-
-fn render_list(list: &MdList, refs: &RefTable) -> String {
-    let loose = list_is_loose(list);
-    let mut parts: List<String> = [];
-    for let item of list.items {
-        parts.push(render_item(&item, loose, refs));
-    }
-    let inner = parts.join("\n");
-    let [open, close] = list_tags(list);
-    return `{open}\n{inner}\n{close}`;
 }
 
 fn list_is_loose(list: &MdList) -> bool {
@@ -107,48 +227,6 @@ fn list_tags(list: &MdList) -> [String, String] {
         return [`<ol start="{list.start}">`, "</ol>"];
     }
     return ["<ol>", "</ol>"];
-}
-
-fn render_item(item: &MdItem, loose: bool, refs: &RefTable) -> String {
-    let marker = match item.marker {
-        Some(m) => if m.checked { "[x] " } else { "[ ] " },
-        None => "",
-    };
-    let content = render_item_children(&item.children, loose, marker, refs);
-    if loose {
-        return `<li>\n{content}\n</li>`;
-    }
-    return `<li>{content}</li>`;
-}
-
-/// In a tight list a paragraph item contributes its inline content directly;
-/// in a loose list it is wrapped in `<p>`. Nested blocks render normally. A
-/// task-list marker (`[ ] ` / `[x] `) leads the first child's content, so it
-/// lands inside the `<p>` of a loose item without inspecting the output.
-fn render_item_children(children: &List<Node>, loose: bool, marker: String, refs: &RefTable) -> String {
-    let mut parts: List<String> = [];
-    let mut first = true;
-    for let child of children {
-        let lead = if first { marker } else { "" };
-        parts.push(render_item_child(child, loose, &lead, refs));
-        first = false;
-    }
-    return parts.join("\n");
-}
-
-fn render_item_child(child: &Node, loose: bool, lead: &String, refs: &RefTable) -> String {
-    match child {
-        Node::Paragraph(p) => {
-            let inline = render_inline_seq(&p.children, refs);
-            if loose {
-                return `<p>{lead}{inline}</p>`;
-            }
-            return `{lead}{inline}`;
-        },
-        _ => {
-            return `{lead}{render_block(child, refs)}`;
-        },
-    }
 }
 
 // --- tables ---
@@ -218,14 +296,14 @@ fn render_inline_node(node: &Node, refs: &RefTable, out: &mut String) {
         Node::Emphasis(em) => wrap_inline(&"em", &em.children, refs, out),
         Node::Strong(children) => wrap_inline(&"strong", children, refs, out),
         Node::Strikethrough(children) => wrap_inline(&"del", children, refs, out),
-        Node::Code(s) => out.push_str(&`<code>{escape_text(s)}</code>`),
+        Node::Code(s) => out.push_str(&`<code>{escape_text_ref(s)}</code>`),
         Node::InlineLink(link) => render_link(&link.url, &link.title, &link.children, refs, out),
         Node::ReferenceLink(link) => render_reference_link(link, refs, out),
         Node::ShortcutLink(link) => render_reference_link(link, refs, out),
         Node::AutoLink(link) => render_autolink(&link.url, out),
         Node::InlineImage(img) => render_image(&img.alt, &img.url, &img.title, out),
         Node::ReferenceImage(img) => render_reference_image(img, refs, out),
-        Node::Html(s) => out.push_str(&escape_text(s)),
+        Node::Html(s) => out.push_str(&escape_text_ref(s)),
         _ => panic("marl-html: unexpected node in inline position"),
     }
 }
@@ -238,7 +316,7 @@ fn wrap_inline(tag: &String, children: &List<Node>, refs: &RefTable, out: &mut S
 /// source spelling (`\*`) so the formatter round-trips it, but HTML output
 /// wants the escaped character itself (`*`).
 fn text_to_html(s: &String) -> String {
-    return escape_text(&unescape_backslashes(s));
+    return escape_text_ref(&unescape_backslashes(s));
 }
 
 fn unescape_backslashes(s: &String) -> String {
@@ -258,8 +336,29 @@ fn unescape_backslashes(s: &String) -> String {
     return out;
 }
 
+/// Neutralize a link/image destination whose scheme could execute script:
+/// return it unchanged when the scheme is safe (or absent), else `""`. Blocks
+/// `javascript:`, `data:`, `vbscript:`, and any other unlisted scheme.
+fn sanitize_url(url: &String) -> String {
+    let mut scheme = String::new();
+    for let c of url.chars() {
+        if c == ':' {
+            return if scheme_is_safe(&scheme) { *url } else { "" };
+        }
+        if c matches { '/' | '?' | '#' } {
+            return *url;
+        }
+        scheme.push(c.to_ascii_lowercase());
+    }
+    return *url;
+}
+
+fn scheme_is_safe(scheme: &String) -> bool {
+    return *scheme == "http" || *scheme == "https" || *scheme == "mailto" || *scheme == "tel";
+}
+
 fn render_link(url: &String, title: &String, children: &List<Node>, refs: &RefTable, out: &mut String) {
-    let href = escape_attr(&sanitize_url(url));
+    let href = escape_attr_ref(&sanitize_url(url));
     out.push_str(&`<a href="{href}"{title_attr(title)}>{render_inline_seq(children, refs)}</a>`);
 }
 
@@ -273,13 +372,13 @@ fn render_reference_link(link: &ReferenceLinkNode, refs: &RefTable, out: &mut St
 }
 
 fn render_autolink(url: &String, out: &mut String) {
-    let href = escape_attr(&sanitize_url(url));
-    out.push_str(&`<a href="{href}">{escape_text(url)}</a>`);
+    let href = escape_attr_ref(&sanitize_url(url));
+    out.push_str(&`<a href="{href}">{escape_text_ref(url)}</a>`);
 }
 
 fn render_image(alt: &String, url: &String, title: &String, out: &mut String) {
-    let src = escape_attr(&sanitize_url(url));
-    out.push_str(&`<img src="{src}" alt="{escape_attr(alt)}"{title_attr(title)} />`);
+    let src = escape_attr_ref(&sanitize_url(url));
+    out.push_str(&`<img src="{src}" alt="{escape_attr_ref(alt)}"{title_attr(title)} />`);
 }
 
 fn render_reference_image(img: &ReferenceImageNode, refs: &RefTable, out: &mut String) {
@@ -293,5 +392,5 @@ fn title_attr(title: &String) -> String {
     if title.len() == 0 {
         return "";
     }
-    return ` title="{escape_attr(title)}"`;
+    return ` title="{escape_attr_ref(title)}"`;
 }

--- a/package-marl/src/fmt_html.wado
+++ b/package-marl/src/fmt_html.wado
@@ -6,9 +6,8 @@
 //! link/image/autolink destinations are scheme-filtered (see
 //! `docs/wep-2026-07-05-marl.md`, "HTML safety").
 //!
-//! `render` returns both the HTML and the heading outline it collected, so a
-//! consumer (e.g. a CMS) can opt into a table of contents. Every heading gets
-//! a GFM-compatible `id` (see `fmt_slug.wado`).
+//! `render` also returns the heading outline it collects, so a consumer can
+//! opt into a table of contents; every heading gets a GFM `id` (`fmt_slug`).
 
 use {
     Node,
@@ -29,23 +28,18 @@ use { is_ascii_punct } from "./fmt_parse_inline.wado";
 use { chars_of } from "./str_cursor.wado";
 use { slugify, Slugger } from "./fmt_slug.wado";
 
-/// A rendered Markdown document: the HTML plus the heading outline collected
-/// while rendering. Consuming `headings` is opt-in — ignore it for plain HTML,
-/// or walk it to build a table of contents.
+/// The HTML plus the heading outline collected while rendering; walk
+/// `headings` to build a table of contents, or use `html` alone.
 pub struct RenderResult {
     pub html: String,
     pub headings: List<HeadingInfo>,
 }
 
-/// One heading in the document outline, in document order.
+/// A heading in document order: its level (1..=6), slug `id`, and plain-text
+/// label.
 pub struct HeadingInfo {
-    /// Heading level, 1..=6.
     pub level: u8,
-    /// GFM-compatible slug, unique within the document; also the heading's
-    /// `id` attribute.
     pub id: String,
-    /// Plain-text content of the heading, used both as the slug source and as
-    /// a ready-made table-of-contents label.
     pub text: String,
 }
 
@@ -63,8 +57,6 @@ pub fn render(source: String) -> RenderResult {
     return RenderResult { html, headings: r.headings };
 }
 
-/// Rendering state threaded through the block walk: the document's reference
-/// definitions plus the slug deduplicator and the heading outline being built.
 struct Renderer {
     refs: RefTable,
     slugger: Slugger,
@@ -166,12 +158,6 @@ impl Renderer {
     }
 }
 
-// --- heading text extraction ---
-
-/// The plain-text content of a heading's inline children — the slug source and
-/// TOC label. Mirrors GFM's `textContent`: code-span text is included, link
-/// and emphasis text is flattened, autolinks contribute their URL, and image
-/// alt text is excluded.
 fn heading_text(children: &List<Node>) -> String {
     let mut out = String::new();
     collect_heading_text(children, &mut out);
@@ -195,8 +181,6 @@ fn collect_heading_text(children: &List<Node>, out: &mut String) {
         }
     }
 }
-
-// --- blocks (reference-only) ---
 
 fn render_code_block(cb: &CodeBlock) -> String {
     let mut out = String::new();

--- a/package-marl/src/fmt_html.wado
+++ b/package-marl/src/fmt_html.wado
@@ -177,7 +177,8 @@ fn collect_heading_text(children: &List<Node>, out: &mut String) {
             Node::ShortcutLink(link) => collect_heading_text(&link.children, out),
             Node::AutoLink(link) => out.push_str(&link.url),
             Node::Html(s) => out.push_str(s),
-            _ => {},
+            _ => {
+            },
         }
     }
 }

--- a/package-marl/src/fmt_html_test.wado
+++ b/package-marl/src/fmt_html_test.wado
@@ -3,31 +3,31 @@ use { render } from "./fmt_html.wado";
 // --- blocks ---
 
 test "render wraps a line in a paragraph" {
-    assert render(&"hello world") == "<p>hello world</p>";
+    assert render("hello world").html == "<p>hello world</p>";
 }
 
 test "render emits ATX headings by level" {
-    assert render(&"# Title") == "<h1>Title</h1>";
-    assert render(&"### Deep") == "<h3>Deep</h3>";
-    assert render(&"###### Six") == "<h6>Six</h6>";
+    assert render("# Title").html == "<h1 id=\"title\">Title</h1>";
+    assert render("### Deep").html == "<h3 id=\"deep\">Deep</h3>";
+    assert render("###### Six").html == "<h6 id=\"six\">Six</h6>";
 }
 
 test "render joins consecutive lines into one paragraph" {
-    assert render(&"line one
-line two") == "<p>line one
+    assert render("line one
+line two").html == "<p>line one
 line two</p>";
 }
 
 test "render separates paragraphs on a blank line" {
-    assert render(&"first
+    assert render("first
 
-second") == "<p>first</p>
+second").html == "<p>first</p>
 <p>second</p>";
 }
 
 test "render emits a thematic break" {
-    assert render(&"---") == "<hr />";
-    assert render(&"***") == "<hr />";
+    assert render("---").html == "<hr />";
+    assert render("***").html == "<hr />";
 }
 
 test "render mixes headings, paragraphs, and breaks" {
@@ -38,59 +38,59 @@ A paragraph.
 ---
 
 Another.";
-    assert render(&input) == "<h1>Heading</h1>
+    assert render(input).html == "<h1 id=\"heading\">Heading</h1>
 <p>A paragraph.</p>
 <hr />
 <p>Another.</p>";
 }
 
 test "render strips an ATX closing sequence" {
-    assert render(&"## foo ##") == "<h2>foo</h2>";
+    assert render("## foo ##").html == "<h2 id=\"foo\">foo</h2>";
 }
 
 // --- code ---
 
 test "render emits a fenced code block" {
-    assert render(&"```
+    assert render("```
 code
-```") == "<pre><code>code
+```").html == "<pre><code>code
 </code></pre>";
 }
 
 test "render tags a fenced code block with its language" {
-    assert render(&"```wado
+    assert render("```wado
 let x = 1;
-```") == "<pre><code class=\"language-wado\">let x = 1;
+```").html == "<pre><code class=\"language-wado\">let x = 1;
 </code></pre>";
 }
 
 test "render escapes html in a code fence but not markdown" {
-    assert render(&"```
+    assert render("```
 a < b & *c*
-```") == "<pre><code>a &lt; b &amp; *c*
+```").html == "<pre><code>a &lt; b &amp; *c*
 </code></pre>";
 }
 
 // --- blockquotes ---
 
 test "render emits a blockquote" {
-    assert render(&"> quote") == "<blockquote>
+    assert render("> quote").html == "<blockquote>
 <p>quote</p>
 </blockquote>";
 }
 
 test "render renders block structure inside a blockquote" {
-    assert render(&"> # Title") == "<blockquote>
-<h1>Title</h1>
+    assert render("> # Title").html == "<blockquote>
+<h1 id=\"title\">Title</h1>
 </blockquote>";
 }
 
 // --- lists ---
 
 test "render emits a tight unordered list" {
-    assert render(&"- a
+    assert render("- a
 - b
-- c") == "<ul>
+- c").html == "<ul>
 <li>a</li>
 <li>b</li>
 <li>c</li>
@@ -98,31 +98,31 @@ test "render emits a tight unordered list" {
 }
 
 test "render emits an ordered list" {
-    assert render(&"1. one
-2. two") == "<ol>
+    assert render("1. one
+2. two").html == "<ol>
 <li>one</li>
 <li>two</li>
 </ol>";
 }
 
 test "render emits an ol start attribute for a non-1 first number" {
-    assert render(&"3. three
-4. four") == "<ol start=\"3\">
+    assert render("3. three
+4. four").html == "<ol start=\"3\">
 <li>three</li>
 <li>four</li>
 </ol>";
 }
 
 test "render renders inline markup in list items" {
-    assert render(&"- **bold** item") == "<ul>
+    assert render("- **bold** item").html == "<ul>
 <li><strong>bold</strong> item</li>
 </ul>";
 }
 
 test "render wraps loose list items in paragraphs" {
-    assert render(&"- a
+    assert render("- a
 
-- b") == "<ul>
+- b").html == "<ul>
 <li>
 <p>a</p>
 </li>
@@ -133,8 +133,8 @@ test "render wraps loose list items in paragraphs" {
 }
 
 test "render nests a list under an item" {
-    assert render(&"- parent
-  - child") == "<ul>
+    assert render("- parent
+  - child").html == "<ul>
 <li>parent
 <ul>
 <li>child</li>
@@ -143,17 +143,17 @@ test "render nests a list under an item" {
 }
 
 test "render prints task-list markers as literal text" {
-    assert render(&"- [ ] todo
-- [x] done") == "<ul>
+    assert render("- [ ] todo
+- [x] done").html == "<ul>
 <li>[ ] todo</li>
 <li>[x] done</li>
 </ul>";
 }
 
 test "render keeps task-list markers inside p for a loose list" {
-    assert render(&"- [ ] todo
+    assert render("- [ ] todo
 
-- [x] done") == "<ul>
+- [x] done").html == "<ul>
 <li>
 <p>[ ] todo</p>
 </li>
@@ -169,7 +169,7 @@ test "render emits a GFM table" {
     let input = "| a | b |
 | --- | --- |
 | 1 | 2 |";
-    assert render(&input) == "<table>
+    assert render(input).html == "<table>
 <thead>
 <tr>
 <th>a</th>
@@ -189,7 +189,7 @@ test "render applies table column alignment" {
     let input = "| L | C | R |
 | :-- | :-: | --: |
 | a | b | c |";
-    assert render(&input) == "<table>
+    assert render(input).html == "<table>
 <thead>
 <tr>
 <th align=\"left\">L</th>
@@ -210,51 +210,51 @@ test "render applies table column alignment" {
 // --- inline ---
 
 test "render emits strong, emphasis, strikethrough" {
-    assert render(&"**bold**") == "<p><strong>bold</strong></p>";
-    assert render(&"*em*") == "<p><em>em</em></p>";
-    assert render(&"~~gone~~") == "<p><del>gone</del></p>";
+    assert render("**bold**").html == "<p><strong>bold</strong></p>";
+    assert render("*em*").html == "<p><em>em</em></p>";
+    assert render("~~gone~~").html == "<p><del>gone</del></p>";
 }
 
 test "render renders inline code and escapes within it" {
-    assert render(&"`a<b & c>`") == "<p><code>a&lt;b &amp; c&gt;</code></p>";
+    assert render("`a<b & c>`").html == "<p><code>a&lt;b &amp; c&gt;</code></p>";
 }
 
 test "render leaves intraword underscores literal" {
-    assert render(&"foo_bar_baz") == "<p>foo_bar_baz</p>";
+    assert render("foo_bar_baz").html == "<p>foo_bar_baz</p>";
 }
 
 test "render escapes plain angle brackets and ampersands" {
-    assert render(&"# a < b & c") == "<h1>a &lt; b &amp; c</h1>";
-    assert render(&"x < y & z") == "<p>x &lt; y &amp; z</p>";
+    assert render("# a < b & c").html == "<h1 id=\"a--b--c\">a &lt; b &amp; c</h1>";
+    assert render("x < y & z").html == "<p>x &lt; y &amp; z</p>";
 }
 
 test "render resolves backslash escapes for HTML" {
-    assert render(&"\\*not em\\*") == "<p>*not em*</p>";
-    assert render(&"a \\& b") == "<p>a &amp; b</p>";
+    assert render("\\*not em\\*").html == "<p>*not em*</p>";
+    assert render("a \\& b").html == "<p>a &amp; b</p>";
 }
 
 test "render makes a hard break on a trailing backslash" {
-    assert render(&"a\\
-b") == "<p>a<br />
+    assert render("a\\
+b").html == "<p>a<br />
 b</p>";
 }
 
 // --- links and images ---
 
 test "render renders an inline link with an escaped href" {
-    assert render(&"[home](http://example.com)") == "<p><a href=\"http://example.com\">home</a></p>";
+    assert render("[home](http://example.com)").html == "<p><a href=\"http://example.com\">home</a></p>";
 }
 
 test "render renders an inline link title" {
-    assert render(&"[home](http://x.test \"Home\")") == "<p><a href=\"http://x.test\" title=\"Home\">home</a></p>";
+    assert render("[home](http://x.test \"Home\")").html == "<p><a href=\"http://x.test\" title=\"Home\">home</a></p>";
 }
 
 test "render renders an image" {
-    assert render(&"![a cat](cat.png)") == "<p><img src=\"cat.png\" alt=\"a cat\" /></p>";
+    assert render("![a cat](cat.png)").html == "<p><img src=\"cat.png\" alt=\"a cat\" /></p>";
 }
 
 test "render autolinks a bare url" {
-    assert render(&"see https://wado.example/docs here") == "<p>see <a href=\"https://wado.example/docs\">https://wado.example/docs</a> here</p>";
+    assert render("see https://wado.example/docs here").html == "<p>see <a href=\"https://wado.example/docs\">https://wado.example/docs</a> here</p>";
 }
 
 // --- reference-style links (resolved via the definition table) ---
@@ -263,45 +263,45 @@ test "render resolves a reference link" {
     let input = "[home][h]
 
 [h]: http://example.com \"Home\"";
-    assert render(&input) == "<p><a href=\"http://example.com\" title=\"Home\">home</a></p>";
+    assert render(input).html == "<p><a href=\"http://example.com\" title=\"Home\">home</a></p>";
 }
 
 test "render resolves a shortcut reference link" {
     let input = "[home]
 
 [home]: /x";
-    assert render(&input) == "<p><a href=\"/x\">home</a></p>";
+    assert render(input).html == "<p><a href=\"/x\">home</a></p>";
 }
 
 test "render omits link reference definitions from output" {
     let input = "[a][b]
 
 [b]: /url";
-    assert render(&input) == "<p><a href=\"/url\">a</a></p>";
+    assert render(input).html == "<p><a href=\"/url\">a</a></p>";
 }
 
 // --- safety ---
 
 test "render neutralizes unsafe URL schemes" {
-    assert render(&"[x](javascript:alert(1))") == "<p><a href=\"\">x</a></p>";
-    assert render(&"![x](data:text/html,evil)") == "<p><img src=\"\" alt=\"x\" /></p>";
+    assert render("[x](javascript:alert(1))").html == "<p><a href=\"\">x</a></p>";
+    assert render("![x](data:text/html,evil)").html == "<p><img src=\"\" alt=\"x\" /></p>";
 }
 
 test "render keeps safe and relative URLs" {
-    assert render(&"[x](mailto:a@b.com)") == "<p><a href=\"mailto:a@b.com\">x</a></p>";
-    assert render(&"[x](#anchor)") == "<p><a href=\"#anchor\">x</a></p>";
+    assert render("[x](mailto:a@b.com)").html == "<p><a href=\"mailto:a@b.com\">x</a></p>";
+    assert render("[x](#anchor)").html == "<p><a href=\"#anchor\">x</a></p>";
 }
 
 test "render neutralizes an unsafe scheme in an angle autolink" {
-    assert render(&"<javascript:foo>") == "<p><a href=\"\">javascript:foo</a></p>";
+    assert render("<javascript:foo>").html == "<p><a href=\"\">javascript:foo</a></p>";
 }
 
 test "render escapes a raw inline HTML span as literal text" {
-    assert render(&"a <b>c</b> d") == "<p>a &lt;b&gt;c&lt;/b&gt; d</p>";
+    assert render("a <b>c</b> d").html == "<p>a &lt;b&gt;c&lt;/b&gt; d</p>";
 }
 
 test "render escapes a raw HTML block as literal text" {
-    assert render(&"<div>x</div>") == "&lt;div&gt;x&lt;/div&gt;";
+    assert render("<div>x</div>").html == "&lt;div&gt;x&lt;/div&gt;";
 }
 
 // --- front matter ---
@@ -311,5 +311,108 @@ test "render skips leading front matter" {
 title: x
 ---
 body";
-    assert render(&input) == "<p>body</p>";
+    assert render(input).html == "<p>body</p>";
+}
+
+// --- heading ids (GFM slugs) ---
+
+test "render slugifies a heading with spaces and punctuation" {
+    assert render("## Hello, World!").html == "<h2 id=\"hello-world\">Hello, World!</h2>";
+}
+
+test "render keeps hyphens and underscores in a slug" {
+    assert render("# foo_bar-baz").html == "<h1 id=\"foo_bar-baz\">foo_bar-baz</h1>";
+}
+
+test "render keeps non-ASCII characters verbatim in a slug" {
+    assert render("## 日本語").html == "<h2 id=\"日本語\">日本語</h2>";
+}
+
+test "render lowercases only ASCII letters in a slug" {
+    // Option A: non-ASCII letters are kept verbatim, not case-folded, so the
+    // uppercase Ü stays Ü while the ASCII C is lowered to c.
+    assert render("## Café Über").html == "<h2 id=\"café-Über\">Café Über</h2>";
+}
+
+test "render slugifies from a code span's text" {
+    assert render("## `code` span").html == "<h2 id=\"code-span\"><code>code</code> span</h2>";
+}
+
+test "render slugifies from link and emphasis text, not markup" {
+    assert render("## a [link](/x) and *em*").html
+        == "<h2 id=\"a-link-and-em\">a <a href=\"/x\">link</a> and <em>em</em></h2>";
+}
+
+test "render deduplicates repeated heading slugs" {
+    let input = "# Dup
+
+# Dup
+
+# Dup";
+    assert render(input).html == "<h1 id=\"dup\">Dup</h1>
+<h1 id=\"dup-1\">Dup</h1>
+<h1 id=\"dup-2\">Dup</h1>";
+}
+
+test "render avoids a dedup slug colliding with an explicit one" {
+    let input = "# a
+
+# a
+
+# a-1";
+    assert render(input).html == "<h1 id=\"a\">a</h1>
+<h1 id=\"a-1\">a</h1>
+<h1 id=\"a-1-1\">a-1</h1>";
+}
+
+test "render emits an empty slug for punctuation-only headings" {
+    let input = "# !!!
+
+# !!!";
+    assert render(input).html == "<h1 id=\"\">!!!</h1>
+<h1 id=\"-1\">!!!</h1>";
+}
+
+// --- rendered outline (opt-in table of contents) ---
+
+test "render returns the heading outline in document order" {
+    let input = "# Intro
+
+## Details
+
+Body.
+
+## Details";
+    let result = render(input);
+    assert result.headings.len() == 3;
+
+    assert result.headings[0].level == 1 as u8;
+    assert result.headings[0].id == "intro";
+    assert result.headings[0].text == "Intro";
+
+    assert result.headings[1].level == 2 as u8;
+    assert result.headings[1].id == "details";
+    assert result.headings[1].text == "Details";
+
+    assert result.headings[2].id == "details-1";
+    assert result.headings[2].text == "Details";
+}
+
+test "render collects a heading nested in a blockquote" {
+    let result = render("> # Quoted");
+    assert result.headings.len() == 1;
+    assert result.headings[0].id == "quoted";
+    assert result.headings[0].text == "Quoted";
+}
+
+test "render reports plain text with markup stripped in the outline" {
+    let result = render("## a `code` and **bold**");
+    assert result.headings.len() == 1;
+    assert result.headings[0].text == "a code and bold";
+    assert result.headings[0].id == "a-code-and-bold";
+}
+
+test "render reports no headings for a heading-free document" {
+    let result = render("just a paragraph");
+    assert result.headings.is_empty();
 }

--- a/package-marl/src/fmt_html_test.wado
+++ b/package-marl/src/fmt_html_test.wado
@@ -337,8 +337,7 @@ test "render slugifies from a code span's text" {
 }
 
 test "render slugifies from link and emphasis text, not markup" {
-    assert render("## a [link](/x) and *em*").html
-        == "<h2 id=\"a-link-and-em\">a <a href=\"/x\">link</a> and <em>em</em></h2>";
+    assert render("## a [link](/x) and *em*").html == "<h2 id=\"a-link-and-em\">a <a href=\"/x\">link</a> and <em>em</em></h2>";
 }
 
 test "render deduplicates repeated heading slugs" {

--- a/package-marl/src/fmt_html_test.wado
+++ b/package-marl/src/fmt_html_test.wado
@@ -328,9 +328,7 @@ test "render keeps non-ASCII characters verbatim in a slug" {
     assert render("## 日本語").html == "<h2 id=\"日本語\">日本語</h2>";
 }
 
-test "render lowercases only ASCII letters in a slug" {
-    // Option A: non-ASCII letters are kept verbatim, not case-folded, so the
-    // uppercase Ü stays Ü while the ASCII C is lowered to c.
+test "render keeps non-ASCII letters verbatim, lowercasing only ASCII" {
     assert render("## Café Über").html == "<h2 id=\"café-Über\">Café Über</h2>";
 }
 

--- a/package-marl/src/fmt_slug.wado
+++ b/package-marl/src/fmt_slug.wado
@@ -1,15 +1,8 @@
-//! GFM-compatible heading slugs.
-//!
-//! `slugify` follows github-slugger: lowercase ASCII letters, keep ASCII
-//! alphanumerics / `-` / `_`, turn each space into `-`, drop other ASCII
-//! punctuation, and keep non-ASCII characters verbatim (raw UTF-8, so
-//! `## 日本語` yields `id="日本語"`). A `Slugger` deduplicates within one
-//! document by appending `-1`, `-2`, … to a repeated base — including
-//! collisions with an explicit slug that already reads like a suffixed one.
+//! GFM-compatible heading slugs (github-slugger rules) with per-document
+//! deduplication. See `docs/wep-2026-07-05-marl.md`.
 
 use { TreeMap } from "core:collections";
 
-/// Turn heading text into its base slug, before deduplication.
 internal fn slugify(text: &String) -> String {
     let mut out = String::with_capacity(text.len());
     for let c of text.chars() {
@@ -26,12 +19,10 @@ internal fn slugify(text: &String) -> String {
     return out;
 }
 
-/// ASCII characters kept verbatim: lowercase letters, digits, `-`, `_`.
 fn is_slug_char(c: char) -> bool {
     return c.is_ascii_lowercase() || c >= '0' && c <= '9' || c == '-' || c == '_';
 }
 
-/// Per-document slug deduplicator (the github-slugger scheme).
 internal struct Slugger {
     counts: TreeMap<String, i32>,
 }
@@ -41,8 +32,6 @@ impl Slugger {
         return Slugger { counts: TreeMap::<String, i32>::new() };
     }
 
-    /// Return a unique slug for `base`, recording it so a later repeat of the
-    /// same base gets the next `-N` suffix that is still free.
     internal fn slug(&mut self, base: String) -> String {
         let mut result = base;
         while self.counts.contains_key(result) {

--- a/package-marl/src/fmt_slug.wado
+++ b/package-marl/src/fmt_slug.wado
@@ -1,0 +1,60 @@
+//! GFM-compatible heading slugs.
+//!
+//! `slugify` follows github-slugger: lowercase ASCII letters, keep ASCII
+//! alphanumerics / `-` / `_`, turn each space into `-`, drop other ASCII
+//! punctuation, and keep non-ASCII characters verbatim (raw UTF-8, so
+//! `## 日本語` yields `id="日本語"`). A `Slugger` deduplicates within one
+//! document by appending `-1`, `-2`, … to a repeated base — including
+//! collisions with an explicit slug that already reads like a suffixed one.
+
+use { TreeMap } from "core:collections";
+
+/// Turn heading text into its base slug, before deduplication.
+internal fn slugify(text: &String) -> String {
+    let mut out = String::with_capacity(text.len());
+    for let c of text.chars() {
+        if c.is_ascii_uppercase() {
+            out.push(c.to_ascii_lowercase());
+        } else if is_slug_char(c) {
+            out.push(c);
+        } else if c == ' ' {
+            out.push('-');
+        } else if c as u32 >= 0x80 {
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// ASCII characters kept verbatim: lowercase letters, digits, `-`, `_`.
+fn is_slug_char(c: char) -> bool {
+    return c.is_ascii_lowercase() || c >= '0' && c <= '9' || c == '-' || c == '_';
+}
+
+/// Per-document slug deduplicator (the github-slugger scheme).
+internal struct Slugger {
+    counts: TreeMap<String, i32>,
+}
+
+impl Slugger {
+    internal fn new() -> Slugger {
+        return Slugger { counts: TreeMap::<String, i32>::new() };
+    }
+
+    /// Return a unique slug for `base`, recording it so a later repeat of the
+    /// same base gets the next `-N` suffix that is still free.
+    internal fn slug(&mut self, base: String) -> String {
+        let mut result = base;
+        while self.counts.contains_key(result) {
+            let current = match self.counts.get(base) {
+                Some(n) => n,
+                None => 0,
+            };
+            let next = current + 1;
+            self.counts[base] = next;
+            result = `{base}-{next}`;
+        }
+        self.counts[result] = 0;
+        return result;
+    }
+}

--- a/package-marl/src/format.wado
+++ b/package-marl/src/format.wado
@@ -7,6 +7,6 @@
 use { parse_document } from "./fmt_parse_block.wado";
 use { print_document } from "./fmt_print.wado";
 
-pub fn format(source: &String) -> String {
-    return print_document(&parse_document(source));
+pub fn format(source: String) -> String {
+    return print_document(&parse_document(&source));
 }

--- a/package-marl/src/format_test.wado
+++ b/package-marl/src/format_test.wado
@@ -2,23 +2,23 @@ use { format } from "./format.wado";
 
 test "format is idempotent" {
     let source = "# Title\n\nSome *text* with a [link](https://example.com).\n\n- a\n- b\n";
-    let once = format(&source);
-    let twice = format(&once);
+    let once = format(source);
+    let twice = format(once);
     assert once == twice;
 }
 
 test "format normalizes a heading and collapses inline whitespace runs" {
-    assert format(&"#   Title   \n\nhello   world") == "# Title\n\nhello world\n";
+    assert format("#   Title   \n\nhello   world") == "# Title\n\nhello world\n";
 }
 
 test "format leaves a bare url as plain text" {
-    assert format(&"see https://example.com/x here\n") == "see https://example.com/x here\n";
+    assert format("see https://example.com/x here\n") == "see https://example.com/x here\n";
 }
 
 test "format keeps a bare url in parentheses intact" {
-    assert format(&"a port of zlib (https://github.com/madler/zlib).\n") == "a port of zlib (https://github.com/madler/zlib).\n";
+    assert format("a port of zlib (https://github.com/madler/zlib).\n") == "a port of zlib (https://github.com/madler/zlib).\n";
 }
 
 test "format preserves an angle-bracketed autolink" {
-    assert format(&"<https://example.com>\n") == "<https://example.com>\n";
+    assert format("<https://example.com>\n") == "<https://example.com>\n";
 }

--- a/package-marl/src/html.wado
+++ b/package-marl/src/html.wado
@@ -1,7 +1,17 @@
 //! HTML escaping and URL sanitization helpers.
 
 /// Escape text for use in HTML element content: `&`, `<`, `>`.
-pub fn escape_text(s: &String) -> String {
+pub fn escape_text(s: String) -> String {
+    return escape_text_ref(&s);
+}
+
+/// Escape text for use in a double-quoted HTML attribute value:
+/// element-content escapes plus `"`.
+pub fn escape_attr(s: String) -> String {
+    return escape_attr_ref(&s);
+}
+
+internal fn escape_text_ref(s: &String) -> String {
     let mut out = String::with_capacity(s.len());
     for let c of s.chars() {
         push_escaped(&mut out, c, false);
@@ -9,9 +19,7 @@ pub fn escape_text(s: &String) -> String {
     return out;
 }
 
-/// Escape text for use in a double-quoted HTML attribute value:
-/// element-content escapes plus `"`.
-pub fn escape_attr(s: &String) -> String {
+internal fn escape_attr_ref(s: &String) -> String {
     let mut out = String::with_capacity(s.len());
     for let c of s.chars() {
         push_escaped(&mut out, c, true);
@@ -27,25 +35,4 @@ fn push_escaped(out: &mut String, c: char, in_attr: bool) {
         '"' && in_attr => out.push_str(&"&quot;"),
         _ => out.push(c),
     }
-}
-
-/// Neutralize a link/image destination whose scheme could execute script:
-/// return it unchanged when the scheme is safe (or absent), else `""`. Blocks
-/// `javascript:`, `data:`, `vbscript:`, and any other unlisted scheme.
-pub fn sanitize_url(url: &String) -> String {
-    let mut scheme = String::new();
-    for let c of url.chars() {
-        if c == ':' {
-            return if scheme_is_safe(&scheme) { *url } else { "" };
-        }
-        if c matches { '/' | '?' | '#' } {
-            return *url;
-        }
-        scheme.push(c.to_ascii_lowercase());
-    }
-    return *url;
-}
-
-fn scheme_is_safe(scheme: &String) -> bool {
-    return *scheme == "http" || *scheme == "https" || *scheme == "mailto" || *scheme == "tel";
 }

--- a/package-marl/src/html_test.wado
+++ b/package-marl/src/html_test.wado
@@ -1,21 +1,21 @@
 use { escape_text, escape_attr } from "./html.wado";
 
 test "escape_text escapes ampersand, lt, gt" {
-    assert escape_text(&"a & b < c > d") == "a &amp; b &lt; c &gt; d";
+    assert escape_text("a & b < c > d") == "a &amp; b &lt; c &gt; d";
 }
 
 test "escape_text encodes an ampersand before an entity name" {
-    assert escape_text(&"AT&T <tag>") == "AT&amp;T &lt;tag&gt;";
+    assert escape_text("AT&T <tag>") == "AT&amp;T &lt;tag&gt;";
 }
 
 test "escape_text leaves quotes untouched" {
-    assert escape_text(&"say \"hi\"") == "say \"hi\"";
+    assert escape_text("say \"hi\"") == "say \"hi\"";
 }
 
 test "escape_attr also escapes double quotes" {
-    assert escape_attr(&"a \"b\" & c") == "a &quot;b&quot; &amp; c";
+    assert escape_attr("a \"b\" & c") == "a &quot;b&quot; &amp; c";
 }
 
 test "escape_text passes plain text through unchanged" {
-    assert escape_text(&"hello world") == "hello world";
+    assert escape_text("hello world") == "hello world";
 }

--- a/package-marl/src/lib.wado
+++ b/package-marl/src/lib.wado
@@ -5,6 +5,6 @@
 //! walks the tree to safe HTML, `format` prints it back to canonical
 //! Markdown. See `docs/wep-2026-07-05-marl.md`.
 
-pub use { render } from "./fmt_html.wado";
+pub use { render, RenderResult, HeadingInfo } from "./fmt_html.wado";
 pub use { escape_text, escape_attr } from "./html.wado";
 pub use { format } from "./format.wado";

--- a/package-marl/src/main.wado
+++ b/package-marl/src/main.wado
@@ -62,7 +62,7 @@ export fn run() with Stdout, Stderr, Environment, Preopens, Exit {
                 continue;
             },
         };
-        let formatted = format(&original);
+        let formatted = format(original);
         if formatted == original {
             continue;
         }

--- a/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
@@ -100,7 +100,7 @@ type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref Array<u8>
 
 type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(39)
 
-type "functype//local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
+type "functype//local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
 
 type "functype//core:prelude/format.wado/Formatter::new" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/format.wado//Formatter";  // TypeId(41)
 
@@ -136,7 +136,7 @@ global global:local_item_newtype_definition.wado::__const_obj_0: ref null "core:
 global global:local_item_newtype_definition.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(108, 111, 99, 97, 108, 95, 105, 116, 101, 109, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110, 46, 119, 97, 100, 111)), used: 34 };
 global global:local_item_newtype_definition.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(95, 95, 116, 101, 115, 116, 95, 48, 95, 108, 111, 99, 97, 108, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110)), used: 33 };
 global global:local_item_newtype_definition.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(65, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 32, 105, 110, 32)), used: 20 };
-global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 55, 58, 49, 57, 41)), used: 25 };
+global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 56, 58, 49, 57, 41)), used: 25 };
 global global:core:prelude/format.wado::__const_obj_10: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(46, 46, 46)), used: 3 };
 global global:core:prelude/format.wado::__const_obj_11: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(92, 117, 123)), used: 3 };
 
@@ -199,7 +199,7 @@ fn "local_item_newtype_definition.wado/__cm_export____test_1_sibling_test_blocks
         cold_path;
         "core:rt/panic"(__local_3 = "core:prelude/string.wado/String::with_capacity"(118); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_sibling_test_blocks_may_declare_same_named_local_newtypes_with_different_base_types"), used: 92 }); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push"(__local_3, 97); "core:prelude/string.wado/String::push"(__local_3, 116); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("local_item_newtype_definition.wado"), used: 34 }); "core:prelude/string.wado/String::push"(__local_3, 58); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 17 }, __local_4); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: id == \"abc\"
-"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
+"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
         unreachable;
     }
     "wasi/task-return"(0);
@@ -588,7 +588,7 @@ fn "core:prelude/string.wado/String::push"(self, c) {
     }
 }
 
-fn "local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect"(self, f) {
+fn "local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     "core:prelude/format.wado/String^Inspect::inspect"(self, f);
     s = global:local_item_newtype_definition.wado::__const_obj_9;


### PR DESCRIPTION
## Summary

Adds GFM-compatible heading `id`s to Marl's HTML renderer and returns the heading outline alongside the HTML, so a consumer (e.g. a CMS) can opt into a table of contents. The public renderer API is redesigned to be value-only, so it maps directly onto a WIT interface (no references).

## Public API (breaking)

```wado
pub fn render(source: String) -> RenderResult

pub struct RenderResult {
    pub html: String,
    pub headings: List<HeadingInfo>,
}

pub struct HeadingInfo {
    pub level: u8,     // 1..=6
    pub id: String,    // GFM slug, unique in the document; also the `id` attr
    pub text: String,  // plain-text content: slug source and TOC label
}

pub fn escape_text(s: String) -> String   // was &String
pub fn escape_attr(s: String) -> String   // was &String
pub fn format(source: String) -> String   // was &String
```

- `render` previously returned a bare `String`; it now returns `RenderResult`. `headings` is opt-in — ignore it for plain HTML, or walk it to build a table of contents.
- The public surface takes and returns values only (no `&T`), so it is WIT-representable. Reference-taking workhorses stay `internal` behind the value facade, keeping the hot path copy-free.

## Heading ids (GFM slugs)

Every heading is emitted as `<hN id="slug">…</hN>` and recorded in `RenderResult.headings` in document order (including headings nested in blockquotes and list items). Slugs follow github-slugger:

- lowercase ASCII letters; keep ASCII alphanumerics, `-`, and `_`;
- turn each space into `-`; drop other ASCII punctuation;
- keep non-ASCII characters verbatim as UTF-8, so `## 日本語` yields `id="日本語"`;
- deduplicate within the document by appending `-1`, `-2`, … to a repeated base, skipping any suffix that collides with an explicit slug.

Fidelity is exact for ASCII and for caseless scripts (CJK). The one accepted divergence from GitHub: non-ASCII letters are not case-folded (an uppercase `Ü` stays `Ü`), since the guest has ASCII-only case tables and full Unicode case folding is out of scope for this iteration.

## Changes

- New `fmt_slug.wado`: `slugify` + a per-document `Slugger` deduplicator.
- `fmt_html.wado`: a `Renderer` threads the slug state and outline through the block walk; `render` returns `RenderResult`.
- `sanitize_url` moved from `html.wado` into `fmt_html.wado` as a private helper.
- `lib.wado` re-exports `RenderResult` / `HeadingInfo`.
- WEP `docs/wep-2026-07-05-marl.md` updated (new API, slug spec, WIT note).


---
_Generated by [Claude Code](https://claude.ai/code/session_01U1Jjuf1WBvvccV8qUrhe8f)_