### PR TITLE
feat(compiler): consume a facade library as a CM component (Marl from the registry)

### DIFF
--- a/docs/wep-2026-07-05-marl.md
+++ b/docs/wep-2026-07-05-marl.md
@@ -65,9 +65,13 @@ the `escape_text` / `escape_attr` helpers for HTML-templating consumers.
 ### Public API: WIT-representable, no references
 
 The public surface takes and returns values only — no `&T` — so it maps
-directly onto a WIT interface (`string`, `list`, records) should Marl ever be
-exposed as a Component Model component. Reference-taking workhorses stay
-`internal` behind the value-based facade, so the hot path avoids copies.
+directly onto a WIT interface (`string`, `list`, records). `render` and
+`format` are `export`: a `--lib` build lowers them into a CM `interface marl`
+(with `RenderResult` / `HeadingInfo` riding along `render`'s signature), so any
+Component Model consumer can pull Marl from a registry. `escape_text` /
+`escape_attr` stay `pub` (Wado-native, no CM boundary). Reference-taking
+workhorses stay `internal` behind the value-based facade, so the hot path
+avoids copies.
 
 ### Rendering: the HTML backend
 
@@ -89,7 +93,7 @@ pub struct HeadingInfo {
     pub text: String,  // plain-text content: slug source and TOC label
 }
 
-pub fn render(source: String) -> RenderResult { ... }
+export fn render(source: String) -> RenderResult { ... }
 ```
 
 ### Heading ids (GFM slugs)

--- a/package-marl/src/fmt_html.wado
+++ b/package-marl/src/fmt_html.wado
@@ -43,7 +43,7 @@ pub struct HeadingInfo {
     pub text: String,
 }
 
-pub fn render(source: String) -> RenderResult {
+export fn render(source: String) -> RenderResult {
     let parsed = parse(&source);
     let mut r = Renderer {
         refs: parsed.refs,

--- a/package-marl/src/format.wado
+++ b/package-marl/src/format.wado
@@ -7,6 +7,6 @@
 use { parse_document } from "./fmt_parse_block.wado";
 use { print_document } from "./fmt_print.wado";
 
-pub fn format(source: String) -> String {
+export fn format(source: String) -> String {
     return print_document(&parse_document(&source));
 }

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -254,41 +254,6 @@ fn test_wit_lib_emits_root_world() {
 }
 
 #[test]
-fn test_wit_lib_surfaces_facade_reexported_export() {
-    // A facade entry module re-exports an `export fn` from a submodule via
-    // `pub use`; the library world must still surface it as a CM export. This
-    // is the shape package-marl uses — `lib.wado` re-exports `render` / `format`
-    // from submodules — so a registry consumer sees them across the CM boundary.
-    let tmp = tempfile::tempdir().unwrap();
-    let dir = tmp.path();
-    std::fs::write(
-        dir.join("wado.toml"),
-        "[package]\nnamespace = \"acme\"\nname = \"facade\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
-    )
-    .unwrap();
-    std::fs::create_dir_all(dir.join("src")).unwrap();
-    std::fs::write(
-        dir.join("src").join("lib.wado"),
-        "pub use { greet } from \"./sub.wado\";\n",
-    )
-    .unwrap();
-    std::fs::write(
-        dir.join("src").join("sub.wado"),
-        "export fn greet(name: String) -> String { return name; }\n",
-    )
-    .unwrap();
-
-    wado_in(dir)
-        .arg("wit")
-        .arg("--lib")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(
-            "export greet: func(name: string) -> string;",
-        ));
-}
-
-#[test]
 fn test_wit_lib_conflicts_with_world() {
     wado()
         .arg("wit")
@@ -793,4 +758,74 @@ fn test_test_parallel_long_option() {
         .assert()
         .success()
         .stdout(predicate::str::contains("2 passed, 0 failed"));
+}
+
+#[test]
+fn test_lib_facade_submodule_export_with_nested_records() {
+    // A library's public API lives in a submodule as `export fn`, surfaced by a
+    // `pub use` facade in the entry module. The `--lib` build must lower it as a
+    // real CM export — including a return type that nests records inside a list,
+    // which the lift/lower must resolve to the submodule-defined struct rather
+    // than an i32 handle.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"doc\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "pub use { render, Doc, Node } from \"./render.wado\";\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src").join("render.wado"),
+        "pub struct Node { pub level: u8, pub text: String }\n\
+         pub struct Doc { pub html: String, pub nodes: List<Node> }\n\
+         export fn render(s: String) -> Doc { return Doc { html: s, nodes: [Node { level: 1, text: s }] }; }\n",
+    )
+    .unwrap();
+
+    // WIT surfaces the facade export, grouped into the package interface with
+    // both records and the nested `list<node>`.
+    wado_in(dir)
+        .arg("wit")
+        .arg("--lib")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("interface doc {"))
+        .stdout(predicate::str::contains("list<node>"))
+        .stdout(predicate::str::contains("render: func(s: string) -> doc;"));
+
+    // The build must reach codegen: the export adapter calls the submodule
+    // function and lowers the nested list-of-records return without panicking.
+    wado_in(dir).arg("build").arg("--lib").assert().success();
+}
+
+#[test]
+fn test_lib_without_exports_is_rejected() {
+    // A `--lib` whose modules define no `export fn` produces a component that
+    // exposes nothing; reject it rather than emit an empty library.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"empty\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "pub fn helper() -> i32 { return 0; }\n",
+    )
+    .unwrap();
+
+    wado_in(dir)
+        .arg("build")
+        .arg("--lib")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("exports nothing"));
 }

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -829,3 +829,73 @@ fn test_lib_without_exports_is_rejected() {
         .failure()
         .stderr(predicate::str::contains("exports nothing"));
 }
+
+#[test]
+fn test_lib_duplicate_export_name_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"dup\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "pub use { f } from \"./a.wado\";\npub use { g } from \"./b.wado\";\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src").join("a.wado"),
+        "export fn f(s: String) -> String { return s; }\nexport fn dup(s: String) -> String { return s; }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src").join("b.wado"),
+        "export fn g(s: String) -> String { return s; }\nexport fn dup(s: String) -> String { return s; }\n",
+    )
+    .unwrap();
+
+    wado_in(dir)
+        .arg("build")
+        .arg("--lib")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("two functions named `dup`"));
+}
+
+#[test]
+fn test_lib_duplicate_type_name_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"dup\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "pub use { f } from \"./a.wado\";\npub use { g } from \"./b.wado\";\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src").join("a.wado"),
+        "pub struct Node { pub v: String }\nexport fn f(s: String) -> Node { return Node { v: s }; }\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src").join("b.wado"),
+        "pub struct Node { pub v: String }\nexport fn g(s: String) -> Node { return Node { v: s }; }\n",
+    )
+    .unwrap();
+
+    wado_in(dir)
+        .arg("build")
+        .arg("--lib")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "library type `Node` is defined in more than one module",
+        ));
+}

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -254,6 +254,41 @@ fn test_wit_lib_emits_root_world() {
 }
 
 #[test]
+fn test_wit_lib_surfaces_facade_reexported_export() {
+    // A facade entry module re-exports an `export fn` from a submodule via
+    // `pub use`; the library world must still surface it as a CM export. This
+    // is the shape package-marl uses — `lib.wado` re-exports `render` / `format`
+    // from submodules — so a registry consumer sees them across the CM boundary.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"facade\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "pub use { greet } from \"./sub.wado\";\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src").join("sub.wado"),
+        "export fn greet(name: String) -> String { return name; }\n",
+    )
+    .unwrap();
+
+    wado_in(dir)
+        .arg("wit")
+        .arg("--lib")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "export greet: func(name: string) -> string;",
+        ));
+}
+
+#[test]
 fn test_wit_lib_conflicts_with_world() {
     wado()
         .arg("wit")

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -649,6 +649,12 @@ pub struct CmInterfaceRegistry {
     /// source is derived from the FQ by `module_source_for_cm_interface`.
     cm_interface_module_sources: IndexMap<String, ModuleSource>,
 
+    /// Lib-local named type -> the module that actually defines it. A library
+    /// spreads its public types across submodules, so the interface FQ (which
+    /// maps to the entry module) cannot alone locate a submodule-defined type
+    /// like `HeadingInfo`. Keyed by name — unique within a library's API.
+    lib_local_type_sources: IndexMap<String, ModuleSource>,
+
     /// FQs of interfaces imported from a CM component dependency. The plan
     /// classifies these as [`crate::wir::ImportKind::Component`] for composition.
     component_interfaces: IndexSet<String>,
@@ -1566,84 +1572,119 @@ impl CmInterfaceRegistry {
         iface_fq: &str,
         entry_source: ModuleSource,
     ) {
-        use crate::ast::Item;
-
         // Record the FQ -> entry ModuleSource so consumers resolve lib-local
         // types' module source (and detect lib-local provenance) without
         // prefix-sniffing the FQ.
         self.cm_interface_module_sources
-            .insert(iface_fq.to_string(), entry_source);
+            .insert(iface_fq.to_string(), entry_source.clone());
 
         for item in &module.items {
-            match item {
-                Item::Newtype(alias) => register_unique(
-                    &mut self.newtypes,
-                    "newtype",
+            self.register_lib_local_item(item, iface_fq, &entry_source);
+        }
+    }
+
+    /// Register named type decls that reach the library's public surface from a
+    /// non-entry local module (a facade re-exports them, and an `export fn`
+    /// signature names them). Registered under the same lib-local interface FQ
+    /// as the entry module's own types, so lift/lower resolves them uniformly.
+    /// Each carries the module that defines it, so resolution can locate a
+    /// submodule type the entry-FQ mapping cannot.
+    pub fn register_lib_local_items(
+        &mut self,
+        items: &[(ModuleSource, crate::ast::Item)],
+        iface_fq: &str,
+    ) {
+        for (source, item) in items {
+            self.register_lib_local_item(item, iface_fq, source);
+        }
+    }
+
+    fn register_lib_local_item(
+        &mut self,
+        item: &crate::ast::Item,
+        iface_fq: &str,
+        module_source: &ModuleSource,
+    ) {
+        use crate::ast::Item;
+        if let Some(name) = match item {
+            Item::Newtype(d) => Some(&d.name),
+            Item::Struct(d) => Some(&d.name),
+            Item::Flags(d) => Some(&d.name),
+            Item::Enum(d) => Some(&d.name),
+            Item::Variant(d) => Some(&d.name),
+            _ => None,
+        } {
+            self.lib_local_type_sources
+                .insert(name.clone(), module_source.clone());
+        }
+        match item {
+            Item::Newtype(alias) => register_unique(
+                &mut self.newtypes,
+                "newtype",
+                iface_fq.to_string(),
+                alias.name.clone(),
+                alias.ty.clone(),
+            ),
+            Item::Struct(struct_def) => {
+                let fields: Vec<(String, Type)> = struct_def
+                    .fields
+                    .iter()
+                    .map(|f| (to_kebab(&f.name), f.ty.clone()))
+                    .collect();
+                let wado_fields: Vec<(String, String, Type)> = struct_def
+                    .fields
+                    .iter()
+                    .map(|f| (f.name.clone(), to_kebab(&f.name), f.ty.clone()))
+                    .collect();
+                register_unique(
+                    &mut self.structs,
+                    "struct",
                     iface_fq.to_string(),
-                    alias.name.clone(),
-                    alias.ty.clone(),
-                ),
-                Item::Struct(struct_def) => {
-                    let fields: Vec<(String, Type)> = struct_def
-                        .fields
-                        .iter()
-                        .map(|f| (to_kebab(&f.name), f.ty.clone()))
-                        .collect();
-                    let wado_fields: Vec<(String, String, Type)> = struct_def
-                        .fields
-                        .iter()
-                        .map(|f| (f.name.clone(), to_kebab(&f.name), f.ty.clone()))
-                        .collect();
-                    register_unique(
-                        &mut self.structs,
-                        "struct",
-                        iface_fq.to_string(),
-                        struct_def.name.clone(),
-                        (to_kebab(&struct_def.name), fields, wado_fields),
-                    );
-                }
-                Item::Flags(flags_def) => {
-                    let members: Vec<String> =
-                        flags_def.flags.iter().map(|m| to_kebab(&m.name)).collect();
-                    register_unique(
-                        &mut self.flags,
-                        "flags",
-                        iface_fq.to_string(),
-                        flags_def.name.clone(),
-                        (to_kebab(&flags_def.name), members),
-                    );
-                }
-                Item::Enum(enum_def) => {
-                    let variants: Vec<String> =
-                        enum_def.cases.iter().map(|c| to_kebab(&c.name)).collect();
-                    register_unique(
-                        &mut self.enums,
-                        "enum",
-                        iface_fq.to_string(),
-                        enum_def.name.clone(),
-                        (to_kebab(&enum_def.name), variants),
-                    );
-                }
-                Item::Variant(variant_def) => {
-                    let cases: Vec<CmVariantCase> = variant_def
-                        .cases
-                        .iter()
-                        .map(|c| CmVariantCase {
-                            cm_name: to_kebab(&c.name),
-                            wado_name: c.name.clone(),
-                            payload: c.payload.clone(),
-                        })
-                        .collect();
-                    register_unique(
-                        &mut self.variants,
-                        "variant",
-                        iface_fq.to_string(),
-                        variant_def.name.clone(),
-                        (to_kebab(&variant_def.name), cases),
-                    );
-                }
-                _ => {}
+                    struct_def.name.clone(),
+                    (to_kebab(&struct_def.name), fields, wado_fields),
+                );
             }
+            Item::Flags(flags_def) => {
+                let members: Vec<String> =
+                    flags_def.flags.iter().map(|m| to_kebab(&m.name)).collect();
+                register_unique(
+                    &mut self.flags,
+                    "flags",
+                    iface_fq.to_string(),
+                    flags_def.name.clone(),
+                    (to_kebab(&flags_def.name), members),
+                );
+            }
+            Item::Enum(enum_def) => {
+                let variants: Vec<String> =
+                    enum_def.cases.iter().map(|c| to_kebab(&c.name)).collect();
+                register_unique(
+                    &mut self.enums,
+                    "enum",
+                    iface_fq.to_string(),
+                    enum_def.name.clone(),
+                    (to_kebab(&enum_def.name), variants),
+                );
+            }
+            Item::Variant(variant_def) => {
+                let cases: Vec<CmVariantCase> = variant_def
+                    .cases
+                    .iter()
+                    .map(|c| CmVariantCase {
+                        cm_name: to_kebab(&c.name),
+                        wado_name: c.name.clone(),
+                        payload: c.payload.clone(),
+                    })
+                    .collect();
+                register_unique(
+                    &mut self.variants,
+                    "variant",
+                    iface_fq.to_string(),
+                    variant_def.name.clone(),
+                    (to_kebab(&variant_def.name), cases),
+                );
+            }
+            _ => {}
         }
     }
 
@@ -1926,6 +1967,13 @@ impl CmInterfaceRegistry {
     /// derived from the FQ by naming convention) or an unknown FQ.
     pub fn cm_interface_module_source_of(&self, iface_fq: &str) -> Option<&ModuleSource> {
         self.cm_interface_module_sources.get(iface_fq)
+    }
+
+    /// The module that defines a lib-local named type, when known. Locates a
+    /// submodule-defined public type (e.g. `HeadingInfo` inside a facade
+    /// library) that the interface-FQ mapping alone cannot.
+    pub fn lib_local_type_source(&self, name: &str) -> Option<&ModuleSource> {
+        self.lib_local_type_sources.get(name)
     }
 
     /// Resolve a named type to its source interface across all CM namespaces

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -381,9 +381,97 @@ fn emit_unused_diagnostics<H: CompilerHost>(
 // published component's WIT carries a package-specific identity.
 const KILN_GENERATOR_IMPL_FQ: &str = "kiln:generator/generator@0.1.0";
 
+/// Collect `export fn`s defined in the library's non-entry local modules.
+///
+/// A library's entry module is a facade (`lib.wado`) that `pub use`-re-exports
+/// its submodules' API, but `export` stays on the declaration: any `export fn`
+/// in a local module is part of the library's Component Model surface, wherever
+/// it lives. The entry module's own `export fn`s are gathered separately by
+/// [`synthesize_lib_world_info`]; this returns the rest, each carrying
+/// `reexport_origin` so the codegen adapter calls the function in its own
+/// module rather than expecting it in the entry module.
+fn collect_nonentry_lib_exports(
+    entry_source: &ModuleSource,
+    modules: &crate::hashmap::IndexMap<ModuleSource, ast::Module>,
+) -> Vec<world_registry::WorldExportInfo> {
+    use crate::ast::Item;
+    use crate::world_registry::WorldExportInfo;
+
+    let mut out = Vec::new();
+    for (source, module) in modules {
+        if source == entry_source || !source.is_local() {
+            continue;
+        }
+        for item in &module.items {
+            let Item::Function(func) = item else { continue };
+            if !func.is_export {
+                continue;
+            }
+            out.push(WorldExportInfo {
+                name: func.name.clone(),
+                is_async: func.is_async,
+                params: func
+                    .params
+                    .iter()
+                    .map(|p| (p.name.clone(), p.ty.clone()))
+                    .collect(),
+                return_type: func.return_type.clone(),
+                from_interface_fq: None,
+                reexport_origin: Some((source.clone(), func.name.clone())),
+            });
+        }
+    }
+    out
+}
+
+/// Named type decls in the library's non-entry local modules. These reach the
+/// public surface through the facade (an `export fn` names them), so they must
+/// be registered as lib-local CM types alongside the entry module's own.
+fn collect_nonentry_lib_type_decls(
+    entry_source: &ModuleSource,
+    modules: &crate::hashmap::IndexMap<ModuleSource, ast::Module>,
+) -> Vec<(ModuleSource, ast::Item)> {
+    use crate::ast::Item;
+
+    let mut out = Vec::new();
+    for (source, module) in modules {
+        if source == entry_source || !source.is_local() {
+            continue;
+        }
+        for item in &module.items {
+            if matches!(
+                item,
+                Item::Struct(_)
+                    | Item::Enum(_)
+                    | Item::Variant(_)
+                    | Item::Flags(_)
+                    | Item::Newtype(_)
+            ) {
+                out.push((source.clone(), item.clone()));
+            }
+        }
+    }
+    out
+}
+
+/// The declared name of a type-kind item, or `None` for non-type items.
+fn lib_type_decl_name(item: &ast::Item) -> Option<String> {
+    use crate::ast::Item;
+    match item {
+        Item::Struct(d) => Some(d.name.clone()),
+        Item::Enum(d) => Some(d.name.clone()),
+        Item::Variant(d) => Some(d.name.clone()),
+        Item::Flags(d) => Some(d.name.clone()),
+        Item::Newtype(d) => Some(d.name.clone()),
+        _ => None,
+    }
+}
+
 fn synthesize_lib_world_info(
     fq: &str,
     entry_module: Option<&ast::Module>,
+    reexports: &[world_registry::WorldExportInfo],
+    submodule_type_names: &crate::hashmap::IndexSet<String>,
 ) -> world_registry::WorldInfo {
     use crate::ast::Item;
     use crate::world_registry::{WorldExportInfo, WorldInfo};
@@ -404,12 +492,14 @@ fn synthesize_lib_world_info(
                             .collect(),
                         return_type: func.return_type.clone(),
                         from_interface_fq: None,
+                        reexport_origin: None,
                     }),
                     _ => None,
                 })
                 .collect()
         })
         .unwrap_or_default();
+    exports.extend(reexports.iter().cloned());
 
     // A/B grouping (mirrors the WIT producer, `wit_emit`): if any exported
     // signature references a user-defined named type, the exports cannot be
@@ -431,7 +521,7 @@ fn synthesize_lib_world_info(
     // library's default-interface FQ, matching `register_lib_local_decls`, so
     // the lift/lower machinery resolves them like WASI types. Only the module's
     // own declarations — types from other interfaces keep their source.
-    let local_type_names: crate::hashmap::IndexSet<String> = entry_module
+    let mut local_type_names: crate::hashmap::IndexSet<String> = entry_module
         .map(|module| {
             module
                 .items
@@ -447,6 +537,9 @@ fn synthesize_lib_world_info(
                 .collect()
         })
         .unwrap_or_default();
+    // Types defined in submodules but reached through the facade's exported
+    // signatures are lib-local too (registered via `register_lib_local_items`).
+    local_type_names.extend(submodule_type_names.iter().cloned());
     for export in &mut exports {
         for (_, ty) in &mut export.params {
             annotate_lib_local_sources(ty, fq, &local_type_names);
@@ -495,6 +588,38 @@ fn annotate_lib_local_sources(
         }
         Type::Reference(inner) | Type::MutReference(inner) => {
             annotate_lib_local_sources(inner, fq, local_type_names);
+        }
+        _ => {}
+    }
+}
+
+/// Tag the field / payload types of a lib-local type decl with the library's
+/// default-interface FQ, so a nested user type (e.g. `HeadingInfo` inside
+/// `RenderResult.headings: List<HeadingInfo>`) resolves against the same
+/// registration as the fields the CM lift/lower reads. Mirrors
+/// `annotate_lib_local_sources` for export signatures, but reaches inside the
+/// registered type's own fields.
+fn tag_lib_local_decl_fields(
+    item: &mut ast::Item,
+    fq: &str,
+    local_type_names: &crate::hashmap::IndexSet<String>,
+) {
+    use crate::ast::Item;
+    match item {
+        Item::Struct(d) => {
+            for field in &mut d.fields {
+                annotate_lib_local_sources(&mut field.ty, fq, local_type_names);
+            }
+        }
+        Item::Variant(d) => {
+            for case in &mut d.cases {
+                if let Some(payload) = case.payload.as_mut() {
+                    annotate_lib_local_sources(payload, fq, local_type_names);
+                }
+            }
+        }
+        Item::Newtype(d) => {
+            annotate_lib_local_sources(&mut d.ty, fq, local_type_names);
         }
         _ => {}
     }
@@ -758,9 +883,47 @@ fn compile_after_load<H: CompilerHost>(
         .lib_world
         .clone()
         .or_else(|| is_kiln_generator.then(|| KILN_GENERATOR_IMPL_FQ.to_string()));
-    let mut lib_world_info = synth_world_fq
-        .as_ref()
-        .map(|fq| synthesize_lib_world_info(fq, sem.modules.get(&sem.entry_module_source)));
+    // A kiln generator's `generate` lives in the entry module; only a real
+    // `--lib` package spreads its API (and the types it exposes) across
+    // submodules. Captured here (owned) so they outlive the `sem` destructure
+    // below and can be registered into the CM interface registry.
+    let mut lib_submodule_type_decls: Vec<(ModuleSource, ast::Item)> =
+        if options.lib_world.is_some() {
+            collect_nonentry_lib_type_decls(&sem.entry_module_source, &sem.modules)
+        } else {
+            Vec::new()
+        };
+    let lib_submodule_type_names: crate::hashmap::IndexSet<String> = lib_submodule_type_decls
+        .iter()
+        .filter_map(|(_, item)| lib_type_decl_name(item))
+        .collect();
+    // Tag nested user types inside the submodule decls' own fields, so a type
+    // like `HeadingInfo` reached only through `RenderResult.headings` resolves
+    // against the same lib-local registration. The name set spans every
+    // lib-local type (entry module + submodules).
+    if let Some(fq) = synth_world_fq.as_ref() {
+        let mut all_lib_type_names = lib_submodule_type_names.clone();
+        if let Some(entry) = sem.modules.get(&sem.entry_module_source) {
+            for item in &entry.items {
+                if let Some(name) = lib_type_decl_name(item) {
+                    all_lib_type_names.insert(name);
+                }
+            }
+        }
+        for (_, decl) in &mut lib_submodule_type_decls {
+            tag_lib_local_decl_fields(decl, fq, &all_lib_type_names);
+        }
+    }
+
+    let mut lib_world_info = synth_world_fq.as_ref().map(|fq| {
+        let entry = sem.modules.get(&sem.entry_module_source);
+        let nonentry = if options.lib_world.is_some() {
+            collect_nonentry_lib_exports(&sem.entry_module_source, &sem.modules)
+        } else {
+            Vec::new()
+        };
+        synthesize_lib_world_info(fq, entry, &nonentry, &lib_submodule_type_names)
+    });
 
     if is_kiln_generator && let Some(world) = lib_world_info.as_mut() {
         // Only `generate` is the generator world's contract; a helper
@@ -797,6 +960,24 @@ fn compile_after_load<H: CompilerHost>(
             // it — the user writes `fn generate`, not `async fn`.
             export.is_async = true;
         }
+    }
+
+    // A `--lib` build whose world has no exports produces a component that
+    // exposes nothing — almost always a facade that forgot `export`, or a
+    // package with no public API. Reject it rather than emit an empty library.
+    if options.lib_world.is_some()
+        && let Some(world) = lib_world_info.as_ref()
+        && world.exports.is_empty()
+    {
+        let _ = logger.error(compiler_host::Diagnostic {
+            severity: compiler_host::Severity::Error,
+            code: compiler_host::Code::CodegenError,
+            message: "a library (`--lib`) exports nothing; mark at least one \
+                      function `export fn` so the component has a public API"
+                .to_string(),
+            span: None,
+        });
+        return Err(Bail);
     }
 
     // Capture the entry module so its own named types can be registered into
@@ -836,11 +1017,10 @@ fn compile_after_load<H: CompilerHost>(
     // holds a reference — so the shared copy is never mutated; only this
     // compilation's registry gains the local types.
     if let (Some(fq), Some(entry)) = (synth_world_fq.as_ref(), lib_entry_module.as_ref()) {
-        std::sync::Arc::make_mut(&mut tysys.cm_interface_registry).register_lib_local_decls(
-            entry,
-            fq,
-            entry_module_source.clone(),
-        );
+        let registry = std::sync::Arc::make_mut(&mut tysys.cm_interface_registry);
+        registry.register_lib_local_decls(entry, fq, entry_module_source.clone());
+        // Submodule-defined types reachable through the facade's exports.
+        registry.register_lib_local_items(&lib_submodule_type_decls, fq);
     }
 
     debug_assert_eq!(
@@ -1809,7 +1989,12 @@ fn helper(x: u32) -> u32 { return x; }
 export fn id_bool(v: bool) -> bool { return v; }
 "#;
         let module = super::parse(src).ast;
-        let world = synthesize_lib_world_info("wado:mylib/mylib@0.1.0", Some(&module));
+        let world = synthesize_lib_world_info(
+            "wado:mylib/mylib@0.1.0",
+            Some(&module),
+            &[],
+            &Default::default(),
+        );
 
         assert_eq!(world.fq_name, "wado:mylib/mylib@0.1.0");
         assert!(world.imports.is_empty());
@@ -1827,7 +2012,7 @@ export fn id_bool(v: bool) -> bool { return v; }
 
     #[test]
     fn empty_when_no_entry_module() {
-        let world = synthesize_lib_world_info("wado:x/x@0.1.0", None);
+        let world = synthesize_lib_world_info("wado:x/x@0.1.0", None, &[], &Default::default());
         assert!(world.exports.is_empty());
     }
 
@@ -1842,7 +2027,12 @@ export fn id_u32(v: u32) -> u32 { return v; }
 export fn id_points(v: List<Point>) -> List<Point> { return v; }
 "#;
         let module = super::parse(src).ast;
-        let world = synthesize_lib_world_info("wado:geo/geo@0.1.0", Some(&module));
+        let world = synthesize_lib_world_info(
+            "wado:geo/geo@0.1.0",
+            Some(&module),
+            &[],
+            &Default::default(),
+        );
         assert!(
             world
                 .exports
@@ -1861,7 +2051,8 @@ export fn id_list(v: List<u8>) -> List<u8> { return v; }
 export fn id_opt(v: Option<String>) -> Option<String> { return v; }
 "#;
         let module = super::parse(src).ast;
-        let world = synthesize_lib_world_info("wado:c/c@0.1.0", Some(&module));
+        let world =
+            synthesize_lib_world_info("wado:c/c@0.1.0", Some(&module), &[], &Default::default());
         assert!(
             world.exports.iter().all(|e| e.from_interface_fq.is_none()),
             "primitive containers do not force an interface",

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -381,77 +381,63 @@ fn emit_unused_diagnostics<H: CompilerHost>(
 // published component's WIT carries a package-specific identity.
 const KILN_GENERATOR_IMPL_FQ: &str = "kiln:generator/generator@0.1.0";
 
-/// Collect `export fn`s defined in the library's non-entry local modules.
-///
-/// A library's entry module is a facade (`lib.wado`) that `pub use`-re-exports
-/// its submodules' API, but `export` stays on the declaration: any `export fn`
-/// in a local module is part of the library's Component Model surface, wherever
-/// it lives. The entry module's own `export fn`s are gathered separately by
-/// [`synthesize_lib_world_info`]; this returns the rest, each carrying
-/// `reexport_origin` so the codegen adapter calls the function in its own
-/// module rather than expecting it in the entry module.
-fn collect_nonentry_lib_exports(
+struct LibSurface {
+    submodule_exports: Vec<world_registry::WorldExportInfo>,
+    submodule_type_decls: Vec<(ModuleSource, ast::Item)>,
+}
+
+fn collect_lib_surface(
     entry_source: &ModuleSource,
     modules: &crate::hashmap::IndexMap<ModuleSource, ast::Module>,
-) -> Vec<world_registry::WorldExportInfo> {
+) -> LibSurface {
     use crate::ast::Item;
     use crate::world_registry::WorldExportInfo;
 
-    let mut out = Vec::new();
+    let mut submodule_exports = Vec::new();
+    let mut submodule_type_decls = Vec::new();
     for (source, module) in modules {
         if source == entry_source || !source.is_local() {
             continue;
         }
         for item in &module.items {
-            let Item::Function(func) = item else { continue };
-            if !func.is_export {
-                continue;
+            match item {
+                Item::Function(func) if func.is_export => {
+                    submodule_exports.push(WorldExportInfo {
+                        name: func.name.clone(),
+                        is_async: func.is_async,
+                        params: func
+                            .params
+                            .iter()
+                            .map(|p| (p.name.clone(), p.ty.clone()))
+                            .collect(),
+                        return_type: func.return_type.clone(),
+                        from_interface_fq: None,
+                        reexport_origin: Some((source.clone(), func.name.clone())),
+                    });
+                }
+                _ if lib_type_decl_name(item).is_some()
+                    && item.visibility().is_some_and(ast::Visibility::is_public) =>
+                {
+                    submodule_type_decls.push((source.clone(), item.clone()));
+                }
+                _ => {}
             }
-            out.push(WorldExportInfo {
-                name: func.name.clone(),
-                is_async: func.is_async,
-                params: func
-                    .params
-                    .iter()
-                    .map(|p| (p.name.clone(), p.ty.clone()))
-                    .collect(),
-                return_type: func.return_type.clone(),
-                from_interface_fq: None,
-                reexport_origin: Some((source.clone(), func.name.clone())),
-            });
         }
     }
-    out
+    LibSurface {
+        submodule_exports,
+        submodule_type_decls,
+    }
 }
 
-/// Named type decls in the library's non-entry local modules. These reach the
-/// public surface through the facade (an `export fn` names them), so they must
-/// be registered as lib-local CM types alongside the entry module's own.
-fn collect_nonentry_lib_type_decls(
-    entry_source: &ModuleSource,
-    modules: &crate::hashmap::IndexMap<ModuleSource, ast::Module>,
-) -> Vec<(ModuleSource, ast::Item)> {
-    use crate::ast::Item;
-
-    let mut out = Vec::new();
-    for (source, module) in modules {
-        if source == entry_source || !source.is_local() {
-            continue;
-        }
-        for item in &module.items {
-            if matches!(
-                item,
-                Item::Struct(_)
-                    | Item::Enum(_)
-                    | Item::Variant(_)
-                    | Item::Flags(_)
-                    | Item::Newtype(_)
-            ) {
-                out.push((source.clone(), item.clone()));
-            }
+fn first_duplicate<'a>(names: impl IntoIterator<Item = &'a str>) -> Option<String> {
+    let mut seen = crate::hashmap::IndexSet::default();
+    for name in names {
+        if !seen.insert(name.to_string()) {
+            return Some(name.to_string());
         }
     }
-    out
+    None
 }
 
 /// The declared name of a type-kind item, or `None` for non-type items.
@@ -885,45 +871,87 @@ fn compile_after_load<H: CompilerHost>(
         .or_else(|| is_kiln_generator.then(|| KILN_GENERATOR_IMPL_FQ.to_string()));
     // A kiln generator's `generate` lives in the entry module; only a real
     // `--lib` package spreads its API (and the types it exposes) across
-    // submodules. Captured here (owned) so they outlive the `sem` destructure
+    // submodules. Captured here (owned) so it outlives the `sem` destructure
     // below and can be registered into the CM interface registry.
-    let mut lib_submodule_type_decls: Vec<(ModuleSource, ast::Item)> =
-        if options.lib_world.is_some() {
-            collect_nonentry_lib_type_decls(&sem.entry_module_source, &sem.modules)
-        } else {
-            Vec::new()
-        };
-    let lib_submodule_type_names: crate::hashmap::IndexSet<String> = lib_submodule_type_decls
-        .iter()
-        .filter_map(|(_, item)| lib_type_decl_name(item))
-        .collect();
-    // Tag nested user types inside the submodule decls' own fields, so a type
-    // like `HeadingInfo` reached only through `RenderResult.headings` resolves
-    // against the same lib-local registration. The name set spans every
-    // lib-local type (entry module + submodules).
-    if let Some(fq) = synth_world_fq.as_ref() {
-        let mut all_lib_type_names = lib_submodule_type_names.clone();
-        if let Some(entry) = sem.modules.get(&sem.entry_module_source) {
-            for item in &entry.items {
-                if let Some(name) = lib_type_decl_name(item) {
-                    all_lib_type_names.insert(name);
-                }
-            }
+    let mut lib_surface = if options.lib_world.is_some() {
+        collect_lib_surface(&sem.entry_module_source, &sem.modules)
+    } else {
+        LibSurface {
+            submodule_exports: Vec::new(),
+            submodule_type_decls: Vec::new(),
         }
-        for (_, decl) in &mut lib_submodule_type_decls {
-            tag_lib_local_decl_fields(decl, fq, &all_lib_type_names);
+    };
+
+    let entry_type_names: Vec<String> = sem
+        .modules
+        .get(&sem.entry_module_source)
+        .map(|m| m.items.iter().filter_map(lib_type_decl_name).collect())
+        .unwrap_or_default();
+    let lib_type_names: crate::hashmap::IndexSet<String> = entry_type_names
+        .iter()
+        .cloned()
+        .chain(
+            lib_surface
+                .submodule_type_decls
+                .iter()
+                .filter_map(|(_, item)| lib_type_decl_name(item)),
+        )
+        .collect();
+
+    if options.lib_world.is_some() {
+        let all_names: Vec<String> = entry_type_names
+            .iter()
+            .cloned()
+            .chain(
+                lib_surface
+                    .submodule_type_decls
+                    .iter()
+                    .filter_map(|(_, item)| lib_type_decl_name(item)),
+            )
+            .collect();
+        if let Some(dup) = first_duplicate(all_names.iter().map(String::as_str)) {
+            let _ = logger.error(compiler_host::Diagnostic {
+                severity: compiler_host::Severity::Error,
+                code: compiler_host::Code::DuplicateDefinition,
+                message: format!(
+                    "library type `{dup}` is defined in more than one module; a \
+                     library's public types must have distinct names"
+                ),
+                span: None,
+            });
+            return Err(Bail);
+        }
+    }
+
+    // Tag nested user types inside each submodule decl's own fields, so a type
+    // like `HeadingInfo` reached only through `RenderResult.headings` resolves
+    // against the same lib-local registration as the fields the lift/lower reads.
+    if let Some(fq) = synth_world_fq.as_ref() {
+        for (_, decl) in &mut lib_surface.submodule_type_decls {
+            tag_lib_local_decl_fields(decl, fq, &lib_type_names);
         }
     }
 
     let mut lib_world_info = synth_world_fq.as_ref().map(|fq| {
         let entry = sem.modules.get(&sem.entry_module_source);
-        let nonentry = if options.lib_world.is_some() {
-            collect_nonentry_lib_exports(&sem.entry_module_source, &sem.modules)
-        } else {
-            Vec::new()
-        };
-        synthesize_lib_world_info(fq, entry, &nonentry, &lib_submodule_type_names)
+        synthesize_lib_world_info(fq, entry, &lib_surface.submodule_exports, &lib_type_names)
     });
+
+    if options.lib_world.is_some()
+        && let Some(world) = lib_world_info.as_ref()
+        && let Some(dup) = first_duplicate(world.exports.iter().map(|e| e.name.as_str()))
+    {
+        let _ = logger.error(compiler_host::Diagnostic {
+            severity: compiler_host::Severity::Error,
+            code: compiler_host::Code::DuplicateDefinition,
+            message: format!(
+                "library exports two functions named `{dup}`; a library's \
+                 `export fn`s must have distinct names"
+            ),
+            span: None,
+        });
+        return Err(Bail);
+    }
 
     if is_kiln_generator && let Some(world) = lib_world_info.as_mut() {
         // Only `generate` is the generator world's contract; a helper
@@ -1020,7 +1048,7 @@ fn compile_after_load<H: CompilerHost>(
         let registry = std::sync::Arc::make_mut(&mut tysys.cm_interface_registry);
         registry.register_lib_local_decls(entry, fq, entry_module_source.clone());
         // Submodule-defined types reachable through the facade's exports.
-        registry.register_lib_local_items(&lib_submodule_type_decls, fq);
+        registry.register_lib_local_items(&lib_surface.submodule_type_decls, fq);
     }
 
     debug_assert_eq!(
@@ -1993,7 +2021,7 @@ export fn id_bool(v: bool) -> bool { return v; }
             "wado:mylib/mylib@0.1.0",
             Some(&module),
             &[],
-            &Default::default(),
+            &crate::hashmap::IndexSet::default(),
         );
 
         assert_eq!(world.fq_name, "wado:mylib/mylib@0.1.0");
@@ -2012,7 +2040,12 @@ export fn id_bool(v: bool) -> bool { return v; }
 
     #[test]
     fn empty_when_no_entry_module() {
-        let world = synthesize_lib_world_info("wado:x/x@0.1.0", None, &[], &Default::default());
+        let world = synthesize_lib_world_info(
+            "wado:x/x@0.1.0",
+            None,
+            &[],
+            &crate::hashmap::IndexSet::default(),
+        );
         assert!(world.exports.is_empty());
     }
 
@@ -2031,7 +2064,7 @@ export fn id_points(v: List<Point>) -> List<Point> { return v; }
             "wado:geo/geo@0.1.0",
             Some(&module),
             &[],
-            &Default::default(),
+            &crate::hashmap::IndexSet::default(),
         );
         assert!(
             world
@@ -2051,8 +2084,12 @@ export fn id_list(v: List<u8>) -> List<u8> { return v; }
 export fn id_opt(v: Option<String>) -> Option<String> { return v; }
 "#;
         let module = super::parse(src).ast;
-        let world =
-            synthesize_lib_world_info("wado:c/c@0.1.0", Some(&module), &[], &Default::default());
+        let world = synthesize_lib_world_info(
+            "wado:c/c@0.1.0",
+            Some(&module),
+            &[],
+            &crate::hashmap::IndexSet::default(),
+        );
         assert!(
             world.exports.iter().all(|e| e.from_interface_fq.is_none()),
             "primitive containers do not force an interface",

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -465,41 +465,71 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
             let binding_cm_package = world_info.package().to_string();
 
             for export in &world_info.exports {
-                // Find the user's export function and check for missing `export` keyword
-                let mut found_exported = None;
-                let mut found_without_export = false;
-                for f in &entry_module.functions {
-                    let func = f.borrow();
-                    if func.name == export.name {
-                        if func.is_export {
-                            found_exported = Some(f.clone());
-                        } else {
-                            found_without_export = true;
+                // A library spreads its `export fn`s across submodules; an
+                // export defined outside the entry module carries its origin
+                // module, and the adapter calls it there. The callee's module
+                // is the `tir_modules` key (a function's own `module_source` is
+                // not set until link, which runs after this synthesis).
+                let callee_module = export
+                    .reexport_origin
+                    .as_ref()
+                    .map(|(m, _)| m.clone())
+                    .unwrap_or_else(|| entry_source.clone());
+                let user_func_rc = if let Some((origin_module, origin_name)) =
+                    &export.reexport_origin
+                {
+                    let origin = project.tir_modules.get(origin_module).and_then(|m| {
+                        m.functions
+                            .iter()
+                            .find(|f| f.borrow().name == *origin_name)
+                            .cloned()
+                    });
+                    match origin {
+                        Some(f) => f,
+                        None => {
+                            return Err(format!(
+                                "re-exported function `{}` (origin `{}`) is not defined",
+                                export.name, origin_name
+                            ));
                         }
                     }
-                }
+                } else {
+                    // Find the user's export function and check for missing `export` keyword
+                    let mut found_exported = None;
+                    let mut found_without_export = false;
+                    for f in &entry_module.functions {
+                        let func = f.borrow();
+                        if func.name == export.name {
+                            if func.is_export {
+                                found_exported = Some(f.clone());
+                            } else {
+                                found_without_export = true;
+                            }
+                        }
+                    }
 
-                if found_exported.is_none() && found_without_export {
-                    return Err(format!(
-                        "function `{}` exists but is not marked with `export` keyword. \
-                         Add `export` to make it a world entry point: `export fn {}(...)`",
-                        export.name, export.name
-                    ));
-                }
+                    if found_exported.is_none() && found_without_export {
+                        return Err(format!(
+                            "function `{}` exists but is not marked with `export` keyword. \
+                             Add `export` to make it a world entry point: `export fn {}(...)`",
+                            export.name, export.name
+                        ));
+                    }
 
-                // A world export with no function at all is a missing entry
-                // point. The test world handles `test` blocks separately and
-                // never reaches this loop, so in CLI / HTTP / other worlds the
-                // entry must be defined — never silently stubbed.
-                if found_exported.is_none() {
-                    return Err(format!(
-                        "function `{}` is required as a world entry point but is not defined. \
-                         Define it with: `export fn {}(...)`",
-                        export.name, export.name
-                    ));
-                }
+                    // A world export with no function at all is a missing entry
+                    // point. The test world handles `test` blocks separately and
+                    // never reaches this loop, so in CLI / HTTP / other worlds the
+                    // entry must be defined — never silently stubbed.
+                    if found_exported.is_none() {
+                        return Err(format!(
+                            "function `{}` is required as a world entry point but is not defined. \
+                             Define it with: `export fn {}(...)`",
+                            export.name, export.name
+                        ));
+                    }
 
-                let user_func_rc = found_exported.expect("required export presence verified above");
+                    found_exported.expect("required export presence verified above")
+                };
                 let binding_name = export_binding_func_name(&export.name);
                 let adapter = {
                     // Validate parameter count matches world declaration
@@ -622,7 +652,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                         synthesize_async_export_binding(
                             &export.name,
                             user_func_rc,
-                            &entry_source,
+                            &callee_module,
                             &project.tir_modules,
                             &entry_type_table,
                             &export.params,
@@ -637,7 +667,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                         synthesize_sync_export_binding(
                             &export.name,
                             user_func_rc,
-                            &entry_source,
+                            &callee_module,
                             &project.tir_modules,
                             &entry_type_table,
                             &export.params,
@@ -673,7 +703,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                             synthesize_result_export_binding(
                                 &export.name,
                                 user_func_rc,
-                                &entry_source,
+                                &callee_module,
                                 export.return_type.as_ref().unwrap(),
                                 &flat_types,
                                 &project.tir_modules,
@@ -697,7 +727,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                                 synthesize_void_export_binding(
                                     &export.name,
                                     user_func_rc,
-                                    &entry_source,
+                                    &callee_module,
                                 )
                             } else {
                                 // Sync export returning a plain value (not a
@@ -713,7 +743,7 @@ pub fn generate_adapters(mut project: Package) -> Result<Package, String> {
                                 synthesize_sync_export_binding(
                                     &export.name,
                                     user_func_rc,
-                                    &entry_source,
+                                    &callee_module,
                                     &project.tir_modules,
                                     &entry_type_table,
                                     &export.params,

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -1361,7 +1361,7 @@ fn build_export_adapter_params(
 pub(super) fn synthesize_result_export_binding(
     export_name: &str,
     user_func: Rc<RefCell<TirFunction>>,
-    entry_source: &ModuleSource,
+    callee_module: &ModuleSource,
     _return_type: &Type,
     flat_return_types: &[cm_abi::CmValType],
     tir_modules: &IndexMap<ModuleSource, TirModule>,
@@ -1476,7 +1476,7 @@ pub(super) fn synthesize_result_export_binding(
         user_func.borrow().params.iter().map(|p| p.is_mut).collect();
     let call_user = TirExpr::new(
         TirExprKind::Call {
-            func: FunctionRef::from_resolved(&user_func.borrow(), entry_source.clone()),
+            func: FunctionRef::from_resolved(&user_func.borrow(), callee_module.clone()),
             type_args: vec![],
             args: call_args
                 .into_iter()
@@ -1881,7 +1881,7 @@ pub(super) fn synthesize_variant_lower_to_flat(
 pub(super) fn synthesize_void_export_binding(
     export_name: &str,
     user_func: Rc<RefCell<TirFunction>>,
-    entry_source: &ModuleSource,
+    callee_module: &ModuleSource,
 ) -> Rc<RefCell<TirFunction>> {
     let binding_name = export_binding_func_name(export_name);
     let mut body_stmts: Vec<TirStmt> = Vec::new();
@@ -1889,7 +1889,7 @@ pub(super) fn synthesize_void_export_binding(
     // Call the user's export function
     let call_user = TirExpr::new(
         TirExprKind::Call {
-            func: FunctionRef::from_resolved(&user_func.borrow(), entry_source.clone()),
+            func: FunctionRef::from_resolved(&user_func.borrow(), callee_module.clone()),
             type_args: vec![],
             args: vec![],
         },
@@ -1935,7 +1935,7 @@ pub(super) fn synthesize_void_export_binding(
 pub(super) fn synthesize_sync_export_binding(
     export_name: &str,
     user_func: Rc<RefCell<TirFunction>>,
-    entry_source: &ModuleSource,
+    callee_module: &ModuleSource,
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     type_table: &Rc<RefCell<TypeTable>>,
     world_params: &[(String, Type)],
@@ -1971,7 +1971,7 @@ pub(super) fn synthesize_sync_export_binding(
         user_func.borrow().params.iter().map(|p| p.is_mut).collect();
     let call_user = TirExpr::new(
         TirExprKind::Call {
-            func: FunctionRef::from_resolved(&user_func.borrow(), entry_source.clone()),
+            func: FunctionRef::from_resolved(&user_func.borrow(), callee_module.clone()),
             type_args: vec![],
             args: call_args
                 .into_iter()
@@ -2119,7 +2119,7 @@ pub(super) fn synthesize_sync_export_binding(
 pub(super) fn synthesize_async_export_binding(
     export_name: &str,
     user_func: Rc<RefCell<TirFunction>>,
-    entry_source: &ModuleSource,
+    callee_module: &ModuleSource,
     tir_modules: &IndexMap<ModuleSource, TirModule>,
     type_table: &Rc<RefCell<TypeTable>>,
     world_params: &[(String, Type)],
@@ -2223,7 +2223,7 @@ pub(super) fn synthesize_async_export_binding(
         user_func.borrow().params.iter().map(|p| p.is_mut).collect();
     let call_user = TirExpr::new(
         TirExprKind::Call {
-            func: FunctionRef::from_resolved(&user_func.borrow(), entry_source.clone()),
+            func: FunctionRef::from_resolved(&user_func.borrow(), callee_module.clone()),
             type_args: vec![],
             args: call_args
                 .into_iter()

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -296,6 +296,14 @@ pub fn cm_type_to_type_id(
                         .and_then(|fq| registry.cm_interface_module_source_of(fq))
                         .and_then(|ms| type_table.find_named_type_by_source(&named.name, ms))
                 })
+                // A lib-local type defined in a submodule: the interface FQ maps
+                // to the entry module, so resolve via the type's own recorded
+                // module instead.
+                .or_else(|| {
+                    registry
+                        .lib_local_type_source(&named.name)
+                        .and_then(|ms| type_table.find_named_type_by_source(&named.name, ms))
+                })
                 .unwrap_or(TypeTable::I32),
         },
         Type::Generic(g) => {

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -245,6 +245,7 @@ fn build_world_export_plans(
             params: vec![],
             return_type: None,
             from_interface_fq: None,
+            reexport_origin: None,
         }]
     });
 

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -9,6 +9,7 @@
 use crate::hashmap::IndexMap;
 
 use crate::ast::{Type, WorldDecl, WorldExport, WorldExportFn, WorldImport};
+use crate::module_source::ModuleSource;
 
 /// Well-known world name for the test world.
 ///
@@ -40,6 +41,12 @@ pub struct WorldExportInfo {
     /// `"wasi:http/handler@0.3.0"`). `None` for direct
     /// `export fn ...` declarations.
     pub from_interface_fq: Option<String>,
+    /// For an `export use` re-export: the origin module and the origin
+    /// function's own name (which differs from `name` when the re-export is
+    /// aliased). The codegen adapter calls the origin `pub fn` instead of
+    /// expecting an `export fn name` in the entry module. `None` for a direct
+    /// `export fn` in the entry module.
+    pub reexport_origin: Option<(ModuleSource, String)>,
 }
 
 impl WorldExportInfo {
@@ -59,6 +66,7 @@ impl WorldExportInfo {
             params,
             return_type: export.return_type.clone(),
             from_interface_fq: None,
+            reexport_origin: None,
         }
     }
 
@@ -316,6 +324,7 @@ impl WorldRegistry {
                             params: method.params,
                             return_type: method.return_type,
                             from_interface_fq: Some(lookup.cm_interface_fq.clone()),
+                            reexport_origin: None,
                         });
                     }
                 }
@@ -575,6 +584,7 @@ mod tests {
             params: vec![],
             return_type: Some(result_return("Response", "ErrorCode")),
             from_interface_fq: Some("wasi:http/handler@0.3.0".to_string()),
+            reexport_origin: None,
         };
         let mut http_world = world_info("wasi:http/service");
         http_world.exports.push(http_handler);
@@ -594,6 +604,7 @@ mod tests {
             params: vec![],
             return_type: Some(result_return("Widget", "WidgetError")),
             from_interface_fq: Some("acme:widget/handler@1.0.0".to_string()),
+            reexport_origin: None,
         });
         assert!(
             widget_world.exports[0].is_handler_instance_export(),
@@ -620,6 +631,7 @@ mod tests {
             params: vec![],
             return_type: Some(result_return_unit()),
             from_interface_fq: Some("wasi:http/run@1.0.0".to_string()),
+            reexport_origin: None,
         });
         assert!(!unit_export.exports[0].is_handler_instance_export());
         assert!(!unit_export.has_http_handler_export());


### PR DESCRIPTION
Make a `--lib` package whose public API is spread across submodules build into a real, consumable Component Model component — and use it to expose Marl (`render` / `format`) so a consumer can pull `wado-lang:marl` from the registry.

## The problem

A library keeps `export` on the declaration (the single source of truth) and surfaces its API through a `pub use` facade in the entry module (`lib.wado`). Previously the `--lib` world synthesis only saw the *entry module's own* `export fn`s, so a facade produced a component that advertised the functions in its WIT but exported nothing callable — a consumer got `symbol 'X' not found`. Marl's `render` was in exactly this shape, so the earlier `export fn` change (first commit) didn't actually make it consumable.

## The fix (second commit)

- **Module-wide export collection.** The lib world now gathers `export fn`s across every local module, tagging each non-entry export with its origin module.
- **Cross-module export adapter.** The synthesized `__cm_export__` adapter calls the function in its origin module — the `tir_modules` key, since a `TirFunction`'s own `module_source` is unset until link (which runs after this synthesis). Previously it hard-coded the entry module and the call failed to resolve (`[WIR] unresolved Call`).
- **Lib-local type resolution across submodules.** A submodule-defined public type is registered with its real module source, so a nested type like `HeadingInfo` inside `RenderResult { headings: List<HeadingInfo> }` resolves to the actual struct instead of falling back to an `i32` handle (which crashed the list-of-records lowering).
- **Zero-export guard.** A `--lib` whose world has no exports is now a compile error instead of an empty component.

## Result

`wado build --lib` on `package-marl` emits `interface marl { record render-result; record heading-info; format; render }`, and a consumer importing `wado-lang:marl` runs `Marl::render("# Hi\n\nHello *world*.")` across the CM boundary, returning `<h1 id="hi">Hi</h1>\n<p>Hello <em>world</em>.</p>`.

## Verification

- Full `mise run test` green (unit + O0/O1/O2 e2e fixture sweep), no regressions; `cargo clippy` clean on both crates.
- New CLI tests: a facade `--lib` with a nested `List<record>` export builds and emits the grouped interface; a `--lib` with no `export fn` is rejected.
- Manual end-to-end: Marl built as `--lib`, cached, and consumed via `Marl::render`.

## Follow-up (separate)

The Sheaf site can then switch its Marl import from vendored source to `wado-lang:marl` (using the `Marl::` namespace form), once a release publishes this component to ghcr. The `escape_text` / `escape_attr` helpers stay `pub` (Wado-native) for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrNa2dR3XekiV3sE2xo9jd