### PR TITLE
docs: move the design philosophy out of the README into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # The Wado Programming Language
 
-A type-safe, high-level WebAssembly.
+Wado is a statically-typed, high-level WebAssembly language and toolchain that targets only the WebAssembly Component Model and WASI 0.3+. The compiler is 100% agentic-coded. The language takes Rust as its base — made garbage-collected, with no lifetimes and no borrow checker — and borrows its surface syntax from TypeScript.
 
-## Why Wado?
-
-Wado was born from a practical need: embedding small Wasm modules in JavaScript projects without the binary size explosion that comes with existing Wasm-targeting languages.
-
-Existing solutions bundle their own memory management runtime into every `.wasm` file, resulting in bloated binaries even for simple tasks. Wado takes a different approach: by leveraging **Wasm GC**, the garbage collector is provided by the Wasm runtime itself (currently wasmtime; browser support pending Wasm Component Model), keeping your binaries minimal.
-
-The timing matters too. With Wasm Component Model and WASI P3 maturing in 2026, Wado is designed from the ground up for this new era — no legacy baggage, no retrofitting.
+See [docs/design-philosophy.md](docs/design-philosophy.md) for the reasoning behind these choices, and [wado-lang.org](https://wado-lang.org) for the docs and blog.
 
 ## Installing
 
@@ -36,9 +30,7 @@ cargo install --git https://github.com/wado-lang/wado wado-cli
 This builds the current `main` branch from source. Re-run the same command
 to update.
 
-## Examples
-
-### Hello World
+## Hello World
 
 ```wado
 #!/usr/bin/env wado run
@@ -50,177 +42,26 @@ export fn run() with Stdout {
 }
 ```
 
-Run it:
-
 ```sh
-wado run example/hello.wado
+wado run example/hello.wado                    # run it directly
+wado compile -o hello.wasm example/hello.wado  # compile to Wasm
+wado compile -o hello.wat  example/hello.wado  # or to WAT
 ```
-
-Compile to WebAssembly:
-
-```sh
-wado compile example/hello.wado # generates example/hello.wasm
-wado compile -o example/hello.wasm example/hello.wado # ditto
-wado compile --format wasm example/hello.wado # ditto
-
-wado compile --format wat example/hello.wado # generates example/hello.wat with WAT format
-wado compile -o example/hello.wat example/hello.wado  # ditto
-```
-
-### FizzBuzz
-
-```wado
-use { println, Stdout } from "core:cli";
-
-variant FizzBuzz {
-    Fizz,
-    Buzz,
-    FizzBuzz,
-    Number(i32),
-}
-
-fn classify(n: i32) -> FizzBuzz {
-    if n % 15 == 0 { return FizzBuzz::FizzBuzz; }
-    if n % 3 == 0 { return FizzBuzz::Fizz; }
-    if n % 5 == 0 { return FizzBuzz::Buzz; }
-    return FizzBuzz::Number(n);
-}
-
-export fn run() with Stdout {
-    for let mut i = 1; i <= 20; i += 1 {
-        println(match classify(i) {
-            Fizz => "Fizz",
-            Buzz => "Buzz",
-            FizzBuzz => "FizzBuzz",
-            Number(n) => `{n}`,
-        });
-    }
-}
-```
-
-```sh
-wado run example/fizzbuzz.wado
-```
-
-## Key Features
-
-### Language Basics
-
-- Static typing with generics — strong type system with generic types, functions, and methods. No `any` escape hatch
-- Rust-like semantics without lifetimes — value semantics, references (`&T`, `&mut T`), and structs with `impl` blocks, but memory is managed by Wasm GC, so no lifetime annotations needed
-- Familiar syntax — borrows from Rust (structs, `impl`, `let`/`let mut`) and JavaScript/TypeScript (template strings with backticks, ES module-style `use {...} from "..."` imports)
-
-### Effect System
-
-Effects map directly to WASI capabilities, making side effects explicit and controllable:
-
-```wado
-use { println, Stdout } from "core:cli";
-use { Url } from "core:url";
-use { Client, Request, Response, ErrorCode, Fields, Scheme, Trailers } from "wasi:http";
-
-fn scheme_of(url: Url) -> Scheme {
-    return match url.scheme {
-        "http" => Scheme::Http,
-        "https" => Scheme::Https,
-        scheme => Scheme::Other(scheme),
-    };
-}
-
-fn send_get(url: Url) -> Response with Client {
-    let headers = Fields::new();
-    let [trailers_rx, trailers_tx] = Future::<Result<Option<Trailers>, ErrorCode>>::new();
-    let [req, _req_future] = Request::new(headers, null, trailers_rx, null);
-    req.set_scheme(Option::Some(scheme_of(url)));
-    req.set_authority(Option::Some(url.authority()));
-    req.set_path_with_query(Option::Some(url.path_with_query()));
-
-    let result = Client::send(req).wait();
-    trailers_tx.write(Result::Ok(null));
-
-    return match result {
-        Ok(resp) => resp,
-        Err(e) => panic(`HTTP request failed: {e}`),
-    };
-}
-
-export fn run() with Stdout, Client {
-    let url = Url::parse("https://httpbin.org/get").unwrap();
-    let resp = send_get(url);
-    println(`Status: {resp.get_status_code() as i32}`);
-}
-```
-
-`Client::send(...).wait()` is colorless async: the `wait()` suspends the task while the
-runtime drives the request, without coloring `send_get` or `run` as `async`. See
-[`example/http_get.wado`](example/http_get.wado) for the full version (request body,
-streaming the response body, scheme handling).
-
-The `with` clause tells you exactly what a function can do. This enables:
-
-- **Security**: Sandbox plugins with only the capabilities you grant
-- **Testability**: Swap real effects with mocks via handlers
-- **Clarity**: No hidden side effects
-
-## Design Principles
-
-### What You See Is What You Get
-
-No macros. The code you read is the code that runs — Wasm in plain sight.
-
-### Readable Without Context Switching
-
-Explicit over implicit. No implicit type conversions, no function overloading, no hidden dependencies. You shouldn't need to jump to other files to understand what a function does.
-
-### Type-Safe by Design
-
-Strong static typing with no escape hatches like `any`. This prevents the defensive programming patterns (excessive `try-catch`, runtime type checks) that tend to creep into dynamically-typed codebases.
-
-### No Exception Unwinding
-
-Errors are handled explicitly with `Result<T, E>` instead of unwinding exceptions. This makes control flow predictable and easier to reason about.
-
-### Minimal Binary Size
-
-By leveraging Wasm GC instead of bundling a runtime, Wado produces compact `.wasm` files. This is the core motivation behind the language.
 
 ## Status
 
-Wado is experimental. The core language — syntax, static typing, generics, closures, modules — is implemented and functional.
-
-However:
-
-- **WASI P3 is not yet finalized**: The spec is at release candidate stage, and runtime support is limited
-- **Wasm Component Model** is not yet supported in browsers
-- **Wasm stack switching** is not yet available in wasmtime
-
-That said, Wado is already usable for its original purpose: embedding lightweight Wasm modules in JS projects where binary size matters.
-
-## Future Directions
-
-### Full WASI P3 Integration
-
-As the spec finalizes and runtime support matures, Wado will leverage async streams, futures, and the full capability model.
-
-## Informed by Agentic Coding
-
-Wado is developed entirely through agentic coding — AI agents write the entire code while the human handles design decisions and project management.
-
-This isn't just a curiosity; it shaped the language itself. After a year of intensive agentic coding experience, certain patterns became clear:
-
-- **Agents excel at volume but struggle with ambiguity.** Implicit behaviors get multiplied across a codebase. Explicit, predictable semantics work better.
-- **Agents tend toward defensive programming.** Without type safety, they pepper code with `hasattr` checks and nested `try-except` blocks. Strong types eliminate this need.
-- **Exceptions break agent reasoning.** Non-local control flow is hard to predict. `Result<T, E>` keeps everything visible.
-
-The result: a language where common agentic coding pitfalls are eliminated by design, not convention.
+Wado is experimental. The core language — static typing, generics, closures, modules, traits, pattern matching, the effect system — is implemented and functional, and already usable for its original purpose: embedding small, type-safe Wasm modules where binary size matters. It waits on the broader ecosystem — the Component Model in browsers, WASI 1.0, and GC across component boundaries — to reach its full shape.
 
 ## Documentation
 
-- [Cheatsheet](docs/cheatsheet.md) - Quick syntax reference
-- [Language Specification](docs/spec.md) - Full language reference
-- [Compiler Implementation](docs/compiler.md) - Compiler internals and feature checklist
-- [Benchmarks](benchmark/README.md) - Performance benchmarks vs C and JavaScript, and so on
-- [Other Documentation](docs) - WEP, research notes, etc.
+- [Design Philosophy](docs/design-philosophy.md) — why Wado is the way it is
+- [Cheatsheet](docs/cheatsheet.md) — quick syntax reference
+- [Language Specification](docs/spec.md) — full language reference
+- [Compiler Implementation](docs/compiler.md) — compiler internals and feature checklist
+- [Benchmarks](benchmark/README.md) — performance vs C, JavaScript, and others
+- [Other Documentation](docs) — WEPs, research notes, and more
+
+These are also published, alongside the blog, at [wado-lang.org](https://wado-lang.org).
 
 ## Development
 

--- a/docs/design-philosophy.md
+++ b/docs/design-philosophy.md
@@ -1,0 +1,77 @@
+# Design Philosophy
+
+Why Wado is the way it is.
+
+## Why Wado exists
+
+Wado was born from a practical need: embedding small Wasm modules in JavaScript projects without the binary-size explosion that comes with existing Wasm-targeting languages.
+
+Existing solutions bundle their own memory-management runtime into every `.wasm` file, so even a trivial program ships a bloated binary. Wado takes a different approach: by targeting Wasm GC, the garbage collector is provided by the host runtime (wasmtime today; browsers once the Component Model lands), so nothing ships inside the module but the program's own logic.
+
+The timing matters too. With the Wasm Component Model and WASI 0.3 maturing, Wado is designed from the ground up for this platform — no legacy backend to carry, no glue layer to retrofit. It targets that platform and nothing else.
+
+## Principles
+
+### Wasm in plain sight
+
+No macros. The code you read is the code that runs, so the emitted WAT is something you can reason about by looking at the source.
+
+### Readable without context switching
+
+Explicit over implicit: no implicit type conversions, no function overloading, no hidden dependencies. You should never have to jump to another file to know what a function does.
+
+### Type-safe by design
+
+Strong static typing with no escape hatch like `any`. That removes the reason to reach for the defensive patterns — excessive `try-catch`, runtime type checks — that accumulate in dynamically-typed codebases.
+
+### Errors are values
+
+Errors are handled with `Result<T, E>` and `Option<T>`, not by unwinding exceptions. Control flow stays local and visible; there is no stack unwinding as a language feature.
+
+### Small binaries
+
+Leaning on Wasm GC instead of bundling a runtime keeps `.wasm` output compact. This is the core motivation behind the language.
+
+## Effects are WASI capabilities
+
+The most Wado-specific idea: every effect a function can perform is part of its type. Effects map directly onto WASI capabilities, so a side effect is never hidden — it appears in the signature.
+
+```wado
+use { println, Stdout } from "core:cli";
+
+export fn run() with Stdout {
+    println("Hello, world!");
+}
+```
+
+The `with Stdout` clause says exactly what this function can touch. That one idea buys three things:
+
+- Security: a plugin runs with only the capabilities you grant it.
+- Testability: real effects can be swapped for mocks via handlers.
+- Clarity: there are no hidden side effects to discover.
+
+`Stdout` is not a Wado invention; it is `wasi:cli`'s standard-output interface. Effects surface as `interface` — a namespace of operations — and `resource` — a handle to something outside the program; the platform's capability boundaries and the language's effects are the same thing. One `interface` is at once a WASI interface, a Component Model import/export, and a user-defined effect, so effects are not only declared but handled: swap a real one for a mock, or interpret your own. See [`example/http_get.wado`](../example/http_get.wado) for a larger example that threads an outbound HTTP `Client` capability through the type.
+
+## The platform's vocabulary, both ways
+
+Wado didn't invent a type system and then map it onto WIT — its constructs are WIT's type kinds: `interface`, `record` → `struct`, `variant`, `enum`, `flags`, `resource`, `world`, `func` → `fn`, `async func` / `stream` / `future`, `tuple` → `[a, b]`, and `option` / `result` / `list` → `Option` / `Result` / `List`. The `wasi:*` standard library is generated from WIT this way.
+
+It runs both directions. Wado synthesizes WIT from your declarations and bundles it into the component, so any other Component Model language can bind to it — and when both ends are Wado, it skips the canonical ABI and shares Wasm GC types directly.
+
+## The language, in one breath
+
+Wado takes Rust as its base and adapts it for this platform:
+
+- Rust's structs, `impl` blocks, generics, traits, and exhaustive pattern matching — but no lifetimes, no borrow checker, no `unsafe`. Memory is the Wasm garbage collector's job, and values have value semantics: assigning or passing deep-copies, and only `&T` / `&mut T` share.
+- Rust's `enum` is split to match the Component Model's type kinds: `variant` for sum types with payloads, `enum` for bare discriminants, `flags` for bitsets.
+- TypeScript's influence shows in the surface: template strings with backtick interpolation, and ES-module-style `use { … } from "…"` imports.
+
+## Informed by agentic coding
+
+Wado is developed entirely through agentic coding: AI agents write the code while the human handles design and direction. That is not a side note — it shaped the language. After a stretch of intensive agentic work, a few things were clear:
+
+- Agents are fast but literal. Implicit behavior multiplies across a codebase, so predictable, explicit semantics work better — hence no implicit conversions, no overloading, no macros.
+- Agents drift toward defensive code. Without type safety they pile on runtime checks and nested error handling; strong static types remove the reason to.
+- Exceptions break their reasoning. Non-local control flow is hard to predict, so failures are values that stay visible at the call site.
+
+The result is a language where common agentic-coding pitfalls are removed by design, not by convention.


### PR DESCRIPTION
The README had grown into a full design manifesto that now duplicates the website. This moves the philosophy into `docs/` and slims the README to the essentials.

## New doc

`docs/design-philosophy.md` collects the design rationale — why Wado exists, the principles (Wasm in plain sight, readable-without-context-switching, type-safe, errors-as-values, small binaries), effects as WASI capabilities, the Rust/TypeScript lineage, and the "informed by agentic coding" reasoning. The site's docs pipeline publishes it under `/docs` automatically.

## README

Kept a short positioning blurb — targets only the Component Model + WASI 0.3+, 100% agentic-coded, a GC'd Rust base with TypeScript surface syntax — plus only the practical sections: install, a hello world, status, documentation links (now including the design doc), development, and the release process. 335 → 175 lines.

Notes:
- The "Informed by agentic coding" content lives as a section of the design doc for now, so nothing is lost; it can be lifted into a standalone blog post later.
- A small follow-up on the site can special-case `design-philosophy` into the docs index's "Language reference" group so it sits alongside the spec and cheatsheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrNa2dR3XekiV3sE2xo9jd

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrNa2dR3XekiV3sE2xo9jd)_