### PR TITLE
feat(playground): run Wado entirely in the browser (compiler + jco as wasm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,9 +301,13 @@ jobs:
           MISE_VERBOSE: ${{ runner.debug }}
 
       - run: mise run check-deps
-      # wado-compiler and wado-manifest must both compile for wasm32 (see
-      # CLAUDE.md / wado-manifest); check them directly with the locked lockfile.
+      # wado-compiler, wado-lsp, and wado-manifest must all compile for wasm32
+      # (see CLAUDE.md / wado-manifest). This is deliberate: the compiler and
+      # LSP engine stay OS-independent so they can run in the browser (the
+      # playground), with all I/O delegated to the wado-cli host. Check them
+      # directly with the locked lockfile.
       - run: cargo check --locked -p wado-compiler --target wasm32-unknown-unknown
+      - run: cargo check --locked -p wado-lsp --target wasm32-unknown-unknown
       - run: cargo check --locked -p wado-manifest --target wasm32-unknown-unknown
 
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,6 +3477,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wado-playground"
+version = "0.0.17"
+dependencies = [
+ "wado-compiler",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["wado-compiler", "wado-cli", "wado-from-idl", "wado-bundled-libm", "wado-manifest", "wado-dev-tools", "wado-lsp"]
+members = ["wado-compiler", "wado-cli", "wado-from-idl", "wado-bundled-libm", "wado-manifest", "wado-dev-tools", "wado-lsp", "wado-playground"]
 exclude = ["vendor"]
 resolver = "3" # v3 resolver
 

--- a/mise.toml
+++ b/mise.toml
@@ -676,3 +676,21 @@ for i in $(seq 1 "$RUNS"); do
   fi
 done
 """
+
+[tasks.playground-web-build]
+description = "Build the client-side browser playground assets into wado-playground/web/"
+depends = ["jco-deps"]
+run = "wado-playground/web/build.sh"
+
+[tasks.playground-web-serve]
+description = "Serve the browser playground on http://127.0.0.1:8088 (run playground-web-build first)"
+run = "cd wado-playground/web && python3 -m http.server 8088"
+
+[tasks.playground-web-test]
+description = "Browser smoke test for the playground (installs playwright-core; needs Chromium 137+)"
+run = """
+#!/usr/bin/env bash
+set -e -o pipefail
+(cd scripts/jco && node -e "require.resolve('playwright-core')" 2>/dev/null || npm install playwright-core)
+node wado-playground/web/test-browser.mjs
+"""

--- a/mise.toml
+++ b/mise.toml
@@ -57,6 +57,7 @@ run = """
 set -xe -o pipefail
 cargo check
 cargo check -p wado-compiler --target wasm32-unknown-unknown
+cargo check -p wado-lsp --target wasm32-unknown-unknown
 cargo check -p wado-manifest --target wasm32-unknown-unknown
 """
 

--- a/scripts/jco/package-lock.json
+++ b/scripts/jco/package-lock.json
@@ -7,6 +7,9 @@
       "name": "wado-jco-released",
       "dependencies": {
         "@bytecodealliance/jco": "^1.24.3"
+      },
+      "devDependencies": {
+        "esbuild": "^0.28.1"
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {
@@ -252,6 +255,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1355,6 +1800,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fd-slicer": {

--- a/scripts/jco/package.json
+++ b/scripts/jco/package.json
@@ -5,5 +5,8 @@
   "description": "Vendor-free jco pipeline: transpile Wado components with the released jco and supply the missing P3 runtime as a post-process layer.",
   "dependencies": {
     "@bytecodealliance/jco": "^1.24.3"
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.1"
   }
 }

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -6,6 +6,7 @@ Language service engine for the Wado compiler toolchain.
 
 - Types follow LSP semantics (0-based positions, standard severity levels).
 - See [LSP Architecture WEP](../docs/wep-2026-04-18-lsp-architecture.md) for crate scope and build targets. The WEP supersedes earlier rules about this crate being IO-free, `wasm32-unknown-unknown`-only, or protocol-agnostic.
+- The crate still compiles for `wasm32-unknown-unknown` (CI-enforced: `cargo check -p wado-lsp --target wasm32-unknown-unknown`), keeping the `Engine` and query path OS-independent so the browser playground can run the language service without a WASI host. Runtime I/O (filesystem source loading) is delegated to the host — `wado-cli` on the desktop, an in-memory host in the browser.
 
 ## Architecture
 

--- a/wado-playground/Cargo.toml
+++ b/wado-playground/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "wado-playground"
+version = { workspace = true }
+edition = "2024"
+license.workspace = true
+rust-version.workspace = true
+description = "wasm32 wrapper exposing the Wado compiler for an in-browser playground"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wado-compiler = { path = "../wado-compiler" }
+
+[lints]
+workspace = true

--- a/wado-playground/src/lib.rs
+++ b/wado-playground/src/lib.rs
@@ -1,19 +1,13 @@
 //! wasm32 wrapper exposing the Wado compiler for an in-browser playground.
 //!
-//! The C ABI is intentionally minimal so the browser side can drive it with
-//! plain `WebAssembly` (no wasm-bindgen runtime):
+//! Minimal C ABI so the browser can drive it with plain `WebAssembly` (no
+//! wasm-bindgen):
 //!
-//! - `wado_alloc(len)` reserves `len` bytes the host fills with UTF-8 source.
-//! - `wado_compile(ptr, len)` compiles that source and returns a pointer to a
-//!   result buffer laid out as `[status:u32 LE][len:u32 LE][payload…]`.
-//!   `status == 1`: payload is the component Wasm. `status == 0`: payload is
-//!   UTF-8 diagnostics text. It **consumes** the input buffer (frees it), so
-//!   the host must not reuse `ptr` afterwards.
-//! - `wado_free(ptr, len)` releases a buffer. The host calls it on the result
-//!   pointer (with `len == 8 + payload_len`) once it has copied the bytes out.
-//!
-//! Every buffer is allocated with an exact `[u8; len]` layout and freed with
-//! the same layout, so alloc/dealloc always agree (no `Vec` capacity slack).
+//! - `wado_alloc(len)` reserves `len` bytes for the host to fill with UTF-8 source.
+//! - `wado_compile(ptr, len)` compiles it, freeing the input buffer, and returns
+//!   an owned result buffer `[status:u32 LE][len:u32 LE][payload…]` — `status 1`
+//!   payload is the component Wasm, `status 0` payload is UTF-8 diagnostics.
+//! - `wado_free(ptr, len)` releases a buffer (result buffers: `len == 8 + payload`).
 
 use std::alloc::{Layout, alloc, dealloc};
 use std::future::Future;
@@ -76,8 +70,7 @@ pub unsafe extern "C" fn wado_compile(ptr: *mut u8, len: usize) -> *const u8 {
     }
 }
 
-/// Allocate a result buffer `[status:u32 LE][len:u32 LE][payload…]` and return
-/// it for the host to read and then release with [`wado_free`].
+/// Allocate and fill an owned `[status:u32 LE][len:u32 LE][payload…]` buffer.
 fn encode(status: u32, payload: &[u8]) -> *const u8 {
     let total = 8 + payload.len();
     let out = wado_alloc(total);
@@ -90,10 +83,9 @@ fn encode(status: u32, payload: &[u8]) -> *const u8 {
     out
 }
 
-/// Drive a future to completion. `InMemoryCompilerHost` never truly suspends
-/// (every `load_source` resolves immediately), so the noop waker suffices; a
-/// `Pending` would mean that invariant broke, so fail loudly instead of
-/// spinning forever.
+/// Poll a future to completion. `InMemoryCompilerHost` resolves every
+/// `load_source` immediately, so one poll suffices; a `Pending` means that
+/// invariant broke — panic rather than spin forever.
 fn block_on<F: Future>(fut: F) -> F::Output {
     let waker = Waker::noop();
     let mut cx = Context::from_waker(waker);

--- a/wado-playground/src/lib.rs
+++ b/wado-playground/src/lib.rs
@@ -3,43 +3,56 @@
 //! The C ABI is intentionally minimal so the browser side can drive it with
 //! plain `WebAssembly` (no wasm-bindgen runtime):
 //!
-//! - `wado_alloc(len)` reserves a buffer the host fills with UTF-8 source.
-//! - `wado_compile(ptr, len)` compiles it and returns a pointer to a result
-//!   buffer laid out as `[status:u32 LE][len:u32 LE][payload…]`.
+//! - `wado_alloc(len)` reserves `len` bytes the host fills with UTF-8 source.
+//! - `wado_compile(ptr, len)` compiles that source and returns a pointer to a
+//!   result buffer laid out as `[status:u32 LE][len:u32 LE][payload…]`.
 //!   `status == 1`: payload is the component Wasm. `status == 0`: payload is
-//!   UTF-8 diagnostics text.
+//!   UTF-8 diagnostics text. It **consumes** the input buffer (frees it), so
+//!   the host must not reuse `ptr` afterwards.
+//! - `wado_free(ptr, len)` releases a buffer. The host calls it on the result
+//!   pointer (with `len == 8 + payload_len`) once it has copied the bytes out.
+//!
+//! Every buffer is allocated with an exact `[u8; len]` layout and freed with
+//! the same layout, so alloc/dealloc always agree (no `Vec` capacity slack).
 
+use std::alloc::{Layout, alloc, dealloc};
 use std::future::Future;
 use std::task::{Context, Poll, Waker};
 
 use wado_compiler::compiler_host::InMemoryCompilerHost;
 use wado_compiler::{CompilerOptions, OptLevel, compile_with_options};
 
-/// Reserve `len` bytes and return a pointer the host can write into.
-///
-/// # Safety
-/// The returned pointer is owned by the caller until passed back to
-/// [`wado_compile`]. Leaking here is fine: the playground compiles once per
-/// call and the wasm instance is short-lived.
-#[unsafe(no_mangle)]
-pub extern "C" fn wado_alloc(len: usize) -> *mut u8 {
-    let mut buf = Vec::<u8>::with_capacity(len);
-    let ptr = buf.as_mut_ptr();
-    std::mem::forget(buf);
-    ptr
+/// Exact byte-buffer layout. `len == 0` is rounded to 1 so alloc never sees a
+/// zero size; `wado_free` applies the same rounding, so the layouts match.
+fn layout(len: usize) -> Layout {
+    Layout::from_size_align(len.max(1), 1).expect("valid byte layout")
 }
 
-/// Compile the UTF-8 source at `ptr..ptr+len`.
+/// Reserve `len` bytes and return a pointer the host can write into.
+#[unsafe(no_mangle)]
+pub extern "C" fn wado_alloc(len: usize) -> *mut u8 {
+    unsafe { alloc(layout(len)) }
+}
+
+/// Free a buffer previously returned by [`wado_alloc`] or [`wado_compile`].
 ///
 /// # Safety
-/// `ptr..ptr+len` must be a valid buffer previously returned by
-/// [`wado_alloc`] and filled with `len` bytes of UTF-8.
+/// `ptr` must come from [`wado_alloc`]/[`wado_compile`] and `len` must be the
+/// exact length it was allocated with (for a result buffer, `8 + payload_len`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wado_free(ptr: *mut u8, len: usize) {
+    unsafe { dealloc(ptr, layout(len)) }
+}
+
+/// Compile the UTF-8 source at `ptr..ptr+len`, consuming (freeing) that buffer.
+///
+/// # Safety
+/// `ptr..ptr+len` must be a valid buffer previously returned by [`wado_alloc`]
+/// and filled with `len` bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wado_compile(ptr: *mut u8, len: usize) -> *const u8 {
-    let source = unsafe {
-        let bytes = Vec::from_raw_parts(ptr, len, len);
-        String::from_utf8_lossy(&bytes).into_owned()
-    };
+    let source = unsafe { String::from_utf8_lossy(std::slice::from_raw_parts(ptr, len)).into_owned() };
+    unsafe { wado_free(ptr, len) };
 
     let host = InMemoryCompilerHost::new();
     let options = CompilerOptions {
@@ -50,40 +63,87 @@ pub unsafe extern "C" fn wado_compile(ptr: *mut u8, len: usize) -> *const u8 {
     };
 
     let fut = compile_with_options(&source, &host, Some("playground.wado"), options);
-    match block_on(fut) {
-        Ok(result) => encode(1, result.wasm),
-        Err(_) => {
-            let text = host
-                .diagnostics()
-                .iter()
-                .map(|d| d.to_string())
-                .collect::<Vec<_>>()
-                .join("\n");
-            encode(0, text.into_bytes())
-        }
+    if let Ok(result) = block_on(fut) {
+        encode(1, &result.wasm)
+    } else {
+        let text = host
+            .diagnostics()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        encode(0, text.as_bytes())
     }
 }
 
-/// `[status:u32 LE][len:u32 LE][payload…]`, leaked for the host to read.
-fn encode(status: u32, payload: Vec<u8>) -> *const u8 {
-    let mut out = Vec::with_capacity(8 + payload.len());
-    out.extend_from_slice(&status.to_le_bytes());
-    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
-    out.extend_from_slice(&payload);
-    let ptr = out.as_ptr();
-    std::mem::forget(out);
-    ptr
+/// Allocate a result buffer `[status:u32 LE][len:u32 LE][payload…]` and return
+/// it for the host to read and then release with [`wado_free`].
+fn encode(status: u32, payload: &[u8]) -> *const u8 {
+    let total = 8 + payload.len();
+    let out = wado_alloc(total);
+    unsafe {
+        let buf = std::slice::from_raw_parts_mut(out, total);
+        buf[0..4].copy_from_slice(&status.to_le_bytes());
+        buf[4..8].copy_from_slice(&(payload.len() as u32).to_le_bytes());
+        buf[8..].copy_from_slice(payload);
+    }
+    out
 }
 
 /// Drive a future to completion. `InMemoryCompilerHost` never truly suspends
-/// (every `load_source` resolves immediately), so the noop waker suffices.
+/// (every `load_source` resolves immediately), so the noop waker suffices; a
+/// `Pending` would mean that invariant broke, so fail loudly instead of
+/// spinning forever.
 fn block_on<F: Future>(fut: F) -> F::Output {
     let waker = Waker::noop();
     let mut cx = Context::from_waker(waker);
     let mut fut = Box::pin(fut);
-    loop {
-        if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
-            return v;
-        }
+    let Poll::Ready(v) = fut.as_mut().poll(&mut cx) else {
+        panic!("compile future suspended, but InMemoryCompilerHost never yields");
+    };
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip a source string through the C ABI, exercising the exact
+    /// alloc → compile → free path the browser uses.
+    fn compile_str(src: &str) -> (u32, Vec<u8>) {
+        let bytes = src.as_bytes();
+        let ptr = wado_alloc(bytes.len());
+        unsafe { std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len()) };
+
+        let out = unsafe { wado_compile(ptr, bytes.len()) };
+        let header = unsafe { std::slice::from_raw_parts(out, 8) };
+        let status = u32::from_le_bytes(header[0..4].try_into().unwrap());
+        let plen = u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize;
+        let payload = unsafe { std::slice::from_raw_parts(out.add(8), plen).to_vec() };
+        unsafe { wado_free(out.cast_mut(), 8 + plen) };
+        (status, payload)
+    }
+
+    #[test]
+    fn compiles_hello_to_a_component() {
+        let src = "use { println, Stdout } from \"core:cli\";\n\nexport fn run() with Stdout {\n    println(\"hi\");\n}\n";
+        let (status, payload) = compile_str(src);
+        assert_eq!(status, 1, "expected success");
+        assert_eq!(&payload[0..4], b"\0asm", "Wasm magic");
+        assert_eq!(&payload[6..8], &[0x01, 0x00], "component layer");
+    }
+
+    #[test]
+    fn reports_diagnostics_on_error() {
+        let (status, payload) = compile_str("this is not valid wado");
+        assert_eq!(status, 0, "expected failure");
+        assert!(!payload.is_empty(), "diagnostics text present");
+        assert!(std::str::from_utf8(&payload).is_ok(), "diagnostics are UTF-8");
+    }
+
+    #[test]
+    fn handles_empty_source() {
+        let (status, _) = compile_str("");
+        assert_eq!(status, 0, "empty source is an error, not a crash");
     }
 }

--- a/wado-playground/src/lib.rs
+++ b/wado-playground/src/lib.rs
@@ -1,0 +1,89 @@
+//! wasm32 wrapper exposing the Wado compiler for an in-browser playground.
+//!
+//! The C ABI is intentionally minimal so the browser side can drive it with
+//! plain `WebAssembly` (no wasm-bindgen runtime):
+//!
+//! - `wado_alloc(len)` reserves a buffer the host fills with UTF-8 source.
+//! - `wado_compile(ptr, len)` compiles it and returns a pointer to a result
+//!   buffer laid out as `[status:u32 LE][len:u32 LE][payload…]`.
+//!   `status == 1`: payload is the component Wasm. `status == 0`: payload is
+//!   UTF-8 diagnostics text.
+
+use std::future::Future;
+use std::task::{Context, Poll, Waker};
+
+use wado_compiler::compiler_host::InMemoryCompilerHost;
+use wado_compiler::{CompilerOptions, OptLevel, compile_with_options};
+
+/// Reserve `len` bytes and return a pointer the host can write into.
+///
+/// # Safety
+/// The returned pointer is owned by the caller until passed back to
+/// [`wado_compile`]. Leaking here is fine: the playground compiles once per
+/// call and the wasm instance is short-lived.
+#[unsafe(no_mangle)]
+pub extern "C" fn wado_alloc(len: usize) -> *mut u8 {
+    let mut buf = Vec::<u8>::with_capacity(len);
+    let ptr = buf.as_mut_ptr();
+    std::mem::forget(buf);
+    ptr
+}
+
+/// Compile the UTF-8 source at `ptr..ptr+len`.
+///
+/// # Safety
+/// `ptr..ptr+len` must be a valid buffer previously returned by
+/// [`wado_alloc`] and filled with `len` bytes of UTF-8.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wado_compile(ptr: *mut u8, len: usize) -> *const u8 {
+    let source = unsafe {
+        let bytes = Vec::from_raw_parts(ptr, len, len);
+        String::from_utf8_lossy(&bytes).into_owned()
+    };
+
+    let host = InMemoryCompilerHost::new();
+    let options = CompilerOptions {
+        opt_level: OptLevel::O2,
+        // V8/browsers do not implement the wide-arithmetic proposal.
+        codegen_flags: vec!["no-wide-arithmetic".to_string()],
+        ..CompilerOptions::default()
+    };
+
+    let fut = compile_with_options(&source, &host, Some("playground.wado"), options);
+    match block_on(fut) {
+        Ok(result) => encode(1, result.wasm),
+        Err(_) => {
+            let text = host
+                .diagnostics()
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            encode(0, text.into_bytes())
+        }
+    }
+}
+
+/// `[status:u32 LE][len:u32 LE][payload…]`, leaked for the host to read.
+fn encode(status: u32, payload: Vec<u8>) -> *const u8 {
+    let mut out = Vec::with_capacity(8 + payload.len());
+    out.extend_from_slice(&status.to_le_bytes());
+    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    out.extend_from_slice(&payload);
+    let ptr = out.as_ptr();
+    std::mem::forget(out);
+    ptr
+}
+
+/// Drive a future to completion. `InMemoryCompilerHost` never truly suspends
+/// (every `load_source` resolves immediately), so the noop waker suffices.
+fn block_on<F: Future>(fut: F) -> F::Output {
+    let waker = Waker::noop();
+    let mut cx = Context::from_waker(waker);
+    let mut fut = Box::pin(fut);
+    loop {
+        if let Poll::Ready(v) = fut.as_mut().poll(&mut cx) {
+            return v;
+        }
+    }
+}

--- a/wado-playground/src/lib.rs
+++ b/wado-playground/src/lib.rs
@@ -45,7 +45,8 @@ pub unsafe extern "C" fn wado_free(ptr: *mut u8, len: usize) {
 /// and filled with `len` bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wado_compile(ptr: *mut u8, len: usize) -> *const u8 {
-    let source = unsafe { String::from_utf8_lossy(std::slice::from_raw_parts(ptr, len)).into_owned() };
+    let source =
+        unsafe { String::from_utf8_lossy(std::slice::from_raw_parts(ptr, len)).into_owned() };
     unsafe { wado_free(ptr, len) };
 
     let host = InMemoryCompilerHost::new();
@@ -130,7 +131,10 @@ mod tests {
         let (status, payload) = compile_str("this is not valid wado");
         assert_eq!(status, 0, "expected failure");
         assert!(!payload.is_empty(), "diagnostics text present");
-        assert!(std::str::from_utf8(&payload).is_ok(), "diagnostics are UTF-8");
+        assert!(
+            std::str::from_utf8(&payload).is_ok(),
+            "diagnostics are UTF-8"
+        );
     }
 
     #[test]

--- a/wado-playground/web/.gitignore
+++ b/wado-playground/web/.gitignore
@@ -1,0 +1,6 @@
+# Generated build artifacts — reproduce with `mise run playground-web-build`.
+wado-playground.wasm
+wado-playground.opt.wasm
+vendor/*.wasm
+vendor/jco-transpile.browser.js
+vendor/missing-intrinsics.js

--- a/wado-playground/web/.gitignore
+++ b/wado-playground/web/.gitignore
@@ -4,3 +4,4 @@ wado-playground.opt.wasm
 vendor/*.wasm
 vendor/jco-transpile.browser.js
 vendor/missing-intrinsics.js
+vendor/postprocess.js

--- a/wado-playground/web/README.md
+++ b/wado-playground/web/README.md
@@ -37,7 +37,7 @@ is the UI.
 ## Requirements
 
 - A **JSPI-capable browser**: Chromium/Chrome **137+** (stable JSPI). Both the
-  transpiled program *and* jco's own bindgen use `WebAssembly.Suspending`.
+  transpiled program _and_ jco's own bindgen use `WebAssembly.Suspending`.
 - WasmGC (Chrome 119+, Firefox 120+) — Wado uses GC.
 
 ## Build

--- a/wado-playground/web/README.md
+++ b/wado-playground/web/README.md
@@ -1,0 +1,66 @@
+# Wado Browser Playground
+
+Compile **and** run Wado entirely in the browser — no server round-trip. The
+Wado compiler and jco's component transpiler both run as WebAssembly in the
+page.
+
+## Pipeline
+
+```
+Wado source
+   │  ① wado-playground.wasm   (the Wado compiler, built for wasm32-unknown-unknown)
+   ▼
+Component Model Wasm
+   │  ② jco transpileBytes      (js-component-bindgen, itself Wasm, bundled for the browser)
+   ▼
+JS module + inlined core Wasm
+   │  ③ dynamic import() + WASI browser shims + JSPI
+   ▼
+program output
+```
+
+All three stages run client-side. `playground.js` orchestrates them; `index.html`
+is the UI.
+
+- **①** `wado-playground` exposes a tiny C ABI (`wado_alloc` / `wado_compile`)
+  over `compile_with_options` + `InMemoryCompilerHost`. The stdlib is embedded in
+  the compiler (`include_str!`), so a single-file program needs no host I/O.
+  Compiled with `no-wide-arithmetic` — V8 has no wide-arithmetic proposal.
+- **②** `@bytecodealliance/jco-transpile`'s `transpileBytes` is bundled with
+  `build-jco.mjs` (esbuild + `node:*` stubs). jco's bindgen already loads its
+  `.core.wasm` via `fetch` in the browser.
+- **③** `shims/{cli,clocks,random}.js` implement the WASI P3 imports against
+  browser APIs (`console`/DOM, `performance.now`, `crypto.getRandomValues`). The
+  released-jco P3 gaps (future-end classes, stdout write hook) are re-injected by
+  the same post-process as the Node pipeline.
+
+## Requirements
+
+- A **JSPI-capable browser**: Chromium/Chrome **137+** (stable JSPI). Both the
+  transpiled program *and* jco's own bindgen use `WebAssembly.Suspending`.
+- WasmGC (Chrome 119+, Firefox 120+) — Wado uses GC.
+
+## Build
+
+```sh
+mise run playground-web-build      # compiles the wasm, bundles jco, stages assets
+```
+
+This produces the git-ignored artifacts (`wado-playground.wasm`, `vendor/*`).
+
+## Run
+
+```sh
+mise run playground-web-serve      # http://127.0.0.1:8088
+```
+
+Open the URL in a JSPI-capable browser and click **Run**.
+
+## Limitations
+
+- **Compute + stdout/stderr only.** Programs that read files (`wasi:filesystem` /
+  preopens) hang on a known jco async read-stream gap — same blocker as the Node
+  jco pipeline (see `.claude/skills/jco`).
+- `wasi:http/service` programs don't transpile through released jco.
+- Multi-file programs (relative `use "./x.wado"`) would need the host to feed
+  those sources into `InMemoryCompilerHost`; the current UI compiles one file.

--- a/wado-playground/web/build-jco.mjs
+++ b/wado-playground/web/build-jco.mjs
@@ -1,0 +1,74 @@
+// Bundle jco's `transpileBytes` for the browser.
+//
+// `@bytecodealliance/jco-transpile` targets Node by default: its dependency
+// graph statically imports a handful of `node:*` builtins. The actual
+// bytes-in/files-out transpile path never executes the filesystem ones, so we
+// stub every `node:*` specifier — `node:path` with real (pure) string impls,
+// the rest with minimal shapes that only need to satisfy the named imports.
+//
+// The bindgen glue resolves its two `.core.wasm` files via
+// `new URL('./…core.wasm', import.meta.url)`, so the output must sit next to
+// them in web/vendor/.
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// jco-transpile + esbuild live under scripts/jco/node_modules.
+const jcoDir = join(here, "..", "..", "scripts", "jco");
+const { build } = await import(
+  pathToFileURL(join(jcoDir, "node_modules", "esbuild", "lib", "main.js")).href
+);
+const outfile = join(here, "vendor", "jco-transpile.browser.js");
+
+const NODE_STUBS = {
+  "node:path": `
+    export const sep = "/";
+    export function basename(p, ext) { let b = String(p).split("/").pop() ?? ""; if (ext && b.endsWith(ext)) b = b.slice(0, -ext.length); return b; }
+    export function extname(p) { const b = String(p).split("/").pop() ?? ""; const i = b.lastIndexOf("."); return i > 0 ? b.slice(i) : ""; }
+    export function dirname(p) { const s = String(p).split("/"); s.pop(); return s.join("/") || "."; }
+    export function join(...xs) { return xs.filter(Boolean).join("/").replace(/\\/+/g, "/"); }
+    export function resolve(...xs) { return "/" + xs.filter(Boolean).join("/").replace(/\\/+/g, "/").replace(/^\\/+/, ""); }
+    export function normalize(p) { return String(p).replace(/\\/+/g, "/"); }
+  `,
+  "node:url": `export function fileURLToPath(u) { return String(u).replace(/^file:\\/\\//, ""); }`,
+  "node:buffer": `export const Buffer = globalThis.Buffer ?? { from: (x) => new Uint8Array(x) };`,
+  "node:process": `export const platform = "browser"; export const argv0 = "browser";`,
+  "node:util": `export const TextEncoder = globalThis.TextEncoder; export const TextDecoder = globalThis.TextDecoder; export function promisify(f) { return f; }`,
+  "node:os": `export function tmpdir() { return "/tmp"; }`,
+  "node:fs/promises": `
+    const nope = async () => { throw new Error("node:fs/promises is not available in the browser transpile path"); };
+    export const readFile = nope, writeFile = nope, rm = nope, mkdtemp = nope, mkdir = nope;
+  `,
+  "node:fs": `export function readFileSync() { throw new Error("node:fs is not available in the browser transpile path"); }`,
+  "node:child_process": `export function spawn() { throw new Error("node:child_process is not available in the browser transpile path"); }`,
+};
+
+const nodeStubPlugin = {
+  name: "node-stub",
+  setup(b) {
+    const filter = /^node:/;
+    b.onResolve({ filter }, (args) => ({ path: args.path, namespace: "node-stub" }));
+    b.onLoad({ filter: /.*/, namespace: "node-stub" }, (args) => {
+      const contents = NODE_STUBS[args.path];
+      if (!contents) throw new Error(`no stub for ${args.path}`);
+      return { contents, loader: "js" };
+    });
+  },
+};
+
+await build({
+  stdin: {
+    contents: `export { transpileBytes } from "@bytecodealliance/jco-transpile";`,
+    resolveDir: jcoDir,
+    loader: "js",
+  },
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  outfile,
+  plugins: [nodeStubPlugin],
+  logLevel: "info",
+});
+
+console.log("bundled →", outfile);

--- a/wado-playground/web/build.sh
+++ b/wado-playground/web/build.sh
@@ -18,8 +18,8 @@ echo "==> optimizing with wasm-opt -O2"
   target/wasm32-unknown-unknown/release/wado_playground.wasm \
   -o "$WEB/wado-playground.wasm"
 
-echo "==> installing released jco (if needed)"
-[ -d "$JCO/node_modules/@bytecodealliance/jco-transpile" ] || (cd "$JCO" && npm install)
+echo "==> installing jco + esbuild (if needed)"
+{ [ -d "$JCO/node_modules/@bytecodealliance/jco-transpile" ] && [ -d "$JCO/node_modules/esbuild" ]; } || (cd "$JCO" && npm install)
 
 echo "==> bundling jco transpileBytes for the browser"
 mkdir -p "$WEB/vendor"
@@ -29,6 +29,9 @@ echo "==> staging jco runtime assets"
 cp "$JCO_VENDOR"/js-component-bindgen-component.core*.wasm "$WEB/vendor/"
 cp "$JCO_VENDOR"/wasm-tools.core*.wasm "$WEB/vendor/"
 cp "$JCO/missing-intrinsics.js" "$WEB/vendor/"
+# Stage with a .js extension: some static servers (python http.server) don't map
+# .mjs to a JavaScript MIME type, which blocks `import` of an ES module.
+cp "$JCO/postprocess.mjs" "$WEB/vendor/postprocess.js"
 
 echo "==> done. Serve wado-playground/web/ over HTTP and open index.html"
 ls -la "$WEB/wado-playground.wasm" "$WEB/vendor/"

--- a/wado-playground/web/build.sh
+++ b/wado-playground/web/build.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build every generated asset the in-browser playground needs. Idempotent.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WEB="$ROOT/wado-playground/web"
+JCO="$ROOT/scripts/jco"
+WASM_OPT="$JCO/node_modules/binaryen/bin/wasm-opt"
+JCO_VENDOR="$JCO/node_modules/@bytecodealliance/jco-transpile/vendor"
+
+cd "$ROOT"
+
+echo "==> compiling wado-playground (wasm32-unknown-unknown, release)"
+cargo build --release -p wado-playground --target wasm32-unknown-unknown
+
+echo "==> optimizing with wasm-opt -O2"
+"$WASM_OPT" -O2 --strip-debug -all \
+  target/wasm32-unknown-unknown/release/wado_playground.wasm \
+  -o "$WEB/wado-playground.wasm"
+
+echo "==> installing released jco (if needed)"
+[ -d "$JCO/node_modules/@bytecodealliance/jco-transpile" ] || (cd "$JCO" && npm install)
+
+echo "==> bundling jco transpileBytes for the browser"
+mkdir -p "$WEB/vendor"
+node "$WEB/build-jco.mjs"
+
+echo "==> staging jco runtime assets"
+cp "$JCO_VENDOR"/js-component-bindgen-component.core*.wasm "$WEB/vendor/"
+cp "$JCO_VENDOR"/wasm-tools.core*.wasm "$WEB/vendor/"
+cp "$JCO/missing-intrinsics.js" "$WEB/vendor/"
+
+echo "==> done. Serve wado-playground/web/ over HTTP and open index.html"
+ls -la "$WEB/wado-playground.wasm" "$WEB/vendor/"

--- a/wado-playground/web/index.html
+++ b/wado-playground/web/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Wado Playground</title>
+    <style>
+      body { font: 14px/1.5 system-ui, sans-serif; margin: 0; padding: 1rem; }
+      h1 { font-size: 1.1rem; }
+      textarea { width: 100%; height: 12rem; font-family: ui-monospace, monospace; }
+      button { padding: 0.4rem 1rem; font-size: 1rem; }
+      pre { background: #111; color: #eee; padding: 0.75rem; overflow: auto; min-height: 3rem; white-space: pre-wrap; }
+      .err { color: #ff6b6b; }
+    </style>
+  </head>
+  <body>
+    <h1>Wado Playground — compile &amp; run in the browser</h1>
+    <p>Compiler and jco both run as WebAssembly, entirely client-side. Needs a JSPI-capable browser (Chrome/Chromium 137+).</p>
+    <textarea id="src">use { println, Stdout } from "core:cli";
+
+export fn run() with Stdout {
+    println("Hello from a browser-side Wado compiler!");
+}
+</textarea>
+    <p><button id="run">Run</button> <span id="status"></span></p>
+    <pre id="out"></pre>
+
+    <script type="module">
+      import { run } from "./playground.js";
+
+      const $ = (id) => document.getElementById(id);
+      const status = (t) => ($("status").textContent = t);
+
+      async function go() {
+        $("out").textContent = "";
+        $("out").classList.remove("err");
+        status("running…");
+        try {
+          const t0 = performance.now();
+          const { stdout, stderr } = await run($("src").value);
+          const ms = Math.round(performance.now() - t0);
+          $("out").textContent = (stdout + (stderr ? "\n[stderr]\n" + stderr : "")) || "(no output)";
+          status(`done in ${ms} ms`);
+        } catch (e) {
+          $("out").textContent = String(e.message ?? e);
+          $("out").classList.add("err");
+          status("error");
+        }
+      }
+
+      $("run").addEventListener("click", go);
+
+      // Test hook: lets Playwright drive a run and read the result.
+      globalThis.__wadoRun = (source) => run(source ?? $("src").value);
+    </script>
+  </body>
+</html>

--- a/wado-playground/web/playground.js
+++ b/wado-playground/web/playground.js
@@ -3,6 +3,9 @@
 // (also wasm, in-browser), then import and run the result — all in the browser.
 
 import { transpileBytes } from "./vendor/jco-transpile.browser.js";
+// Same P3-runtime re-injection the Node pipeline uses; staged by build.sh so
+// the browser and Node paths share one source of truth (no drift on jco bumps).
+import { postprocess } from "./vendor/postprocess.js";
 
 const BASE = new URL(".", import.meta.url);
 
@@ -11,57 +14,40 @@ let _compilerInstance = null;
 async function loadCompiler() {
   if (_compilerInstance) return _compilerInstance;
   const wasmUrl = new URL("./wado-playground.wasm", BASE);
-  const { instance } = await WebAssembly.instantiateStreaming(fetch(wasmUrl), {});
+  const resp = await fetch(wasmUrl);
+  if (!resp.ok) throw new Error(`failed to load ${wasmUrl}: HTTP ${resp.status}`);
+  const { instance } = await WebAssembly.instantiateStreaming(resp, {});
   _compilerInstance = instance;
   return instance;
 }
 
 /** Compile Wado source → Component Model Wasm bytes (or throw with diagnostics). */
 export async function compile(source) {
-  const { memory, wado_alloc, wado_compile } = (await loadCompiler()).exports;
+  const { memory, wado_alloc, wado_compile, wado_free } = (await loadCompiler()).exports;
   const src = new TextEncoder().encode(source);
   const inPtr = wado_alloc(src.length);
   new Uint8Array(memory.buffer, inPtr, src.length).set(src);
 
+  // wado_compile consumes (frees) the input buffer and returns a result buffer
+  // we own: [status:u32][len:u32][payload…]. Copy the payload out, then free it.
   const outPtr = wado_compile(inPtr, src.length);
   const header = new DataView(memory.buffer, outPtr, 8);
   const status = header.getUint32(0, true);
   const len = header.getUint32(4, true);
   const payload = new Uint8Array(memory.buffer, outPtr + 8, len).slice();
+  wado_free(outPtr, 8 + len);
 
   if (status === 1) return payload;
   throw new Error(new TextDecoder().decode(payload));
 }
 
-// The released jco omits the P3 future-end classes and the stdout write hook;
-// re-inject them exactly as scripts/jco/postprocess.mjs does for Node.
-const INTERNAL_FUTURE = /class InternalFuture\s*\{/;
-const STREAM_WRITE_FN = /async function streamWrite\s*\(/;
-const STREAM_COPY = "const result = await streamEnd.copy({";
-const STREAM_HOOK = `if (typeof globalThis._jcoStreamWriteHook === 'function' && streamEnd.isWritable()) {
-        const count_ = count >>> 0;
-        const data_ = new Uint8Array(getMemoryFn().buffer, ptr, count_).slice();
-        if (globalThis._jcoStreamWriteHook(streamEndWaitableIdx, data_)) { return (count_ << 4) | 0; }
-      }
-      `;
-
-function postprocess(js, classes) {
-  if (INTERNAL_FUTURE.test(js) && !/class FutureReadableEnd\b/.test(js)) {
-    js = js.replace(INTERNAL_FUTURE, (m) => `${classes}\n\n    ${m}`);
-  }
-  const sw = STREAM_WRITE_FN.exec(js);
-  if (sw) {
-    const copyIdx = js.indexOf(STREAM_COPY, sw.index);
-    if (copyIdx === -1) throw new Error("postprocess: streamWrite copy anchor not found");
-    js = js.slice(0, copyIdx) + STREAM_HOOK + js.slice(copyIdx);
-  }
-  return js;
-}
-
 let _missingIntrinsics = null;
 async function missingIntrinsics() {
   if (_missingIntrinsics == null) {
-    _missingIntrinsics = await (await fetch(new URL("./vendor/missing-intrinsics.js", BASE))).text();
+    const url = new URL("./vendor/missing-intrinsics.js", BASE);
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`failed to load ${url}: HTTP ${res.status}`);
+    _missingIntrinsics = await res.text();
   }
   return _missingIntrinsics;
 }
@@ -86,29 +72,40 @@ export async function transpileToModule(componentBytes, name = "program") {
   if (jsFiles.length !== 1) {
     throw new Error(`expected a single JS file, got: ${jsFiles.map(([f]) => f).join(", ")}`);
   }
-  let js = decoder.decode(jsFiles[0][1]);
-  js = postprocess(js, await missingIntrinsics());
+  const { js } = postprocess(decoder.decode(jsFiles[0][1]), await missingIntrinsics());
 
   const blob = new Blob([js], { type: "text/javascript" });
   return URL.createObjectURL(blob);
 }
 
+let _running = false;
+
 /** Compile + transpile + run, returning captured stdout/stderr text. */
 export async function run(source) {
+  if (_running) throw new Error("a program is already running");
+  _running = true;
   const out = { stdout: "", stderr: "" };
+  const prevWrite = globalThis._wadoWrite;
   globalThis._wadoWrite = (kind, text) => { out[kind] += text; };
-
-  const component = await compile(source);
-  const moduleUrl = await transpileToModule(component);
-  const mod = await import(moduleUrl);
-
-  // wasi:cli/command exports the `run` interface with a `run()` function.
-  if (mod.run?.run) {
-    await mod.run.run();
-  } else if (typeof mod.run === "function") {
-    await mod.run();
-  } else {
-    throw new Error(`no runnable export found (keys: ${Object.keys(mod).join(", ")})`);
+  try {
+    const component = await compile(source);
+    const moduleUrl = await transpileToModule(component);
+    try {
+      const mod = await import(moduleUrl);
+      // wasi:cli/command exports the `run` interface with a `run()` function.
+      if (mod.run?.run) {
+        await mod.run.run();
+      } else if (typeof mod.run === "function") {
+        await mod.run();
+      } else {
+        throw new Error(`no runnable export found (keys: ${Object.keys(mod).join(", ")})`);
+      }
+    } finally {
+      URL.revokeObjectURL(moduleUrl);
+    }
+    return out;
+  } finally {
+    globalThis._wadoWrite = prevWrite;
+    _running = false;
   }
-  return out;
 }

--- a/wado-playground/web/playground.js
+++ b/wado-playground/web/playground.js
@@ -1,0 +1,114 @@
+// Fully client-side Wado playground: compile Wado source to a component with
+// the wasm-sandboxed Wado compiler, transpile that component to JS with jco
+// (also wasm, in-browser), then import and run the result — all in the browser.
+
+import { transpileBytes } from "./vendor/jco-transpile.browser.js";
+
+const BASE = new URL(".", import.meta.url);
+
+let _compilerInstance = null;
+
+async function loadCompiler() {
+  if (_compilerInstance) return _compilerInstance;
+  const wasmUrl = new URL("./wado-playground.wasm", BASE);
+  const { instance } = await WebAssembly.instantiateStreaming(fetch(wasmUrl), {});
+  _compilerInstance = instance;
+  return instance;
+}
+
+/** Compile Wado source → Component Model Wasm bytes (or throw with diagnostics). */
+export async function compile(source) {
+  const { memory, wado_alloc, wado_compile } = (await loadCompiler()).exports;
+  const src = new TextEncoder().encode(source);
+  const inPtr = wado_alloc(src.length);
+  new Uint8Array(memory.buffer, inPtr, src.length).set(src);
+
+  const outPtr = wado_compile(inPtr, src.length);
+  const header = new DataView(memory.buffer, outPtr, 8);
+  const status = header.getUint32(0, true);
+  const len = header.getUint32(4, true);
+  const payload = new Uint8Array(memory.buffer, outPtr + 8, len).slice();
+
+  if (status === 1) return payload;
+  throw new Error(new TextDecoder().decode(payload));
+}
+
+// The released jco omits the P3 future-end classes and the stdout write hook;
+// re-inject them exactly as scripts/jco/postprocess.mjs does for Node.
+const INTERNAL_FUTURE = /class InternalFuture\s*\{/;
+const STREAM_WRITE_FN = /async function streamWrite\s*\(/;
+const STREAM_COPY = "const result = await streamEnd.copy({";
+const STREAM_HOOK = `if (typeof globalThis._jcoStreamWriteHook === 'function' && streamEnd.isWritable()) {
+        const count_ = count >>> 0;
+        const data_ = new Uint8Array(getMemoryFn().buffer, ptr, count_).slice();
+        if (globalThis._jcoStreamWriteHook(streamEndWaitableIdx, data_)) { return (count_ << 4) | 0; }
+      }
+      `;
+
+function postprocess(js, classes) {
+  if (INTERNAL_FUTURE.test(js) && !/class FutureReadableEnd\b/.test(js)) {
+    js = js.replace(INTERNAL_FUTURE, (m) => `${classes}\n\n    ${m}`);
+  }
+  const sw = STREAM_WRITE_FN.exec(js);
+  if (sw) {
+    const copyIdx = js.indexOf(STREAM_COPY, sw.index);
+    if (copyIdx === -1) throw new Error("postprocess: streamWrite copy anchor not found");
+    js = js.slice(0, copyIdx) + STREAM_HOOK + js.slice(copyIdx);
+  }
+  return js;
+}
+
+let _missingIntrinsics = null;
+async function missingIntrinsics() {
+  if (_missingIntrinsics == null) {
+    _missingIntrinsics = await (await fetch(new URL("./vendor/missing-intrinsics.js", BASE))).text();
+  }
+  return _missingIntrinsics;
+}
+
+/** Transpile a component to a single importable ES module URL (blob). */
+export async function transpileToModule(componentBytes, name = "program") {
+  const shim = (m) => `${new URL(`./shims/${m}`, BASE).href}#*`;
+  const { files } = await transpileBytes(componentBytes, {
+    name,
+    wasiShim: false,
+    // Inline every core Wasm as base64 so the output is a single JS module.
+    base64Cutoff: 1 << 30,
+    map: {
+      "wasi:cli/*": shim("cli.js"),
+      "wasi:random/*": shim("random.js"),
+      "wasi:clocks/*": shim("clocks.js"),
+    },
+  });
+
+  const decoder = new TextDecoder();
+  const jsFiles = Object.entries(files).filter(([f]) => f.endsWith(".js"));
+  if (jsFiles.length !== 1) {
+    throw new Error(`expected a single JS file, got: ${jsFiles.map(([f]) => f).join(", ")}`);
+  }
+  let js = decoder.decode(jsFiles[0][1]);
+  js = postprocess(js, await missingIntrinsics());
+
+  const blob = new Blob([js], { type: "text/javascript" });
+  return URL.createObjectURL(blob);
+}
+
+/** Compile + transpile + run, returning captured stdout/stderr text. */
+export async function run(source) {
+  const out = { stdout: "", stderr: "" };
+  globalThis._wadoWrite = (kind, text) => { out[kind] += text; };
+
+  const component = await compile(source);
+  const moduleUrl = await transpileToModule(component);
+  const mod = await import(moduleUrl);
+
+  // wasi:cli/command exports the `run` interface with a `run()` function.
+  if (mod.run?.run) {
+    await mod.run.run();
+  } else if (typeof mod.run === "function") {
+    await mod.run();
+  } else {
+    throw new Error(`no runnable export found (keys: ${Object.keys(mod).join(", ")})`);
+  }
+  return out;
+}

--- a/wado-playground/web/playground.js
+++ b/wado-playground/web/playground.js
@@ -1,10 +1,8 @@
-// Fully client-side Wado playground: compile Wado source to a component with
-// the wasm-sandboxed Wado compiler, transpile that component to JS with jco
-// (also wasm, in-browser), then import and run the result — all in the browser.
+// Client-side Wado playground: compile → transpile (jco) → import and run, all
+// in the browser. See README.md for the pipeline.
 
 import { transpileBytes } from "./vendor/jco-transpile.browser.js";
-// Same P3-runtime re-injection the Node pipeline uses; staged by build.sh so
-// the browser and Node paths share one source of truth (no drift on jco bumps).
+// Shared with the Node pipeline (staged by build.sh) to avoid drift on jco bumps.
 import { postprocess } from "./vendor/postprocess.js";
 
 const BASE = new URL(".", import.meta.url);
@@ -28,8 +26,7 @@ export async function compile(source) {
   const inPtr = wado_alloc(src.length);
   new Uint8Array(memory.buffer, inPtr, src.length).set(src);
 
-  // wado_compile consumes (frees) the input buffer and returns a result buffer
-  // we own: [status:u32][len:u32][payload…]. Copy the payload out, then free it.
+  // wado_compile frees inPtr and returns an owned result buffer; copy, then free.
   const outPtr = wado_compile(inPtr, src.length);
   const header = new DataView(memory.buffer, outPtr, 8);
   const status = header.getUint32(0, true);

--- a/wado-playground/web/shims/cli.js
+++ b/wado-playground/web/shims/cli.js
@@ -1,0 +1,52 @@
+// Browser WASI P3 CLI shim for jco-transpiled Wado programs.
+//
+// Mirrors example/jco-shim/cli.js but targets the browser: stdout/stderr bytes
+// captured via `_jcoStreamWriteHook` are decoded and delivered to
+// `globalThis._wadoWrite(kind, text)` (kind = "stdout" | "stderr") instead of
+// Node's process streams.
+
+const _decoder = new TextDecoder();
+
+function _sink(kind) {
+  return {
+    write(data) {
+      const text = _decoder.decode(data, { stream: true });
+      if (typeof globalThis._wadoWrite === "function") globalThis._wadoWrite(kind, text);
+    },
+  };
+}
+
+const _streamTargets = new Map();
+let _defaultTarget = _sink("stdout");
+
+globalThis._jcoStreamWriteHook = (writableEndIdx, data) => {
+  if (!_streamTargets.has(writableEndIdx) && _defaultTarget) {
+    _streamTargets.set(writableEndIdx, _defaultTarget);
+  }
+  const target = _streamTargets.get(writableEndIdx);
+  if (target) {
+    target.write(data);
+    return true;
+  }
+  return false;
+};
+
+export const types = {
+  OutputStream: class OutputStream {},
+};
+
+export const stdout = {
+  writeViaStream(_stream) {
+    _defaultTarget = _sink("stdout");
+    return Promise.resolve({ tag: "ok" });
+  },
+};
+stdout.writeViaStream._isHostProvided = true;
+
+export const stderr = {
+  writeViaStream(_stream) {
+    _defaultTarget = _sink("stderr");
+    return Promise.resolve({ tag: "ok" });
+  },
+};
+stderr.writeViaStream._isHostProvided = true;

--- a/wado-playground/web/shims/cli.js
+++ b/wado-playground/web/shims/cli.js
@@ -1,16 +1,11 @@
-// Browser WASI P3 CLI shim for jco-transpiled Wado programs.
+// Browser WASI P3 CLI shim: bytes from `_jcoStreamWriteHook` are decoded and
+// delivered to `globalThis._wadoWrite(kind, text)`.
 //
-// stdout/stderr bytes captured via `_jcoStreamWriteHook` are decoded and
-// delivered to `globalThis._wadoWrite(kind, text)` (kind = "stdout" | "stderr").
-//
-// jco's write hook identifies a stream only by its writable-end index, and jco
-// recycles those indices once a stream is dropped — so a permanent
-// index→target map mis-routes a later stream that reuses an old index (this is
-// how stderr bytes leaked into stdout). We instead track the most recently
-// opened stream: `println`/`eprintln` open a stream, write, and drop it, so the
-// last `writeViaStream` before a write is always the right target. Each open
-// gets its own `TextDecoder`, so a multi-byte glyph split across writes on one
-// stream decodes intact and never bleeds into the other stream.
+// jco identifies a write only by a writable-end index and recycles those, so a
+// permanent index→target map mis-routes (stderr leaked into stdout). We target
+// the most recently opened stream instead — `println`/`eprintln` open, write,
+// and drop, so the last `writeViaStream` is the right target. Each open gets its
+// own `TextDecoder`, so multi-byte glyphs don't corrupt or cross streams.
 
 function _sink(kind) {
   const decoder = new TextDecoder();

--- a/wado-playground/web/shims/cli.js
+++ b/wado-playground/web/shims/cli.js
@@ -1,34 +1,32 @@
 // Browser WASI P3 CLI shim for jco-transpiled Wado programs.
 //
-// Mirrors example/jco-shim/cli.js but targets the browser: stdout/stderr bytes
-// captured via `_jcoStreamWriteHook` are decoded and delivered to
-// `globalThis._wadoWrite(kind, text)` (kind = "stdout" | "stderr") instead of
-// Node's process streams.
-
-const _decoder = new TextDecoder();
+// stdout/stderr bytes captured via `_jcoStreamWriteHook` are decoded and
+// delivered to `globalThis._wadoWrite(kind, text)` (kind = "stdout" | "stderr").
+//
+// jco's write hook identifies a stream only by its writable-end index, and jco
+// recycles those indices once a stream is dropped — so a permanent
+// index→target map mis-routes a later stream that reuses an old index (this is
+// how stderr bytes leaked into stdout). We instead track the most recently
+// opened stream: `println`/`eprintln` open a stream, write, and drop it, so the
+// last `writeViaStream` before a write is always the right target. Each open
+// gets its own `TextDecoder`, so a multi-byte glyph split across writes on one
+// stream decodes intact and never bleeds into the other stream.
 
 function _sink(kind) {
+  const decoder = new TextDecoder();
   return {
     write(data) {
-      const text = _decoder.decode(data, { stream: true });
-      if (typeof globalThis._wadoWrite === "function") globalThis._wadoWrite(kind, text);
+      const text = decoder.decode(data, { stream: true });
+      if (text && typeof globalThis._wadoWrite === "function") globalThis._wadoWrite(kind, text);
     },
   };
 }
 
-const _streamTargets = new Map();
-let _defaultTarget = _sink("stdout");
+let _current = _sink("stdout");
 
-globalThis._jcoStreamWriteHook = (writableEndIdx, data) => {
-  if (!_streamTargets.has(writableEndIdx) && _defaultTarget) {
-    _streamTargets.set(writableEndIdx, _defaultTarget);
-  }
-  const target = _streamTargets.get(writableEndIdx);
-  if (target) {
-    target.write(data);
-    return true;
-  }
-  return false;
+globalThis._jcoStreamWriteHook = (_writableEndIdx, data) => {
+  _current.write(data);
+  return true;
 };
 
 export const types = {
@@ -37,7 +35,7 @@ export const types = {
 
 export const stdout = {
   writeViaStream(_stream) {
-    _defaultTarget = _sink("stdout");
+    _current = _sink("stdout");
     return Promise.resolve({ tag: "ok" });
   },
 };
@@ -45,7 +43,7 @@ stdout.writeViaStream._isHostProvided = true;
 
 export const stderr = {
   writeViaStream(_stream) {
-    _defaultTarget = _sink("stderr");
+    _current = _sink("stderr");
     return Promise.resolve({ tag: "ok" });
   },
 };

--- a/wado-playground/web/shims/clocks.js
+++ b/wado-playground/web/shims/clocks.js
@@ -1,0 +1,29 @@
+// Browser WASI P3 clocks shim.
+
+export const monotonicClock = {
+  now() {
+    return BigInt(Math.round(performance.now() * 1e6));
+  },
+  resolution() {
+    return 1n;
+  },
+  subscribeInstant(_when) {
+    return { tag: "ok" };
+  },
+  subscribeDuration(_duration) {
+    return { tag: "ok" };
+  },
+};
+
+export const wallClock = {
+  now() {
+    const ms = Date.now();
+    return {
+      seconds: BigInt(Math.floor(ms / 1000)),
+      nanoseconds: (ms % 1000) * 1000000,
+    };
+  },
+  resolution() {
+    return { seconds: 0n, nanoseconds: 1000000 };
+  },
+};

--- a/wado-playground/web/shims/random.js
+++ b/wado-playground/web/shims/random.js
@@ -1,0 +1,28 @@
+// Browser WASI P3 random shim (crypto.getRandomValues).
+
+function fill(len) {
+  const out = new Uint8Array(len);
+  for (let off = 0; off < len; off += 65536) {
+    crypto.getRandomValues(out.subarray(off, Math.min(off + 65536, len)));
+  }
+  return out;
+}
+
+function u64() {
+  const b = fill(8);
+  return new DataView(b.buffer).getBigUint64(0, true);
+}
+
+export const random = {
+  getRandomBytes(len) { return fill(Number(len)); },
+  getRandomU64() { return u64(); },
+};
+
+export const insecure = {
+  getInsecureRandomBytes(len) { return fill(Number(len)); },
+  getInsecureRandomU64() { return u64(); },
+};
+
+export const insecureSeed = {
+  insecureSeed() { return [u64(), u64()]; },
+};

--- a/wado-playground/web/test-browser.mjs
+++ b/wado-playground/web/test-browser.mjs
@@ -1,0 +1,87 @@
+// Browser smoke test for the client-side playground. Serves web/ and drives a
+// JSPI-capable Chromium to compile + transpile + run Wado in the page.
+//
+// Usage: node wado-playground/web/test-browser.mjs
+// Requires playwright-core (mise run playground-web-test installs it) and a
+// Chromium 137+. Set CHROME_PATH to override the browser binary.
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { join, extname, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+
+const WEB = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(join(WEB, "..", "..", "scripts", "jco") + "/");
+const { chromium } = require("playwright-core");
+
+function chromePath() {
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  const glob = "/opt/pw-browsers";
+  if (existsSync(glob)) {
+    const dir = require("node:fs")
+      .readdirSync(glob)
+      .find((d) => d.startsWith("chromium-") && existsSync(join(glob, d, "chrome-linux", "chrome")));
+    if (dir) return join(glob, dir, "chrome-linux", "chrome");
+  }
+  return undefined; // let playwright resolve its own download
+}
+
+const MIME = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".wasm": "application/wasm",
+  ".json": "application/json",
+};
+
+const CASES = [
+  {
+    name: "hello",
+    src: `use { println, Stdout } from "core:cli";\n\nexport fn run() with Stdout {\n    println("hello from browser");\n}\n`,
+    expect: "hello from browser",
+  },
+  {
+    name: "compute+float",
+    src: `use { println, Stdout } from "core:cli";\n\nexport fn run() with Stdout {\n    let mut s = 0;\n    let mut i = 1;\n    while i <= 100 { s = s + i; i = i + 1; }\n    println(\`sum={s} pi={355.0 / 113.0}\`);\n}\n`,
+    expect: "sum=5050 pi=3.14",
+  },
+];
+
+const server = createServer(async (req, res) => {
+  try {
+    const p = join(WEB, decodeURIComponent(new URL(req.url, "http://x").pathname));
+    const body = await readFile(p);
+    res.writeHead(200, { "content-type": MIME[extname(p)] ?? "application/octet-stream" });
+    res.end(body);
+  } catch {
+    res.writeHead(404);
+    res.end("not found");
+  }
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+const browser = await chromium.launch({ executablePath: chromePath(), args: ["--no-sandbox"] });
+let failed = 0;
+try {
+  const page = await browser.newPage();
+  page.on("pageerror", (e) => console.log("[pageerror]", e.message));
+  await page.goto(`http://127.0.0.1:${port}/index.html`, { waitUntil: "load" });
+  for (const c of CASES) {
+    const r = await page.evaluate(async (source) => {
+      try {
+        return { ok: true, ...(await globalThis.__wadoRun(source)) };
+      } catch (e) {
+        return { ok: false, error: String(e?.stack ?? e) };
+      }
+    }, c.src);
+    const pass = r.ok && r.stdout.includes(c.expect);
+    console.log(`${pass ? "✅" : "❌"} ${c.name}: ${JSON.stringify(r.stdout ?? r.error)}`);
+    if (!pass) failed++;
+  }
+} finally {
+  await browser.close();
+  server.close();
+}
+process.exit(failed ? 1 : 0);

--- a/wado-playground/web/test-browser.mjs
+++ b/wado-playground/web/test-browser.mjs
@@ -31,6 +31,7 @@ function chromePath() {
 const MIME = {
   ".html": "text/html",
   ".js": "text/javascript",
+  ".mjs": "text/javascript",
   ".wasm": "application/wasm",
   ".json": "application/json",
 };
@@ -45,6 +46,15 @@ const CASES = [
     name: "compute+float",
     src: `use { println, Stdout } from "core:cli";\n\nexport fn run() with Stdout {\n    let mut s = 0;\n    let mut i = 1;\n    while i <= 100 { s = s + i; i = i + 1; }\n    println(\`sum={s} pi={355.0 / 113.0}\`);\n}\n`,
     expect: "sum=5050 pi=3.14",
+  },
+  {
+    // Exercises the cli.js FIFO sink attribution + per-stream decoders: a
+    // program that opens both stdout and stderr must not cross its channels,
+    // and a multi-byte (non-ASCII) glyph must decode intact.
+    name: "stdout+stderr+utf8",
+    src: `use { println, eprintln, Stdout, Stderr } from "core:cli";\n\nexport fn run() with Stdout, Stderr {\n    println("out: café ☕");\n    eprintln("err: naïve");\n}\n`,
+    expect: "out: café ☕",
+    expectStderr: "err: naïve",
   },
 ];
 
@@ -76,8 +86,13 @@ try {
         return { ok: false, error: String(e?.stack ?? e) };
       }
     }, c.src);
-    const pass = r.ok && r.stdout.includes(c.expect);
-    console.log(`${pass ? "✅" : "❌"} ${c.name}: ${JSON.stringify(r.stdout ?? r.error)}`);
+    const pass =
+      r.ok &&
+      r.stdout.includes(c.expect) &&
+      (c.expectStderr === undefined
+        ? true
+        : r.stderr.includes(c.expectStderr) && !r.stdout.includes(c.expectStderr));
+    console.log(`${pass ? "✅" : "❌"} ${c.name}: ${JSON.stringify(r.ok ? { stdout: r.stdout, stderr: r.stderr } : r.error)}`);
     if (!pass) failed++;
   }
 } finally {

--- a/wado-playground/web/test-browser.mjs
+++ b/wado-playground/web/test-browser.mjs
@@ -48,9 +48,9 @@ const CASES = [
     expect: "sum=5050 pi=3.14",
   },
   {
-    // Exercises the cli.js FIFO sink attribution + per-stream decoders: a
-    // program that opens both stdout and stderr must not cross its channels,
-    // and a multi-byte (non-ASCII) glyph must decode intact.
+    // Exercises cli.js stream routing + per-stream decoders: writing to both
+    // stdout and stderr must not cross channels, and a multi-byte glyph must
+    // decode intact.
     name: "stdout+stderr+utf8",
     src: `use { println, eprintln, Stdout, Stderr } from "core:cli";\n\nexport fn run() with Stdout, Stderr {\n    println("out: café ☕");\n    eprintln("err: naïve");\n}\n`,
     expect: "out: café ☕",


### PR DESCRIPTION
## Summary

A fully client-side browser playground: Wado source is compiled to a Component Model module and run **in the page**, with no server round-trip. Both the Wado compiler and jco's component transpiler execute as WebAssembly in the browser.

```
Wado source
  ① wado-playground.wasm   (the Wado compiler, wasm32-unknown-unknown)   → Component Model Wasm
  ② jco transpileBytes     (js-component-bindgen, itself Wasm)           → JS module + inlined core Wasm
  ③ dynamic import() + WASI browser shims + JSPI                         → program output
```

## What's included

- **`wado-playground/` crate** — a `cdylib` wasm32 wrapper exposing a minimal C ABI (`wado_alloc` / `wado_compile` / `wado_free`) over `compile_with_options` + `InMemoryCompilerHost`. The stdlib is embedded in the compiler, so a single-file program needs no host I/O. Native unit tests cover the alloc → compile → free round-trip.
- **`wado-playground/web/`** — the browser app: `playground.js` orchestrates compile → transpile → run; `build-jco.mjs` bundles jco's `transpileBytes` for the browser (esbuild + `node:*` stubs); `shims/{cli,clocks,random}.js` implement the WASI P3 imports against browser APIs; `index.html` is the UI; `test-browser.mjs` is a headless-Chromium smoke test. Generated binaries are git-ignored and reproduced by `mise run playground-web-build`.
- **CI guard** — `cargo check -p wado-lsp --target wasm32-unknown-unknown` is added alongside `wado-compiler`/`wado-manifest`, locking in the intentional design (per the LSP Architecture WEP) that the compiler and LSP engine stay OS-independent so they can run in the browser, with I/O delegated to the `wado-cli` host.
- **mise tasks** — `playground-web-build`, `playground-web-serve`, `playground-web-test`.

## Requirements & scope

- Needs a **JSPI-capable browser** (Chromium/Chrome **137+**) — both the transpiled program and jco's own bindgen use `WebAssembly.Suspending`. Verified end-to-end in Chromium 141.
- **Compute + stdout/stderr only** today. Programs reading files (`wasi:filesystem`) hang on a known jco async read-stream gap; `wasi:http/service` doesn't transpile through released jco. These are the same blockers as the Node jco pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012mVL5QU7uSern8a9TMuCmU)_