### PR TITLE
fix(compiler): make local-item mangled names deterministic and collision-safe

### DIFF
--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -70,12 +70,19 @@ pub fn namespace_member_alias(namespace: &str, member: &str) -> String {
 /// reaches a diagnostic.
 pub const LOCAL_ITEM_ID_SEP: char = '@';
 
-/// Build the internal storage name for a local item declaration: the
-/// declared name plus its disambiguating `AstId`, unique per declaration
-/// site so same-named local items in different functions never collide in
-/// the module-wide storage tables they're interned into.
+/// Build the internal storage name for a local item declaration: the declared
+/// name plus the `AstId`'s module-local index, unique per declaration site so
+/// same-named local items in different functions never collide in the
+/// module-wide storage tables they're interned into.
+///
+/// Only the `local` index is encoded — never the `AstIdSpace`. The space is a
+/// process-global counter whose value depends on unrelated parse history
+/// (e.g. how many fixtures a parallel golden run compiled first), so encoding
+/// it would leak into mangled WIR names and make compiler output
+/// non-deterministic. The `local` index is dense per module and the module
+/// source already qualifies the name across modules, so it alone suffices.
 pub fn mangle_local_item_name(name: &str, id: crate::ast::AstId) -> String {
-    format!("{name}{LOCAL_ITEM_ID_SEP}{id:?}")
+    format!("{name}{LOCAL_ITEM_ID_SEP}{}", id.local())
 }
 
 /// Recover a local item's user-declared name from its internal storage name
@@ -1475,6 +1482,27 @@ mod tests {
                 "snake form of {input:?} must be ASCII"
             );
         }
+    }
+
+    #[test]
+    fn mangle_local_item_name_is_space_independent() {
+        // The storage name only disambiguates local items *within* a module
+        // (the module source qualifies it across modules), so it must depend
+        // solely on the module-local `local` index — never on the
+        // process-global `AstIdSpace`, which varies with unrelated parse
+        // history and would otherwise leak into compiler output (mangled WIR
+        // function names), making it non-deterministic.
+        use crate::ast::{AstId, AstIdSpace};
+        let space_a = AstIdSpace::next();
+        let space_b = AstIdSpace::next();
+        assert_ne!(space_a, space_b);
+        let a = mangle_local_item_name("UserId", AstId::new(space_a, 19));
+        let b = mangle_local_item_name("UserId", AstId::new(space_b, 19));
+        assert_eq!(a, b, "mangled name must not encode the AstIdSpace");
+        // Distinct declaration sites within a module still get distinct names.
+        assert_ne!(a, mangle_local_item_name("UserId", AstId::new(space_a, 20)));
+        // The declared name is still recoverable.
+        assert_eq!(strip_local_item_id(&a), "UserId");
     }
 
     #[test]

