### PR TITLE
chore(ci): add 60-minute timeout to all workflow jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,6 +32,7 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     outputs:
@@ -67,6 +68,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -84,6 +86,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -101,6 +104,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -118,6 +122,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -135,6 +140,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -152,6 +158,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -169,6 +176,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -193,6 +201,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -217,6 +226,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -241,6 +251,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -271,6 +282,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -308,6 +320,7 @@ jobs:
         check,
       ]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions: {}
     steps:
       - name: Check all jobs passed

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,6 +15,7 @@ jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     outputs:
       tag: ${{ steps.v.outputs.tag }}
       version: ${{ steps.v.outputs.version }}
@@ -101,6 +102,7 @@ jobs:
             archive: zip
             asset_id: windows-aarch64
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:
@@ -155,6 +157,7 @@ jobs:
   release:
     needs: [validate, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -187,6 +190,7 @@ jobs:
   publish:
     needs: [validate, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -223,6 +227,7 @@ jobs:
   deploy-site:
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Generate a token scoped to the site repository
         id: app-token

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   tagpr:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -23,6 +23,7 @@ jobs:
   tidy:
     name: Tidy
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:

--- a/.github/workflows/wado-vscode.yml
+++ b/.github/workflows/wado-vscode.yml
@@ -14,6 +14,7 @@ jobs:
   test-wado-vscode:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
Add `timeout-minutes: 60` to every job across all GitHub Actions workflows, replacing the implicit 360-minute per-job default with a tighter cap so a hung job is killed within an hour instead of consuming a runner for up to six.

GitHub Actions has no workflow-level timeout key — `timeout-minutes` applies only at the job (and step) level — so the cap is set on each job individually.

Jobs covered (23 total):

- `ci.yml` — `changes`, `test-core`, `test-e2e-o0/o1/o2/o3/os`, `test-wado`, `test-gale-o1/o2/o3`, `check`, `test`
- `release.yml` — `validate`, `build`, `release`, `publish`, `deploy-site`
- `benchmark.yml` — `benchmark`
- `copilot-setup-steps.yml` — `copilot-setup-steps`
- `wado-vscode.yml` — `test-wado-vscode`
- `tagpr.yml` — `tagpr`
- `tidy.yml` — `tidy`


---
_Generated by [Claude Code](https://claude.ai/code/session_01JeUu9xHeVU1ZZLMsdBdDdU)_