### PR TITLE
docs: reorganize cheatsheet and fill spec/AGENTS gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,7 +200,7 @@ wado dump --nir-lowered file.wado        # show NIR right after lowering (before
 
 `wado query` answers compiler questions about a symbol, for tooling and docs. A symbol is addressed either by position (`--line`/`--column` in a file) or by _symbol notation_ `MODULE#SYMBOL`:
 
-- `MODULE` is the import specifier (`core:json`, `./utils.wado`); quote it only when it contains `#`.
+- `MODULE` is the import specifier; quote it as in `use` — droppable for a scheme or bare name (`core:json`), required for a path or URL (`"./utils.wado"`).
 - `SYMBOL` uses Wado's operators: bare `name` (free function/type/global), `Type::name` (associated const/fn), `Type.name` (method), `Type^Trait::name` (trait-impl member).
 
 ```sh

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1236,57 +1236,6 @@ test {
 }
 ```
 
-## Standard Library
-
-For full API reference, see:
-
-- Core library:
-  - [`core:prelude`](./stdlib-core-prelude.md) - auto-imported types and traits
-  - [`core:cli`](./stdlib-core-cli.md) - stdout/stderr printing
-  - [`core:collections`](./stdlib-core-collections.md) - `TreeMap<K,V>` and `TreeSet<T>`
-  - [`core:serde`](./stdlib-core-serde.md) - `Serialize` and `Deserialize` framework
-  - [`core:json`](./stdlib-core-json.md) - JSON and its serde integration
-  - [`core:json_nsd`](./stdlib-core-json_nsd.md) - non-self-describing JSON and its serde integration
-  - [`core:args`](./stdlib-core-args.md) - command-line argument parsing via serde
-  - [`core:value`](./stdlib-core-value.md) - dynamic, format-agnostic value and its serde integration
-  - [`core:cbor`](./stdlib-core-cbor.md) - CBOR (RFC 8949) binary serialization and its serde integration
-  - [`core:base64`](./stdlib-core-base64.md) - base64 encoding and decoding
-  - [`core:digest`](./stdlib-core-digest.md) - cryptographic hash functions (SHA-256)
-  - [`core:zlib`](./stdlib-core-zlib.md) - zlib/gzip compression and decompression
-  - [`core:simd`](./stdlib-core-simd.md) - Wasm 128-bit SIMD
-  - [`core:url`](./stdlib-core-url.md) - WHATWG URL parsing
-  - [`core:uuid`](./stdlib-core-uuid.md) - UUID v4 / v7 generation and parsing
-  - [`core:temporal`](./stdlib-core-temporal.md) - date/time types (`Instant`, `ZonedDateTime`)
-  - [`core:kiln`](./stdlib-core-kiln.md) - Kiln IDL host bindings
-- [WASI Standard Library Reference](./stdlib-wasi.md)
-  - `wasi:cli`
-  - `wasi:random`
-  - `wasi:clocks`
-  - `wasi:http`
-  - `wasi:filesystem`
-  - `wasi:sockets`
-  - `wasi:tls`
-
-```wado
-// core:prelude (auto-imported)
-panic("error message");   // trap with message
-unreachable();            // trap
-
-// core:cli
-use { println, eprintln, print, eprint, Stdout, Stderr } from "core:cli";
-use { log_stdout, log_stderr } from "core:cli";  // no effect required
-
-// core:collections
-use { TreeMap, TreeSet } from "core:collections";
-let mut map = TreeMap::<String, i32>::new();
-map["key"] = 42;          // index assignment
-let v = map["key"];       // index access (panics if not found)
-let opt = map.get("key"); // fallible access returns Option<V>
-
-let set = ["foo", "bar", "baz"] as TreeSet<String>;
-assert set.contains("foo");
-```
-
 ## Compile-Time Literals
 
 ```wado
@@ -1343,13 +1292,138 @@ struct Foo {
 global PORT: i32 = 8080;
 ```
 
-## Serialization and Deserialization
+## Standard Library
 
-Wado supports automatic serialization/deserialization via `core:serde`. See [WEP: Serialization and Deserialization](./wep-2026-02-28-serde.md).
+`core:*` and `wasi:*` modules. Full API in each linked module doc.
 
-## SIMD
+### core:prelude
 
