### PR TITLE
chore(release): trigger the wado-lang.github.io deploy after a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,3 +219,22 @@ jobs:
 
       - name: Publish Wado packages
         run: wado publish
+
+  deploy-site:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token scoped to the site repository
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: "${{ secrets.GH_APP_ID }}"
+          private-key: "${{ secrets.GH_APP_PRIVATE_KEY }}"
+          owner: wado-lang
+          repositories: wado-lang.github.io
+          permission-contents: write
+
+      - name: Trigger the wado-lang.github.io deploy
+        env:
+          GH_TOKEN: "${{ steps.app-token.outputs.token }}"
+        run: gh api repos/wado-lang/wado-lang.github.io/dispatches -f event_type=deploy


### PR DESCRIPTION
When a release is published, the site should rebuild so its docs and CLI track the latest Wado.

Adds a `deploy-site` job to the release workflow that runs after `release`. It mints a GitHub App token scoped to `wado-lang.github.io` (same app as `tagpr`, via `GH_APP_ID` / `GH_APP_PRIVATE_KEY`) and fires a `repository_dispatch`:

```
gh api repos/wado-lang/wado-lang.github.io/dispatches -f event_type=deploy
```

The site's deploy workflow listens for that event (`on: repository_dispatch: types: [deploy]`) and republishes.

## Requires

- The `repository_dispatch` trigger on the site's deploy workflow (wado-lang/wado-lang.github.io#22).
- The GitHub App installed on `wado-lang.github.io` with `contents: write`, so the scoped token can dispatch there.

Note: the site pins its `wado` CLI version in `mise.toml`; this rebuild refreshes the cloned docs/Marl source but does not itself bump that pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrNa2dR3XekiV3sE2xo9jd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrNa2dR3XekiV3sE2xo9jd)_