### PR TITLE
fix(publish): unblock releasing facade/types-only libraries; export marl escape helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,11 @@ jobs:
 
       - run: mise run test-wado
 
+      # Reuses the `wado` build from the step above; `--dry-run` builds every
+      # publishable world (catching a package that no longer compiles into a
+      # component) without pushing, so no wkg or credentials are needed.
+      - run: cargo run --locked -p wado-cli -- publish --dry-run
+
   test-gale-o1:
     name: Test (Gale O1)
     needs: changes

--- a/package-marl/src/html.wado
+++ b/package-marl/src/html.wado
@@ -1,13 +1,13 @@
 //! HTML escaping and URL sanitization helpers.
 
 /// Escape text for use in HTML element content: `&`, `<`, `>`.
-pub fn escape_text(s: String) -> String {
+export fn escape_text(s: String) -> String {
     return escape_text_ref(&s);
 }
 
 /// Escape text for use in a double-quoted HTML attribute value:
 /// element-content escapes plus `"`.
-pub fn escape_attr(s: String) -> String {
+export fn escape_attr(s: String) -> String {
     return escape_attr_ref(&s);
 }
 

--- a/wado-cli/src/publish.rs
+++ b/wado-cli/src/publish.rs
@@ -3,8 +3,9 @@
 //! A facade over the build path and `wkg`: it runs the publish-readiness checks
 //! ([`wado_manifest::validate_for_publish`]), builds each publishable world's
 //! component with `[package]` metadata embedded, then shells out to `wkg oci
-//! push` to upload each as an OCI artifact. `--dry-run` stops after the checks
-//! and reports any problems without building or uploading.
+//! push` to upload each as an OCI artifact. `--dry-run` builds every world and
+//! runs the readiness checks but skips the OCI push, so a CI check can catch a
+//! package that no longer builds into a publishable component.
 //!
 //! Each world is a distinct artifact: the library world publishes to the bare
 //! repository `<prefix>/<ns>/<name>`, and every other `[world]` entry (unless
@@ -47,7 +48,7 @@ fn format_usage() -> String {
     writeln!(buf, "Options:").unwrap();
     writeln!(
         buf,
-        "      --dry-run  Run publish-readiness checks without building or uploading"
+        "      --dry-run  Build every world and run readiness checks without uploading"
     )
     .unwrap();
     writeln!(buf, "  -h, --help     Show this help message").unwrap();
@@ -156,12 +157,7 @@ fn classify(manifest: &Manifest) -> Verdict {
 async fn publish_single(project: &ProjectManifest, dry_run: bool) -> Result<(), CliExit> {
     match classify(&project.manifest) {
         Verdict::Ready(coord) => {
-            if dry_run {
-                eprintln!("{coord} is ready to publish");
-                Ok(())
-            } else {
-                publish_package(project, &coord, &project.manifest.registries).await
-            }
+            publish_package(project, &coord, &project.manifest.registries, dry_run).await
         }
         Verdict::Failed(problems) => Err(problems_error(
             "package is not ready to publish:",
@@ -235,20 +231,18 @@ async fn publish_workspace(root: &ProjectManifest, dry_run: bool) -> Result<(), 
         return Err(CliExit::error("no publishable packages in this workspace"));
     }
 
-    if dry_run {
-        let coords: Vec<&str> = ready.iter().map(|(c, _)| c.as_str()).collect();
-        eprintln!(
-            "{} package(s) ready to publish: {}",
-            coords.len(),
-            coords.join(", ")
-        );
-        return Ok(());
-    }
-
     // Publish is a root-only operation, so every member resolves against the
     // workspace root's `[registries]`, not its own.
     for (coord, project) in &ready {
-        publish_package(project, coord, &root.manifest.registries).await?;
+        publish_package(project, coord, &root.manifest.registries, dry_run).await?;
+    }
+    if dry_run {
+        let coords: Vec<&str> = ready.iter().map(|(c, _)| c.as_str()).collect();
+        eprintln!(
+            "(dry-run) {} package(s) build and validate: {}",
+            coords.len(),
+            coords.join(", ")
+        );
     }
     Ok(())
 }
@@ -314,6 +308,7 @@ async fn publish_package(
     project: &ProjectManifest,
     coord: &str,
     registries: &indexmap::IndexMap<String, String>,
+    dry_run: bool,
 ) -> Result<(), CliExit> {
     let pkg = project
         .manifest
@@ -326,7 +321,7 @@ async fn publish_package(
             "{coord} declares no publishable world; add `[package].lib` or a `[world]` entry"
         )));
     }
-    if crate::metadata_embed::working_tree_dirty(&project.root) == Some(true) {
+    if !dry_run && crate::metadata_embed::working_tree_dirty(&project.root) == Some(true) {
         eprintln!(
             "warning: working tree has uncommitted changes; publishing {coord} \
              without a `revision` annotation"
@@ -338,15 +333,22 @@ async fn publish_package(
             BuildWorld::Lib(fq) => (Some(fq.clone()), None),
             BuildWorld::Hosted(fq) => (None, Some(fq.clone())),
         };
+        // Build even on a dry run: it is what catches a package that no longer
+        // compiles into a publishable component (e.g. a `--lib` that exports
+        // nothing), the failure mode a dry run exists to surface before release.
         crate::compile::build_publish_world(&target.entry, &target.output, lib_world, target_world)
             .await?;
-        eprintln!(
-            "Publishing {coord} ({}) -> {reference}",
-            target.subpath.as_deref().unwrap_or("lib")
-        );
-        wkg_oci_push(&reference, &target.output)?;
+        let world = target.subpath.as_deref().unwrap_or("lib");
+        if dry_run {
+            eprintln!("(dry-run) {coord} ({world}) builds; would push -> {reference}");
+        } else {
+            eprintln!("Publishing {coord} ({world}) -> {reference}");
+            wkg_oci_push(&reference, &target.output)?;
+        }
     }
-    eprintln!("Published {coord} ({} artifact(s))", targets.len());
+    if !dry_run {
+        eprintln!("Published {coord} ({} artifact(s))", targets.len());
+    }
     Ok(())
 }
 

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -806,8 +806,8 @@ fn test_lib_facade_submodule_export_with_nested_records() {
 
 #[test]
 fn test_lib_without_exports_is_rejected() {
-    // A `--lib` whose modules define no `export fn` produces a component that
-    // exposes nothing; reject it rather than emit an empty library.
+    // A `--lib` with neither an `export fn` nor a public type exports nothing;
+    // reject it rather than emit an empty library.
     let tmp = tempfile::tempdir().unwrap();
     let dir = tmp.path();
     std::fs::write(
@@ -825,6 +825,74 @@ fn test_lib_without_exports_is_rejected() {
     wado_in(dir)
         .arg("build")
         .arg("--lib")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("exports nothing"));
+}
+
+#[test]
+fn test_lib_with_only_public_types_is_accepted() {
+    // A data-model library (like `jade`) exposes only public types and no
+    // `export fn`. Its component surface is those types, so `--lib` must build
+    // it, not reject it as empty.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(
+        dir.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"model\"\nversion = \"0.1.0\"\nlib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "pub struct Point { pub x: i32, pub y: i32 }\n",
+    )
+    .unwrap();
+
+    wado_in(dir).arg("build").arg("--lib").assert().success();
+}
+
+const PUBLISHABLE_HEADER: &str = "[package]\nnamespace = \"acme\"\nname = \"pkg\"\nversion = \"0.1.0\"\ndescription = \"d\"\nrepository = \"https://x/y\"\nlicense = \"MIT\"\nauthors = [\"A\"]\nlib = \"src/lib.wado\"\n\n[registries]\ndefault = \"oci://ghcr.io\"\n";
+
+#[test]
+fn test_publish_dry_run_builds_without_pushing() {
+    // `--dry-run` builds each world (proving it still compiles into a component)
+    // but skips the OCI push, so it succeeds without wkg or credentials.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(dir.join("wado.toml"), PUBLISHABLE_HEADER).unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "export fn ping() -> i32 { return 1; }\n",
+    )
+    .unwrap();
+
+    wado_in(dir)
+        .arg("publish")
+        .arg("--dry-run")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("dry-run"));
+}
+
+#[test]
+fn test_publish_dry_run_catches_unpublishable_component() {
+    // The dry run builds, so a `--lib` that exports nothing fails it — the
+    // release-time failure the CI check is meant to surface at PR time.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(dir.join("wado.toml"), PUBLISHABLE_HEADER).unwrap();
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("src").join("lib.wado"),
+        "pub fn helper() -> i32 { return 0; }\n",
+    )
+    .unwrap();
+
+    wado_in(dir)
+        .arg("publish")
+        .arg("--dry-run")
         .assert()
         .failure()
         .stderr(predicate::str::contains("exports nothing"));

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -898,6 +898,17 @@ fn compile_after_load<H: CompilerHost>(
         )
         .collect();
 
+    // A data-model library exposes public types with no `export fn`; those types
+    // are its component surface. Submodule type decls are already public-only;
+    // the entry module's are filtered here.
+    let lib_has_public_type = !lib_surface.submodule_type_decls.is_empty()
+        || sem.modules.get(&sem.entry_module_source).is_some_and(|m| {
+            m.items.iter().any(|item| {
+                lib_type_decl_name(item).is_some()
+                    && item.visibility().is_some_and(ast::Visibility::is_public)
+            })
+        });
+
     if options.lib_world.is_some() {
         let all_names: Vec<String> = entry_type_names
             .iter()
@@ -990,12 +1001,13 @@ fn compile_after_load<H: CompilerHost>(
         }
     }
 
-    // A `--lib` build whose world has no exports produces a component that
-    // exposes nothing — almost always a facade that forgot `export`, or a
-    // package with no public API. Reject it rather than emit an empty library.
+    // A `--lib` with neither an `export fn` nor a public type exports nothing —
+    // almost always a facade that forgot `export`. Reject it rather than emit an
+    // empty library. A data-model library (only public types) is valid and kept.
     if options.lib_world.is_some()
         && let Some(world) = lib_world_info.as_ref()
         && world.exports.is_empty()
+        && !lib_has_public_type
     {
         let _ = logger.error(compiler_host::Diagnostic {
             severity: compiler_host::Severity::Error,


### PR DESCRIPTION
## Background

The **v0.0.15** release's `wado publish` job failed. It published `cm-catalog` and `gale`, then died on **`jade`** with:

```
error: a library (`--lib`) exports nothing; mark at least one function `export fn` so the component has a public API
```

`jade` is a types-only data model (JSON Schema): all `pub` types and `Serialize` impls, no `export fn`. The zero-export guard added in #1576 rejected it, and because one package's failure aborts the whole workspace publish, **`marl` never published** (`wado-lang:marl@0.0.15` is absent from ghcr). `jade` had published fine at 0.0.9–0.0.14, so this was a regression.

## Changes

**compiler — allow a types-only library.** The `--lib` zero-export guard now fires only when a library has **neither** an `export fn` **nor** a public type. A data-model library that exposes only public types (`jade`) is valid again and builds. A facade that genuinely exposes nothing is still rejected.

**cli — `wado publish --dry-run` builds every world.** Previously `--dry-run` stopped after the metadata checks without building, so it could not catch a package that no longer compiles into a publishable component. It now builds each world (surfacing exactly this failure) while skipping the OCI push, so it needs no `wkg` or credentials. The **`test-wado`** CI job runs `wado publish --dry-run` (reusing its `wado` build), so publish breakage shows up at PR time instead of at release.

**marl — export the escape helpers.** `escape_text` / `escape_attr` become `export fn`, so marl's component exports them alongside `render` / `format`; a consumer can call them across the CM boundary (they were `pub`-only before).

## Result

`wado publish --dry-run` from the workspace root builds all four packages — `cm-catalog`, `gale`, `jade`, `marl` — and reports success. The next release publishes `marl` (now including `escape-text` / `escape-attr` in its WIT).

## Follow-up (separate)

Once a release publishes `marl` with the escape exports, the Sheaf site can switch its Marl import from vendored source to `wado-lang:marl` and drop the `.tmp/wado` clone dependency entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrNa2dR3XekiV3sE2xo9jd