--- a/wado-compiler/src/optimize/value_copy_elide.rs
+++ b/wado-compiler/src/optimize/value_copy_elide.rs
@@ -126,7 +126,7 @@ fn disjoint(mutated: &AccessPath, read: &AccessPath) -> bool {
             // keep comparing deeper selectors.
             (Selector::Field(_), Selector::Field(_))
             | (Selector::Variant(_), Selector::Variant(_))
-            | (Selector::Index, Selector::Index) => continue,
+            | (Selector::Index, Selector::Index) => {}
             // Mixed selector kinds on the same storage cannot arise for two paths
             // that share a prefix (the type at each depth is fixed); treat any as
             // conservatively overlapping.

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -1294,7 +1294,9 @@ fn generate_inspect_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_,
         let ref_type = tt.make_ref(nt.type_id);
         let span = synth_span();
         let as_suffix = write_str_stmt(
-            format!(" as {}", nt.name),
+            // Strip the local-item storage disambiguator: a user must see
+            // `as UserId`, never the internal `UserId@<local>` mangling.
+            format!(" as {}", crate::name::strip_local_item_id(&nt.name)),
             local_expr(1, "f", fmt_type, span),
             string_type,
             ref_string_type,

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -622,9 +622,14 @@ pub struct TypeTable {
     /// live redirect, an absent slot means "no redirect". `get` consults it
     /// on every call, so the hash-free index matters here too.
     redirects: TypeMap<TypeId>,
-    /// Maps newtype names to their ultimate base type name.
-    /// Populated by `erase_newtypes_and_flags()` and used by `wir_build` for name-based newtype resolution.
-    newtype_to_base_name: IndexMap<String, String>,
+    /// Ultimate base type name of each newtype, keyed by `(name, module_source)`.
+    ///
+    /// A GC-immune snapshot taken by `erase_newtypes_and_flags()` (before the
+    /// NIR DCE `retain` may drop the newtype `TypeId`s and their redirects) and
+    /// read by `wir_build` for name-based newtype-method resolution. Keyed by
+    /// `(name, module_source)` — never the bare name — so two modules that each
+    /// declare a same-named newtype over different base types do not collide.
+    newtype_to_base_name: IndexMap<(String, ModuleSource), String>,
     /// Reverse mapping `Box<T>` `TypeId` → `T`'s `TypeId`, populated by the
     /// boxing pass (`lower/plan/boxing.rs`). The pass rewrites `&T` /
     /// `&mut T` into `Box<T>` wrapper structs for primitives, variants and
@@ -845,12 +850,22 @@ impl TypeTable {
         matches!(self.get(id), ResolvedType::Never)
     }
 
-    /// Erase all newtypes from the `TypeTable`.
-    /// Look up the ultimate base type name for a newtype by its name.
-    /// Returns `None` if the name is not a known newtype.
-    /// Available after `erase_newtypes_and_flags()` is called.
-    pub fn get_newtype_ultimate_base_name(&self, name: &str) -> Option<&str> {
-        self.newtype_to_base_name.get(name).map(String::as_str)
+    /// Ultimate base type name of the newtype declared as `name` in
+    /// `module_source`, or `None` if `(name, module_source)` is not a newtype.
+    ///
+    /// Reads the `(name, module_source)`-keyed snapshot populated by
+    /// [`Self::erase_newtypes_and_flags`], so it is collision-safe across
+    /// modules (two modules may declare a same-named newtype over different base
+    /// types) and available after the newtype `TypeId`s themselves have been
+    /// dropped by DCE.
+    pub fn newtype_ultimate_base_name(
+        &self,
+        name: &str,
+        module_source: &ModuleSource,
+    ) -> Option<&str> {
+        self.newtype_to_base_name
+            .get(&(name.to_string(), module_source.clone()))
+            .map(String::as_str)
     }
 
     /// Iterate over all live types in the type table. Erased slots (`None`,
@@ -2194,11 +2209,19 @@ impl TypeTable {
             };
             if let Some(target) = redirect {
                 self.redirects.set_growing(id, target);
-                // Populate name map for Newtype entries (used by wir_build for name-based lookup)
-                if let Some(ResolvedType::Newtype { name, .. }) = self.types.get(id) {
-                    let name = name.clone();
+                // Snapshot the newtype→ultimate-base name now, keyed by
+                // (name, module_source): the newtype's own `TypeId` may be
+                // dropped by the later NIR DCE `retain`, but `wir_build` still
+                // needs this mapping for name-based newtype-method resolution.
+                if let Some(ResolvedType::Newtype {
+                    name,
+                    module_source,
+                    ..
+                }) = self.types.get(id)
+                {
+                    let key = (name.clone(), module_source.clone());
                     let base_name = self.type_name(target);
-                    self.newtype_to_base_name.insert(name, base_name);
+                    self.newtype_to_base_name.insert(key, base_name);
                 }
             }
         }
@@ -4716,6 +4739,35 @@ mod tests {
         assert_eq!(table.type_of_symbol(&second), Some(second_type));
         assert_eq!(table.type_id_of_decl(first), first_type);
         assert_eq!(table.type_id_of_decl(second), second_type);
+    }
+
+    #[test]
+    fn newtype_ultimate_base_name_is_keyed_per_module() {
+        // Two modules each declare a newtype `Temp` over a *different* base
+        // struct. The snapshot must be keyed by (name, module_source): a
+        // name-only key would let one module's `Temp` overwrite the other's,
+        // misresolving newtype-method dispatch across modules.
+        let mut table = TypeTable::new();
+        let module_a = ModuleSource::entry_point_synthetic();
+        let module_b = ModuleSource::cli();
+
+        let celsius = table.make_struct("Celsius".to_string(), module_a.clone());
+        let fahrenheit = table.make_struct("Fahrenheit".to_string(), module_b.clone());
+        table.make_newtype("Temp".to_string(), module_a.clone(), celsius);
+        table.make_newtype("Temp".to_string(), module_b.clone(), fahrenheit);
+
+        table.erase_newtypes_and_flags();
+
+        assert_eq!(
+            table.newtype_ultimate_base_name("Temp", &module_a),
+            Some("Celsius")
+        );
+        assert_eq!(
+            table.newtype_ultimate_base_name("Temp", &module_b),
+            Some("Fahrenheit")
+        );
+        // A non-newtype name has no entry.
+        assert_eq!(table.newtype_ultimate_base_name("Celsius", &module_a), None);
     }
 
     #[test]

--- a/wado-compiler/src/wir_build/calls.rs
+++ b/wado-compiler/src/wir_build/calls.rs
@@ -138,8 +138,12 @@ impl FunctionTranslator<'_, '_> {
         method_info: &crate::name::LocalMethodName,
     ) -> Option<crate::wir::WirFuncId> {
         let struct_name = &method_info.base_struct_name;
-        // Find a Newtype in the type table with this name
-        let base_name = self.resolve_newtype_to_base_struct_name(struct_name)?;
+        // Resolve the newtype (identified by its (name, module_source)) to its
+        // ultimate base type name.
+        let base_name = self
+            .type_table
+            .newtype_ultimate_base_name(struct_name, module_source)?
+            .to_string();
         // Build a new method name with the base type's struct name
         let mut resolved_info = method_info.clone();
         resolved_info.struct_name.clone_from(&base_name);
@@ -147,14 +151,6 @@ impl FunctionTranslator<'_, '_> {
         let mangled = resolved_info.to_mangled_name();
         let fq = format!("{module_source}/{mangled}");
         self.ctx.func_map.get(&fq).cloned()
-    }
-
-    /// Resolve a newtype name to the ultimate base struct/primitive name.
-    /// Returns `None` if the name is not a newtype.
-    fn resolve_newtype_to_base_struct_name(&self, name: &str) -> Option<String> {
-        self.type_table
-            .get_newtype_ultimate_base_name(name)
-            .map(str::to_owned)
     }
 
     /// Translate a builtin intrinsic call to a WIR instruction.

--- a/wado-compiler/tests/fixtures/local_item_newtype_definition.wado
+++ b/wado-compiler/tests/fixtures/local_item_newtype_definition.wado
@@ -9,6 +9,9 @@ test "local newtype definition" {
     let id: UserId = 42;
     assert id == 42;
     assert `{id}` == "42";
+    // Debug format must show the user-declared name, never the internal
+    // local-item storage disambiguator (`UserId@<local>`).
+    assert `{id:?}` == "42 as UserId";
 }
 
 test "sibling test blocks may declare same-named local newtypes with different base types" {

--- a/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
@@ -100,7 +100,7 @@ type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref Array<u8>
 
 type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(39)
 
-type "functype//local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
+type "functype//local_item_newtype_definition.wado/UserId@24^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
 
 type "functype//core:prelude/format.wado/Formatter::new" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/format.wado//Formatter";  // TypeId(41)
 
@@ -132,34 +132,60 @@ import fn wasi/stream-new from "wasi/stream-new";
 import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-readable:transmission-cli";
 
 global mut global:local_item_newtype_definition.wado::__modules_initialized: bool = 0;
-global global:local_item_newtype_definition.wado::__const_obj_0: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(10, 99, 111, 110, 100, 105, 116, 105, 111, 110, 58, 32, 96, 123, 105, 100, 125, 96, 32, 61, 61, 32, 34, 52, 50, 34, 10)), used: 27 };
-global global:local_item_newtype_definition.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(108, 111, 99, 97, 108, 95, 105, 116, 101, 109, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110, 46, 119, 97, 100, 111)), used: 34 };
-global global:local_item_newtype_definition.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(95, 95, 116, 101, 115, 116, 95, 48, 95, 108, 111, 99, 97, 108, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110)), used: 33 };
-global global:local_item_newtype_definition.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(65, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 32, 105, 110, 32)), used: 20 };
-global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 55, 58, 49, 57, 41)), used: 25 };
-global global:core:prelude/format.wado::__const_obj_10: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(46, 46, 46)), used: 3 };
-global global:core:prelude/format.wado::__const_obj_11: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(92, 117, 123)), used: 3 };
+global global:local_item_newtype_definition.wado::__const_obj_0: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(96, 123, 105, 100, 58, 63, 125, 96, 58, 32)), used: 10 };
+global global:local_item_newtype_definition.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(10, 99, 111, 110, 100, 105, 116, 105, 111, 110, 58, 32, 96, 123, 105, 100, 58, 63, 125, 96, 32, 61, 61, 32, 34, 52, 50, 32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 34, 10)), used: 39 };
+global global:local_item_newtype_definition.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(108, 111, 99, 97, 108, 95, 105, 116, 101, 109, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110, 46, 119, 97, 100, 111)), used: 34 };
+global global:local_item_newtype_definition.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(95, 95, 116, 101, 115, 116, 95, 48, 95, 108, 111, 99, 97, 108, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110)), used: 33 };
+global global:local_item_newtype_definition.wado::__const_obj_4: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(65, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 32, 105, 110, 32)), used: 20 };
+global global:local_item_newtype_definition.wado::__const_obj_5: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100)), used: 10 };
+global global:local_item_newtype_definition.wado::__const_obj_6: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(10, 99, 111, 110, 100, 105, 116, 105, 111, 110, 58, 32, 96, 123, 105, 100, 125, 96, 32, 61, 61, 32, 34, 52, 50, 34, 10)), used: 27 };
+global global:core:prelude/format.wado::__const_obj_16: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(46, 46, 46)), used: 3 };
+global global:core:prelude/format.wado::__const_obj_17: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(92, 117, 123)), used: 3 };
 
 fn "local_item_newtype_definition.wado/__test_0_local_newtype_definition"() {
     let __cond_4: bool;
-    let __local_7: ref "core:prelude/string.wado//String";
-    let __local_8: ref "core:prelude/format.wado//Formatter";
+    let __cond_6: bool;
     let __local_9: ref "core:prelude/string.wado//String";
     let __local_10: ref "core:prelude/format.wado//Formatter";
-    let len_a: i32;
-    __local_7 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
-    __local_8 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_7 };
-    "core:prelude/primitive.wado/i32::fmt_decimal"(42, __local_8);
+    let __local_11: ref "core:prelude/string.wado//String";
+    let __local_12: ref "core:prelude/format.wado//Formatter";
+    let __local_13: ref "core:prelude/string.wado//String";
+    let __local_14: ref "core:prelude/format.wado//Formatter";
+    let __local_15: ref "core:prelude/string.wado//String";
+    let __local_16: ref "core:prelude/format.wado//Formatter";
+    let len_a_27: i32;
+    let s: ref "core:prelude/string.wado//String";
+    let len_a_44: i32;
+    __local_9 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
+    __local_10 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_9 };
+    "core:prelude/primitive.wado/i32::fmt_decimal"(42, __local_10);
     __cond_4 = __inline_String_Eq__eq_5: block -> bool {
-        len_a = __local_7.used;
-        if len_a != 2 {
+        len_a_27 = __local_9.used;
+        if len_a_27 != 2 {
             break __inline_String_Eq__eq_5: 0;
         }
-        break __inline_String_Eq__eq_5: "core:prelude/string.wado/String^Eq::eq_bytes"(__local_7.repr, array.new_fixed<u8>(52, 50), len_a);
+        break __inline_String_Eq__eq_5: "core:prelude/string.wado/String^Eq::eq_bytes"(__local_9.repr, array.new_fixed<u8>(52, 50), len_a_27);
     };
     if @unlikely(__cond_4 == 0) {
         cold_path;
-        "core:rt/panic"(__local_9 = "core:prelude/string.wado/String::with_capacity"(125); "core:prelude/string.wado/String::push_str"(__local_9, global:local_item_newtype_definition.wado::__const_obj_3); "core:prelude/string.wado/String::push_str"(__local_9, global:local_item_newtype_definition.wado::__const_obj_2); "core:prelude/string.wado/String::push"(__local_9, 32); "core:prelude/string.wado/String::push"(__local_9, 97); "core:prelude/string.wado/String::push"(__local_9, 116); "core:prelude/string.wado/String::push"(__local_9, 32); "core:prelude/string.wado/String::push_str"(__local_9, global:local_item_newtype_definition.wado::__const_obj_1); "core:prelude/string.wado/String::push"(__local_9, 58); __local_10 = "core:prelude/format.wado/Formatter::new"(__local_9); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 11 }, __local_10); "core:prelude/string.wado/String::push_str"(__local_9, global:local_item_newtype_definition.wado::__const_obj_0); "core:prelude/string.wado/String::push"(__local_9, 96); "core:prelude/string.wado/String::push"(__local_9, 123); "core:prelude/string.wado/String::push"(__local_9, 105); "core:prelude/string.wado/String::push"(__local_9, 100); "core:prelude/string.wado/String::push"(__local_9, 125); "core:prelude/string.wado/String::push"(__local_9, 96); "core:prelude/string.wado/String::push"(__local_9, 58); "core:prelude/string.wado/String::push"(__local_9, 32); __local_10 = "core:prelude/format.wado/Formatter::new"(__local_9); "core:prelude/format.wado/String^Inspect::inspect"(__local_7, __local_10); "core:prelude/string.wado/String::push"(__local_9, 10); __local_9);
+        "core:rt/panic"(__local_11 = "core:prelude/string.wado/String::with_capacity"(125); "core:prelude/string.wado/String::push_str"(__local_11, global:local_item_newtype_definition.wado::__const_obj_4); "core:prelude/string.wado/String::push_str"(__local_11, global:local_item_newtype_definition.wado::__const_obj_3); "core:prelude/string.wado/String::push"(__local_11, 32); "core:prelude/string.wado/String::push"(__local_11, 97); "core:prelude/string.wado/String::push"(__local_11, 116); "core:prelude/string.wado/String::push"(__local_11, 32); "core:prelude/string.wado/String::push_str"(__local_11, global:local_item_newtype_definition.wado::__const_obj_2); "core:prelude/string.wado/String::push"(__local_11, 58); __local_12 = "core:prelude/format.wado/Formatter::new"(__local_11); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 11 }, __local_12); "core:prelude/string.wado/String::push_str"(__local_11, global:local_item_newtype_definition.wado::__const_obj_6); "core:prelude/string.wado/String::push"(__local_11, 96); "core:prelude/string.wado/String::push"(__local_11, 123); "core:prelude/string.wado/String::push"(__local_11, 105); "core:prelude/string.wado/String::push"(__local_11, 100); "core:prelude/string.wado/String::push"(__local_11, 125); "core:prelude/string.wado/String::push"(__local_11, 96); "core:prelude/string.wado/String::push"(__local_11, 58); "core:prelude/string.wado/String::push"(__local_11, 32); __local_12 = "core:prelude/format.wado/Formatter::new"(__local_11); "core:prelude/format.wado/String^Inspect::inspect"(__local_9, __local_12); "core:prelude/string.wado/String::push"(__local_11, 10); __local_11);
+        unreachable;
+    }
+    __local_13 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
+    __local_14 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_13 };
+    "core:prelude/primitive.wado/i32::fmt_decimal"(42, __local_14);
+    s = global:local_item_newtype_definition.wado::__const_obj_5;
+    "core:prelude/string.wado/String::push_str"(__local_14.buf, s);
+    __cond_6 = __inline_String_Eq__eq_16: block -> bool {
+        len_a_44 = __local_13.used;
+        if len_a_44 != 12 {
+            break __inline_String_Eq__eq_16: 0;
+        }
+        break __inline_String_Eq__eq_16: "core:prelude/string.wado/String^Eq::eq_bytes"(__local_13.repr, array.new_data<u8>("42 as UserId"), len_a_44);
+    };
+    if @unlikely(__cond_6 == 0) {
+        cold_path;
+        "core:rt/panic"(__local_15 = "core:prelude/string.wado/String::with_capacity"(139); "core:prelude/string.wado/String::push_str"(__local_15, global:local_item_newtype_definition.wado::__const_obj_4); "core:prelude/string.wado/String::push_str"(__local_15, global:local_item_newtype_definition.wado::__const_obj_3); "core:prelude/string.wado/String::push"(__local_15, 32); "core:prelude/string.wado/String::push"(__local_15, 97); "core:prelude/string.wado/String::push"(__local_15, 116); "core:prelude/string.wado/String::push"(__local_15, 32); "core:prelude/string.wado/String::push_str"(__local_15, global:local_item_newtype_definition.wado::__const_obj_2); "core:prelude/string.wado/String::push"(__local_15, 58); __local_16 = "core:prelude/format.wado/Formatter::new"(__local_15); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 14 }, __local_16); "core:prelude/string.wado/String::push_str"(__local_15, global:local_item_newtype_definition.wado::__const_obj_1); "core:prelude/string.wado/String::push_str"(__local_15, global:local_item_newtype_definition.wado::__const_obj_0); __local_16 = "core:prelude/format.wado/Formatter::new"(__local_15); "core:prelude/format.wado/String^Inspect::inspect"(__local_13, __local_16); "core:prelude/string.wado/String::push"(__local_15, 10); __local_15);
         unreachable;
     }
 }