-Wado supports 128-bit SIMD operations including Relaxed SIMD. See [WEP: SIMD v128](./wep-2026-01-31-simd-v128.md).
+Auto-imported into every module (disable with `#![no_prelude]`). Provides the
+core types and traits used throughout this cheatsheet: `String`, `List<T>`,
+`Option<T>`, `Result<T, E>`, `RangeExclusive`/`RangeInclusive`, the primitive
+type methods, and the prelude traits (`Eq`, `Ord`, `Default`, `Display`,
+`Inspect`, `FromStr`, `Iterator`, `IntoIterator`, …). See
+[`core:prelude`](./stdlib-core-prelude.md).
+
+```wado
+panic("error message");   // log to stderr and trap
+unreachable();            // trap on unreachable code
+```
+
+### core:cli
+
+`println` / `eprintln` / `print` / `eprint` (effectful), plus `args`, `env`,
+`cwd`, `exit`. `log_stdout` / `log_stderr` print without requiring an effect.
+See [`core:cli`](./stdlib-core-cli.md).
+
+```wado
+use { println, eprintln, print, eprint, Stdout, Stderr } from "core:cli";
+use { args, env } from "core:cli";
+
+println("hello");
+for let arg of args() { println(`arg: {arg}`); }
+if let Some(home) = env("HOME") { println(`HOME={home}`); }
+```
+
+### core:collections
+
+`TreeMap<K, V>` and `TreeSet<T>`, both iterating in insertion order. `TreeMap`
+has no `insert` — assign via `map[key] = value` or a `{ key: value }` literal.
+See [`core:collections`](./stdlib-core-collections.md).
+
+```wado
+use { TreeMap, TreeSet } from "core:collections";
+
+let mut map = TreeMap::<String, i32>::new();
+map["key"] = 42;              // index assignment
+let v = map["key"];           // index access (panics if absent)
+let opt = map.get("key");     // fallible access -> Option<V>
+map.remove("key");            // -> bool
+for let [k, v] of map.entries() { println(`{k}={v}`); }
+
+let sizes = { small: 1, large: 3 } as TreeMap<String, i32>;  // literal
+let set = ["foo", "bar", "baz"] as TreeSet<String>;
+set.contains("foo");          // -> bool; set.insert(x) -> bool
+```
+
+### core:serde
+
+Format-agnostic `Serialize` / `Deserialize` framework. A `T: Serialize` bound
+is satisfied structurally once every field/case is serializable, so a plain
+struct needs no marker; write `impl Serialize for T;` (empty body) to force it
+or to attach `#[serde(...)]`. Wire key defaults to the field name verbatim;
+`#[serde(rename_all = "...")]` (per struct) and `#[serde(rename = "...")]` (per
+field, wins) override it. A field with a default (`f: T = expr`) is optional on
+deserialize; a missing required field errors. See
+[`core:serde`](./stdlib-core-serde.md) and [WEP: Serde](./wep-2026-02-28-serde.md).
+
+```wado
+struct Point { x: i32, y: i32 }         // serializable, no marker needed
+
+// rename_all: camelCase / snake_case / PascalCase / SCREAMING_SNAKE_CASE /
+//             kebab-case / SCREAMING-KEBAB-CASE
+#[serde(rename_all = "camelCase")]
+struct Event {
+    created_at: String,                 // wire key: "createdAt"
+    #[serde(rename = "type")]
+    event_type: String,                 // wire key: "type"
+}
+
+struct Config {
+    host: String,                       // required — error if missing
+    port: i32 = 8080,                   // missing -> 8080
+}
+impl Deserialize for Config;
+```
+
+### core:json
+
+JSON `Serializer` / `Deserializer` over `core:serde`. I/O is bytes-primary:
+prefer `to_bytes` / `from_bytes`. See [`core:json`](./stdlib-core-json.md).
+
+```wado
+use { to_string, to_bytes, from_string, from_bytes } from "core:json";
+use { to_bytes_pretty, to_bytes_canonical } from "core:json";
+
+let json = to_string(&Point { x: 1, y: 2 });      // Ok("{\"x\":1,\"y\":2}")
+let p = from_string::<Point>("{\"x\":1,\"y\":2}"); // Ok(Point { x: 1, y: 2 })
+let bytes = to_bytes(&p);                          // UTF-8 bytes, no re-encode
+let pretty = to_bytes_pretty(&p);                  // indented
+let canon = to_bytes_canonical(&p);                // sorted keys, for signing
+```
+
+### core:cbor
+
+CBOR (RFC 8949) `Serializer` / `Deserializer` — a strict superset of JSON's
+data model, so any JSON-serializable type works with no source change.
+Bytes-only. See [`core:cbor`](./stdlib-core-cbor.md).
+
+```wado
+use { to_bytes, from_bytes, to_bytes_canonical } from "core:cbor";
+
+let enc = to_bytes(&Point { x: 1, y: 2 });   // preferred (shortest) encoding
+let dec = from_bytes::<Point>(enc);          // variation-tolerant decode
+let sig = to_bytes_canonical(&p);            // deterministic, for COSE/CWT
+```
+
+### Other core modules
+
+- [`core:json_nsd`](./stdlib-core-json_nsd.md) — non-self-describing JSON
+- [`core:args`](./stdlib-core-args.md) — command-line argument parsing via serde
+- [`core:value`](./stdlib-core-value.md) — dynamic, format-agnostic value
+- [`core:base64`](./stdlib-core-base64.md) — base64 encoding and decoding
+- [`core:digest`](./stdlib-core-digest.md) — cryptographic hashes (SHA-256)
+- [`core:zlib`](./stdlib-core-zlib.md) — zlib/gzip compression
+- [`core:simd`](./stdlib-core-simd.md) — Wasm 128-bit SIMD, incl. Relaxed SIMD
+- [`core:url`](./stdlib-core-url.md) — WHATWG URL parsing
+- [`core:uuid`](./stdlib-core-uuid.md) — UUID v4 / v7
+- [`core:temporal`](./stdlib-core-temporal.md) — date/time (`Instant`, `ZonedDateTime`)
+- [`core:kiln`](./stdlib-core-kiln.md) — Kiln IDL host bindings
+
+### WASI
+
+[WASI Standard Library Reference](./stdlib-wasi.md): `wasi:cli`, `wasi:random`,
+`wasi:clocks`, `wasi:http`, `wasi:filesystem`, `wasi:sockets`, `wasi:tls`.
 
 ## See Also
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -958,15 +958,29 @@ impl<T: Eq> Eq for Pair<T> {
 
 ### Auto-Derived Traits
 
-All primitives implement `Eq` and `Ord`. Structs and enums auto-derive both (variants: `Eq` only) when every field/case implements the trait — synthesized on demand, not for every type. An explicit `impl Eq for T;` / `impl Ord for T;` marker forces it and is a compile error if ineligible. `Option<T: Eq>`, `Result<T: Eq, E: Eq>`, `List<T: Eq>` implement `Eq`; `List<T: Ord>` implements `Ord`.
+Derivation is _bound-driven_: `Eq`, `Ord`, `Default`, `Serialize`, and `Deserialize` are synthesized for a type only where something actually needs it — an `==`/`<` operator, a `T::default()` call, a serialize/deserialize call, a `T: Trait` bound, or an explicit marker. A declared type nothing uses gets no synthesized code. Synthesis is structural and recursive: it succeeds only when every field/case satisfies the trait, and covers structs (including anonymous), enums, variants (`Ord` excluded), and flags. `Default` instead requires every field of a non-generic struct to carry a default expression (`f: T = expr`). So a plain struct is comparable and serializable with no declaration:
 
-`Inspect` and `InspectAlt` are auto-derived unconditionally for every type. The delegation chain when a trait is not explicitly implemented is `InspectAlt → Inspect`, `Display → Inspect`, and `DisplayAlt → Display` — so `{x:#}` defaults to plain display, while pretty-printing stays on the inspect side (`{x:#?}`). A newtype's `Display`/`DisplayAlt` render transparently like the base value; only `Inspect`/`InspectAlt` add the `as Name` annotation.
+```wado
+struct Point { x: i32, y: i32 }
+let same = Point { x: 1, y: 2 } == Point { x: 1, y: 2 };  // Eq synthesized here
+let json = to_string(&Point { x: 1, y: 2 });              // Serialize synthesized here
+```
 
-`Default` is auto-derived unconditionally for a non-generic struct when every field has a declared default expression (`f: T = expr`).
+All primitives implement `Eq` and `Ord`. `Option<T: Eq>`, `Result<T: Eq, E: Eq>`, and `List<T: Eq>` implement `Eq`; `List<T: Ord>` implements `Ord`.
 
-`Serialize` / `Deserialize` (`core:serde`) derive the same on-demand way, for struct (including anonymous), variant, enum, or flags — no marker required, though their marker (unlike `Eq`/`Ord`'s) doesn't pre-validate. See [WEP: Trait Derivation Policy](./wep-2026-06-25-trait-derivation.md).
+An empty marker `impl Trait for T;` is a static conformance check — like Java's `implements`. It validates `T` structurally at its own span, is a hard compile error if `T` is ineligible, then records the derive exactly as a use would. Writing it is optional for these traits (a use suffices), but it pins down intent, fails loudly if a later field breaks eligibility, and is the way to attach `#[serde(...)]` customization or to derive a type with no current use site.
 
-Auto-derived traits are overridden by user-written `impl Trait for T`.
+```wado
+struct Broken { retries: i32 = 3, name: String }
+impl Default for Broken;   // ERROR: `name` has no default expression
+
+variant Shape { Callback(fn(i32) -> i32), Point }
+impl Serialize for Shape;  // ERROR: the `Callback` payload is not serializable
+```
+
+The format traits `Inspect` / `InspectAlt` / `Display` / `DisplayAlt` are _total_: every type is structurally formattable, so a `T: Inspect` / `T: Display` bound always holds, a marker always validates, and bodies are generated eagerly for every type. When a trait is not explicitly implemented the delegation chain is `InspectAlt → Inspect`, `Display → Inspect`, and `DisplayAlt → Display` — so `{x:#}` defaults to plain display, while pretty-printing stays on the inspect side (`{x:#?}`). A newtype's `Display`/`DisplayAlt` render transparently like the base value; only `Inspect`/`InspectAlt` add the `as Name` annotation.
+
+A hand-written `impl Trait for T { … }` always wins over synthesis. See [WEP: Trait Derivation Policy](./wep-2026-06-25-trait-derivation.md).
 
 ## Associated Constants
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -612,7 +612,7 @@ let grade = match score {
 };
 
 // Constant patterns: an immutable global or associated const matches by
-// value, not a binding (unlike Rust). TK_FOO/TK_BAR are `global`s.
+// value, not a binding. TK_FOO/TK_BAR are `global`s.
 let kind = match token {
     TK_FOO | TK_BAR => "keyword",
     i32::MAX        => "max",

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -966,7 +966,7 @@ Point { x: 1, y: 2 } == Point { x: 1, y: 2 };  // Eq synthesized here
 to_string(&Point { x: 1, y: 2 });              // Serialize synthesized here
 ```
 
-An empty marker `impl Trait for T;` is a static conformance check (like Java's `implements`): it's a hard compile error if `T` is ineligible. Optional for these traits, but it documents intent and is the way to attach `#[serde(...)]` customization.
+An empty marker `impl Trait for T;` asserts conformance: the compiler checks `T` is eligible and errors if not. Optional for these traits, but it documents intent and is the way to attach `#[serde(...)]` customization.
 
 ```wado
 struct Broken { retries: i32 = 3, name: String }

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -958,29 +958,24 @@ impl<T: Eq> Eq for Pair<T> {
 
 ### Auto-Derived Traits
 
-Derivation is _bound-driven_: `Eq`, `Ord`, `Default`, `Serialize`, and `Deserialize` are synthesized for a type only where something actually needs it — an `==`/`<` operator, a `T::default()` call, a serialize/deserialize call, a `T: Trait` bound, or an explicit marker. A declared type nothing uses gets no synthesized code. Synthesis is structural and recursive: it succeeds only when every field/case satisfies the trait, and covers structs (including anonymous), enums, variants (`Ord` excluded), and flags. `Default` instead requires every field of a non-generic struct to carry a default expression (`f: T = expr`). So a plain struct is comparable and serializable with no declaration:
+`Eq`, `Ord`, `Default`, `Serialize`, and `Deserialize` are _bound-driven_: the compiler synthesizes them where a use or bound needs them, no marker required. A plain struct is comparable and serializable with no declaration:
 
 ```wado
 struct Point { x: i32, y: i32 }
-let same = Point { x: 1, y: 2 } == Point { x: 1, y: 2 };  // Eq synthesized here
-let json = to_string(&Point { x: 1, y: 2 });              // Serialize synthesized here
+Point { x: 1, y: 2 } == Point { x: 1, y: 2 };  // Eq synthesized here
+to_string(&Point { x: 1, y: 2 });              // Serialize synthesized here
 ```
 
-All primitives implement `Eq` and `Ord`. `Option<T: Eq>`, `Result<T: Eq, E: Eq>`, and `List<T: Eq>` implement `Eq`; `List<T: Ord>` implements `Ord`.
-
-An empty marker `impl Trait for T;` is a static conformance check — like Java's `implements`. It validates `T` structurally at its own span, is a hard compile error if `T` is ineligible, then records the derive exactly as a use would. Writing it is optional for these traits (a use suffices), but it pins down intent, fails loudly if a later field breaks eligibility, and is the way to attach `#[serde(...)]` customization or to derive a type with no current use site.
+An empty marker `impl Trait for T;` is a static conformance check (like Java's `implements`): it's a hard compile error if `T` is ineligible. Optional for these traits, but it documents intent and is the way to attach `#[serde(...)]` customization.
 
 ```wado
 struct Broken { retries: i32 = 3, name: String }
 impl Default for Broken;   // ERROR: `name` has no default expression
-
-variant Shape { Callback(fn(i32) -> i32), Point }
-impl Serialize for Shape;  // ERROR: the `Callback` payload is not serializable
 ```
 
-The format traits `Inspect` / `InspectAlt` / `Display` / `DisplayAlt` are _total_: every type is structurally formattable, so a `T: Inspect` / `T: Display` bound always holds, a marker always validates, and bodies are generated eagerly for every type. When a trait is not explicitly implemented the delegation chain is `InspectAlt → Inspect`, `Display → Inspect`, and `DisplayAlt → Display` — so `{x:#}` defaults to plain display, while pretty-printing stays on the inspect side (`{x:#?}`). A newtype's `Display`/`DisplayAlt` render transparently like the base value; only `Inspect`/`InspectAlt` add the `as Name` annotation.
+The format traits (`Inspect` / `InspectAlt` / `Display` / `DisplayAlt`) are always available for every type. Unimplemented ones delegate `InspectAlt → Inspect`, `Display → Inspect`, `DisplayAlt → Display` — so `{x:#}` defaults to plain display while `{x:#?}` pretty-prints. A newtype renders transparently under `Display`; only `Inspect` adds the `as Name` annotation.
 
-A hand-written `impl Trait for T { … }` always wins over synthesis. See [WEP: Trait Derivation Policy](./wep-2026-06-25-trait-derivation.md).
+A hand-written `impl Trait for T { … }` always wins. See [WEP: Trait Derivation Policy](./wep-2026-06-25-trait-derivation.md).
 
 ## Associated Constants
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -610,6 +610,15 @@ let grade = match score {
     90..=100 => "A",
     _ => "invalid",
 };
+
+// Constant patterns: a name resolving to an immutable global or an
+// associated const matches by value, not a binding (differs from Rust,
+// where a bare lowercase name always binds). TK_FOO/TK_BAR are `global`s.
+let kind = match token {
+    TK_FOO | TK_BAR => "keyword",
+    i32::MAX        => "max",
+    _               => "other",
+};
 ```
 
 Semicolons do not have particular semantics; they are just separators to statements. Convention in `wado format`: single-line block does not use semicolon.

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1307,8 +1307,7 @@ global PORT: i32 = 8080;
 
 ### core:prelude
 
-Auto-imported into every module (disable with `#![no_prelude]`). Provides the
-core types and traits used throughout this cheatsheet: `String`, `List<T>`,
+Auto-imported (disable with `#![no_prelude]`). Home of `String`, `List<T>`,
 `Option<T>`, `Result<T, E>`, `RangeExclusive`/`RangeInclusive`, the primitive
 type methods, and the prelude traits (`Eq`, `Ord`, `Default`, `Display`,
 `Inspect`, `FromStr`, `Iterator`, `IntoIterator`, …). See
@@ -1321,9 +1320,9 @@ unreachable();            // trap on unreachable code
 
 ### core:cli
 
-`println` / `eprintln` / `print` / `eprint` (effectful), plus `args`, `env`,
-`cwd`, `exit`. `log_stdout` / `log_stderr` print without requiring an effect.
-See [`core:cli`](./stdlib-core-cli.md).
+`println` / `eprintln` / `print` / `eprint` (effectful), `args`, `env`, `cwd`,
+`exit`; `log_stdout` / `log_stderr` print with no effect. See
+[`core:cli`](./stdlib-core-cli.md).
 
 ```wado
 use { println, eprintln, print, eprint, Stdout, Stderr } from "core:cli";
@@ -1336,9 +1335,9 @@ if let Some(home) = env("HOME") { println(`HOME={home}`); }
 
 ### core:collections
 
-`TreeMap<K, V>` and `TreeSet<T>`, both iterating in insertion order. `TreeMap`
-has no `insert` — assign via `map[key] = value` or a `{ key: value }` literal.
-See [`core:collections`](./stdlib-core-collections.md).
+`TreeMap<K, V>` and `TreeSet<T>`, iterating in insertion order. `TreeMap` has
+no `insert` — use `map[key] = value` or a `{ key: value }` literal. See
+[`core:collections`](./stdlib-core-collections.md).
 
 ```wado
 use { TreeMap, TreeSet } from "core:collections";
@@ -1357,14 +1356,12 @@ set.contains("foo");          // -> bool; set.insert(x) -> bool
 
 ### core:serde
 
-Format-agnostic `Serialize` / `Deserialize` framework. A `T: Serialize` bound
-is satisfied structurally once every field/case is serializable, so a plain
-struct needs no marker; write `impl Serialize for T;` (empty body) to force it
-or to attach `#[serde(...)]`. Wire key defaults to the field name verbatim;
-`#[serde(rename_all = "...")]` (per struct) and `#[serde(rename = "...")]` (per
-field, wins) override it. A field with a default (`f: T = expr`) is optional on
-deserialize; a missing required field errors. See
-[`core:serde`](./stdlib-core-serde.md) and [WEP: Serde](./wep-2026-02-28-serde.md).
+Format-agnostic `Serialize` / `Deserialize`. A plain struct derives with no
+marker (see Auto-Derived Traits); `impl Serialize for T;` attaches
+`#[serde(...)]` customization. Wire keys default to the field name; override
+with `#[serde(rename_all = "...")]` (per struct) or `#[serde(rename = "...")]`
+(per field). See [`core:serde`](./stdlib-core-serde.md) and
+[WEP: Serde](./wep-2026-02-28-serde.md).
 
 ```wado
 struct Point { x: i32, y: i32 }         // serializable, no marker needed
@@ -1387,8 +1384,8 @@ impl Deserialize for Config;
 
 ### core:json
 
-JSON `Serializer` / `Deserializer` over `core:serde`. I/O is bytes-primary:
-prefer `to_bytes` / `from_bytes`. See [`core:json`](./stdlib-core-json.md).
+JSON over `core:serde`; bytes-primary (prefer `to_bytes` / `from_bytes`). See
+[`core:json`](./stdlib-core-json.md).
 
 ```wado
 use { to_string, to_bytes, from_string, from_bytes } from "core:json";
@@ -1403,9 +1400,8 @@ let canon = to_bytes_canonical(&p);                // sorted keys, for signing
 
 ### core:cbor
 
-CBOR (RFC 8949) `Serializer` / `Deserializer` — a strict superset of JSON's
-data model, so any JSON-serializable type works with no source change.
-Bytes-only. See [`core:cbor`](./stdlib-core-cbor.md).
+CBOR (RFC 8949), same serde model as JSON — any JSON-serializable type works
+unchanged. Bytes-only. See [`core:cbor`](./stdlib-core-cbor.md).
 
 ```wado
 use { to_bytes, from_bytes, to_bytes_canonical } from "core:cbor";

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1418,7 +1418,9 @@ let sig = to_bytes_canonical(&p);            // deterministic, for COSE/CWT
 - [`core:url`](./stdlib-core-url.md) — WHATWG URL parsing
 - [`core:uuid`](./stdlib-core-uuid.md) — UUID v4 / v7
 - [`core:temporal`](./stdlib-core-temporal.md) — date/time (`Instant`, `ZonedDateTime`)
+- [`core:router`](./stdlib-core-router.md) — HTTP path router
 - [`core:kiln`](./stdlib-core-kiln.md) — Kiln IDL host bindings
+- [`core:benchmark`](./stdlib-core-benchmark.md) — benchmark timing/throughput utilities
 
 ### WASI
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -611,9 +611,8 @@ let grade = match score {
     _ => "invalid",
 };
 
-// Constant patterns: a name resolving to an immutable global or an
-// associated const matches by value, not a binding (differs from Rust,
-// where a bare lowercase name always binds). TK_FOO/TK_BAR are `global`s.
+// Constant patterns: an immutable global or associated const matches by
+// value, not a binding (unlike Rust). TK_FOO/TK_BAR are `global`s.
 let kind = match token {
     TK_FOO | TK_BAR => "keyword",
     i32::MAX        => "max",

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -4730,6 +4730,21 @@ struct Foo {
 }
 ```
 
+#### `#[param]` / `#[param(from_env = "...")]` / `#[param(name = "...")]`
+
+Marks a `global` as a compile-time build input. The type annotation gives the type, the initializer is the fallback, and read sites are ordinary global references. Each parameter resolves highest-priority-first: `-D NAME=value` (alias `--define`) on the `wado` invocation, then `from_env`, then the initializer. Overrides are parsed into the declared scalar type with the `LenientFromStr` spellings. See [WEP: Compile-Time Parameters](./wep-2026-04-26-compile-time-params.md).
+
+```wado
+#[param]
+global API_URL: String = "http://localhost";   // -D API_URL=...
+
+#[param(from_env = "PORT")]
+global PORT: i32 = 8080;                        // read from an env var
+
+#[param(name = "build.id")]
+global BUILD_ID: String = "dev";                // -D build.id=...
+```
+
 #### `#[expect_trap]`
 
 Test block attribute. Marks a test that is expected to trap. The test passes if the body traps, and fails if it completes normally.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3505,6 +3505,21 @@ Module paths are validated before loading to provide clear error messages:
 
 Bare names (`"router"`) are rejected. See [WEP: Package and Module Specifier Syntax](./wep-2026-06-17-package-module-syntax.md) for resolution and version rules.
 
+### Symbol Notation
+
+A symbol is named `MODULE#SYMBOL` — the written form used by docs, `wado query`, and diagnostics. `MODULE` is the import specifier verbatim (quoted as in `use`; quotes may be dropped for a scheme or bare name with no whitespace). `SYMBOL` uses Wado's own operators, so its kind is visible from the separator: `::` for static scope, `.` for an instance method, `^` for a trait-impl member.
+
+```
+core:json#parse                      # free function / global
+core:math#f64::PI                    # associated const / static fn
+core:collections#TreeMap.insert      # instance method
+core:collections#List<String>::len   # generics use Wado angle brackets
+core:fmt#Point^Display::fmt          # trait-impl member
+"./utils.wado"#Helper::new           # relative path — must be quoted
+```
+
+See [WEP: Symbol Notation](./wep-2026-06-14-symbol-notation.md).
+
 ### Import Syntax
 
 ```wado

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -681,19 +681,20 @@ match command {
 
 **Pattern Syntax:**
 
-| Pattern       | Example                      | Description                            |
-| ------------- | ---------------------------- | -------------------------------------- |
-| Wildcard      | `_`                          | Matches anything                       |
-| Variable      | `x`                          | Binds matched value                    |
-| Mut variable  | `mut x`, `Some(mut x)`       | Binds as mutable                       |
-| Literal       | `0`, `"hello"`, `true`       | Matches exact value                    |
-| Variant       | `Some(x)`, `None`            | Matches variant case                   |
-| Tuple         | `[a, b, c]`                  | Destructures tuple                     |
-| Nested tuple  | `[10, Some(x)]`              | Literal/variant sub-patterns in tuple  |
-| Struct        | `{ x, y }`, `Point { x, y }` | Destructures struct                    |
-| Nested struct | `{ x: 0, y }`                | Literal/variant sub-patterns in struct |
-| Or            | `Red \| Blue`                | Matches either pattern                 |
-| Guard         | `Some(x) && x > 0`           | Pattern with condition                 |
+| Pattern       | Example                      | Description                                  |
+| ------------- | ---------------------------- | -------------------------------------------- |
+| Wildcard      | `_`                          | Matches anything                             |
+| Variable      | `x`                          | Binds matched value                          |
+| Mut variable  | `mut x`, `Some(mut x)`       | Binds as mutable                             |
+| Literal       | `0`, `"hello"`, `true`       | Matches exact value                          |
+| Constant      | `MAX_LEN`, `i32::MAX`        | Matches an immutable global / const by value |
+| Variant       | `Some(x)`, `None`            | Matches variant case                         |
+| Tuple         | `[a, b, c]`                  | Destructures tuple                           |
+| Nested tuple  | `[10, Some(x)]`              | Literal/variant sub-patterns in tuple        |
+| Struct        | `{ x, y }`, `Point { x, y }` | Destructures struct                          |
+| Nested struct | `{ x: 0, y }`                | Literal/variant sub-patterns in struct       |
+| Or            | `Red \| Blue`                | Matches either pattern                       |
+| Guard         | `Some(x) && x > 0`           | Pattern with condition                       |
 
 **Exhaustiveness:**
 
@@ -717,6 +718,21 @@ match customer {
     Premium(_) => 0.2,
     _ => 0.1,
 }
+```
+
+**Constant Patterns:**
+
+A pattern identifier that resolves to an immutable `global` or an associated constant matches by value, instead of binding a new variable:
+
+```wado
+global TK_FOO: i32 = 1;
+global TK_BAR: i32 = 2;
+
+let kind = match token {
+    TK_FOO | TK_BAR => "keyword",
+    i32::MAX        => "max",
+    _               => "other",
+};
 ```
 
 **Or Patterns:**
@@ -2966,6 +2982,23 @@ impl Default for Point {
 }
 ```
 
+### String Parsing Traits
+
+Two prelude traits parse a value from a `String`, both returning `Result`. `FromStr` is strict; `LenientFromStr` is forgiving of human input. The built-in scalars (`String`, `char`, the integer types, `f32`/`f64`, `bool`) implement both.
+
+```wado
+i32::from_str(&"42")              // Ok(42)
+i32::from_str(&"0x2A")            // Err — strict rejects the prefix
+
+i32::from_str_lenient(&"0x2A")    // Ok(42)  — radix prefixes 0x/0o/0b
+i32::from_str_lenient(&"1_000")   // Ok(1000) — `_` digit separators
+bool::from_str_lenient(&"TRUE")   // Ok(true) — casing, plus 1/0
+f64::from_str_lenient(&"inf")     // Ok(f64::INFINITY)
+i32::from_str_lenient(&" 1 ")     // Err — never trims whitespace
+```
+
+`FromStr`'s fundamental operation is `from_str_range(s, start, end)` (parse a byte range with no substring allocation); `from_str` defaults to calling it over the whole string. See [WEP: Lenient String Parsing](./wep-2026-06-22-lenient-from-str.md).
+
 ### Indexing Traits
 
 The prelude defines traits for index-based access:
@@ -3279,7 +3312,7 @@ let base = { user_id: 1, ip: "10.0.0.1" };
 let event = { ..base, level: "warn" };  // { user_id, ip, level } — auto-Serialize
 ```
 
-The explicit marker `impl Serialize for T;` still works — write it to force the impl with no bound present, or to attach `#[serde(rename_all = "...")]` customization. Unlike `Eq` / `Ord`'s marker (below), it doesn't pre-validate: an ineligible field is a compile error at the bound site, not the marker. See [WEP: Trait Derivation Policy](./wep-2026-06-25-trait-derivation.md).
+The explicit marker `impl Serialize for T;` still works — write it to force the impl with no bound present, or to attach `#[serde(rename_all = "...")]` customization. Like `Eq` / `Ord`'s marker (below), it is a conformance check: an ineligible field or case is a compile error at the marker's own span. See [WEP: Trait Derivation Policy](./wep-2026-06-25-trait-derivation.md).
 
 ### Bound-Driven Eq / Ord
 
@@ -3839,6 +3872,14 @@ test "slow computation" {
     let result = expensive_computation();
     assert result == 42;
 }
+
+// Synopsis test: runs like any test; `wado doc` renders its body as the
+// module's `## Synopsis` section.
+#[synopsis]
+test {
+    let p = Point { x: 3, y: 4 };
+    assert p.length() == 5.0;
+}
 ```
 
 **Syntax Rules:**
@@ -3848,7 +3889,7 @@ test "slow computation" {
 - Test body is a block containing statements
 - No return type or effect declarations needed
 - Tests can use any effects (side effects are allowed in tests)
-- Attributes (e.g., `#[expect_trap]`, `#[TODO]`, `#[timeout_ms(N)]`) may appear before the `test` keyword
+- Attributes (e.g., `#[expect_trap]`, `#[TODO]`, `#[timeout_ms(N)]`, `#[synopsis]`) may appear before the `test` keyword
 
 **Test Identification:**
 
@@ -4712,6 +4753,18 @@ Test block attribute. Overrides the default test timeout (1000ms). `N` is an int
 test "slow computation" {
     let result = expensive_computation();
     assert result == 42;
+}
+```
+
+#### `#[synopsis]`
+
+Test block attribute. The test runs like any other, and `wado doc` renders its body as the module's `## Synopsis` section — a compiled, always-current usage example. See [WEP: Synopsis Tests](./wep-2026-04-26-synopsis-tests.md).
+
+```wado
+#[synopsis]
+test {
+    let p = Point { x: 3, y: 4 };
+    assert p.length() == 5.0;
 }
 ```
 

--- a/docs/wep-2026-01-10-deterministic-libm.md
+++ b/docs/wep-2026-01-10-deterministic-libm.md
@@ -1,4 +1,4 @@
-# ARD: Deterministic Math Library (libm) Integration
+# WEP: Deterministic Math Library (libm) Integration
 
 ## Context
 

--- a/docs/wep-2026-01-10-tagged-template-literals.md
+++ b/docs/wep-2026-01-10-tagged-template-literals.md
@@ -1,4 +1,4 @@
-# Tagged Template Literals for Compile-Time Execution
+# WEP: Tagged Template Literals for Compile-Time Execution
 
 ## Context
 

--- a/docs/wep-2026-01-20-associated-types.md
+++ b/docs/wep-2026-01-20-associated-types.md
@@ -1,4 +1,4 @@
-# Associated Types in Traits
+# WEP: Associated Types in Traits
 
 This WEP defines associated types for Wado's trait system.
 

--- a/docs/wep-2026-01-20-effect-system-randomness.md
+++ b/docs/wep-2026-01-20-effect-system-randomness.md
@@ -1,4 +1,4 @@
-# Effect System and Randomness in Collections
+# WEP: Effect System and Randomness in Collections
 
 ## Context
 

--- a/docs/wep-2026-01-20-indexing-traits.md
+++ b/docs/wep-2026-01-20-indexing-traits.md
@@ -1,4 +1,4 @@
-# Indexing Traits Design
+# WEP: Indexing Traits Design
 
 This WEP defines the trait system for indexing operations (`[]` operator) in Wado.
 

--- a/docs/wep-2026-01-20-string-template-desugaring.md
+++ b/docs/wep-2026-01-20-string-template-desugaring.md
@@ -1,4 +1,4 @@
-# String Template Desugaring
+# WEP: String Template Desugaring
 
 ## Context
 

--- a/docs/wep-2026-01-23-compile-time-location-literals.md
+++ b/docs/wep-2026-01-23-compile-time-location-literals.md
@@ -1,4 +1,4 @@
-# Compile-Time Location Literals
+# WEP: Compile-Time Location Literals
 
 ## Context
 

--- a/docs/wep-2026-01-25-pub-use-reexport.md
+++ b/docs/wep-2026-01-25-pub-use-reexport.md
@@ -1,4 +1,4 @@
-# Re-export Syntax (`pub use`)
+# WEP: Re-export Syntax (`pub use`)
 
 ## Context
 

--- a/docs/wep-2026-01-27-effect-system-design.md
+++ b/docs/wep-2026-01-27-effect-system-design.md
@@ -1,4 +1,4 @@
-# Effect System Design
+# WEP: Effect System Design
 
 Status: Draft
 

--- a/docs/wep-2026-01-28-match-expression-design.md
+++ b/docs/wep-2026-01-28-match-expression-design.md
@@ -1,4 +1,4 @@
-# Match Expression Design
+# WEP: Match Expression Design
 
 ## Context
 

--- a/docs/wep-2026-01-31-simd-v128.md
+++ b/docs/wep-2026-01-31-simd-v128.md
@@ -1,4 +1,4 @@
-# SIMD v128 Types
+# WEP: SIMD v128 Types
 
 ## Context
 

--- a/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
+++ b/docs/wep-2026-02-10-compile-time-tuple-enumeration.md
@@ -1,4 +1,4 @@
-# Compile-Time Tuple Enumeration
+# WEP: Compile-Time Tuple Enumeration
 
 ## Context
 

--- a/docs/wep-2026-03-02-gale.md
+++ b/docs/wep-2026-03-02-gale.md
@@ -1,4 +1,4 @@
-# Gale — Grammar Adaptive LL Engine
+# WEP: Gale — Grammar Adaptive LL Engine
 
 ## Context
 

--- a/docs/wep-2026-03-02-include-str.md
+++ b/docs/wep-2026-03-02-include-str.md
@@ -1,4 +1,4 @@
-# Compile-Time File Inclusion (`#include_str`, `#include_bytes`)
+# WEP: Compile-Time File Inclusion (`#include_str`, `#include_bytes`)
 
 ## Context
 

--- a/docs/wep-2026-04-01-tide.md
+++ b/docs/wep-2026-04-01-tide.md
@@ -1,4 +1,4 @@
-# WebIDL Binding Generator (`wado-from-idl`)
+# WEP: WebIDL Binding Generator (`wado-from-idl`)
 
 ## Context
 

--- a/docs/wep-2026-04-04-reactive-signals.md
+++ b/docs/wep-2026-04-04-reactive-signals.md
@@ -1,4 +1,4 @@
-# Reactive Signals
+# WEP: Reactive Signals
 
 **Status: Not yet implemented**
 

--- a/docs/wep-2026-04-11-effect-handler.md
+++ b/docs/wep-2026-04-11-effect-handler.md
@@ -1,4 +1,4 @@
-# Effect Handler
+# WEP: Effect Handler
 
 Status: Stable
 

--- a/docs/wep-2026-04-12-kiln.md
+++ b/docs/wep-2026-04-12-kiln.md
@@ -1,4 +1,4 @@
-# Kiln — Keyed IDL Lowering Notation
+# WEP: Kiln — Keyed IDL Lowering Notation
 
 ## Context
 

--- a/docs/wep-2026-04-18-lsp-architecture.md
+++ b/docs/wep-2026-04-18-lsp-architecture.md
@@ -1,4 +1,4 @@
-# LSP Architecture
+# WEP: LSP Architecture
 
 ## Context
 

--- a/docs/wep-2026-04-28-resource-inheritance.md
+++ b/docs/wep-2026-04-28-resource-inheritance.md
@@ -1,4 +1,4 @@
-# Resource Inheritance and Downcast (`resource extends`)
+# WEP: Resource Inheritance and Downcast (`resource extends`)
 
 ## Context
 

--- a/docs/wep-2026-06-13-jade.md
+++ b/docs/wep-2026-06-13-jade.md
@@ -1,4 +1,4 @@
-# Jade — JSON Schema for Wado
+# WEP: Jade — JSON Schema for Wado
 
 ## Context
 

--- a/docs/wep-2026-06-13-reflect-derivation.md
+++ b/docs/wep-2026-06-13-reflect-derivation.md
@@ -1,4 +1,4 @@
-# Library-Defined Derivation: `Reflect` Extensions and the `#[validate]` Attribute
+# WEP: Library-Defined Derivation: `Reflect` Extensions and the `#[validate]` Attribute
 
 ## Context
 

--- a/docs/wep-2026-06-25-core-log.md
+++ b/docs/wep-2026-06-25-core-log.md
@@ -1,4 +1,4 @@
-# Structured Logging and Tracing Standard Library (`core:log`)
+# WEP: Structured Logging and Tracing Standard Library (`core:log`)
 
 Status: Draft
 

--- a/docs/wep-2026-06-25-trait-derivation.md
+++ b/docs/wep-2026-06-25-trait-derivation.md
@@ -1,4 +1,4 @@
-# Trait Derivation Policy — Bound-Driven Synthesis
+# WEP: Trait Derivation Policy — Bound-Driven Synthesis
 
 Status: Implemented. `Eq` / `Ord` / `Default` / `Serialize` / `Deserialize`
 are _demand_ `on_bound`: a body is synthesized only where a reference needs

--- a/docs/wep-2026-07-03-literal-spread.md
+++ b/docs/wep-2026-07-03-literal-spread.md
@@ -1,4 +1,4 @@
-# Literal Spread (`..base`)
+# WEP: Literal Spread (`..base`)
 
 ## Context
 

--- a/docs/wep-2026-07-05-iterator-reference-model.md
+++ b/docs/wep-2026-07-05-iterator-reference-model.md
@@ -1,4 +1,4 @@
-# Iterator Reference Model
+# WEP: Iterator Reference Model
 
 Align `List` iteration with Rust's `iter` / `iter_mut` / `into_iter`.
 

--- a/docs/wep-2026-07-05-marl.md
+++ b/docs/wep-2026-07-05-marl.md
@@ -1,4 +1,4 @@
-# Marl — Markdown Renderer and Formatter
+# WEP: Marl — Markdown Renderer and Formatter
 
 > Historical note: this WEP absorbs the former "Marl Format" WEP
 > (`wep-2026-07-10-marl-format.md`), which added the Markdown-to-Markdown

--- a/docs/wep-2026-07-09-local-item-definitions.md
+++ b/docs/wep-2026-07-09-local-item-definitions.md
@@ -1,4 +1,4 @@
-# Local Item Definitions
+# WEP: Local Item Definitions
 
 ## Context
 

--- a/docs/wep-2026-07-10-struct-walkability.md
+++ b/docs/wep-2026-07-10-struct-walkability.md
@@ -1,4 +1,4 @@
-# Struct Walkability — Field Walks over `Reflect` and `#[secret]` Fields
+# WEP: Struct Walkability — Field Walks over `Reflect` and `#[secret]` Fields
 
 Status: Draft
 


### PR DESCRIPTION
## Summary

Documentation-only pass over `docs/` and `AGENTS.md`.

### Cheatsheet (`docs/cheatsheet.md`)
- Reorganized section order: language features first, all `core:*` / `wasi:*` standard-library content grouped into one trailing **Standard Library** section.
- Digested the key modules into short subsections: `core:prelude`, `core:cli`, `core:collections`, `core:serde`, `core:json`, `core:cbor`; every publicly-documented core lib is now listed by name (added `core:router`, `core:benchmark`). Internal-only modules (builtin, rt, allocator) are excluded.
- Dropped the standalone SIMD section (now just a link under Other core modules).
- Rewrote **Auto-Derived Traits** for the bound-driven synthesis policy: `Eq`/`Ord`/`Default`/`Serialize`/`Deserialize` are synthesized where a use or bound needs them (no marker required), and an empty `impl Trait for T;` marker is a conformance check that errors if `T` is ineligible.
- Documented **constant patterns** (an immutable global or associated const matched by value) in the match section.

### Spec (`docs/spec.md`)
- Fixed a stale contradiction: the serde `impl … for T;` marker **is** a conformance check (validates at its own span), consistent with the Compiler-Synthesized impl section and the derivation-policy WEP.
- Added: constant patterns, `#[synopsis]` tests, a **String Parsing Traits** section (`FromStr` / `LenientFromStr`), **Symbol Notation** (`MODULE#SYMBOL` full pattern), and `#[param]` compile-time parameters — all previously missing.

### AGENTS.md
- Corrected the symbol-notation quoting rule (quote as in `use`; droppable for a scheme/bare name, required for a path or URL).

### WEP hygiene
- Normalized every WEP title to the `# WEP: ...` prefix (29 files were missing it; one still carried the stale `ARD:` term).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YNC64q6rcHyRRjRKUPcU8

---
_Generated by [Claude Code](https://claude.ai/code/session_018YNC64q6rcHyRRjRKUPcU8)_