### PR TITLE
fix(gale): don't over-shadow a named single-literal lexer rule

### DIFF
--- a/example/Wado.g4
+++ b/example/Wado.g4
@@ -82,7 +82,7 @@ useDecl
     ;
 
 importGroup
-    : OPEN_BRACE importList? CLOSE_BRACE
+    : '{' importList? '}'
     | IDENTIFIER
     | '_'
     ;
@@ -145,7 +145,7 @@ storesItem
     ;
 
 structDecl
-    : 'struct' IDENTIFIER genericParams? OPEN_BRACE fieldList? CLOSE_BRACE
+    : 'struct' IDENTIFIER genericParams? '{' fieldList? '}'
     ;
 
 fieldList
@@ -157,7 +157,7 @@ fieldDecl
     ;
 
 enumDecl
-    : 'enum' IDENTIFIER OPEN_BRACE enumCaseList? CLOSE_BRACE
+    : 'enum' IDENTIFIER '{' enumCaseList? '}'
     ;
 
 enumCaseList
@@ -169,7 +169,7 @@ enumCase
     ;
 
 flagsDecl
-    : 'flags' IDENTIFIER OPEN_BRACE flagsCaseList? CLOSE_BRACE
+    : 'flags' IDENTIFIER '{' flagsCaseList? '}'
     ;
 
 flagsCaseList
@@ -181,7 +181,7 @@ flagsCase
     ;
 
 variantDecl
-    : 'variant' IDENTIFIER genericParams? OPEN_BRACE variantCaseList? CLOSE_BRACE
+    : 'variant' IDENTIFIER genericParams? '{' variantCaseList? '}'
     ;
 
 variantCaseList
@@ -193,18 +193,18 @@ variantCase
     ;
 
 traitDecl
-    : 'trait' IDENTIFIER genericParams? OPEN_BRACE traitMember* CLOSE_BRACE
+    : 'trait' IDENTIFIER genericParams? '{' traitMember* '}'
     ;
 
 // A WIT-style interface: a named set of function signatures (and associated
 // types), modeled with the same members as a trait.
 interfaceDecl
-    : 'interface' IDENTIFIER genericParams? OPEN_BRACE traitMember* CLOSE_BRACE
+    : 'interface' IDENTIFIER genericParams? '{' traitMember* '}'
     ;
 
 // A WIT-style world: a set of `import` / `export` items naming interfaces.
 worldDecl
-    : 'world' IDENTIFIER OPEN_BRACE worldItem* CLOSE_BRACE
+    : 'world' IDENTIFIER '{' worldItem* '}'
     ;
 
 worldItem
@@ -214,7 +214,7 @@ worldItem
 // A WIT-style resource: an opaque handle with method / static-function
 // signatures (or a bodyless unit resource `resource X;`).
 resourceDecl
-    : 'resource' IDENTIFIER genericParams? (OPEN_BRACE resourceMember* CLOSE_BRACE | ';')
+    : 'resource' IDENTIFIER genericParams? ('{' resourceMember* '}' | ';')
     ;
 
 resourceMember
@@ -231,7 +231,7 @@ traitMemberBody
     ;
 
 implBlock
-    : 'impl' genericParams? typeRef ('for' typeRef)? (OPEN_BRACE implMember* CLOSE_BRACE | ';')
+    : 'impl' genericParams? typeRef ('for' typeRef)? ('{' implMember* '}' | ';')
     ;
 
 implMember
@@ -310,7 +310,7 @@ memberName
 
 // Optional trailing expression with no `;` is the block's value (`{ 1 }`).
 block
-    : OPEN_BRACE statement* expression? CLOSE_BRACE
+    : '{' statement* expression? '}'
     ;
 
 statement
@@ -460,7 +460,7 @@ postfixOp
     | '::' typeArgs '(' argumentList? ')'
     | '.' (memberName ('::' typeArgs)? ('(' argumentList? ')')? | INTEGER | FLOAT)
     | '[' expression ']'
-    | 'matches' OPEN_BRACE pattern ('&&' expression)? CLOSE_BRACE
+    | 'matches' '{' pattern ('&&' expression)? '}'
     | '?'
     ;
 
@@ -501,7 +501,7 @@ withBinding
 // `TreeMap<String, V>` by context. Excluded from `primaryNoStruct` because a
 // `{` after an `if`/`while`/`for` header opens the body.
 mapLiteral
-    : OPEN_BRACE (mapEntry (',' mapEntry)* ','?)? CLOSE_BRACE
+    : '{' (mapEntry (',' mapEntry)* ','?)? '}'
     ;
 
 mapEntry
@@ -563,7 +563,7 @@ primaryNoStruct
     ;
 
 structLiteral
-    : path OPEN_BRACE fieldInitList? CLOSE_BRACE
+    : path '{' fieldInitList? '}'
     ;
 
 fieldInitList
@@ -601,7 +601,7 @@ ifExpr
     ;
 
 matchExpr
-    : 'match' exprNoStruct OPEN_BRACE (matchArm (',' matchArm)* ','?)? CLOSE_BRACE
+    : 'match' exprNoStruct '{' (matchArm (',' matchArm)* ','?)? '}'
     ;
 
 matchArm
@@ -619,7 +619,7 @@ patternPrimary
     | literal
     | '-' INTEGER
     | path ('(' (pattern (',' pattern)*)? ')')?
-    | 'mut'? path? OPEN_BRACE patternFieldList? CLOSE_BRACE
+    | 'mut'? path? '{' patternFieldList? '}'
     | '(' (pattern (',' pattern)*)? ')'
     | '[' patternElements? ']'
     ;
@@ -661,7 +661,7 @@ templatePart
     ;
 
 interpolation
-    : OPEN_BRACE expression (':' formatSpec)? CLOSE_BRACE
+    : INTERP_OPEN expression (':' formatSpec)? '}'
     ;
 
 // A format specifier follows Rust's mini-language; its pieces are lexed as