@@ -197,9 +223,9 @@ fn "local_item_newtype_definition.wado/__cm_export____test_1_sibling_test_blocks
     };
     if @unlikely(__cond == 0) {
         cold_path;
-        "core:rt/panic"(__local_3 = "core:prelude/string.wado/String::with_capacity"(118); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_sibling_test_blocks_may_declare_same_named_local_newtypes_with_different_base_types"), used: 92 }); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push"(__local_3, 97); "core:prelude/string.wado/String::push"(__local_3, 116); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("local_item_newtype_definition.wado"), used: 34 }); "core:prelude/string.wado/String::push"(__local_3, 58); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 17 }, __local_4); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
+        "core:rt/panic"(__local_3 = "core:prelude/string.wado/String::with_capacity"(118); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_sibling_test_blocks_may_declare_same_named_local_newtypes_with_different_base_types"), used: 92 }); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push"(__local_3, 97); "core:prelude/string.wado/String::push"(__local_3, 116); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("local_item_newtype_definition.wado"), used: 34 }); "core:prelude/string.wado/String::push"(__local_3, 58); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 20 }, __local_4); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: id == \"abc\"
-"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
+"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@24^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
         unreachable;
     }
     "wasi/task-return"(0);
@@ -217,12 +243,12 @@ fn "core:prelude/primitive.wado/count_digits_i64"(val) {
     }
     n = 0;
     t = val;
