### PR TITLE
fix(format): preserve doc comments on trait associated types

### DIFF
--- a/wado-compiler/lib/core/prelude/traits.wado
+++ b/wado-compiler/lib/core/prelude/traits.wado
@@ -60,23 +60,22 @@ internal trait Default {
 
 /// Compile-time struct introspection. The compiler synthesizes an impl for
 /// every struct; it cannot be implemented in user code and is callable only in
-/// monomorphized contexts (`T` a concrete struct). `Fields` is the field types
-/// as a tuple `[F_0, F_1, ...]`; `fields` returns those values as a tuple,
-/// `field_names` the source names, and `type_name` the struct name.
+/// monomorphized contexts (`T` a concrete struct).
 /// See WEP 2026-06-13.
 #[compiler_item("reflect")]
 internal trait Reflect {
+    /// The field types as a tuple `[F_0, F_1, ...]`.
     type Fields;
 
-
+    /// Returns the field values as a tuple.
     #[compiler_item("reflect_fields")]
     fn fields(&self) -> Self::Fields;
 
-
+    /// Returns the source field names.
     #[compiler_item("reflect_field_names")]
     fn field_names() -> List<String>;
 
-
+    /// Returns the struct name.
     #[compiler_item("reflect_type_name")]
     fn type_name() -> String;
 }

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -1074,29 +1074,31 @@ impl<'a> Unparser<'a> {
 
         self.with_braced_body(t.span, |this| {
             for assoc in &t.associated_types {
-                this.write_indent();
-                this.output.push_str("type ");
-                this.output.push_str(&assoc.name);
-                if !assoc.bounds.is_empty() {
-                    this.output.push_str(": ");
-                    this.comma_sep_with(" + ", &assoc.bounds, |this, bound| {
-                        this.output.push_str(&bound.name);
-                        if !bound.assoc_types.is_empty() {
-                            this.delimited("<", ">", &bound.assoc_types, |this, ab| {
-                                this.output.push_str(&ab.name);
-                                this.output.push_str(" = ");
-                                this.unparse_type(&ab.ty);
-                            });
-                        }
-                    });
-                }
-                this.output.push_str(";\n");
-                this.last_source_line = assoc.span.end_line();
+                this.emit_member(assoc.id, assoc.span, &[], |this| {
+                    this.write_indent();
+                    this.output.push_str("type ");
+                    this.output.push_str(&assoc.name);
+                    if !assoc.bounds.is_empty() {
+                        this.output.push_str(": ");
+                        this.comma_sep_with(" + ", &assoc.bounds, |this, bound| {
+                            this.output.push_str(&bound.name);
+                            if !bound.assoc_types.is_empty() {
+                                this.delimited("<", ">", &bound.assoc_types, |this, ab| {
+                                    this.output.push_str(&ab.name);
+                                    this.output.push_str(" = ");
+                                    this.unparse_type(&ab.ty);
+                                });
+                            }
+                        });
+                    }
+                    this.output.push(';');
+                });
             }
 
             for method in &t.methods {
+                let effective_line = effective_start_line(&method.attrs, method.span.line);
                 this.emit_leading_for(method.id);
-                this.emit_blank_lines_to(method.span.line);
+                this.emit_blank_lines_to(effective_line);
                 this.unparse_function(method);
                 this.last_source_line = method.span.end_line();
             }

--- a/wado-compiler/tests/format.rs
+++ b/wado-compiler/tests/format.rs
@@ -831,6 +831,44 @@ impl Container for Foo {
 }
 
 #[test]
+fn test_format_preserves_trait_assoc_type_leading_comment() {
+    // Regression (#1598): a doc comment on a trait's associated-type
+    // declaration must be preserved, not dropped (fail-closed).
+    let source = r"trait Foo {
+    /// The item type.
+    type Item;
+
+    /// Get the item.
+    fn get(&self) -> Self::Item;
+}
+";
+    let formatted = wado_compiler::format(source).expect("format failed");
+    assert_eq!(formatted, source, "trait assoc-type doc comment should round-trip");
+    let formatted2 = wado_compiler::format(&formatted).expect("format failed");
+    assert_eq!(formatted, formatted2, "should be idempotent");
+}
+
+#[test]
+fn test_format_preserves_trait_doc_before_attributed_member() {
+    // Regression (#1598): a doc comment immediately before a member carrying
+    // an attribute must stay attached — no blank line inserted between the
+    // doc comment and the attribute, and the output must be idempotent.
+    let source = r#"trait Reflect {
+    /// The field types as a tuple.
+    type Fields;
+
+    /// Returns the field values.
+    #[compiler_item("reflect_fields")]
+    fn fields(&self) -> Self::Fields;
+}
+"#;
+    let formatted = wado_compiler::format(source).expect("format failed");
+    assert_eq!(formatted, source, "trait doc-before-attribute should round-trip");
+    let formatted2 = wado_compiler::format(&formatted).expect("format failed");
+    assert_eq!(formatted, formatted2, "should be idempotent");
+}
+
+#[test]
 fn test_format_comment_inside_nested_block() {
     let source = r"fn run() {
     if true {

--- a/wado-compiler/tests/format.rs
+++ b/wado-compiler/tests/format.rs
@@ -843,7 +843,10 @@ fn test_format_preserves_trait_assoc_type_leading_comment() {
 }
 ";
     let formatted = wado_compiler::format(source).expect("format failed");
-    assert_eq!(formatted, source, "trait assoc-type doc comment should round-trip");
+    assert_eq!(
+        formatted, source,
+        "trait assoc-type doc comment should round-trip"
+    );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
 }
@@ -863,7 +866,10 @@ fn test_format_preserves_trait_doc_before_attributed_member() {
 }
 "#;
     let formatted = wado_compiler::format(source).expect("format failed");
-    assert_eq!(formatted, source, "trait doc-before-attribute should round-trip");
+    assert_eq!(
+        formatted, source,
+        "trait doc-before-attribute should round-trip"
+    );
     let formatted2 = wado_compiler::format(&formatted).expect("format failed");
     assert_eq!(formatted, formatted2, "should be idempotent");
 }


### PR DESCRIPTION
Fixes #1598.

## Problem

`wado format` could not preserve a `///` doc comment attached to a trait's associated-type declaration (`type X;`). It detected the would-be drop and failed closed:

```
format error: formatting would drop a comment (`///The item type.`)
```

A related symptom: a doc comment immediately before a member carrying an attribute (e.g. `#[compiler_item(...)]`) got a spurious blank line inserted between the doc comment and the attribute, detaching the doc and producing non-idempotent output.

## Cause

In `unparse_trait` (`wado-compiler/src/unparse.rs`):

- The associated-types loop emitted `type X;` directly (`write_indent` + `push_str`), bypassing the comment-attachment path — so any leading doc comment was never claimed, and the post-format guard correctly refused to emit lossy output.
- The methods loop targeted blank lines at `method.span.line` instead of the effective start line, inserting a blank between a doc comment and a following attribute.

## Fix

- Route associated types through `emit_member`, the same helper the impl-block path already uses, so leading/trailing comments and blank-line padding are preserved.
- Use `effective_start_line(&method.attrs, method.span.line)` for method blank-line targeting, matching `unparse_interface`.
- Remove the workaround from PR #1597 by restoring the per-member doc comments on the internal `Reflect` trait (`lib/core/prelude/traits.wado`), which the fixed formatter now handles.

Added regression fixtures covering a doc-commented associated type and a doc comment before an attributed member (`wado-compiler/tests/format.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpfuBAV9DrJYxFSNSdkGk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01CpfuBAV9DrJYxFSNSdkGk9)_