@@ -691,14 +691,13 @@ STRING_LITERAL
     : 'b'? '"' ('\\' . | ~["\\])* '"'
     ;
 
-// Named (not inline) so they can carry the mode commands that balance a
-// template interpolation's nested braces: `{` pushes, `}` pops. The stack
-// returns to its start for balanced input, so non-template code is unaffected.
-OPEN_BRACE
+// Brace tokens carry the mode commands that inline `'{'` / `'}'` inherit, so a
+// template interpolation's nested braces balance via the mode stack.
+LBRACE
     : '{' -> pushMode(DEFAULT_MODE)
     ;
 
-CLOSE_BRACE
+RBRACE
     : '}' -> popMode
     ;
 
@@ -752,8 +751,8 @@ TEMPLATE_TEXT
     : ('\\' . | ~[`{\\])+
     ;
 
-TEMPLATE_INTERP_OPEN
-    : '{' -> type(OPEN_BRACE), pushMode(DEFAULT_MODE)
+INTERP_OPEN
+    : '{' -> pushMode(DEFAULT_MODE)
     ;
 
 TEMPLATE_END

--- a/package-gale/src/lexer_gen.wado
+++ b/package-gale/src/lexer_gen.wado
@@ -1291,6 +1291,9 @@ fn is_literal_duplicate(
     grammar_opts: &List<GrammarOption>,
     grammar_ci: bool,
 ) -> bool {
+    if rule.mode != 0 {
+        return false;
+    }
     let rule_ci = resolve_ci(grammar_opts, &rule.options);
     if rule_ci != grammar_ci {
         return false;
@@ -1570,6 +1573,40 @@ fn best_state_extras(
 
 fn default_extras(use_modes: bool, has_set_mode_rules: bool, has_more_rules: bool, has_channel_rules: bool) -> String {
     return best_state_extras(-1, false, -1, false, 0, use_modes, has_set_mode_rules, has_more_rules, has_channel_rules);
+}
+
+fn literal_command_extras(
+    lit: &LitToken,
+    lexer_rules: &List<LexerRule>,
+    grammar_opts: &List<GrammarOption>,
+    grammar_ci: bool,
+    emit_modes: bool,
+    has_set_mode_rules: bool,
+    has_more_rules: bool,
+    has_channel_rules: bool,
+) -> String {
+    for let rule of lexer_rules {
+        if rule.is_fragment || rule.is_virtual || rule.mode != 0 {
+            continue;
+        }
+        if resolve_ci(grammar_opts, &rule.options) != grammar_ci {
+            continue;
+        }
+        if try_extract_fixed_text(rule) == Option::Some(lit.text) {
+            return best_state_extras(
+                rule.push_mode,
+                rule.pop_mode,
+                rule.set_mode,
+                rule.more,
+                rule.channel,
+                emit_modes,
+                has_set_mode_rules,
+                has_more_rules,
+                has_channel_rules,
+            );
+        }
+    }
+    return default_extras(emit_modes, has_set_mode_rules, has_more_rules, has_channel_rules);
 }
 
 /// Compute the first-char set for a lexer rule body's first element.
@@ -2020,7 +2057,16 @@ fn gen_tokenize_fn(
                 for let lit of lit_tokens {
                     let fn_name = lit_try_fn_name(&lit.const_name);
                     w.line(&`end = {fn_name}(&lexer.chars, start);`);
-                    let lit_reset = default_extras(true, has_set_mode_rules, has_more_rules, has_channel_rules);
+                    let lit_reset = literal_command_extras(
+                        lit,
+                        lexer_rules,
+                        grammar_opts,
+                        grammar_ci,
+                        true,
+                        has_set_mode_rules,
+                        has_more_rules,
+                        has_channel_rules,
+                    );
                     w.line(
                         &`if end > best_end \{ best_end = end; best_kind = {lit.const_name};{lit_reset} \}`,
                     );
@@ -2061,7 +2107,6 @@ fn gen_tokenize_fn(
     } else {
         // No modes — first-character dispatch
         let needs_extras = has_set_mode_rules || has_more_rules || has_channel_rules;
-        let lit_extras = default_extras(false, has_set_mode_rules, has_more_rules, has_channel_rules);
         let mut all_calls: List<TryCall> = [];
         for let lit of lit_tokens {
             let fn_name = lit_try_fn_name(&lit.const_name);
@@ -2071,6 +2116,16 @@ fn gen_tokenize_fn(
             // the literal's first char may appear in either case.
             add_folded_range(&mut fc, c, c, grammar_ci);
             let tk = lit.const_name;
+            let lit_extras = literal_command_extras(
+                lit,
+                lexer_rules,
+                grammar_opts,
+                grammar_ci,
+                false,
+                has_set_mode_rules,
+                has_more_rules,
+                has_channel_rules,
+            );
             all_calls.push(TryCall {
                 fn_name,
                 token_kind: tk,

--- a/package-gale/tests/driver_lit_command_shadow_test.wado
+++ b/package-gale/tests/driver_lit_command_shadow_test.wado
@@ -1,0 +1,12 @@
+//! A lexer command on a named single-literal rule must survive even when the
+//! same literal is written inline in a parser rule (ANTLR unifies the two).
+
+use g from "./grammars/lit_command_shadow.g4"
+    with {
+        generator: { module: "../src/generator.wado", output_dir: "./generated/lit_command_shadow" },
+    };
+
+test "inline literal keeps its named rule's lexer command" {
+    let r = g::parse(&"{abc");
+    assert r.ok(), `tree: '{g::to_string_tree(&r)}'`;
+}

--- a/package-gale/tests/driver_mode_lit_shadow_test.wado
+++ b/package-gale/tests/driver_mode_lit_shadow_test.wado
@@ -1,0 +1,13 @@
+//! A `{` rule in a non-default lexer mode must not be shadowed by an inline
+//! `{` literal used in a parser rule — inline literals are only matched in the
+//! default mode, so the mode would otherwise lose its `{` matcher.
+
+use g from "./grammars/mode_lit_shadow.g4"
+    with {
+        generator: { module: "../src/generator.wado", output_dir: "./generated/mode_lit_shadow" },
+    };
+
+test "a non-default-mode literal rule keeps its matcher" {
+    let r = g::parse(&"{} `{x}`");
+    assert r.ok(), `tree: '{g::to_string_tree(&r)}'`;
+}

--- a/package-gale/tests/generated/action_arg_pred/wado_arg_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_arg_pred/wado_arg_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e80f819cb07676d0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_arg_pred.g4",
     "hash": "b6e9fd26f1e4936b34f10ed2108b0fad8b57c16b49f42707b509a9966ec692bc"

--- a/package-gale/tests/generated/action_atn_pred/wado_atn_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_atn_pred/wado_atn_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-873f523c716cd4d1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_atn_pred.g4",
     "hash": "418c3fffe47dbad329d0442fa2f8777413a3fd4fed06493c857d0d38f0f020a1"

--- a/package-gale/tests/generated/action_camel/wado_camel_label.g4.kiln.json
+++ b/package-gale/tests/generated/action_camel/wado_camel_label.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e3b09d9b3841e994",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_camel_label.g4",
     "hash": "8498bcbaa19080272d289cd209c4de583f2f2bc7468ffa60f79247b762cd8852"

--- a/package-gale/tests/generated/action_cross_vals/wado_cross_vals.g4.kiln.json
+++ b/package-gale/tests/generated/action_cross_vals/wado_cross_vals.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-557f17ff6595225c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_cross_vals.g4",
     "hash": "907233d022174f59cf1cfdaa307c49264f47101ed6cdf4f2fb4f1fe4fb204cc7"

--- a/package-gale/tests/generated/action_ctx_pred/wado_ctx_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_ctx_pred/wado_ctx_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b5e444fbba4fbca1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_ctx_pred.g4",
     "hash": "2bb6b8f708a23d0e4e563490539674cd9d218a84b5914a8767294facfc30e5a0"

--- a/package-gale/tests/generated/action_ctx_tree/wado_ctx_tree.g4.kiln.json
+++ b/package-gale/tests/generated/action_ctx_tree/wado_ctx_tree.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f37652fd7e23d882",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_ctx_tree.g4",
     "hash": "bcb7da72ec780de959259b673398a1c56cb4e35d4a11e5b25fefa7827c2a4913"

--- a/package-gale/tests/generated/action_dedup_ref/wado_dedup_ref.g4.kiln.json
+++ b/package-gale/tests/generated/action_dedup_ref/wado_dedup_ref.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8eb7c5c18c76387f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_dedup_ref.g4",
     "hash": "9db8e7bfa006d8fd5ded4f5b1277636d941f2b76307619a4e1245969f8ff84ea"

--- a/package-gale/tests/generated/action_emit/wado_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_emit/wado_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0696ace5b552ad11",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_action.g4",
     "hash": "13474a9b2b58d0babd0bf8644fbe8a2650cff69c648085d555e0323f29ebb98d"

--- a/package-gale/tests/generated/action_lex_frag_boundary_pred/wado_lex_frag_boundary_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_frag_boundary_pred/wado_lex_frag_boundary_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ff9d6857e2aa43d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lex_frag_boundary_pred.g4",
     "hash": "a200d6ef5d887eef3ea5c47a2054a03280630e8e3b99dae3e54c2ca625eb9501"

--- a/package-gale/tests/generated/action_lex_frag_pred/wado_lex_frag_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_frag_pred/wado_lex_frag_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b26118fdda96dd69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lex_frag_pred.g4",
     "hash": "4567851df78dbf2dcc1fc4f50d66ef802e82d3c506681dd9faa35124b689635d"

--- a/package-gale/tests/generated/action_lex_group_pred/wado_lex_group_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_group_pred/wado_lex_group_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c360f7b3051940c9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lex_group_pred.g4",
     "hash": "bd31f5842146ead0837f69ff2d604a8afcbb607d92c452604c1aacce7456dc90"

--- a/package-gale/tests/generated/action_lex_mid_pred/wado_lex_mid_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_mid_pred/wado_lex_mid_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ab4593ac7580568",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lex_mid_pred.g4",
     "hash": "ae3dd26483f7ec0f047be3dd69a9649fc3673220b97f0bf3a56b9099a88a28ea"

--- a/package-gale/tests/generated/action_lex_multi_pred/wado_lex_multi_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_multi_pred/wado_lex_multi_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e4cdc93c2365c95",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lex_multi_pred.g4",
     "hash": "659f190b659ccd3690641b96b4af14927661a54f47771f475d6537c5599d30a6"

--- a/package-gale/tests/generated/action_lex_pred/wado_lex_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_pred/wado_lex_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b82dd31e53ff5e74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lex_pred.g4",
     "hash": "19bcddb240cdfa316ea17d4e7ac8965373dfa3a342f3628402060b54b1c1be39"

--- a/package-gale/tests/generated/action_lex_text_pred/wado_lex_text_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_text_pred/wado_lex_text_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6d83ad91dbb14745",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lex_text_pred.g4",
     "hash": "a69c0307921fcc9d602b1e8e92f9a8f1be1607caf06a28221e9cab91b6838a3b"

--- a/package-gale/tests/generated/action_lr_action/wado_lr_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_action/wado_lr_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8327f2775c781cc7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lr_action.g4",
     "hash": "3d2f91b83009b4016739d0262ee6c8bd68222e051ae64b25e9c386ad19ddcabb"

--- a/package-gale/tests/generated/action_lr_ctx_tree/wado_lr_ctx_tree.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_ctx_tree/wado_lr_ctx_tree.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-553398c1d1d9e0bb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lr_ctx_tree.g4",
     "hash": "373f8c3ebd49df335ae2e97412b070560baa061d894e73fbd0bcb54389af1c71"

--- a/package-gale/tests/generated/action_lr_p/wado_lr_p.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_p/wado_lr_p.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6eba93a643a5f281",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lr_p.g4",
     "hash": "0bfd6b3fc311afb60a142c23bcb61cfaef1ab5475e40f9e86d4e38cdc30f62ba"

--- a/package-gale/tests/generated/action_lr_prequel/wado_lr_prequel.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_prequel/wado_lr_prequel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dc6436677dc26e8c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lr_prequel.g4",
     "hash": "ce36a27591d2a84308dbc3046c53a13e1c82f72187ddae9414e62986ad5403fd"

--- a/package-gale/tests/generated/action_lr_vals/wado_lr_vals.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_vals/wado_lr_vals.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f7d2aaced992bf2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_lr_vals.g4",
     "hash": "58368c1c13738159bb4258b037810e70cd32152a176aa06645e1e591b2fc3b0f"

--- a/package-gale/tests/generated/action_multi_arg/wado_multi_arg.g4.kiln.json
+++ b/package-gale/tests/generated/action_multi_arg/wado_multi_arg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-650f92b8451f6b65",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_multi_arg.g4",
     "hash": "9f0b5af84dac170c8abcc8b557b42af55e4718cfb5b7cf9a615058b9835a44e5"

--- a/package-gale/tests/generated/action_multi_prequel/wado_multi_prequel.g4.kiln.json
+++ b/package-gale/tests/generated/action_multi_prequel/wado_multi_prequel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6e650f2542d1aa83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_multi_prequel.g4",
     "hash": "e4d65fbf1b51f1769f7d0e64cdb783fb2db57d777cd1710149f27579765b79b3"

--- a/package-gale/tests/generated/action_multi_vals/wado_multi_vals.g4.kiln.json
+++ b/package-gale/tests/generated/action_multi_vals/wado_multi_vals.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-08075013495a9f85",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_multi_vals.g4",
     "hash": "f3e04890417c43fc62e69fc2b765587697c9db12a703c8d073192baba5cfb3e2"

--- a/package-gale/tests/generated/action_pred_direct/wado_pred_direct.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_direct/wado_pred_direct.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5e061c7be549197d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_pred_direct.g4",
     "hash": "e092f3749a943ddf550a6a71b95bd03cad20773c919e70783c1dd81231c86f40"

--- a/package-gale/tests/generated/action_pred_la/wado_pred_la.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_la/wado_pred_la.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da1441b223e14727",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_pred_la.g4",
     "hash": "45c10f850f573ce0a566001e93626c9a530d9586cb4beb171f3a041330495569"

--- a/package-gale/tests/generated/action_pred_mixed/wado_pred_mixed.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_mixed/wado_pred_mixed.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ca54db1f2499f4bb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_pred_mixed.g4",
     "hash": "bbc420572b0acbfc0e53c8a6d2f79ed0fd1878634711e9c79fdfa5b5e5d294c4"

--- a/package-gale/tests/generated/action_pred_select/wado_pred_select.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_select/wado_pred_select.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b327e5a5e039ffee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_pred_select.g4",
     "hash": "84580d852a7a09a0c820d47fa8e4e2280ec070e3d98497b8f9513317a157f9db"

--- a/package-gale/tests/generated/action_pred_single/wado_pred_single.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_single/wado_pred_single.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-025f5de49e5ae1e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_pred_single.g4",
     "hash": "0d7912e38ff400aaca30b2461edcae7aca24336c4f6de5125244671c90146a87"

--- a/package-gale/tests/generated/action_predicate/wado_predicate.g4.kiln.json
+++ b/package-gale/tests/generated/action_predicate/wado_predicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0f6f2d45a8be8bf4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_predicate.g4",
     "hash": "d0d8e42a8c9fb83b9b4059ef6b880e28927e9b83ec9abdd7eaf9b3cf507b9a0a"

--- a/package-gale/tests/generated/action_prequel/wado_prequel.g4.kiln.json
+++ b/package-gale/tests/generated/action_prequel/wado_prequel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c4f501158f90b0c6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_prequel.g4",
     "hash": "a6af59b74e9cb5e4d525c57e8e9f48b3bead2dc68176c10429d54e0f7b776a1e"

--- a/package-gale/tests/generated/action_rule_arg/wado_rule_arg.g4.kiln.json
+++ b/package-gale/tests/generated/action_rule_arg/wado_rule_arg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-696b74c7625b82e8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_rule_arg.g4",
     "hash": "c9d39c5a3b8f15425035b11cb605c2111a2f9af176bc99df70b23e32f548334c"

--- a/package-gale/tests/generated/action_rule_text/wado_rule_text.g4.kiln.json
+++ b/package-gale/tests/generated/action_rule_text/wado_rule_text.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cb5561321a332653",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_rule_text.g4",
     "hash": "4b852c099e7d878056bbfeceac970ea29a8c24e2ebd431e5cd17530a7e47c215"

--- a/package-gale/tests/generated/action_start_stop/wado_start_stop.g4.kiln.json
+++ b/package-gale/tests/generated/action_start_stop/wado_start_stop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3249021442fd1f8b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_start_stop.g4",
     "hash": "4cb61738c56fd40069eb631d154b86b4925b4599f71f59669d0628a0593c436f"

--- a/package-gale/tests/generated/action_tok_members/wado_tok_members.g4.kiln.json
+++ b/package-gale/tests/generated/action_tok_members/wado_tok_members.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ae6eaafe3479c391",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_tok_members.g4",
     "hash": "e65023bec4db60f199679d93d1346f4187bed10a196a378b97b97979428d07cf"

--- a/package-gale/tests/generated/action_token_text/wado_token_text.g4.kiln.json
+++ b/package-gale/tests/generated/action_token_text/wado_token_text.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b4a5c6c2eb999ebd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_token_text.g4",
     "hash": "b1eb3baf9ed5a0b3cb2e1c2b5fefa8f9221b4387d7e293d8fbb2af18851f2ce9"

--- a/package-gale/tests/generated/action_vals/wado_vals.g4.kiln.json
+++ b/package-gale/tests/generated/action_vals/wado_vals.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9ad6f91f8540f97",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/wado_vals.g4",
     "hash": "7546c296eda6088ecff8173abd1b1dd6ca3b595618c796960f1a2c8d9da06a28"

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/AmbiguityNoLoop/AmbiguityNoLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/AmbiguityNoLoop/AmbiguityNoLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0809d2f7841463f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/AmbiguityNoLoop.g4",
     "hash": "4a5ea9400a16c409961ca654fbd830c7065473b123890f128d89c973c9f54116"

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-10862b0dddd3e3ce",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "3cef241a3f1aeefa4734eedc02294ff8d4e3b06d7b68b3bede9c69774c2b98f1"

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/LoopsSimulateTailRecursion/LoopsSimulateTailRecursion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/LoopsSimulateTailRecursion/LoopsSimulateTailRecursion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5692020f51c4cb8e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/LoopsSimulateTailRecursion.g4",
     "hash": "f110e04e7dbbeecd1db8bff0b481240c206c9744c0ae7e16332c80541090207d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6dba95df275228d1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_1.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c75e07f954524ebd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_2.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-05c4a7a54efa10d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_3.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-70c7ec0c9f713396",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_4.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-79a75dae3777f4e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_5.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-724c6291ef0ee955",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_1.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ec23e0d9aec1c2f6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_10.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8dcf81200324c571",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_2.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f313624ad6edc976",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_3.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1dc67c7db6d6d52f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_4.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abe31a1d6808ce47",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_5.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-477f17c2463b8e96",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_6.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-10b57559aeaf3bcc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_7.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d4098b0e07414b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_8.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e79fb0d29171ffdd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_9.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f827f329afceaee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-defde4108f71c68b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b0bb19f34c7e7e99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5e0bb2a71cb18ef0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_1.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-792a24e4c5c84950",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_2.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5ddf90110c8adfd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_3.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8c70cca85955bb7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_4.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b27749b045ce13de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_5.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8a5e49d006b9be98",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_6.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-10bdbb84da5c4d9d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_7.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-82c4f42335aded29",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd15c85db4a62501",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6608e8be66945304",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-97f8a98ba183d09e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4f2e7c4ee02457ea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fdc5f8ecb1581ced",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9bd3774852624c48",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e0b676e62be0622",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f3aeeff62f332d72",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-57aae01f9f5af6d6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a376df5b65f50eba",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6daa01c64eb48fd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-67fdb6e3085259fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-901da49e00dbf5c5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7ce86a56591743af",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4c875b19fd3b35fd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-237496525c89e858",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d2561963ef8e372e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-39985628aae4cb1b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0895caf4c8e2a330",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f7f208812b8635e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e3ef3f336d04e01a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c41367194dc3a19f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfacbe6db622e778",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ab1af22394a68c5c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dd789b61f267295f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0c8335b8ea486a97",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "2a585adcc4ff6452f8676164c5cc06d1193e60a1f365ced112583ade997878da"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9361b59d78a17c06",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "253110b6fce663add55c6e20a5eea61c026c00ba1848ed7ff547f6d5b46f0020"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2ed7a2793bc8bc6c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "253110b6fce663add55c6e20a5eea61c026c00ba1848ed7ff547f6d5b46f0020"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8542ba9833c00c8f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fc1d346535bb08d3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7d08f41a3235744e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8f7bbbb71846d9a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6336653abd1152d9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fcae849bf6ee92c1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-420e0774837f8368",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fdde20ad6ee5b649",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d2b33966d9bec5b7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e4b4d8e09f55c8e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c7e4f03502e1969a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-59c158919da3896f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-63a6d0d25ef7c602",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfda504c3fba4c04",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-95c0ae71c4e43bc6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-55dd948e9dc09b16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_1.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1ff0ff2b6b58c78e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_2.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e6e02a58699299b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_3.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5752f12e23140fae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_4.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-62ff79f71482513f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPred.g4",
     "hash": "a106deb55eb2abfedaa31b38e5a85311ee1e2be76765ae4c41a8b133cd6b68f4"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9b11ca68a5374163",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_1.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7d1e8b8611394f9c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_2.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-830fd21b47bd0c5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_3.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa79ef279fbe7c3c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ea14c1a3e2e23694",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abf3ff3cc2d5cf21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed67d2b10520b3db",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-939c90efc705053a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b468c061e6f07b7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-74c3e1872ddbddd7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cd93634ca93fd5bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-52a1ecc107f43f69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e4c414946515e719",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-853182052d75cda1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-592ae0778a69b671",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2adf8f906040290b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bb4ab705fb304e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-82512f883620f99a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5c64b29f5282c291",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cc0f8b655e083ff4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-463eed3672b1a6ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_1/WhitespaceInfluence_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_1/WhitespaceInfluence_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-17276d278a535112",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/WhitespaceInfluence_1.g4",
     "hash": "eb2ee832bbd5bc64766c64a697b83e430bc397e5e3c51480f276099243202a4c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_2/WhitespaceInfluence_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_2/WhitespaceInfluence_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d0a000e3185c7b3b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/WhitespaceInfluence_2.g4",
     "hash": "eb2ee832bbd5bc64766c64a697b83e430bc397e5e3c51480f276099243202a4c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f2f1422e8c0310b3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/DFAToATNThatFailsBackToDFA.g4",
     "hash": "48db67da6df9caa67f3e56b39408023058c363703e5eac58a74bea22a92f0066"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4dadcf88635a7676",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/DFAToATNThatMatchesThenFailsInATN.g4",
     "hash": "ce03131129eb8147280be2cb5319ce363f7a4184ab6b871b761128c49ce4edb3"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1ef8751859ed5604",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/EnforcedGreedyNestedBraces_1.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78b62e31b94c4361",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/EnforcedGreedyNestedBraces_2.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-93010c260c740be7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/ErrorInMiddle.g4",
     "hash": "ca5afb8c050f2d8b96fd19595dc603645d812846f62c9d767d56f7d0a0c5a0d9"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-13d8ba3fca6a0ebd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharAtStart.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-57106fa9edd42507",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharAtStartAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-71000f947fddc067",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharInToken.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b09ad19d2b68620a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharInTokenAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3de5a518e71a434f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/LexerExecDFA.g4",
     "hash": "9082786e9c7fc41aaf4fdfc2878c546039534e8b4ce83af668f95a9189b005d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa64fb074cffe6ab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/StringsEmbeddedInActions_1.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bdf529f43ece1728",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/StringsEmbeddedInActions_2.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c91fa185b6865077",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ActionPlacement.g4",
     "hash": "91771340407dde2b4532c24859aa784b279b79ac31c35b87f9e2fc4b13a628ee"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-aebed58c11eebec3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSet.g4",
     "hash": "7f0dc97864a229fb1ade2c9e6bb9c1e0a53992cf496e74170879deba7ac9be7e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f66b1b9b792de13d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetInSet.g4",
     "hash": "f181de0ae729e9b5f597000b968235effa143bdd7d29d6acbe87fcd5d8e06a6c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e0e01a3e71a3fc0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetNot.g4",
     "hash": "0acfa451e3320feb7147da2dbed756195d32df523501c7f4955251641164eb53"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2c0777939fa86890",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetPlus.g4",
     "hash": "68ed054fd1eb28b0376a5b2dd2fded19969077892161f56068df69cb754614e0"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-14995edf9a3a85af",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetRange.g4",
     "hash": "db0704abd79e9ce7c4f60ce25be1be804bdf07b6b994b85e1e6bb1e9d087ad94"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e42740b41f8491e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithEscapedChar.g4",
     "hash": "97dab8c7f42040028016a333b619486812b9eb6fc194367b3c531b4d52ea03c9"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1636fc5a0e2a7684",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithMissingEscapeChar.g4",
     "hash": "1100c51654e45fc483c6392018b186d6c7a62c40c10b5d9db7065209064605e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-52cbf5a819a80b51",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithQuote1.g4",
     "hash": "f639d3e26e1a25fd463d1afe1f39069faa6a2fe61917ab0c7cae87457c52f21f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7a4fe128d4e0713e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithQuote2.g4",
     "hash": "380857ab4bdd331efa9f3c0f6be2825bd53341c22505a2566a21f1bd1a557d72"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e8ebde2e4a96043e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/EOFSuffixInFirstRule_2.g4",
     "hash": "441bbb7e472213eb37da15d9b0992d1c4d399644b0fa057762e0b579ae06e531"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-186920fb399c84b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/EscapedCharacters.g4",
     "hash": "88a4f34355fb87e7adbc718fcfe030c51f5c362d158b4cce6a5796189ba1cd4a"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d79c0f03bf29a36d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyClosure.g4",
     "hash": "d1458a9fc1db2a1bc64866ee5b621bdea6b8aca8fd321a6053f7b64c496bf279"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4b2b773c85659db6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyConfigs.g4",
     "hash": "137ae29cb06b7b4e2019c66137635475ebb092d4adab59d505f39b6b398b94b5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-59c03763c0684b73",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyOptional.g4",
     "hash": "0e2acf0a59884a4de77f9b74b30c2dc30770c78b1a11db4db50b1cea97df2d4d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-185f3b7faecee4ca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyPositiveClosure.g4",
     "hash": "5d96b0c62fad69596130c0cfe142462b2dffa59bcc399e1decfd28cd0ad2ac03"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cfe5f404fc84ed38",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/HexVsID.g4",
     "hash": "a1aa12f4fe19f66adc2b83628e3806eb535b11a974c9e7173202674b57eb3bf2"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b878aaea220b7a7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/KeywordID.g4",
     "hash": "5eec334a6818219de3e310c919f6fa92ee282ea3d98561d1e53fa586df4b7645"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3a1f814f024de92a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyClosure.g4",
     "hash": "919895cc80becbaa85e86b313156de11fb8cc30e641612bb47a295326f546a2c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dba435445aaa5bbe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyConfigs.g4",
     "hash": "8d874c3637641d5e317e644b769d00acaf7ee045164ee9f5deafbd88677e2c0e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bf45839c003aad34",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyOptional.g4",
     "hash": "611a3d559cf19bd50743e764270d813639b924662b03e7075f24f3ac3520ac9d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e73ca4af79497afc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyPositiveClosure.g4",
     "hash": "a19bcb18c02be6721bf1028a7c1335d28291e3e247dbd8e5fa2fcbc88d716fe4"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f5f43763cdcb57b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyTermination1.g4",
     "hash": "5841fcdcd5adf818f59bf6e0f6a29db4d1027ce77dcc476160b96079fcf35a8b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78e4cbcd74e35bcf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyTermination2.g4",
     "hash": "9ea5e3f0fd959bb4a51b464e3c49d7f20e95f5189bab762287847163d70a5960"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0b1b5a3c8b4b5713",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/Parentheses.g4",
     "hash": "10a47eed1b802ff2274c0d7ffffc1a145b6142f25340091ecdb1176446429acc"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d2d18fe86528ccbe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/QuoteTranslation.g4",
     "hash": "fd454e5ff551c86e4eab1e50e2375a62b8246aae8b700f386202c3fbc795225f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-978fdd26b14ef3bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1.g4",
     "hash": "ccf3affeed08d41932ee1b94716d414b1bae3d229b6c7f3f4d17e62300e91492"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f12d192e2bc55a11",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1.g4",
     "hash": "7b6ed71096a57f601b91ad9c0bee2e6b2fc376dcf23c80eb7430b84c165be764"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c8cb897d1dcbcbbb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother.g4",
     "hash": "95a088465b495a7bfbf61a77ce9bb6ae79caa9288236175927e10273cca715f1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-907d0bd38b8779aa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ReservedWordsEscaping.g4",
     "hash": "66600b7a97e9750d7527d65b8f6799e6e8f39806bf1a1bc70f349d2d79549d04"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7d7a03811d0ce28e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ReservedWordsEscaping_NULL.g4",
     "hash": "c0512ddd17eb85b03ec5ee0bdfbd91e04bf5186ea196a43c6699b55bf350e582"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7ce50634698ad555",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/Slashes.g4",
     "hash": "8542b8d313ce35cd690e1408d548786844016931b7659852bbcb1af80919f7df"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e21ffc2e20097cda",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/StackoverflowDueToNotEscapedHyphen.g4",
     "hash": "8ac36d903f20ad5d1c01d8de6e7555e7095b62f80282b91c7309cb119f6e0e81"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/TokenType0xFFFF/TokenType0xFFFF.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/TokenType0xFFFF/TokenType0xFFFF.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f262d3761453c23c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/TokenType0xFFFF.g4",
     "hash": "510dfbf59b57e04442706e8d5ae998b7daa9bfb6e4ab2347959fcaf010e4793c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a43c20a2765b5e78",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/UnicodeCharSet.g4",
     "hash": "be6380e8ca1f1838a7908f37fc269bbfe32d7522dff990274bfc144c90d5a73f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1dc63c416f1a1e13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ZeroLengthToken.g4",
     "hash": "602fefbd71118c707ee514a7eb2d6eeac92032b2009e51b705b154429bffd5ea"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/ExtraTokensAndAltLabels/ExtraTokensAndAltLabels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/ExtraTokensAndAltLabels/ExtraTokensAndAltLabels.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-38b66bd8122f6427",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/ExtraTokensAndAltLabels.g4",
     "hash": "307e9405ad7c575d0c7bc3fe8f69cef2aba30fe9afbc7a93336e689a9725c855"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f9dec17daa020bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/RuleRef.g4",
     "hash": "d36f799562d5b5075bc37a123b6a6a2143de5376215c61781d2528fb20bfb872"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-12469ea38671fffb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Token2.g4",
     "hash": "6cd80a43bb370ffe5c24d939690ca5a01587d8722d37bcb6e7ef47465f4b3f28"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-500d88e92ed070c8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "a638aad22706396ab56c298fec81040d05225611bb2c1c55b5af65d0d5e6460f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7e035fc27b024880",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAlts.g4",
     "hash": "79b50c115868f434c423fbe49a9db89ec5ea12828b98d6cc90f1daef29b09b7a"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0195fd565da9cb85",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ConjuringUpToken.g4",
     "hash": "204f0b6cd9b5dba20f999caaf203da12efff0cfb7192ae6ea579a39cc9bc55af"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-485d99d36bf8253d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ConjuringUpTokenFromSet.g4",
     "hash": "adc51be2e2652ad8246b01a2be475f20cf314cc4614db7910f92807e4dbfa160"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7cb040514b4d8550",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ContextListGetters.g4",
     "hash": "5c0f1a3091c6de8a91d73791a7a55080a0ef042ad5b662b82d5947e976f700ab"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f876fb4ea120fe24",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_1.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4aeb64ac2f848ca2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_2.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2852c8f877e16427",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_3.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2646e62a9bd34ea1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_4.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19bb65344fed7a6d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ExtraneousInput.g4",
     "hash": "d65f706ca2451405802574364ae8d3d7abf995b07027e8a4625c575ee48c919b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-971fd74760856567",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/InvalidATNStateRemoval.g4",
     "hash": "a61822facc746668e46fb82a4f967cebdfc94f80ed44bf9a14bb879c3fadc104"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78b11d2968a7b9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "6fdb1536b5d50a39105a35527d0a8f63cff00a1682e45af84ee262aed25dec0f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-da3662947095ba6c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL2.g4",
     "hash": "2aaa2b6a34f4a4348b34477ca85e32d712d0090ea04767439f00a52c9e369525"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e5f481f17edb72e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL3.g4",
     "hash": "c71f82724eba5c68a8618a7e086bdd6d4945e4a769695822a02a3e560fc12d76"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dff5a67e2d850dfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LLStar.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5a21ceff6d015b8b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionBeforeLoop.g4",
     "hash": "e85e3274b80d9927fac0d6f6fd84f36c85e3495b5c8288e0dcb1117c16f07173"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b354e50735f603f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionBeforeLoop2.g4",
     "hash": "fd6968e798351061bbc2284243713a2f29ffd06066cf5ff1f3ef91e3a0de79ff"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c6de053fdca9cd20",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f59a4af78bfaa358",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionDuringLoop2.g4",
     "hash": "6b92671abb0fe47306019a2b498ff80170d85e888bbe48df128b882eee77731e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e2dc404a432bf2e8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/NoViableAltAvoidance.g4",
     "hash": "b28914eab8290e79724e3e1b2ac223e8b6c5021ac6ca3c564ee873762146bbfc"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-571104d65eeb7ea8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleSetInsertion.g4",
     "hash": "5c5213e807e10eac992c2dd076d8f12a8df33bb71c1803ee039588b15da2782b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4295366fe9bdc424",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletion.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9deeff3f59619bbb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeAlt.g4",
     "hash": "8620c2090497e410ec32e4c6556c760c41ffe1a00ca410ee8a598dfdd77baf3c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-88e54058582f681b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeLoop.g4",
     "hash": "981912e9f61c0e8e34da6607456532112011597125c30dcbddf0125401041f85"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8e7a747965f3e89",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeLoop2.g4",
     "hash": "633635c9fdff3d0c984a8ceed258f6d51168ab8b4eef2f8f6250af32d225f19b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2dd5808cf3e08083",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforePredict.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-77e75b00557857b6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c7a1c76dcd0feb61",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionDuringLoop2.g4",
     "hash": "6b92671abb0fe47306019a2b498ff80170d85e888bbe48df128b882eee77731e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e70dcb6157b29f19",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionExpectingSet.g4",
     "hash": "82fab2ac95de6f83693cfada43a42fb29c81c33276e86a92c9ffe512e0619240"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f9ecf857a1dda7fb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenInsertion.g4",
     "hash": "4153af41f9ffb8e3498f2f8624598a75ecb726bce94b85532bc26a2f9a553a93"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-718adb9ff8473449",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/TokenMismatch.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-eeba7589f5d8a734",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/TokenMismatch2.g4",
     "hash": "4bd0badd70e068efac023f2f42dff67c8439fb46b31ad4ecffa908f2eb619d18"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0e768432ad217228",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/APlus.g4",
     "hash": "65afa725cbcac09fa8c5ef09b106193b0653e9a43d9f7dca8f80cfbdab0244cc"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc656e8f273b5048",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AStar_2.g4",
     "hash": "32e20668bb74b32537e8ed784776ad010334047540356bf8e558bc448a1a4f1a"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e455fb79e0e760d5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAPlus.g4",
     "hash": "2d2f766470d77cd144a3c195c0abac3b491e9622212042e47a005e0cd803c497"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f0a4df9cad5ce7a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAStar_2.g4",
     "hash": "3373095cb5525150349456ff369eeabb2648d7369578d70344fa82843e4795fe"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0bf329c8c63c777b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorB.g4",
     "hash": "526a8a1a4c649b84d041ba7f0dd3f0d2dac2cd930858c7a432207f26448d0985"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6fe4df601f8fb7e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBPlus.g4",
     "hash": "b24888c439f265999017b6c8d5cac646a8ea99c2c029f29bb49c9abcf813ea8e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-251c61a3417e52fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBStar_2.g4",
     "hash": "8ff040f2bd87b3c1cb83765d26a42f034fe40acabc9979cd9a48d3c4a4116786"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-25a70a6980012d9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Basic.g4",
     "hash": "2785b5f535bab4a06559235161609d47fcf9d752f82ddc5b44bf0fa197a87a5e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-81d548e32786ef7b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "eb2c2950e7f80585c973ffc612ea059eab4da91ea8fb7e50034dfb78e768fa87"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-90cfc510612af10b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "eb2c2950e7f80585c973ffc612ea059eab4da91ea8fb7e50034dfb78e768fa87"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-60f5a9a16604d6e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "440e59e87cf909864372e2572e161b8ac1102e2b33ca17024622c8cbd691c1f3"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0c64a9174f394f19",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "d57cdde3a5790f927f5bb3a08edc39254365cd598a989a331b50ad31d96b64f4"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8e7c2737b7b0f40b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding1.g4",
     "hash": "52c0d8947d2dad4eda6c969dded97b1e509ebabd582b34e4f1bd545fa7e3d98a"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3f270e9e32b462e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "c509006b579b65d3a2bb33cc73f2867396e0457f2e3caf43918c15fdf55f4ba7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19a487ef9ab2d274",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_1.g4",
     "hash": "d67c4f8218be21f6104f600109218250c5738f3abd72780bffdd9c90a167b4d7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-53b24b4c4131b10c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_2.g4",
     "hash": "95b786e26fd0411bc4877c9ce220c361d43eef988f480687b4d8a2391b8c6c7d"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-108ee69dd95708f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_3.g4",
     "hash": "7bd91c8ffe4349c62fab43f7e24eccf0cb98ce10f96bb7fd8a4c18eb4c7288eb"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-316e47f9cb1bbc4b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_4.g4",
     "hash": "fc3f61392647c8ee0a4d42fa4d6935e257c040a5177fe7c9849988191e9be6da"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cbb5c83bd36dfc44",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_5.g4",
     "hash": "1b99bef44dff0f4b76fe9b8aaedb7fec1fd8c90e6fc6caec51a524204dc07b3d"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-97ad497ee3062dbe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_6.g4",
     "hash": "ff61271aca142ca5ce907d2f8c44c240da8b965be1a57bddafcf7e2389ed74de"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-993de6f9d029cdb3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "bec71119542848512f3dafd408fa0bbbe7279fa597ea3cfa8674dd7778424d5c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19319eed76368793",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "63a8d3816100691a88d9aeff5c64ae599bf52dbf429c8972ae160de32b215a80"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Labels/Labels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Labels/Labels.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1abd98df9faa1037",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Labels.g4",
     "hash": "6263c0c263ff2e359d5ffe29f5156e36760ebc32acbd8fcae5cb2b94eea08fae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3c9cf123dd4997d6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelForClosureContext.g4",
     "hash": "d564bc2775d8fa8ae1e3dd036aab81140f0ed275c2767d0211ff685752ac3ee7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f5666f268c7aa0fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelsOnRuleRefStartOfAlt.g4",
     "hash": "3aa6084c13250ca71372eb09e5bc4d92097d46d3be5b3fc3df32760e0aa15708"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnSet/ListLabelsOnSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnSet/ListLabelsOnSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-522a40a1b79a7b0e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelsOnSet.g4",
     "hash": "3e061c74b0839caf5d204be5aa58fad88f4a12eacb1a4b5987312548a5e87351"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed45665f83f5726d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/MultipleEOFHandling.g4",
     "hash": "f1cb5bab46a024203403073ff94ae02fed6987c2e63b627edf697a7d299b08c6"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7d6dcf4d3e116f36",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case1.g4",
     "hash": "150bd511e2898329b4a1be0d94cbab3775c9d762da1821db48a2acd09867e922"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7eaca01e9531e506",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case2.g4",
     "hash": "09b70ed5e0fe15e7bca784b725980f263bcfd0da3a8f9108d60bbeb4a7b7ef5c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ecedd277b785d87e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case3.g4",
     "hash": "09b70ed5e0fe15e7bca784b725980f263bcfd0da3a8f9108d60bbeb4a7b7ef5c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-799636ddb90c3b40",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_1.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-12013ce7871cd1fc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_2.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-493c6bc2ecc7d1c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_3.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e65be639da0c2871",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_4.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d1fe93a61add0269",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OrderingPredicates.g4",
     "hash": "9e1c1b5e4eb5492597f2e750d5935cb9a2fad092868471a4a1244f39f05c60e5"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-efdb61dfce95da1d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredicatedIfIfElse.g4",
     "hash": "84950f45715e14e61fd604dba5bdeb1168784e3abd7ed28dfe0f0433014fe90d"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c60a4d59c5c71db1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionIssue334.g4",
     "hash": "ef72aadf8f7a725e4784a4b40db3fd7131460bfd444256ed6fa7a6bc4804454c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9319ef8088209c5e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "12bb5d21b00f7b51319887f14af975acc95a45ec6c8e2349c58d9e3036223dae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_SLL/PredictionMode_SLL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_SLL/PredictionMode_SLL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e3a408232a5ca722",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionMode_SLL.g4",
     "hash": "4b0ad60a0311866dd33a7bcd48ff62ddd3991c2f006b9b2f7489f3a221e32e6e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-05d54229af5ddb42",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "219dd0ab0de17f74119b2a502d847cef78f678320fb64cee55025e147beac015"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe600c4e82ebbc18",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReservedWordsEscaping.g4",
     "hash": "1255013e85ee5370b81b22637b60dcc49fe82706c1f6a539154d35e5cd605b9e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7d3cbaec23431d82",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/TokenOffset.g4",
     "hash": "dfda12fb116e3c99f5f42c2618eb51727e857e5c05836e80bc1d2cc161fe42e7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-79d73209896a1038",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Wildcard.g4",
     "hash": "11e95949cf96d6ef6495192ed616530367d1722b686f81d39a09e32761f3e9df"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f4d3608d014cdf23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "807557a1c66b8ed1fbd0bd199253542faba1296ec9860f9e19a5aba35c7ffbc5"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4c632dfbe56a6674",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_1.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78d170410f8aef16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_2.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-23cbb08475e72322",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_3.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-65001294d8797ce5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_4.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d7c66dbb7941b2ef",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_5.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_1/ExpressionGrammar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_1/ExpressionGrammar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4dfcb50ddd40cd9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/ExpressionGrammar_1.g4",
     "hash": "fdad284b75dbe1e75f3820211869d5d5e166b393077d55d5450945c644e77f47"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_2/ExpressionGrammar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_2/ExpressionGrammar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-361540f6d9ce9d5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/ExpressionGrammar_2.g4",
     "hash": "fdad284b75dbe1e75f3820211869d5d5e166b393077d55d5450945c644e77f47"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-198077ec5ef4751f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/DisableRule.g4",
     "hash": "f62ea4e6c4d943b34fa987dcd883eff02bc0dbfcd3ad4663a81205e5955c7156"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d50d43a1aa9c0020",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/EnumNotID.g4",
     "hash": "9f0460d77a0406a03e0c63525201b2c910c1a708f8cf8fc2e8f20e39959436de"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f4985c5a5f57ac6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/IDnotEnum.g4",
     "hash": "d6fa9bfcf22626c43627cc5391f6c73765bcc1c3a43abcaf722875c4412a527d"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ef5f330af36bb529",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/IDvsEnum.g4",
     "hash": "10cb45c65ab65b1e015e3b7d691258acc911483ee369d6834593b6e8487afec5"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f2c9c5b2c6e6ef7e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/Indent.g4",
     "hash": "db8e01ca65078787390e766163db1dff28a8e88c2df734b8e396560fbca2ef7b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-167660d5e423e96d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/LexerInputPositionSensitivePredicates.g4",
     "hash": "3e09ac0de3a83ce4f5e42794587418e31bca2aa5c9f3e2e32d4bc05fd9d0a6cc"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-10e2afd27654c878",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/PredicatedKeywords.g4",
     "hash": "16010edac128bb7ff75a99600a5b7ffa8181e5a0a541a5e74ce1858f1a28abdc"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0cfe04ac4bfd6a3b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/RuleSempredFunction.g4",
     "hash": "3adb7a1189fb3d47c18f34bfccc6311ac16a3bb0caf93c623832feca744a6f8d"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a5be53022ad1b17b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "c4e01650ae90615c32bc3eee5f57f4d611342dcef12948a0907ea38cd714c377"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3abc78f1a1dd0875",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "952c48fb5ebd8dd1c896728f60456def84c4a80ed9f7b9b68b9e341308e04214"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9327154feeb93d80",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/AtomWithClosureInTranslatedLRRule.g4",
     "hash": "92e1a1f0924ff1342f55dce399ac903cbd1ee449cb61b490823161e0100e84ea"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e80e63432313ae6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "f8449f4767b4dfdf52b6113a6c931ea0d5841a7b738c195bee631d4fba689b58"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e825ffff4663fe4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4",
     "hash": "8553bb8579e273475bec5dffac33d751cf4e86039144543bdd5a11d5cdf332a7"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-96fdf79d1d505df2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DisabledAlternative.g4",
     "hash": "a92a4c2ebf0d1f93e9d80589cf4ab3e9a3ecb8bf9e747044ca7d7d128634f8e2"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ff9cd7f68432d91",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "3d7a2878f4652b70aa23384f57b762cf3ebdce090e6be47dc2c4f2e163ff581e"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e7b4b66c5c476d1e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Order.g4",
     "hash": "06ee6c74670bd951fc6adaa3d1d127d38db71c55a076074dacd031c2800e1d3b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-67bda7c2024a7cf0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "46b96c8091c150c5c47391d69259f5ee245aa80438a275d7b1f0602531dc40ee"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5569f9327b68ba4f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "74c1616e4f0f48712c07b5aea8e8be5082e89184828d8814bf2ea1d6244abbcf"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dcaf5cd43868245e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "95f0830d46eaa8d8d4b9472caa4fad3e5c7bfc6bc822a1098fca68853dd1ffec"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-65c77736c57ae6ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg2.g4",
     "hash": "08f048b49e306837679757919e6037adfe1b956f0073cb05390d930c232415ab"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-061a749098f54759",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "435298930cbeb6acec547f5ac93d2d08c38a321dd7dea17a778829c1442580dd"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-05c8aabfff617ec3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "4c58b8b6fd28ccaa4a15af5461aba77078c476d7020ad07f9cb060eebc78d65e"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18e0a54b0bb49e07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Simple.g4",
     "hash": "dbc4c1cffcd9badf83384d7de1fc39fdebea06e0ad0079703cf4e32c073c5fbd"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/SimpleValidate2/SimpleValidate2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/SimpleValidate2/SimpleValidate2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-42a1ed43266f78b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/SimpleValidate2.g4",
     "hash": "39fdd0ae989ec159c97e38ab22f5fab58507340c9aa482f8b14f7d621bcb60f0"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fe3217ab933daf7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "79e26c081d50d8991394f673689871fc36a87b4f801191c773a77620c00db8b0"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-79f3ad75b455946b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "5510b13c3f52df41ab478b80a3d468d5676ff38c36d44e8a35630f43a95cd88c"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/TwoUnpredicatedAlts/TwoUnpredicatedAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/TwoUnpredicatedAlts/TwoUnpredicatedAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8f7c206dbca1f408",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/TwoUnpredicatedAlts.g4",
     "hash": "82b92d5ebdcc53619bd999f5abba8d32fd769b7e3ff402dbf35687bf66dd5312"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/TwoUnpredicatedAltsAndOneOrthogonalAlt/TwoUnpredicatedAltsAndOneOrthogonalAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/TwoUnpredicatedAltsAndOneOrthogonalAlt/TwoUnpredicatedAltsAndOneOrthogonalAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-12cc824da6958082",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/TwoUnpredicatedAltsAndOneOrthogonalAlt.g4",
     "hash": "e3b8e7c6478eb775308bb78d9dccb33851e6df630fbf97bf1a7ed3648e4e96b0"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9a29002fb60d256",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "998b2de4aa9e4153db9d16485ea2c6b528969989d99d0b2af7d9f991b544c2ec"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-55bcf562af70467b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/CharSetLiteral.g4",
     "hash": "1148556229dc59ef2626b0458399983d1636cc24e105edf123aa60544998e683"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1cd9f86e1018566f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerOptionalSet.g4",
     "hash": "9813ec122366d63be434989e2774116a84cf614ff88e6c06654e175e661cf1c2"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ff7d98a7d5e835b5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerPlusSet.g4",
     "hash": "527915ce7cd19bafdf7634fba06323a220718346e187aecd12df786c22a946b6"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18ca170ffdb0afcc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerStarSet.g4",
     "hash": "c29a11128b93b442513fa85c5028140c2ffdcfa0caecb6a9ee9c91477d80b421"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49fbc17fc2bfdbb3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotChar.g4",
     "hash": "8f2432be7a965cbd8766ca8e42dd247c40ee569d5381ece836d645269bd0ffec"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9f7b7f2dae37260f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSet.g4",
     "hash": "4155ec14531984facba34515b3ab2f63205dcc5122b43b35eb0e1a5f8d865653"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6d9f734b246f7ab7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "341497f02eb8299a891ed67de6b5ccf5d1a8370780d5dbf784f8e349d9a8255c"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cc4e7824c362636a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "065d4e9ed01354807c48b541794965b66c5acd0c3843a8d98456ff80114632d0"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e5a36297644ee691",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSet.g4",
     "hash": "dbe1e20ce85e9efb4ea176c99bdb5bc65e426a6abaafa504abb4741e796262da"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9a65cdd583df2656",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSingleElement.g4",
     "hash": "d8242b63e702bee096a3cd3349e04ca94491a4709e97f6db841bf985cf2ce3e7"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-55efb6463177bdd9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotSet.g4",
     "hash": "19c38d099171d47fd0f223833a56a33a3b346c3fefabd4d0ca5cd8cf901969d9"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f9d124d7634800b6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotToken.g4",
     "hash": "190c7d956b90644a68f1a9ea4b1f91ee074c37601d45aa4073cb67e8823ca048"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed43933e5e98153d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "3ac7ed3d0bda73662f6ce22584ef8f716e5c346fbefa877fdb2fd6a51ea4df3c"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-497a997b7e1daa80",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserSet.g4",
     "hash": "3c4ccda24427c3e37b5dd041af7ef3c43dd3de617f05277385fdbdb7f7c2d87d"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d63d389009bdd4ec",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "a3312a0f61691f481f028a21631fdec86d8654463a35a1da7e3bfa8b677562f5"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9a13fd8981eecd43",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusSet.g4",
     "hash": "bc9bf5d4139930b8ac617486305b9a3a835c9215b5bd3d5a28a3a0e52511dcfd"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d706c00a4a6d9072",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/RuleAsSet.g4",
     "hash": "6d0cd361fe29b6aec92e7802b7d9a91db550efedd1556cc128dee78815f9a8cf"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2d064ae4884c1326",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "2a9008d9a05b1a7427be88356896cd2602f039c2ca9027d44353322d83acef51"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ee03249e2dda9d35",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "023ddbb1ca0f01a768584f1cc7c2264fa54660aa24f1c10eafa78239110f8b2e"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7a0fd6ccb94720da",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "023ddbb1ca0f01a768584f1cc7c2264fa54660aa24f1c10eafa78239110f8b2e"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d7b54423d6154fef",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarSet.g4",
     "hash": "60e149f889628a3731a1c6327c9b6637c87b12ba99154cfa59963e2b9849d755"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9ab0e2b39453cd74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPRangeSet.g4",
     "hash": "17176bf7af0966bf96541f77aa167aa82c9f7378cdf13984ba9bbfbea2114fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-377cf238ac1e2028",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPSet.g4",
     "hash": "65b6fd8f5bf44b438979ad93c63cb50c3d5554a231063480c8847b9c28fe278e"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-69887d620f56e26e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPRangeSet.g4",
     "hash": "564298c89ce6db1cc42e929274e9132c38d58c0a48edcdbf43f5fa20bbc5abbd"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSetMismatch/UnicodeEscapedSMPRangeSetMismatch.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSetMismatch/UnicodeEscapedSMPRangeSetMismatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e0386650afbe6634",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPRangeSetMismatch.g4",
     "hash": "564298c89ce6db1cc42e929274e9132c38d58c0a48edcdbf43f5fa20bbc5abbd"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f9493b3cb4b64f24",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPSet.g4",
     "hash": "44e7ffe1963a5eda267386f282dd10523ca29401f8dc76506453b3a2899b7651"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6c3d68741368e295",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4",
     "hash": "ca5ed0a5d7bdeeb899c3b35de97249046efdfe100ebc4182aa201fd3c878bdc8"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b82ad07daca60f42",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "e3d7399c4da29f3cebfa28d1e944e5dd5662c7f1246140332e66ecb63863194d"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e6753cbc42e76fec",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeUnescapedBMPRangeSet.g4",
     "hash": "7c48456074bd5ec29dc876af086e758b959f95fa5e0f0cbaa04c9b989d555027"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ce398239e5d99754",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeUnescapedBMPSet.g4",
     "hash": "65cc6d65b95f981c34e00820029ab11e82d5108fc2799ad3608d49b421fcb984"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3a16a4ff537f8c19",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/ExprAmbiguity_1.g4",
     "hash": "c5d1f3f3b41e83aed087813c0afe816ed99ae15b99daee412d3152ef47674096"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3b182b98fdaccc68",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/ExprAmbiguity_2.g4",
     "hash": "c5d1f3f3b41e83aed087813c0afe816ed99ae15b99daee412d3152ef47674096"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-724c6291ef0ee955",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_1.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ec23e0d9aec1c2f6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_10.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8dcf81200324c571",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_2.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f313624ad6edc976",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_3.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1dc67c7db6d6d52f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_4.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abe31a1d6808ce47",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_5.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-477f17c2463b8e96",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_6.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-10b57559aeaf3bcc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_7.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d4098b0e07414b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_8.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e79fb0d29171ffdd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_9.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f827f329afceaee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-defde4108f71c68b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b0bb19f34c7e7e99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5e0bb2a71cb18ef0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_1.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-792a24e4c5c84950",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_2.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5ddf90110c8adfd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_3.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a8c70cca85955bb7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_4.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b27749b045ce13de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_5.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8a5e49d006b9be98",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_6.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-10bdbb84da5c4d9d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_7.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-82c4f42335aded29",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bd15c85db4a62501",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6608e8be66945304",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-97f8a98ba183d09e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4f2e7c4ee02457ea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4e0b676e62be0622",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f3aeeff62f332d72",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-57aae01f9f5af6d6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a376df5b65f50eba",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6daa01c64eb48fd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-67fdb6e3085259fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-901da49e00dbf5c5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7ce86a56591743af",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4c875b19fd3b35fd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-237496525c89e858",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d2561963ef8e372e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-39985628aae4cb1b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0895caf4c8e2a330",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f7f208812b8635e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0c8335b8ea486a97",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "2a585adcc4ff6452f8676164c5cc06d1193e60a1f365ced112583ade997878da"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9361b59d78a17c06",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "253110b6fce663add55c6e20a5eea61c026c00ba1848ed7ff547f6d5b46f0020"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2ed7a2793bc8bc6c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "253110b6fce663add55c6e20a5eea61c026c00ba1848ed7ff547f6d5b46f0020"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fdde20ad6ee5b649",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e4b4d8e09f55c8e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-59c158919da3896f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfda504c3fba4c04",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-62ff79f71482513f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPred.g4",
     "hash": "a106deb55eb2abfedaa31b38e5a85311ee1e2be76765ae4c41a8b133cd6b68f4"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56b2f70e5a0e82f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "d944920144fd0f2c268bce46eff79f339ec3e9991ef4598c6b7945c6c5e59a30"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9b11ca68a5374163",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_1.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7d1e8b8611394f9c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_2.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-830fd21b47bd0c5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_3.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fa79ef279fbe7c3c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ea14c1a3e2e23694",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-abf3ff3cc2d5cf21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed67d2b10520b3db",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-939c90efc705053a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b468c061e6f07b7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-74c3e1872ddbddd7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cd93634ca93fd5bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-52a1ecc107f43f69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e4c414946515e719",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-853182052d75cda1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-592ae0778a69b671",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2adf8f906040290b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b9bb4ab705fb304e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-82512f883620f99a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5c64b29f5282c291",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cc0f8b655e083ff4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-463eed3672b1a6ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-007ffa48d97e8593",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/ExtraToken.g4",
     "hash": "6c827abcee181be6a84c23d40dd7187d0cd9fd9ae188a58929cbf42ad2a3b6e3"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2da31481e98ccb34",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/NoViableAlt.g4",
     "hash": "14de2839e69a1dea6c0c4927529aaffce7b01e72edef9233977ee146c24d798a"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6f9dec17daa020bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/RuleRef.g4",
     "hash": "d36f799562d5b5075bc37a123b6a6a2143de5376215c61781d2528fb20bfb872"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0de745acc394f91d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Sync.g4",
     "hash": "d7ee47c0c2239a7409d5fab7d5b4484e25cdee8675a516902627bdeee2af9562"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-12469ea38671fffb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Token2.g4",
     "hash": "6cd80a43bb370ffe5c24d939690ca5a01587d8722d37bcb6e7ef47465f4b3f28"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-500d88e92ed070c8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "a638aad22706396ab56c298fec81040d05225611bb2c1c55b5af65d0d5e6460f"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7e035fc27b024880",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAlts.g4",
     "hash": "79b50c115868f434c423fbe49a9db89ec5ea12828b98d6cc90f1daef29b09b7a"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-90cfc510612af10b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "eb2c2950e7f80585c973ffc612ea059eab4da91ea8fb7e50034dfb78e768fa87"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c60a4d59c5c71db1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionIssue334.g4",
     "hash": "ef72aadf8f7a725e4784a4b40db3fd7131460bfd444256ed6fa7a6bc4804454c"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9319ef8088209c5e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "12bb5d21b00f7b51319887f14af975acc95a45ec6c8e2349c58d9e3036223dae"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fb46a428b28ca3df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "46b96c8091c150c5c47391d69259f5ee245aa80438a275d7b1f0602531dc40ee"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-67bda7c2024a7cf0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "46b96c8091c150c5c47391d69259f5ee245aa80438a275d7b1f0602531dc40ee"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-10862b0dddd3e3ce",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "3cef241a3f1aeefa4734eedc02294ff8d4e3b06d7b68b3bede9c69774c2b98f1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fdc5f8ecb1581ced",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9bd3774852624c48",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e3ef3f336d04e01a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c41367194dc3a19f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bfacbe6db622e778",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ab1af22394a68c5c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dd789b61f267295f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8f7bbbb71846d9a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6336653abd1152d9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fcae849bf6ee92c1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-420e0774837f8368",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d2b33966d9bec5b7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-c7e4f03502e1969a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-63a6d0d25ef7c602",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-95c0ae71c4e43bc6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7cb040514b4d8550",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ContextListGetters.g4",
     "hash": "5c0f1a3091c6de8a91d73791a7a55080a0ef042ad5b662b82d5947e976f700ab"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-78b11d2968a7b9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "6fdb1536b5d50a39105a35527d0a8f63cff00a1682e45af84ee262aed25dec0f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0e768432ad217228",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/APlus.g4",
     "hash": "65afa725cbcac09fa8c5ef09b106193b0653e9a43d9f7dca8f80cfbdab0244cc"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-bc656e8f273b5048",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AStar_2.g4",
     "hash": "32e20668bb74b32537e8ed784776ad010334047540356bf8e558bc448a1a4f1a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e455fb79e0e760d5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAPlus.g4",
     "hash": "2d2f766470d77cd144a3c195c0abac3b491e9622212042e47a005e0cd803c497"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f0a4df9cad5ce7a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAStar_2.g4",
     "hash": "3373095cb5525150349456ff369eeabb2648d7369578d70344fa82843e4795fe"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0bf329c8c63c777b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorB.g4",
     "hash": "526a8a1a4c649b84d041ba7f0dd3f0d2dac2cd930858c7a432207f26448d0985"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a6fe4df601f8fb7e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBPlus.g4",
     "hash": "b24888c439f265999017b6c8d5cac646a8ea99c2c029f29bb49c9abcf813ea8e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-251c61a3417e52fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBStar_2.g4",
     "hash": "8ff040f2bd87b3c1cb83765d26a42f034fe40acabc9979cd9a48d3c4a4116786"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-25a70a6980012d9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Basic.g4",
     "hash": "2785b5f535bab4a06559235161609d47fcf9d752f82ddc5b44bf0fa197a87a5e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-81d548e32786ef7b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "eb2c2950e7f80585c973ffc612ea059eab4da91ea8fb7e50034dfb78e768fa87"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-60f5a9a16604d6e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "440e59e87cf909864372e2572e161b8ac1102e2b33ca17024622c8cbd691c1f3"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-0c64a9174f394f19",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "d57cdde3a5790f927f5bb3a08edc39254365cd598a989a331b50ad31d96b64f4"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8e7c2737b7b0f40b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding1.g4",
     "hash": "52c0d8947d2dad4eda6c969dded97b1e509ebabd582b34e4f1bd545fa7e3d98a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3f270e9e32b462e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "c509006b579b65d3a2bb33cc73f2867396e0457f2e3caf43918c15fdf55f4ba7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19a487ef9ab2d274",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_1.g4",
     "hash": "d67c4f8218be21f6104f600109218250c5738f3abd72780bffdd9c90a167b4d7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-53b24b4c4131b10c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_2.g4",
     "hash": "95b786e26fd0411bc4877c9ce220c361d43eef988f480687b4d8a2391b8c6c7d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-108ee69dd95708f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_3.g4",
     "hash": "7bd91c8ffe4349c62fab43f7e24eccf0cb98ce10f96bb7fd8a4c18eb4c7288eb"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-316e47f9cb1bbc4b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_4.g4",
     "hash": "fc3f61392647c8ee0a4d42fa4d6935e257c040a5177fe7c9849988191e9be6da"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cbb5c83bd36dfc44",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_5.g4",
     "hash": "1b99bef44dff0f4b76fe9b8aaedb7fec1fd8c90e6fc6caec51a524204dc07b3d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-97ad497ee3062dbe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_6.g4",
     "hash": "ff61271aca142ca5ce907d2f8c44c240da8b965be1a57bddafcf7e2389ed74de"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-993de6f9d029cdb3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "bec71119542848512f3dafd408fa0bbbe7279fa597ea3cfa8674dd7778424d5c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-19319eed76368793",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "63a8d3816100691a88d9aeff5c64ae599bf52dbf429c8972ae160de32b215a80"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-05d54229af5ddb42",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "219dd0ab0de17f74119b2a502d847cef78f678320fb64cee55025e147beac015"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7d3cbaec23431d82",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/TokenOffset.g4",
     "hash": "dfda12fb116e3c99f5f42c2618eb51727e857e5c05836e80bc1d2cc161fe42e7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-79d73209896a1038",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Wildcard.g4",
     "hash": "11e95949cf96d6ef6495192ed616530367d1722b686f81d39a09e32761f3e9df"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f4d3608d014cdf23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "807557a1c66b8ed1fbd0bd199253542faba1296ec9860f9e19a5aba35c7ffbc5"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a5be53022ad1b17b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "c4e01650ae90615c32bc3eee5f57f4d611342dcef12948a0907ea38cd714c377"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3abc78f1a1dd0875",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "952c48fb5ebd8dd1c896728f60456def84c4a80ed9f7b9b68b9e341308e04214"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e80e63432313ae6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "f8449f4767b4dfdf52b6113a6c931ea0d5841a7b738c195bee631d4fba689b58"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ff9cd7f68432d91",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "3d7a2878f4652b70aa23384f57b762cf3ebdce090e6be47dc2c4f2e163ff581e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e7b4b66c5c476d1e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Order.g4",
     "hash": "06ee6c74670bd951fc6adaa3d1d127d38db71c55a076074dacd031c2800e1d3b"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5569f9327b68ba4f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "74c1616e4f0f48712c07b5aea8e8be5082e89184828d8814bf2ea1d6244abbcf"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-dcaf5cd43868245e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "95f0830d46eaa8d8d4b9472caa4fad3e5c7bfc6bc822a1098fca68853dd1ffec"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-061a749098f54759",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "435298930cbeb6acec547f5ac93d2d08c38a321dd7dea17a778829c1442580dd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-05c8aabfff617ec3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "4c58b8b6fd28ccaa4a15af5461aba77078c476d7020ad07f9cb060eebc78d65e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18e0a54b0bb49e07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Simple.g4",
     "hash": "dbc4c1cffcd9badf83384d7de1fc39fdebea06e0ad0079703cf4e32c073c5fbd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6fe3217ab933daf7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "79e26c081d50d8991394f673689871fc36a87b4f801191c773a77620c00db8b0"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-79f3ad75b455946b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "5510b13c3f52df41ab478b80a3d468d5676ff38c36d44e8a35630f43a95cd88c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e9a29002fb60d256",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "998b2de4aa9e4153db9d16485ea2c6b528969989d99d0b2af7d9f991b544c2ec"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-55bcf562af70467b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/CharSetLiteral.g4",
     "hash": "1148556229dc59ef2626b0458399983d1636cc24e105edf123aa60544998e683"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1cd9f86e1018566f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerOptionalSet.g4",
     "hash": "9813ec122366d63be434989e2774116a84cf614ff88e6c06654e175e661cf1c2"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ff7d98a7d5e835b5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerPlusSet.g4",
     "hash": "527915ce7cd19bafdf7634fba06323a220718346e187aecd12df786c22a946b6"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-18ca170ffdb0afcc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerStarSet.g4",
     "hash": "c29a11128b93b442513fa85c5028140c2ffdcfa0caecb6a9ee9c91477d80b421"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-49fbc17fc2bfdbb3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotChar.g4",
     "hash": "8f2432be7a965cbd8766ca8e42dd247c40ee569d5381ece836d645269bd0ffec"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9f7b7f2dae37260f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSet.g4",
     "hash": "4155ec14531984facba34515b3ab2f63205dcc5122b43b35eb0e1a5f8d865653"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6d9f734b246f7ab7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "341497f02eb8299a891ed67de6b5ccf5d1a8370780d5dbf784f8e349d9a8255c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cc4e7824c362636a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "065d4e9ed01354807c48b541794965b66c5acd0c3843a8d98456ff80114632d0"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e5a36297644ee691",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSet.g4",
     "hash": "dbe1e20ce85e9efb4ea176c99bdb5bc65e426a6abaafa504abb4741e796262da"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9a65cdd583df2656",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSingleElement.g4",
     "hash": "d8242b63e702bee096a3cd3349e04ca94491a4709e97f6db841bf985cf2ce3e7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-55efb6463177bdd9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotSet.g4",
     "hash": "19c38d099171d47fd0f223833a56a33a3b346c3fefabd4d0ca5cd8cf901969d9"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f9d124d7634800b6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotToken.g4",
     "hash": "190c7d956b90644a68f1a9ea4b1f91ee074c37601d45aa4073cb67e8823ca048"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed43933e5e98153d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "3ac7ed3d0bda73662f6ce22584ef8f716e5c346fbefa877fdb2fd6a51ea4df3c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-497a997b7e1daa80",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserSet.g4",
     "hash": "3c4ccda24427c3e37b5dd041af7ef3c43dd3de617f05277385fdbdb7f7c2d87d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d63d389009bdd4ec",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "a3312a0f61691f481f028a21631fdec86d8654463a35a1da7e3bfa8b677562f5"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9a13fd8981eecd43",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusSet.g4",
     "hash": "bc9bf5d4139930b8ac617486305b9a3a835c9215b5bd3d5a28a3a0e52511dcfd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d706c00a4a6d9072",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/RuleAsSet.g4",
     "hash": "6d0cd361fe29b6aec92e7802b7d9a91db550efedd1556cc128dee78815f9a8cf"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2d064ae4884c1326",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "2a9008d9a05b1a7427be88356896cd2602f039c2ca9027d44353322d83acef51"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ee03249e2dda9d35",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "023ddbb1ca0f01a768584f1cc7c2264fa54660aa24f1c10eafa78239110f8b2e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-7a0fd6ccb94720da",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "023ddbb1ca0f01a768584f1cc7c2264fa54660aa24f1c10eafa78239110f8b2e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d7b54423d6154fef",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarSet.g4",
     "hash": "60e149f889628a3731a1c6327c9b6637c87b12ba99154cfa59963e2b9849d755"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b82ad07daca60f42",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "e3d7399c4da29f3cebfa28d1e944e5dd5662c7f1246140332e66ecb63863194d"

--- a/package-gale/tests/generated/cst_alt_option/alt_opt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_alt_option/alt_opt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-48b87baab8830ef8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/alt_opt.g4",
     "hash": "620ef772a707c22fe42276f8c87130ca600fbd64ce60520cac8fcd711135e1aa"

--- a/package-gale/tests/generated/cst_alt_shared_ident_prefix/alt_shared_ident_prefix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_alt_shared_ident_prefix/alt_shared_ident_prefix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f62bbf04d9ca5929",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/alt_shared_ident_prefix.g4",
     "hash": "61bb2be46f96c2c573f0cf8deb04193ba17af86139cf1e7d2ec8d3caedfa0518"

--- a/package-gale/tests/generated/cst_antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1d86a4da709dfb8e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/cst_at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a034c25435c8eab2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/cst_calc/calc_ll.g4.kiln.json
+++ b/package-gale/tests/generated/cst_calc/calc_ll.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f691f3794504d754",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/calc_ll.g4",
     "hash": "c482319990adba1a727e64e12ccf2a0547c6b46b236670971a827fba64a1067c"

--- a/package-gale/tests/generated/cst_calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/cst_calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ae08d4663fb46310",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/cst_ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-303100b90d8385e6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/cst_ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5e9f3f0dc36ada2e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/cst_css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-06e7a0a312ee3e01",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/cst_diagnostics/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_diagnostics/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2ce82ddf83c467e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_error_recovery/error_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_error_recovery/error_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-9d08a08dde09857c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/error_recovery.g4",
     "hash": "47911f94843fe38ff3fc4d77c7a5068a7d6f2104bd74a737a6a63423dd8dc5db"

--- a/package-gale/tests/generated/cst_follow/follow_gate.g4.kiln.json
+++ b/package-gale/tests/generated/cst_follow/follow_gate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-8810c89269d88e2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/follow_gate.g4",
     "hash": "524e44bc7007d56c2d229ad20e6c01bb033592fd8bcec53a7521325c564c5ee7"

--- a/package-gale/tests/generated/cst_group_recovery/group_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_group_recovery/group_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-213de2705ce984eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/group_recovery.g4",
     "hash": "721f7ec1f804bbfcbc0cf0222d5d50b90183eef3707e81b754f25b69d2fa792a"

--- a/package-gale/tests/generated/cst_html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-6ddf224e63e263ee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/cst_json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2ce82ddf83c467e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e954ac3f3cbae5d3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_label_list_collision/label_list_collision.g4.kiln.json
+++ b/package-gale/tests/generated/cst_label_list_collision/label_list_collision.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-db71f6f9596a3326",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/label_list_collision.g4",
     "hash": "245eac983b4d16903ac917751c3f59e886be8be3e55623cdb25e40c782b58d44"

--- a/package-gale/tests/generated/cst_labels/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_labels/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-21135d6356e2d08c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/cst_lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-de78df534bdeb767",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/cst_lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-004dc53ffad392b9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lexer_greedy_suffix.g4",
     "hash": "2286e1ce4403101b6a2c197a88b3ba06ef185d7c31e99ad55033185275953d1a"

--- a/package-gale/tests/generated/cst_ll_at_end_follow_disjoint/ll_at_end_follow_disjoint.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_at_end_follow_disjoint/ll_at_end_follow_disjoint.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3dbaed505a04f3fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_at_end_follow_disjoint.g4",
     "hash": "2d0b95b4fc43bafec2f89886d5aa864fb6bf5db735da6000d4c54d77f295ffeb"

--- a/package-gale/tests/generated/cst_ll_at_end_nullable_gap/ll_at_end_nullable_gap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_at_end_nullable_gap/ll_at_end_nullable_gap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f73feeaa819a13b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_at_end_nullable_gap.g4",
     "hash": "d0568cc42cc4a99cc19f7bae140369eb89606239f5dbd8519358d34a87812782"

--- a/package-gale/tests/generated/cst_ll_basic/ll_basic.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_basic/ll_basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-28d45bcf6d49d260",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_basic.g4",
     "hash": "f830d43f54bf58f877f51407f191785e0b519d8864d2e9cae12424dfb0c8ab3d"

--- a/package-gale/tests/generated/cst_ll_consume_group/ll_consume_group.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_consume_group/ll_consume_group.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d343579a322c6018",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_consume_group.g4",
     "hash": "9222485ca2ed6480753d84cef49f054d149fc919224051f99aa450f812b07a93"

--- a/package-gale/tests/generated/cst_ll_ctx_follow/ll_ctx_follow.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_ctx_follow/ll_ctx_follow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-fe77ba0dc44c000e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_ctx_follow.g4",
     "hash": "c9dd4149b692de6c13dc9dd30cf96e276da36fd421349ed32aa772e16aa9a1ac"

--- a/package-gale/tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-133e14bfde856446",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_empty_alt_group.g4",
     "hash": "2392939a3ceb27e919a24d1d6ad56e13cc613929c6374a340f75a03ae4ccacb7"

--- a/package-gale/tests/generated/cst_ll_k_prefix_cascade/ll_k_prefix_cascade.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_k_prefix_cascade/ll_k_prefix_cascade.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-659393a388bf8809",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_k_prefix_cascade.g4",
     "hash": "379589a434dcaabfbf33d2e739723b0deb2128a26b9bff77163d967e06b04d1a"

--- a/package-gale/tests/generated/cst_ll_longest_vs_context/ll_longest_vs_context.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_longest_vs_context/ll_longest_vs_context.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f19a5d1ac089a36f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_longest_vs_context.g4",
     "hash": "6c586a8f3c0c3576e8147878ede717b11804253a90aac5b5ef82f21f4a883dd3"

--- a/package-gale/tests/generated/cst_ll_lr_atom/ll_lr_atom.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_lr_atom/ll_lr_atom.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b52f9769732455bc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_lr_atom.g4",
     "hash": "d92f5f9744e5f022ce077b4e2237660b199a6ee15b00f94cc56387392f52823d"

--- a/package-gale/tests/generated/cst_ll_multi_alt/ll_multi_alt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_alt/ll_multi_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-39104ddc525a4300",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_multi_alt.g4",
     "hash": "b0e9035037ba8016d5020c5a34dd8743c2489ca12333f76ca51a9af81c4de25a"

--- a/package-gale/tests/generated/cst_ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56a29edc4fc9d49a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_multi_alt_overlap.g4",
     "hash": "1c00866868c72e8b9c1da0332be534856dafa01dfc589ba1a985ff2fbb2affd6"

--- a/package-gale/tests/generated/cst_ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-34d04cd5fb6544c4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_multi_token_tail.g4",
     "hash": "6dd40045f6bebef9292d9845d79c2befb5dddb0b81e2f22f6295dea6e16a7f55"

--- a/package-gale/tests/generated/cst_ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-01ae1a15ca7eec1c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_nullable_suffix.g4",
     "hash": "13724480e4e66b54852130604fc2ea866cc8ed7d6760c0524d9d72702eb42184"

--- a/package-gale/tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-52e3330993884f82",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_optional_non_greedy.g4",
     "hash": "ba2d514d32e3c49ab408c6a2f5e9f1826c68843c9709dc34a5f55fd8e9bf81bf"

--- a/package-gale/tests/generated/cst_ll_optional_non_greedy_multi/ll_optional_non_greedy_multi.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_optional_non_greedy_multi/ll_optional_non_greedy_multi.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-65fa14e39599e00b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_optional_non_greedy_multi.g4",
     "hash": "841512abf6fd71dcd8ac9427c75c8f53c8e2860d0a1ca6e9cbe21625689e2558"

--- a/package-gale/tests/generated/cst_ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-48257f3e59854dd7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_wildcard_alt.g4",
     "hash": "d1c18ea6b2be7b57df8d6ea77777c1de0e0c80ca8f86199e3c0183bcbaf325a8"

--- a/package-gale/tests/generated/cst_lr/arith_lr.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr/arith_lr.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ec7d464346065f78",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/arith_lr.g4",
     "hash": "26556f22f7a2c98d214fc95cb9ea81fb93d2abeeb84fb9b7c6c73a9086985b05"

--- a/package-gale/tests/generated/cst_lr_between/lr_between.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_between/lr_between.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-3ef64ca57aab7088",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_between.g4",
     "hash": "a1efd5682d5a41a5f4766db73e0bdcc06dc0afdf2e50ab4c403306441ffebe93"

--- a/package-gale/tests/generated/cst_lr_between_call/lr_between_call.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_between_call/lr_between_call.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f2c85fa95b494d46",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_between_call.g4",
     "hash": "55189d1a50844969b5054a4be88f80b4ef5ef1e00bdddafb98b8a24084eb682e"

--- a/package-gale/tests/generated/cst_lr_call/lr_call.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_call/lr_call.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-debe1fe586a61340",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_call.g4",
     "hash": "01e881ace397d3af62a29de281d1662a9e7ec86eb7fc2aa4637dea7e6bfe5fd8"

--- a/package-gale/tests/generated/cst_lr_complement_op/lr_complement_op.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_complement_op/lr_complement_op.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-909a229a6e3281f6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_complement_op.g4",
     "hash": "501ba73a08ae31f00d1a310bdb79d4a51ef593ec71b3e6b5a01bae2ccb4eaee0"

--- a/package-gale/tests/generated/cst_lr_dangling_else/lr_dangling_else.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_dangling_else/lr_dangling_else.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-82cdfc1a9d2837b2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_dangling_else.g4",
     "hash": "676bce3fd8100375614484afd821174aa60a5a0759b5e46caaf7f2f3627296c2"

--- a/package-gale/tests/generated/cst_lr_overlap/lr_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_overlap/lr_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-30a70746c0b3246b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_overlap.g4",
     "hash": "5674c6a0f2f951dcbabbc831b2cb923c005d687276df03fea69d088cbae12c1a"

--- a/package-gale/tests/generated/cst_lr_paren/lr_paren.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_paren/lr_paren.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b4b015cf25dab035",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_paren.g4",
     "hash": "58cf6be3c20a432eab6caf7bd38be29f462578030956f800dce7b0d8eb96bea1"

--- a/package-gale/tests/generated/cst_lr_scan_caller/lr_scan_caller.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_scan_caller/lr_scan_caller.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-41bf694c80471b53",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_scan_caller.g4",
     "hash": "a5c160c8e20e4727da1e40c83d884d6f2658153bda5919e2431c5b8bee5f5648"

--- a/package-gale/tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-764739b2433d7c87",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/lr_wildcard_postfix.g4",
     "hash": "525afce18841d8fd1c19378727fb15e3e62e462ffa9202bfcc2253826c35bf98"

--- a/package-gale/tests/generated/cst_mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d282af85b4f73af2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/cst_multiple_eof/multiple_eof.g4.kiln.json
+++ b/package-gale/tests/generated/cst_multiple_eof/multiple_eof.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-ed371b9e29e905eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/multiple_eof.g4",
     "hash": "2b097a4cde773ec14e56e4222cd34af3735931774e74c4c77ca7b37f41afaa43"

--- a/package-gale/tests/generated/cst_non_greedy/non_greedy.g4.kiln.json
+++ b/package-gale/tests/generated/cst_non_greedy/non_greedy.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-5a25ff4cea33619b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/non_greedy.g4",
     "hash": "8df507b6ddb99d4381283f8a2b2af531696f43deadb3aa7e75f7a8d66990d1a0"

--- a/package-gale/tests/generated/cst_non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4ee53b84b0328325",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/cst_opt_sep_list/opt_sep_list.g4.kiln.json
+++ b/package-gale/tests/generated/cst_opt_sep_list/opt_sep_list.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-52e4d0f89320e047",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/opt_sep_list.g4",
     "hash": "c6a879a1e89a7a0cf4fddca366393412ec939a5579f079fab250cee7d8be33fd"

--- a/package-gale/tests/generated/cst_overlap_tournament/ll_overlap_tournament.g4.kiln.json
+++ b/package-gale/tests/generated/cst_overlap_tournament/ll_overlap_tournament.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-926c6460e2a9f76e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_overlap_tournament.g4",
     "hash": "c6fd0821861f96cf907e2a88c796e161295e33bdc2a280ae9567fe31cbc15833"

--- a/package-gale/tests/generated/cst_parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-f9257c59c3f549ab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/cst_parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
+++ b/package-gale/tests/generated/cst_parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1f7e16c027c1834d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/parser_set_group_dispatch.g4",
     "hash": "c36bfab5dcc4c7f598aa83ca22dca3fd716225387804db2223b3c47986b73355"

--- a/package-gale/tests/generated/cst_recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b94286261fae4075",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/cst_right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-e22341b1badabb69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/cst_rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-4450397ae11ad2b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/cst_sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-df217e695dae678d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/cst_sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-a3cbf67768ad9029",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/cst_sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-d0a8be96e4000de8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/cst_tie_recovery/tie_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_tie_recovery/tie_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-af39119443379f30",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/tie_recovery.g4",
     "hash": "b424904a6f362db6e62af0d40479f785c71a19805baf47bc158037899a334ed1"

--- a/package-gale/tests/generated/cst_tour/amb_tour.g4.kiln.json
+++ b/package-gale/tests/generated/cst_tour/amb_tour.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-75a3fc62d79167d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/amb_tour.g4",
     "hash": "074f334123300f55a97b8103d93f22b02603c9fec0e734374e24472343645195"

--- a/package-gale/tests/generated/cst_trace/ll_multi_alt_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_trace/ll_multi_alt_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-56a29edc4fc9d49a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/ll_multi_alt_overlap.g4",
     "hash": "1c00866868c72e8b9c1da0332be534856dafa01dfc589ba1a985ff2fbb2affd6"

--- a/package-gale/tests/generated/cst_typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2e590d7f152dbc56",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"
@@ -18,7 +18,7 @@
   "outputs": [
     {
       "path": "tests/generated/cst_typescript/type_script.wado",
-      "hash": "8b5dafd62bf9adc922b7788e26767f19aa97d7b5807f0952dfb0c3ff53628045",
+      "hash": "3aa23b2eb3003def0cbcf962acb80bd7221af78dd3fec66e917f36745122639e",
       "entry": true
     }
   ]

--- a/package-gale/tests/generated/cst_typescript/type_script.wado
+++ b/package-gale/tests/generated/cst_typescript/type_script.wado
@@ -5998,7 +5998,7 @@ pub fn tokenize(input: &String) -> TokenStream {
             end = try_lit_lbrace(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_rbrace(&lexer.chars, start);
-            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; best_push_mode = -1; best_pop_mode = true; best_channel = 0; }
             end = try_lit_eqgt(&lexer.chars, start);
             if end > best_end { best_end = end; best_kind = TK_LIT_EQGT; best_push_mode = -1; best_pop_mode = false; best_channel = 0; }
             end = try_lit_new(&lexer.chars, start);

--- a/package-gale/tests/generated/cst_unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/cst_unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-2f56d5bf73d1b564",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"

--- a/package-gale/tests/generated/java_action/java_action.g4.kiln.json
+++ b/package-gale/tests/generated/java_action/java_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-cb827aca7a67f8e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/java_action.g4",
     "hash": "f5d358da2351263069770edb99fdfe68de2388fa9a694e14e48ca7c3a3404daf"

--- a/package-gale/tests/generated/java_members/java_members.g4.kiln.json
+++ b/package-gale/tests/generated/java_members/java_members.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-06da003e3a941c38",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/java_members.g4",
     "hash": "d0ef9eeb80b915011f89a5dc53c09c05002c2e273cfe9ad462b8c0f3d474f45a"

--- a/package-gale/tests/generated/java_pred/java_pred.g4.kiln.json
+++ b/package-gale/tests/generated/java_pred/java_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-b0c3ac28e84fd109",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/java_pred.g4",
     "hash": "9b4d36f922a8bd958d74d5d704ebe7e5b682b5be0a8ec2eb8787052a479c9ebf"

--- a/package-gale/tests/generated/lit_command_shadow/lit_command_shadow.g4.kiln.json
+++ b/package-gale/tests/generated/lit_command_shadow/lit_command_shadow.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-ed7d841dd7fcb094",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
+  "primary": {
+    "path": "tests/grammars/lit_command_shadow.g4",
+    "hash": "c9ea9ffe565fe792998be96ebf60731bae11f4705da8e1862a09f33db4c495ac"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "c3a25c0096737aa5544fa4f3ef1441ba827fd737d7e858edfa46443c9c969eed",
+  "outputs": [
+    {
+      "path": "tests/generated/lit_command_shadow/lit_command_shadow.wado",
+      "hash": "c0bd4f204d6fc17351d071fdf58f6812e71ded50463ef1a6665c2acc69c64bd1",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/lit_command_shadow/lit_command_shadow.wado
+++ b/package-gale/tests/generated/lit_command_shadow/lit_command_shadow.wado
@@ -1,0 +1,1833 @@
+#![generated(by = "gale", sources = ["tests/grammars/lit_command_shadow.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at {self.line}:{self.col}: {self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: {self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`{self.severity.label()}[{self.code.name()}] at {self.line}:{self.col}: {self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: {r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text. `rule_names[kind]` names rule nodes (`K_ERROR`
+    /// renders `<error>`); `token_names[kind]` names missing terminals. Real
+    /// terminals with empty text (e.g. EOF) are omitted; missing/skipped
+    /// terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    out.push_str(&"(");
+    if s.a[i] == K_ERROR as i32 {
+        out.push_str(&"<error>");
+    } else {
+        out.push_str(&rule_names[s.a[i]]);
+    }
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing {token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    out.push_str(&"(");
+    if a[i] == K_ERROR as i32 {
+        out.push_str(&"<error>");
+    } else {
+        out.push_str(&rule_names[a[i]]);
+    }
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing {token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.len() * 32);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel={channel},` } else { String::from("") };
+    out.push_str(&`[@{index},{start}:{end_inclusive}='{text_buf}',<{type_id}>,{channel_attr}{line}:{col}]\n`);
+}
+
+/// Compute (line, column) at a 0-based char index in `chars`, with
+/// 1-based line and 0-based column to match ANTLR4's `Token` getters.
+/// The parser's error path reports at most one position per parse, so the
+/// linear scan is fine; the per-token dump uses `line_col_from_starts`.
+fn line_col_at(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    LBRACE,
+    WS,
+    WORD,
+    Eof,
+    Error,
+}
+
+pub global TK_LBRACE: i32 = 0;
+pub global TK_WS: i32 = 1;
+pub global TK_WORD: i32 = 2;
+pub global TK_EOF: i32 = 3;
+pub global TK_ERROR: i32 = 4;
+pub global TK_LIT_LBRACE: i32 = 5;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\r' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { ' ' | '\t' | '\r' | '\n' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_WORD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_lbrace(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '{' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    let mut mode_stack: List<i32> = [];
+    let mut current_mode: i32 = 0;
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        let mut best_push_mode: i32 = -1;
+        let mut best_pop_mode = false;
+        if current_mode == 0 {
+            end = try_lit_lbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; best_push_mode = 1; best_pop_mode = false; }
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; best_push_mode = -1; best_pop_mode = false; }
+        } else if current_mode == 1 {
+            end = try_WORD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; best_push_mode = -1; best_pop_mode = false; }
+        }
+        if best_end < start || (best_end == start && best_push_mode < 0 && !best_pop_mode) {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            if best_push_mode >= 0 {
+                mode_stack.push(current_mode);
+                current_mode = best_push_mode;
+                best_push_mode = -1;
+            }
+            if best_pop_mode {
+                if mode_stack.is_empty() {
+                    current_mode = 0;
+                } else {
+                    current_mode = mode_stack[mode_stack.len() - 1];
+                    mode_stack.pop();
+                }
+                best_pop_mode = false;
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_LBRACE => "LBRACE",
+        TK_WS => "WS",
+        TK_WORD => "WORD",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_LBRACE => "TK_LIT_LBRACE",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_PROG: NodeKind = 0;
+
+global RULE_NAMES: List<String> = ["prog"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`({*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [] };
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "{self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing {name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "{self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected {name}, got "{self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected {name}, got "{self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "{self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "{self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "{self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_prog(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos] != TK_WORD { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos] != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_prog__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let lbrace = p.expect(TK_LIT_LBRACE, &SYNC_0);
+    let word = p.expect(TK_WORD, &SYNC_1);
+    let eof = p.expect(TK_EOF, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_prog(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_PROG, _start);
+    _parse_prog__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("prog");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got {max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_prog(input, max_errors);
+}
+
+pub fn parse_prog(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_prog(p));
+}
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_WORD];
+global SYNC_1: List<i32> = [TK_EOF];
+

--- a/package-gale/tests/generated/mode_lit_shadow/mode_lit_shadow.g4.kiln.json
+++ b/package-gale/tests/generated/mode_lit_shadow/mode_lit_shadow.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-6a675431ccc57bb5",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
+  "primary": {
+    "path": "tests/grammars/mode_lit_shadow.g4",
+    "hash": "5c60cce9b9ffec9ce6475e3c2c68304cf4608def43b1205523b3d30bad0fad84"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "c3a25c0096737aa5544fa4f3ef1441ba827fd737d7e858edfa46443c9c969eed",
+  "outputs": [
+    {
+      "path": "tests/generated/mode_lit_shadow/mode_lit_shadow.wado",
+      "hash": "01628b440b7475ff288bfe8a45cd2e7cfbc254c02a100c98fcb55d253d0c6bd8",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/mode_lit_shadow/mode_lit_shadow.wado
+++ b/package-gale/tests/generated/mode_lit_shadow/mode_lit_shadow.wado
@@ -1,0 +1,1985 @@
+#![generated(by = "gale", sources = ["tests/grammars/mode_lit_shadow.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at {self.line}:{self.col}: {self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: {self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`{self.severity.label()}[{self.code.name()}] at {self.line}:{self.col}: {self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: {r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text. `rule_names[kind]` names rule nodes (`K_ERROR`
+    /// renders `<error>`); `token_names[kind]` names missing terminals. Real
+    /// terminals with empty text (e.g. EOF) are omitted; missing/skipped
+    /// terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    out.push_str(&"(");
+    if s.a[i] == K_ERROR as i32 {
+        out.push_str(&"<error>");
+    } else {
+        out.push_str(&rule_names[s.a[i]]);
+    }
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing {token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    out.push_str(&"(");
+    if a[i] == K_ERROR as i32 {
+        out.push_str(&"<error>");
+    } else {
+        out.push_str(&rule_names[a[i]]);
+    }
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing {token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.len() * 32);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel={channel},` } else { String::from("") };
+    out.push_str(&`[@{index},{start}:{end_inclusive}='{text_buf}',<{type_id}>,{channel_attr}{line}:{col}]\n`);
+}
+
+/// Compute (line, column) at a 0-based char index in `chars`, with
+/// 1-based line and 0-based column to match ANTLR4's `Token` getters.
+/// The parser's error path reports at most one position per parse, so the
+/// linear scan is fine; the per-token dump uses `line_col_from_starts`.
+fn line_col_at(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    BACKTICK,
+    WORD,
+    LBRACE,
+    RBRACE,
+    WS,
+    INTERP_OPEN,
+    STR_END,
+    Eof,
+    Error,
+}
+
+pub global TK_BACKTICK: i32 = 0;
+pub global TK_WORD: i32 = 1;
+pub global TK_LBRACE: i32 = 2;
+pub global TK_RBRACE: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_INTERP_OPEN: i32 = 5;
+pub global TK_STR_END: i32 = 6;
+pub global TK_EOF: i32 = 7;
+pub global TK_ERROR: i32 = 8;
+pub global TK_LIT_LBRACE: i32 = 9;
+pub global TK_LIT_RBRACE: i32 = 10;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_BACKTICK(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '`' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_WORD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\r' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { ' ' | '\t' | '\r' | '\n' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_INTERP_OPEN(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '{' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_STR_END(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '`' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_lit_lbrace(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '{' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rbrace(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '}' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    let mut mode_stack: List<i32> = [];
+    let mut current_mode: i32 = 0;
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        let mut best_push_mode: i32 = -1;
+        let mut best_pop_mode = false;
+        if current_mode == 0 {
+            end = try_lit_lbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LBRACE; best_push_mode = 0; best_pop_mode = false; }
+            end = try_lit_rbrace(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RBRACE; best_push_mode = -1; best_pop_mode = true; }
+            end = try_BACKTICK(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BACKTICK; best_push_mode = 1; best_pop_mode = false; }
+            end = try_WORD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WORD; best_push_mode = -1; best_pop_mode = false; }
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; best_push_mode = -1; best_pop_mode = false; }
+        } else if current_mode == 1 {
+            end = try_INTERP_OPEN(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INTERP_OPEN; best_push_mode = 0; best_pop_mode = false; }
+            end = try_STR_END(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BACKTICK; best_push_mode = -1; best_pop_mode = true; }
+        }
+        if best_end < start || (best_end == start && best_push_mode < 0 && !best_pop_mode) {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            if best_push_mode >= 0 {
+                mode_stack.push(current_mode);
+                current_mode = best_push_mode;
+                best_push_mode = -1;
+            }
+            if best_pop_mode {
+                if mode_stack.is_empty() {
+                    current_mode = 0;
+                } else {
+                    current_mode = mode_stack[mode_stack.len() - 1];
+                    mode_stack.pop();
+                }
+                best_pop_mode = false;
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_BACKTICK => "BACKTICK",
+        TK_WORD => "WORD",
+        TK_LBRACE => "LBRACE",
+        TK_RBRACE => "RBRACE",
+        TK_WS => "WS",
+        TK_INTERP_OPEN => "INTERP_OPEN",
+        TK_STR_END => "STR_END",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_LBRACE => "TK_LIT_LBRACE",
+        TK_LIT_RBRACE => "TK_LIT_RBRACE",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_PROG: NodeKind = 0;
+pub global RK_BLOCK: NodeKind = 1;
+pub global RK_TSTR: NodeKind = 2;
+pub global RK_INTERP: NodeKind = 3;
+
+global RULE_NAMES: List<String> = ["prog", "block", "tstr", "interp"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`({*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [] };
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "{self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing {name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "{self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.tokens.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected {name}, got "{self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected {name}, got "{self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "{self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "{self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "{self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_prog(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_block(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    pos = scan_tstr(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos] != TK_EOF { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_block(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_LBRACE { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_tstr(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_BACKTICK { return -1; }
+    pos += 1;
+    pos = scan_interp(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos] != TK_BACKTICK { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_interp(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_INTERP_OPEN { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos] != TK_WORD { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_RBRACE { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_prog__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let block = _parse_block(p);
+    let tstr = _parse_tstr(p);
+    let eof = p.expect(TK_EOF, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_prog(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_PROG, _start);
+    _parse_prog__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("prog");
+    }
+}
+
+fn _parse_block__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let lbrace = p.expect(TK_LIT_LBRACE, &SYNC_0);
+    let rbrace = p.expect(TK_LIT_RBRACE, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_block(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_BLOCK, _start);
+    _parse_block__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("block");
+    }
+}
+
+fn _parse_tstr__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let backtick = p.expect(TK_BACKTICK, &SYNC_1);
+    let interp = _parse_interp(p);
+    let backtick_2 = p.expect(TK_BACKTICK, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_tstr(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_TSTR, _start);
+    _parse_tstr__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("tstr");
+    }
+}
+
+fn _parse_interp__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let interp_open = p.expect(TK_INTERP_OPEN, &SYNC_2);
+    let word = p.expect(TK_WORD, &SYNC_0);
+    let rbrace = p.expect(TK_LIT_RBRACE, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_interp(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_INTERP, _start);
+    _parse_interp__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("interp");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got {max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_prog(input, max_errors);
+}
+
+pub fn parse_prog(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_prog(p));
+}
+
+pub fn parse_block(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_block(p));
+}
+
+pub fn parse_tstr(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_tstr(p));
+}
+
+pub fn parse_interp(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_interp(p));
+}
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(11);
+    for let mut k = 0; k < 11; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(11);
+    for let mut k = 0; k < 11; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_RBRACE];
+global SYNC_1: List<i32> = [TK_INTERP_OPEN];
+global SYNC_2: List<i32> = [TK_WORD];
+

--- a/package-gale/tests/generated/nested_list_follow/nested_list_follow.g4.kiln.json
+++ b/package-gale/tests/generated/nested_list_follow/nested_list_follow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 2,
   "invocation": "kiln-1add3cc04a11db4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "1643df14eae0060ba9b95d6c2e481c3fb2101c41567a6449fada5a6a67052881",
+  "generator_source_hash": "00b535d94c1595bb4861a404b18aff940cd2064800e0c839aee342238f2fc4f5",
   "primary": {
     "path": "tests/grammars/nested_list_follow.g4",
     "hash": "584493fc9fc1de92e1eea1934a4aec63d681c4c012c50a3f05a70b4f182c4360"

--- a/package-gale/tests/grammars/lit_command_shadow.g4
+++ b/package-gale/tests/grammars/lit_command_shadow.g4
@@ -1,0 +1,12 @@
+// Source: hand-written regression for the inline-literal / named-rule shadow.
+// License: project-internal test fixture.
+// `{` is written inline in a parser rule and also has a named lexer rule that
+// carries a mode-push command. ANTLR unifies the two, so the command must fire:
+// WORD is only lexable in the pushed mode, so a dropped command leaves it
+// unrecognized.
+grammar LitCommandShadow;
+prog   : '{' WORD EOF ;
+LBRACE : '{' -> pushMode(INNER) ;
+WS     : [ \t\r\n]+ -> skip ;
+mode INNER;
+WORD : [a-z]+ ;

--- a/package-gale/tests/grammars/mode_lit_shadow.g4
+++ b/package-gale/tests/grammars/mode_lit_shadow.g4
@@ -1,0 +1,21 @@
+// Source: hand-written regression for the mode / inline-literal shadow.
+// License: project-internal test fixture.
+// `{` is an inline literal in `block`, so it is a parser literal token. A `{`
+// rule (INTERP_OPEN) also lives in the STR mode; it must keep its matcher —
+// inline literals are only matched in the default mode, so shadowing it would
+// leave STR with no `{` and the interpolation would never open.
+grammar ModeLitShadow;
+prog   : block tstr EOF ;
+block  : '{' '}' ;
+tstr   : BACKTICK interp BACKTICK ;
+interp : INTERP_OPEN WORD '}' ;
+
+BACKTICK : '`' -> pushMode(STR) ;
+WORD     : [a-z]+ ;
+LBRACE   : '{' -> pushMode(DEFAULT_MODE) ;
+RBRACE   : '}' -> popMode ;
+WS       : [ \t\r\n]+ -> skip ;
+
+mode STR;
+INTERP_OPEN : '{' -> pushMode(DEFAULT_MODE) ;
+STR_END     : '`' -> type(BACKTICK), popMode ;


### PR DESCRIPTION
## Summary

A named single-literal lexer rule whose text also appears as a parser inline literal was dropped as a pure duplicate. That is wrong in two ways, both fixed here, and the example `Wado.g4` is then rewritten to use braces naturally.

## The bug

When a parser rule uses a literal inline (e.g. `'{'`) *and* a named lexer rule defines the same single literal, ANTLR treats them as one token. Gale instead skipped the named rule's matcher and lexed the literal with no commands:

- **Default-mode commands were lost.** `X : '{' -> pushMode(M)` used inline as `'{'` silently dropped its `pushMode` / `popMode` / `channel` / `more`. The real-world **TypeScript lexer** hit this — its template-string `}` (used inline) never ran its `popMode`, so its generated lexer was wrong.
- **Non-default-mode rules were dropped.** Inline literals are only matched in the default mode, so a same-text rule in another mode was left with no matcher for that text at all.

## The fix (`lexer_gen.wado`)

- A literal token now inherits the lexer commands of a same-text default-mode named rule (`literal_command_extras`).
- `is_literal_duplicate` no longer treats a non-default-mode rule as a duplicate.

Output is byte-identical for a literal with no commanded default-mode shadow rule, so the only generated-code content change across the whole driver-test corpus is `cst_typescript`'s `}` gaining its `popMode`; the rest is a generator-source hash bump.

## Fixtures (TDD)

- `lit_command_shadow` — a command on a named rule survives when the literal is used inline.
- `mode_lit_shadow` — a `{` rule in a non-default mode keeps its matcher despite an inline `{`.

## Example grammar naturalized

With the fix, a lexer command rides on an inline literal, so `example/Wado.g4`'s parser rules no longer need braces spelled as named `OPEN_BRACE` / `CLOSE_BRACE`. They revert to plain `'{'` / `'}'`; the mode commands are declared once on the `LBRACE` / `RBRACE` rules and inherited by the inline usages, and the template interpolation opens with its own `INTERP_OPEN` token. The full highlighter suite (52 tests, incl. interpolation) stays green — validating both facets end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiM67sW3V17FGZYP8AeQ7j

---
_Generated by [Claude Code](https://claude.ai/code/session_01WiM67sW3V17FGZYP8AeQ7j)_