-    b5: block {
-        l6: loop {
-            break_if b5 t <= 0_i64;
+    b7: block {
+        l8: loop {
+            break_if b7 t <= 0_i64;
             n = n + 1;
             t = t / 10_i64;
-            continue l6;
+            continue l8;
         };
     };
     return n;
@@ -236,13 +262,13 @@ fn "core:prelude/primitive.wado/write_decimal_digits"(arr, offset, abs_val, digi
         builtin::array_set_u8(arr, offset, 48);
     } else {
         temp = abs_val;
-        b8: block {
-            l9: loop {
-                break_if b8 temp <= 0_i64;
+        b10: block {
+            l11: loop {
+                break_if b10 temp <= 0_i64;
                 pos = pos - 1;
                 builtin::array_set_u8(arr, pos, (48 + builtin::i32_wrap_i64(temp % 10_i64)) & 255);
                 temp = temp / 10_i64;
-                continue l9;
+                continue l11;
             };
         };
     }
@@ -258,28 +284,28 @@ fn "core:prelude/primitive.wado/count_digits_u64_base"(val_i64, bits_per_digit) 
     highest_bit = 0;
     if ((val_i64 >> 32_i64) & 4294967295_i64) != 0_i64 {
         b_4 = 63;
-        b12: block {
-            l13: loop {
-                break_if b12 b_4 < 32;
+        b14: block {
+            l15: loop {
+                break_if b14 b_4 < 32;
                 if ((val_i64 >> builtin::i64_extend_i32_s(b_4)) & 1_i64) != 0_i64 {
                     highest_bit = b_4;
-                    break b12;
+                    break b14;
                 }
                 b_4 = b_4 - 1;
-                continue l13;
+                continue l15;
             };
         };
     } else {
         b_5 = 31;
-        b15: block {
-            l16: loop {
-                break_if b15 b_5 < 0;
+        b17: block {
+            l18: loop {
+                break_if b17 b_5 < 0;
                 if ((val_i64 >> builtin::i64_extend_i32_s(b_5)) & 1_i64) != 0_i64 {
                     highest_bit = b_5;
-                    break b15;
+                    break b17;
                 }
                 b_5 = b_5 - 1;
-                continue l16;
+                continue l18;
             };
         };
     }
@@ -297,9 +323,9 @@ fn "core:prelude/primitive.wado/write_u64_base_digits"(arr, offset, val_i64, dig
         builtin::array_set_u8(arr, offset, 48);
     } else {
         temp = val_i64;
-        b19: block {
-            l20: loop {
-                break_if b19 temp == 0_i64;
+        b21: block {
+            l22: loop {
+                break_if b21 temp == 0_i64;
                 pos = pos - 1;
                 digit = builtin::i32_wrap_i64(temp & mask64);
                 builtin::array_set_u8(arr, pos, (if digit < 10 -> i32 {
@@ -308,7 +334,7 @@ fn "core:prelude/primitive.wado/write_u64_base_digits"(arr, offset, val_i64, dig
                     select i32(upper, (65 + digit) - 10, (97 + digit) - 10);
                 }) & 255);
                 temp = temp >>u builtin::i64_extend_i32_s(bits_per_digit);
-                continue l20;
+                continue l22;
             };
         };
     }
@@ -317,12 +343,12 @@ fn "core:prelude/primitive.wado/write_u64_base_digits"(arr, offset, val_i64, dig
 fn "core:rt/gc_array_to_memory"(arr, ptr, len) {
     let i: i32;
     i = 0;
-    b22: block {
-        l23: loop {
-            break_if b22 i >= len;
+    b24: block {
+        l25: loop {
+            break_if b24 i >= len;
             builtin::store_u8(ptr + i, builtin::array_get_u8(arr, i));
             i = i + 1;
-            continue l23;
+            continue l25;
         };
     };
 }
@@ -384,20 +410,20 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
     let offset: i32;
     let result: i32;
     offset = 0;
-    b25: block {
-        l26: loop {
-            break_if b25 offset >= count;
+    b27: block {
+        l28: loop {
+            break_if b27 offset >= count;
             result = "wasi/stream-write"(handle, ptr + (offset * elem_size), count - offset);
             if result == -1 {
                 result = "core:rt/wait_for_blocked"(handle);
             }
             offset = offset + (result >> 4);
-            break_if b25 (if (result >> 4) == 0 -> i32 {
+            break_if b27 (if (result >> 4) == 0 -> i32 {
                 1;
             } else {
                 (result & 15) != 0;
             });
-            continue l26;
+            continue l28;
         };
     };
 }
@@ -501,14 +527,14 @@ fn "core:prelude/string.wado/String::push_str"(self, other) {
 fn "core:prelude/string.wado/String^Eq::eq_bytes"(a, b, len) {
     let i: i32;
     i = 0;
-    b35: block {
-        l36: loop {
-            break_if b35 i >= len;
+    b37: block {
+        l38: loop {
+            break_if b37 i >= len;
             if builtin::array_get<u8>(a, i) != builtin::array_get<u8>(b, i) {
                 return 0;
             }
             i = i + 1;
-            continue l36;
+            continue l38;
         };
     };
     return 1;
@@ -588,10 +614,10 @@ fn "core:prelude/string.wado/String::push"(self, c) {
     }
 }
 
-fn "local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect"(self, f) {
+fn "local_item_newtype_definition.wado/UserId@24^Inspect::inspect"(self, f) {
     let s: ref "core:prelude/string.wado//String";
     "core:prelude/format.wado/String^Inspect::inspect"(self, f);
-    s = global:local_item_newtype_definition.wado::__const_obj_9;
+    s = global:local_item_newtype_definition.wado::__const_obj_5;
     "core:prelude/string.wado/String::push_str"(f.buf, s);
 }
 
@@ -604,12 +630,12 @@ fn "core:prelude/format.wado/Formatter::write_char_n"(self, c, n) {
     let _licm_buf_4: ref "core:prelude/string.wado//String";
     i = 0;
     _licm_buf_4 = self.buf;
-    b46: block {
-        l47: loop {
-            break_if b46 i >= n;
+    b48: block {
+        l49: loop {
+            break_if b48 i >= n;
             "core:prelude/string.wado/String::push"(_licm_buf_4, c);
             i = i + 1;
-            continue l47;
+            continue l49;
         };
     };
 }
@@ -716,8 +742,8 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
     truncated = 0;
     __iter_5 = "local_item_newtype_definition.wado/$value_copy$T64"(self_15 = struct.new "core:prelude/string.wado//StrCharIter" { repr: self.repr, used: self.used, byte_index: 0 }; self_15);
     _licm_arith_52 = limit >= 0;
-    b66: block {
-        l67: loop {
+    b68: block {
+        l69: loop {
             let __sroa___match_10_discriminant: i32;
             let __sroa___match_10_payload_0: char;
             multivalue_bind [__sroa___match_10_discriminant, __sroa___match_10_payload_0] = "core:prelude/string.wado/StrCharIter^Iterator::next"(__iter_5);
@@ -728,7 +754,7 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                     0;
                 }) {
                     truncated = 1;
-                    break b66;
+                    break b68;
                 }
                 if __sroa___match_10_payload_0 == 34 {
                     "core:prelude/string.wado/String::push"(f.buf, 92);
@@ -750,7 +776,7 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                 } else {
                     __sroa___match_10_payload_0 == 127;
                 }) {
-                    s_37 = global:core:prelude/format.wado::__const_obj_11;
+                    s_37 = global:core:prelude/format.wado::__const_obj_17;
                     "core:prelude/string.wado/String::push_str"(f.buf, s_37);
                     __local_8 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(16), used: 0 };
                     __local_9 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_8 };
@@ -762,14 +788,14 @@ fn "core:prelude/format.wado/String^Inspect::inspect"(self, f) {
                 }
                 count = count + 1;
             } else {
-                break b66;
+                break b68;
             }
-            continue l67;
+            continue l69;
         };
     };
     "core:prelude/string.wado/String::push"(f.buf, 34);
     if truncated {
-        s_51 = global:core:prelude/format.wado::__const_obj_10;
+        s_51 = global:core:prelude/format.wado::__const_obj_16;
         "core:prelude/string.wado/String::push_str"(f.buf, s_51);
     }
 }

--- a/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/local_item_newtype_definition.wir.wado
@@ -100,13 +100,7 @@ type "functype//core:prelude/string.wado/String^Eq::eq_bytes" = fn(ref Array<u8>
 
 type "functype//core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(39)
 
-<<<<<<< HEAD
 type "functype//local_item_newtype_definition.wado/UserId@24^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
-||||||| c66576c75
-type "functype//local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
-=======
-type "functype//local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(40)
->>>>>>> origin/main
 
 type "functype//core:prelude/format.wado/Formatter::new" = fn(ref "core:prelude/string.wado//String") -> ref "core:prelude/format.wado//Formatter";  // TypeId(41)
 
@@ -138,7 +132,6 @@ import fn wasi/stream-new from "wasi/stream-new";
 import fn wasi/future-drop-readable:transmission-cli from "wasi/future-drop-readable:transmission-cli";
 
 global mut global:local_item_newtype_definition.wado::__modules_initialized: bool = 0;
-<<<<<<< HEAD
 global global:local_item_newtype_definition.wado::__const_obj_0: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(96, 123, 105, 100, 58, 63, 125, 96, 58, 32)), used: 10 };
 global global:local_item_newtype_definition.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(10, 99, 111, 110, 100, 105, 116, 105, 111, 110, 58, 32, 96, 123, 105, 100, 58, 63, 125, 96, 32, 61, 61, 32, 34, 52, 50, 32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 34, 10)), used: 39 };
 global global:local_item_newtype_definition.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(108, 111, 99, 97, 108, 95, 105, 116, 101, 109, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110, 46, 119, 97, 100, 111)), used: 34 };
@@ -148,23 +141,6 @@ global global:local_item_newtype_definition.wado::__const_obj_5: ref null "core:
 global global:local_item_newtype_definition.wado::__const_obj_6: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(10, 99, 111, 110, 100, 105, 116, 105, 111, 110, 58, 32, 96, 123, 105, 100, 125, 96, 32, 61, 61, 32, 34, 52, 50, 34, 10)), used: 27 };
 global global:core:prelude/format.wado::__const_obj_16: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(46, 46, 46)), used: 3 };
 global global:core:prelude/format.wado::__const_obj_17: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(92, 117, 123)), used: 3 };
-||||||| c66576c75
-global global:local_item_newtype_definition.wado::__const_obj_0: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(10, 99, 111, 110, 100, 105, 116, 105, 111, 110, 58, 32, 96, 123, 105, 100, 125, 96, 32, 61, 61, 32, 34, 52, 50, 34, 10)), used: 27 };
-global global:local_item_newtype_definition.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(108, 111, 99, 97, 108, 95, 105, 116, 101, 109, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110, 46, 119, 97, 100, 111)), used: 34 };
-global global:local_item_newtype_definition.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(95, 95, 116, 101, 115, 116, 95, 48, 95, 108, 111, 99, 97, 108, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110)), used: 33 };
-global global:local_item_newtype_definition.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(65, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 32, 105, 110, 32)), used: 20 };
-global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 55, 58, 49, 57, 41)), used: 25 };
-global global:core:prelude/format.wado::__const_obj_10: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(46, 46, 46)), used: 3 };
-global global:core:prelude/format.wado::__const_obj_11: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(92, 117, 123)), used: 3 };
-=======
-global global:local_item_newtype_definition.wado::__const_obj_0: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(10, 99, 111, 110, 100, 105, 116, 105, 111, 110, 58, 32, 96, 123, 105, 100, 125, 96, 32, 61, 61, 32, 34, 52, 50, 34, 10)), used: 27 };
-global global:local_item_newtype_definition.wado::__const_obj_1: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(108, 111, 99, 97, 108, 95, 105, 116, 101, 109, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110, 46, 119, 97, 100, 111)), used: 34 };
-global global:local_item_newtype_definition.wado::__const_obj_2: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(95, 95, 116, 101, 115, 116, 95, 48, 95, 108, 111, 99, 97, 108, 95, 110, 101, 119, 116, 121, 112, 101, 95, 100, 101, 102, 105, 110, 105, 116, 105, 111, 110)), used: 33 };
-global global:local_item_newtype_definition.wado::__const_obj_3: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(65, 115, 115, 101, 114, 116, 105, 111, 110, 32, 102, 97, 105, 108, 101, 100, 32, 105, 110, 32)), used: 20 };
-global global:local_item_newtype_definition.wado::__const_obj_9: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(32, 97, 115, 32, 85, 115, 101, 114, 73, 100, 64, 65, 115, 116, 73, 100, 40, 50, 48, 49, 56, 58, 49, 57, 41)), used: 25 };
-global global:core:prelude/format.wado::__const_obj_10: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(46, 46, 46)), used: 3 };
-global global:core:prelude/format.wado::__const_obj_11: ref null "core:prelude/string.wado//String" = struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(array.new_fixed<u8>(92, 117, 123)), used: 3 };
->>>>>>> origin/main
 
 fn "local_item_newtype_definition.wado/__test_0_local_newtype_definition"() {
     let __cond_4: bool;
@@ -249,13 +225,7 @@ fn "local_item_newtype_definition.wado/__cm_export____test_1_sibling_test_blocks
         cold_path;
         "core:rt/panic"(__local_3 = "core:prelude/string.wado/String::with_capacity"(118); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("Assertion failed in "), used: 20 }); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("__test_1_sibling_test_blocks_may_declare_same_named_local_newtypes_with_different_base_types"), used: 92 }); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push"(__local_3, 97); "core:prelude/string.wado/String::push"(__local_3, 116); "core:prelude/string.wado/String::push"(__local_3, 32); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("local_item_newtype_definition.wado"), used: 34 }); "core:prelude/string.wado/String::push"(__local_3, 58); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "core:prelude/primitive.wado/i32^Display::fmt"(struct.new "core:prelude/types.wado//Box<i32>" { value: 20 }, __local_4); "core:prelude/string.wado/String::push_str"(__local_3, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("
 condition: id == \"abc\"
-<<<<<<< HEAD
 "), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@24^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
-||||||| c66576c75
-"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
-=======
-"), used: 24 }); "core:prelude/string.wado/String::push"(__local_3, 105); "core:prelude/string.wado/String::push"(__local_3, 100); "core:prelude/string.wado/String::push"(__local_3, 58); "core:prelude/string.wado/String::push"(__local_3, 32); __local_4 = "core:prelude/format.wado/Formatter::new"(__local_3); "local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect"(id, __local_4); "core:prelude/string.wado/String::push"(__local_3, 10); __local_3);
->>>>>>> origin/main
         unreachable;
     }
     "wasi/task-return"(0);
@@ -644,13 +614,7 @@ fn "core:prelude/string.wado/String::push"(self, c) {
     }
 }
 
-<<<<<<< HEAD
 fn "local_item_newtype_definition.wado/UserId@24^Inspect::inspect"(self, f) {
-||||||| c66576c75
-fn "local_item_newtype_definition.wado/UserId@AstId(2017:19)^Inspect::inspect"(self, f) {
-=======
-fn "local_item_newtype_definition.wado/UserId@AstId(2018:19)^Inspect::inspect"(self, f) {
->>>>>>> origin/main
     let s: ref "core:prelude/string.wado//String";
     "core:prelude/format.wado/String^Inspect::inspect"(self, f);
     s = global:local_item_newtype_definition.wado::__const_obj_5;

--- a/wado-compiler/tests/generated/fixtures/local_item_serde_attributes.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/local_item_serde_attributes.wir.wado
@@ -74,7 +74,7 @@ struct tuple//[bool, i32] {  // TypeId(12)
     mut 1: i32,
 }
 
-struct local_item_serde_attributes.wado//Options@AstId(2021:8) {  // TypeId(13)
+struct local_item_serde_attributes.wado//Options@8 {  // TypeId(13)
     mut input: ref "core:prelude/string.wado//String",
     mut verbose: bool,
     mut jobs: i32,
@@ -267,7 +267,7 @@ type "functype//core:prelude/list.wado/List<bool>::push" = fn(ref "core:prelude/
 
 type "functype//core:prelude/list.wado/List<bool>::grow" = fn(ref "core:prelude//List<bool>");  // TypeId(85)
 
-type "functype//core:args/ArgvStructAccess^DeserializeStruct::next_field<local_item_serde_attributes.wado/Options@AstId(2021:8)>" = fn(ref "core:args//ArgvStructAccess") -> ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>";  // TypeId(86)
+type "functype//core:args/ArgvStructAccess^DeserializeStruct::next_field<local_item_serde_attributes.wado/Options@8>" = fn(ref "core:args//ArgvStructAccess") -> ref "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>";  // TypeId(86)
 
 type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(87)
 
@@ -283,15 +283,15 @@ type "functype//core:prelude/intparse.wado/parse_signed_prefix_range" = fn(ref "
 
 type "functype//core:prelude/intparse.wado/parse_i64_radix_range" = fn(ref "core:prelude/string.wado//String", i32, i32, u32, i64, u64) -> [i32, i64, ref null "core:prelude/intparse.wado//ParseIntError"];  // TypeId(93)
 
-type "functype//core:args/core/args/parse<local_item_serde_attributes.wado/Options@AstId(2021:8)>" = fn(ref "core:prelude//List<core:prelude/string.wado/String>") -> [i32, ref null "local_item_serde_attributes.wado//Options@AstId(2021:8)", ref null "core:args//ArgsError"];  // TypeId(94)
+type "functype//core:args/core/args/parse<local_item_serde_attributes.wado/Options@8>" = fn(ref "core:prelude//List<core:prelude/string.wado/String>") -> [i32, ref null "local_item_serde_attributes.wado//Options@8", ref null "core:args//ArgsError"];  // TypeId(94)
 
 type "functype//core:prelude/primitive.wado/bool^LenientFromStr::from_str_lenient" = fn(ref "core:prelude/string.wado//String") -> [i32, bool, ref null "core:prelude/traits.wado//LenientParseError"];  // TypeId(95)
 
 type "functype//core:prelude/primitive.wado/i32^LenientFromStr::from_str_lenient" = fn(ref "core:prelude/string.wado//String") -> [i32, i32, ref null "core:prelude/traits.wado//LenientParseError"];  // TypeId(96)
 
-type "functype//local_item_serde_attributes.wado/Options@AstId(2021:8)^FieldSchema::lookup" = fn(ref "core:prelude/slice.wado//ArraySlice<u8>") -> [i32, i32];  // TypeId(97)
+type "functype//local_item_serde_attributes.wado/Options@8^FieldSchema::lookup" = fn(ref "core:prelude/slice.wado//ArraySlice<u8>") -> [i32, i32];  // TypeId(97)
 
-type "functype//local_item_serde_attributes.wado/Options@AstId(2021:8)^FieldSchema::positional_at" = fn(i32) -> [i32, i32];  // TypeId(98)
+type "functype//local_item_serde_attributes.wado/Options@8^FieldSchema::positional_at" = fn(i32) -> [i32, i32];  // TypeId(98)
 
 type "functype//core:args/ArgvDeserializer::pull_option_value" = fn(ref "core:args//ArgvDeserializer") -> [i32, ref null "core:prelude/string.wado//String", ref null "core:serde//DeserializeError"];  // TypeId(99)
 
@@ -301,7 +301,7 @@ type "functype//core:args/ArgvDeserializer^Deserializer::deserialize_i32" = fn(r
 
 type "functype//core:args/ArgvDeserializer^Deserializer::deserialize_bool" = fn(ref "core:args//ArgvDeserializer") -> [i32, bool, ref null "core:serde//DeserializeError"];  // TypeId(102)
 
-type "functype//local_item_serde_attributes.wado/Options@AstId(2021:8)^Deserialize::deserialize<core:args/ArgvDeserializer>" = fn(ref "core:args//ArgvDeserializer") -> [i32, ref null "local_item_serde_attributes.wado//Options@AstId(2021:8)", ref null "core:serde//DeserializeError"];  // TypeId(103)
+type "functype//local_item_serde_attributes.wado/Options@8^Deserialize::deserialize<core:args/ArgvDeserializer>" = fn(ref "core:args//ArgvDeserializer") -> [i32, ref null "local_item_serde_attributes.wado//Options@8", ref null "core:serde//DeserializeError"];  // TypeId(103)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -349,10 +349,10 @@ global global:core:args::__const_obj_67: ref null "core:prelude/string.wado//Str
 
 fn "local_item_serde_attributes.wado/__test_0_local_struct_field_attributes____serde_positional____and_defaults_resolve"() {
     let __b_0: ref "core:prelude//List<core:prelude/string.wado/String>";
-    let opts_2: ref "local_item_serde_attributes.wado//Options@AstId(2021:8)";
+    let opts_2: ref "local_item_serde_attributes.wado//Options@8";
     let __cond_3: bool;
     let __b_4: ref "core:prelude//List<core:prelude/string.wado/String>";
-    let opts_6: ref "local_item_serde_attributes.wado//Options@AstId(2021:8)";
+    let opts_6: ref "local_item_serde_attributes.wado//Options@8";
     let __cond_7: bool;
     let __local_8: ref "core:prelude/string.wado//String";
     let __local_9: ref "core:prelude/format.wado//Formatter";
@@ -361,9 +361,9 @@ fn "local_item_serde_attributes.wado/__test_0_local_struct_field_attributes____s
     let len_a_25: i32;
     let len_a_33: i32;
     let __sroa_with_flags_discriminant: i32;
-    let __sroa_with_flags_case0_payload_0: ref null "local_item_serde_attributes.wado//Options@AstId(2021:8)";
+    let __sroa_with_flags_case0_payload_0: ref null "local_item_serde_attributes.wado//Options@8";
     let __sroa_with_flags_case1_payload_0: ref null "core:args//ArgsError";
-    multivalue_bind [__sroa_with_flags_discriminant, __sroa_with_flags_case0_payload_0, __sroa_with_flags_case1_payload_0] = "core:args/core/args/parse<local_item_serde_attributes.wado/Options@AstId(2021:8)>"(__b_0 = struct.new "core:prelude//List<core:prelude/string.wado/String>" { repr: array.new_fixed<ref "core:prelude/string.wado//String">(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("in.txt"), used: 6 }, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("--verbose"), used: 9 }, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("--jobs"), used: 6 }, struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(52), used: 1 }), used: 4 }; __b_0);
+    multivalue_bind [__sroa_with_flags_discriminant, __sroa_with_flags_case0_payload_0, __sroa_with_flags_case1_payload_0] = "core:args/core/args/parse<local_item_serde_attributes.wado/Options@8>"(__b_0 = struct.new "core:prelude//List<core:prelude/string.wado/String>" { repr: array.new_fixed<ref "core:prelude/string.wado//String">(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("in.txt"), used: 6 }, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("--verbose"), used: 9 }, struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("--jobs"), used: 6 }, struct.new "core:prelude/string.wado//String" { repr: array.new_fixed<u8>(52), used: 1 }), used: 4 }; __b_0);
     __cond_3 = (if __sroa_with_flags_discriminant == 0 -> bool {
         opts_2 = ref.as_non_null(__sroa_with_flags_case0_payload_0);
         if (if __inline_String_Eq__eq_7: block -> bool {
@@ -392,9 +392,9 @@ condition: with_flags matches { Ok(opts) && opts.input == \"in.txt\" && opts.ver
         unreachable;
     }
     let __sroa_defaults_only_discriminant: i32;
-    let __sroa_defaults_only_case0_payload_0: ref null "local_item_serde_attributes.wado//Options@AstId(2021:8)";
+    let __sroa_defaults_only_case0_payload_0: ref null "local_item_serde_attributes.wado//Options@8";
     let __sroa_defaults_only_case1_payload_0: ref null "core:args//ArgsError";
-    multivalue_bind [__sroa_defaults_only_discriminant, __sroa_defaults_only_case0_payload_0, __sroa_defaults_only_case1_payload_0] = "core:args/core/args/parse<local_item_serde_attributes.wado/Options@AstId(2021:8)>"(__b_4 = struct.new "core:prelude//List<core:prelude/string.wado/String>" { repr: array.new_fixed<ref "core:prelude/string.wado//String">(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("in.txt"), used: 6 }), used: 1 }; __b_4);
+    multivalue_bind [__sroa_defaults_only_discriminant, __sroa_defaults_only_case0_payload_0, __sroa_defaults_only_case1_payload_0] = "core:args/core/args/parse<local_item_serde_attributes.wado/Options@8>"(__b_4 = struct.new "core:prelude//List<core:prelude/string.wado/String>" { repr: array.new_fixed<ref "core:prelude/string.wado//String">(struct.new "core:prelude/string.wado//String" { repr: array.new_data<u8>("in.txt"), used: 6 }), used: 1 }; __b_4);
     __cond_7 = (if __sroa_defaults_only_discriminant == 0 -> bool {
         opts_6 = ref.as_non_null(__sroa_defaults_only_case0_payload_0);
         if (if __inline_String_Eq__eq_12: block -> bool {
@@ -859,12 +859,12 @@ fn "core:rt/cm_stream_write_raw_u8"(handle, data, len) {
     drop("mem/realloc"(ptr, raw_len, 1, 0));
 }
 
-fn "core:args/core/args/parse<local_item_serde_attributes.wado/Options@AstId(2021:8)>"(argv) {
+fn "core:args/core/args/parse<local_item_serde_attributes.wado/Options@8>"(argv) {
     let __b: ref "core:prelude//List<bool>";
     let i: i32;
     let de: ref "core:args//ArgvDeserializer";
     let e_6: ref "core:args//ArgsError";
-    let v: ref "local_item_serde_attributes.wado//Options@AstId(2021:8)";
+    let v: ref "local_item_serde_attributes.wado//Options@8";
     let de_err: ref "core:serde//DeserializeError";
     let __match_9: ref null "core:args//ArgsError";
     let kind: "core:args//enum:ArgsErrorKind";
@@ -882,9 +882,9 @@ fn "core:args/core/args/parse<local_item_serde_attributes.wado/Options@AstId(202
     };
     de = struct.new "core:args//ArgvDeserializer" { tokens: argv, pos: 0, after_dd: 0, cur_is_option: 0, cur_inline: ref.null none, cur_name: struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(0), used: 0 }, consumed: __b, forced: ref.null none, err: ref.null none };
     let __sroa_r_discriminant: i32;
-    let __sroa_r_case0_payload_0: ref null "local_item_serde_attributes.wado//Options@AstId(2021:8)";
+    let __sroa_r_case0_payload_0: ref null "local_item_serde_attributes.wado//Options@8";
     let __sroa_r_case1_payload_0: ref null "core:serde//DeserializeError";
-    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "local_item_serde_attributes.wado/Options@AstId(2021:8)^Deserialize::deserialize<core:args/ArgvDeserializer>"(de);
+    multivalue_bind [__sroa_r_discriminant, __sroa_r_case0_payload_0, __sroa_r_case1_payload_0] = "local_item_serde_attributes.wado/Options@8^Deserialize::deserialize<core:args/ArgvDeserializer>"(de);
     __match_9 = de.err;
     if ref.is_null(__match_9) == 0 {
         e_6 = ref.as_non_null(__match_9);
@@ -1406,7 +1406,7 @@ fn "core:prelude/string.wado/String::replacen"(self, from, to, count) {
     return result;
 }
 
-fn "local_item_serde_attributes.wado/Options@AstId(2021:8)^FieldSchema::lookup"(__key) {
+fn "local_item_serde_attributes.wado/Options@8^FieldSchema::lookup"(__key) {
     let __len: i32;
     __len = __key.end - __key.start;
     if (if (if (if (if (if (if (if __len == 7 -> i32 {
@@ -1462,7 +1462,7 @@ fn "local_item_serde_attributes.wado/Options@AstId(2021:8)^FieldSchema::lookup"(
     return 1, 0;
 }
 
-fn "local_item_serde_attributes.wado/Options@AstId(2021:8)^FieldSchema::positional_at"(__rank) {
+fn "local_item_serde_attributes.wado/Options@8^FieldSchema::positional_at"(__rank) {
     if __rank == 0 {
         return 0, 0;
     }
@@ -1824,7 +1824,7 @@ fn "core:prelude/format.wado/Formatter::prepare_int_write"(self, is_negative, pr
     }
 }
 
-fn "local_item_serde_attributes.wado/Options@AstId(2021:8)^Deserialize::deserialize<core:args/ArgvDeserializer>"(d) {
+fn "local_item_serde_attributes.wado/Options@8^Deserialize::deserialize<core:args/ArgvDeserializer>"(d) {
     let __result: ref "core:prelude/types.wado//Result<core:args/ArgvStructAccess,core:serde/DeserializeError>";
     let __local_2: ref "core:args//ArgvStructAccess";
     let __local_3: ref "core:prelude/string.wado//String";
@@ -1862,7 +1862,7 @@ fn "local_item_serde_attributes.wado/Options@AstId(2021:8)^Deserialize::deserial
         __local_5 = 1;
         b209: block {
             l210: loop {
-                __local_7 = "core:args/ArgvStructAccess^DeserializeStruct::next_field<local_item_serde_attributes.wado/Options@AstId(2021:8)>"(__local_2);
+                __local_7 = "core:args/ArgvStructAccess^DeserializeStruct::next_field<local_item_serde_attributes.wado/Options@8>"(__local_2);
                 if ref.test "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>::Ok"(__local_7) {
                     __local_8 = ref.cast "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>::Ok"(__local_7).payload_0;
                     if ref.test "core:prelude/types.wado//Option<i32>::Some"(__local_8) {
@@ -1928,7 +1928,7 @@ fn "local_item_serde_attributes.wado/Options@AstId(2021:8)^Deserialize::deserial
             return 1, ref.null none, __local_19;
         } else {
         }
-        return 0, struct.new "local_item_serde_attributes.wado//Options@AstId(2021:8)" { input: __local_3, verbose: __local_4, jobs: __local_5 }, ref.null none;
+        return 0, struct.new "local_item_serde_attributes.wado//Options@8" { input: __local_3, verbose: __local_4, jobs: __local_5 }, ref.null none;
     } else {
         return 1, ref.null none, ref.as_non_null(v_35 = ref.cast "core:prelude/types.wado//Result<core:args/ArgvStructAccess,core:serde/DeserializeError>::Err"(__result).payload_0; struct.new "core:serde//DeserializeError" { kind: v_35.kind, message: ref.as_non_null(v_41 = v_35.message; struct.new "core:prelude/string.wado//String" { repr: ref.as_non_null(let __array_clone_src_2: ref Array<u8>; __array_clone_src_2 = v_41.repr; let __array_clone_len_2: i32; __array_clone_len_2 = builtin::array_len(__array_clone_src_2); let __array_clone_dst_2: ref Array<u8>; __array_clone_dst_2 = builtin::array_new<u8>(__array_clone_len_2); builtin::array_copy<u8>(__array_clone_dst_2, 0, __array_clone_src_2, 0, __array_clone_len_2); __array_clone_dst_2), used: v_41.used }), offset: v_35.offset });
     }
@@ -1956,7 +1956,7 @@ fn "core:prelude/list.wado/List<bool>::grow"(self) {
     self.repr = new_repr;
 }
 
-fn "core:args/ArgvStructAccess^DeserializeStruct::next_field<local_item_serde_attributes.wado/Options@AstId(2021:8)>"(self) {
+fn "core:args/ArgvStructAccess^DeserializeStruct::next_field<local_item_serde_attributes.wado/Options@8>"(self) {
     let tok: ref "core:prelude/string.wado//String";
     let rank: i32;
     let __local_6_6: ref "core:prelude/string.wado//String";
@@ -2024,7 +2024,7 @@ fn "core:args/ArgvStructAccess^DeserializeStruct::next_field<local_item_serde_at
                 }
                 let __sroa___match_12_discriminant: i32;
                 let __sroa___match_12_payload_0: i32;
-                multivalue_bind [__sroa___match_12_discriminant, __sroa___match_12_payload_0] = "local_item_serde_attributes.wado/Options@AstId(2021:8)^FieldSchema::lookup"(struct.new "core:prelude/slice.wado//ArraySlice<u8>" { repr: lo_mv_folded.repr, start: 0, end: lo_mv_folded.used });
+                multivalue_bind [__sroa___match_12_discriminant, __sroa___match_12_payload_0] = "local_item_serde_attributes.wado/Options@8^FieldSchema::lookup"(struct.new "core:prelude/slice.wado//ArraySlice<u8>" { repr: lo_mv_folded.repr, start: 0, end: lo_mv_folded.used });
                 if __sroa___match_12_discriminant == 0 {
                     _licm_de_35.cur_is_option = 1;
                     _licm_de_35.cur_inline = lo_mv_inline;
@@ -2043,7 +2043,7 @@ fn "core:args/ArgvStructAccess^DeserializeStruct::next_field<local_item_serde_at
             self.pos_rank = self.pos_rank + 1;
             let __sroa___match_13_discriminant: i32;
             let __sroa___match_13_payload_0: i32;
-            multivalue_bind [__sroa___match_13_discriminant, __sroa___match_13_payload_0] = "local_item_serde_attributes.wado/Options@AstId(2021:8)^FieldSchema::positional_at"(rank);
+            multivalue_bind [__sroa___match_13_discriminant, __sroa___match_13_payload_0] = "local_item_serde_attributes.wado/Options@8^FieldSchema::positional_at"(rank);
             if __sroa___match_13_discriminant == 0 {
                 _licm_de_35.cur_is_option = 0;
                 return struct.new "core:prelude/types.wado//Result<core:prelude/types.wado/Option<i32>,core:serde/DeserializeError>::Ok" { discriminant: 0, payload_0: struct.new "core:prelude/types.wado//Option<i32>::Some" { discriminant: 0, payload_0: __sroa___match_13_payload_0 } };


### PR DESCRIPTION
## Summary

The WIR golden fixture `local_item_newtype_definition.wir.wado` drifted non-deterministically on every regeneration. Root cause: a function-local `struct`/`type`'s internal storage name was mangled as `Name@{AstId:?}`, embedding the full `AstId` including its `AstIdSpace`. `AstIdSpace` is a **process-global** atomic counter whose value depends on unrelated parse history; under the parallel golden-dump tool, concurrent workers interleave their space allocations, so the space number leaked into mangled WIR names (`UserId@AstId(2017:19)`) and varied run to run.

Fixing the leak surfaced a latent collision in a name-keyed table, fixed here too.

## Changes

**Deterministic mangling.** `mangle_local_item_name` now encodes only the `AstId`'s module-local `local()` index, never the `AstIdSpace`. The index is a pure function of the source (dense per-module DFS order), and the module source already qualifies the name across modules, so it alone suffices. Empirically, 12 identical parallel regenerations previously split 2/10 between two space numbers; now every run is byte-identical.

**Display fix.** The auto-derived newtype `Inspect` `as` suffix now strips the local-item storage disambiguator, so debug output shows `42 as UserId` instead of the internal `42 as UserId@<local>`.

**Cross-module collision fix.** `TypeTable::newtype_to_base_name` — the snapshot `wir_build` reads to resolve a method called through a newtype to its base type's implementation — was keyed by the bare newtype name. Two modules each declaring a same-named newtype over different base types collided (the second `erase_newtypes_and_flags` snapshot overwrote the first), misresolving dispatch. The dropped `AstIdSpace` had incidentally masked this for local newtypes; top-level newtypes were affected regardless. The snapshot is now keyed by `(name, module_source)`, matching every other name-based `TypeTable` lookup.

The snapshot is deliberately kept rather than derived on demand: it is taken by `erase_newtypes_and_flags` (phase 9b) before the NIR DCE `retain` (phase 11) drops the newtype `TypeId`s and their redirects, while `wir_build` (phase 12) reads it afterward. Removing it entirely is tracked as an altitude follow-up in #1561 (resolve newtype-method dispatch before lowering).

**Cleanup.** Removed a redundant `continue` flagged by clippy under the pinned toolchain, and folded the two-line `resolve_newtype_to_base_struct_name` wrapper into its sole call site.

## Regenerated fixtures

`local_item_newtype_definition.wir.wado` and `local_item_serde_attributes.wir.wado` — the two goldens that embedded the leaked `AstIdSpace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PE1cDfBCXcTii8TCsarcFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PE1cDfBCXcTii8TCsarcFZ)_