### PR TITLE
fix(diagnostics): attribute diagnostics from the emitter's module, not ambient logger state

### DIFF
--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -330,11 +330,14 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
         span: Span,
     ) -> Option<crate::ast::AstId> {
         if let Some(first) = self.symbols.defined_span_in_module(module_source, name) {
-            let _ = self.logger.error_in(module_source, AnalyzeError::DuplicateDefinition {
-                name: name.to_string(),
-                span,
-                first,
-            });
+            let _ = self.logger.error_in(
+                module_source,
+                AnalyzeError::DuplicateDefinition {
+                    name: name.to_string(),
+                    span,
+                    first,
+                },
+            );
             return None;
         }
         Some(
@@ -684,10 +687,13 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 _ => continue,
             };
             if self.symbols.is_prelude_type(name) {
-                let _ = self.logger.error_in(module_source, AnalyzeError::PreludeTypeCollision {
-                    name: name.clone(),
-                    span,
-                });
+                let _ = self.logger.error_in(
+                    module_source,
+                    AnalyzeError::PreludeTypeCollision {
+                        name: name.clone(),
+                        span,
+                    },
+                );
             }
         }
     }
@@ -869,12 +875,15 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
             return Ok(());
         };
         if !self.import_reachable(from_module_source, target_module, visibility) {
-            self.logger.error_in(from_module_source, AnalyzeError::SymbolNotVisible {
-                name: name.to_string(),
-                module_source: target_module.clone(),
-                visibility,
-                span,
-            })?;
+            self.logger.error_in(
+                from_module_source,
+                AnalyzeError::SymbolNotVisible {
+                    name: name.to_string(),
+                    module_source: target_module.clone(),
+                    visibility,
+                    span,
+                },
+            )?;
         }
         Ok(())
     }
@@ -894,11 +903,14 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 if !is_wasm_asset_use_decl(use_decl)
                     && let Err(message) = validate_module_path(&use_decl.source)
                 {
-                    self.logger.error_in(from_module_source, AnalyzeError::InvalidModulePath {
-                        path: use_decl.source.clone(),
-                        message,
-                        span: use_decl.span,
-                    })?;
+                    self.logger.error_in(
+                        from_module_source,
+                        AnalyzeError::InvalidModulePath {
+                            path: use_decl.source.clone(),
+                            message,
+                            span: use_decl.span,
+                        },
+                    )?;
                     continue;
                 }
 
@@ -911,22 +923,28 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                     Some(&self.entry_module_source),
                     &self.invocations,
                 ) else {
-                    self.logger.error_in(from_module_source, AnalyzeError::InvalidModulePath {
-                        path: use_decl.source.clone(),
-                        message: "wasm asset paths must be relative (`./` or `../`); \
+                    self.logger.error_in(
+                        from_module_source,
+                        AnalyzeError::InvalidModulePath {
+                            path: use_decl.source.clone(),
+                            message: "wasm asset paths must be relative (`./` or `../`); \
                              absolute namespace-qualified paths are not supported here"
-                            .to_string(),
-                        span: use_decl.span,
-                    })?;
+                                .to_string(),
+                            span: use_decl.span,
+                        },
+                    )?;
                     continue;
                 };
 
                 // Check the module exists in pre-loaded modules
                 if !all_modules.contains_key(&module_source) {
-                    self.logger.error_in(from_module_source, AnalyzeError::ModuleNotFound {
-                        module_source: module_source.clone(),
-                        span: use_decl.span,
-                    })?;
+                    self.logger.error_in(
+                        from_module_source,
+                        AnalyzeError::ModuleNotFound {
+                            module_source: module_source.clone(),
+                            span: use_decl.span,
+                        },
+                    )?;
                     continue;
                 }
 
@@ -948,11 +966,14 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                                 self.symbols
                                     .register_import(from_module_source, import_name, key);
                             } else {
-                                self.logger.error_in(from_module_source, AnalyzeError::ImportNotFound {
-                                    module_source: module_source.clone(),
-                                    name: name.clone(),
-                                    span: use_decl.span,
-                                })?;
+                                self.logger.error_in(
+                                    from_module_source,
+                                    AnalyzeError::ImportNotFound {
+                                        module_source: module_source.clone(),
+                                        name: name.clone(),
+                                        span: use_decl.span,
+                                    },
+                                )?;
                             }
                         }
                         UseItem::InterfaceFunctions {
@@ -979,11 +1000,14 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                                         key,
                                     );
                                 } else {
-                                    self.logger.error_in(from_module_source, AnalyzeError::ImportNotFound {
-                                        module_source: module_source.clone(),
-                                        name: lookup_name,
-                                        span: use_decl.span,
-                                    })?;
+                                    self.logger.error_in(
+                                        from_module_source,
+                                        AnalyzeError::ImportNotFound {
+                                            module_source: module_source.clone(),
+                                            name: lookup_name,
+                                            span: use_decl.span,
+                                        },
+                                    )?;
                                 }
                             }
                         }

--- a/wado-compiler/src/analyze.rs
+++ b/wado-compiler/src/analyze.rs
@@ -330,7 +330,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
         span: Span,
     ) -> Option<crate::ast::AstId> {
         if let Some(first) = self.symbols.defined_span_in_module(module_source, name) {
-            let _ = self.logger.error(AnalyzeError::DuplicateDefinition {
+            let _ = self.logger.error_in(module_source, AnalyzeError::DuplicateDefinition {
                 name: name.to_string(),
                 span,
                 first,
@@ -345,7 +345,6 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
 
     /// Collect all definitions from a module into the symbol table
     fn collect_definitions(&mut self, module: &Module, module_source: &ModuleSource) {
-        self.logger.set_file(module_source.source_path());
         for item in &module.items {
             match item {
                 Item::Function(func) => {
@@ -674,7 +673,6 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
         if module.has_no_prelude() {
             return;
         }
-        self.logger.set_file(module_source.source_path());
         for item in &module.items {
             let (name, span) = match item {
                 Item::Struct(d) => (&d.name, d.span),
@@ -686,7 +684,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 _ => continue,
             };
             if self.symbols.is_prelude_type(name) {
-                let _ = self.logger.error(AnalyzeError::PreludeTypeCollision {
+                let _ = self.logger.error_in(module_source, AnalyzeError::PreludeTypeCollision {
                     name: name.clone(),
                     span,
                 });
@@ -755,7 +753,6 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
         modules: &crate::hashmap::IndexMap<ModuleSource, Module>,
     ) -> Result<(), Bail> {
         for (source, module) in modules {
-            self.logger.set_file(source.source_path());
             self.validate_imports(module, source, modules)?;
         }
         Ok(())
@@ -872,7 +869,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
             return Ok(());
         };
         if !self.import_reachable(from_module_source, target_module, visibility) {
-            self.logger.error(AnalyzeError::SymbolNotVisible {
+            self.logger.error_in(from_module_source, AnalyzeError::SymbolNotVisible {
                 name: name.to_string(),
                 module_source: target_module.clone(),
                 visibility,
@@ -897,7 +894,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                 if !is_wasm_asset_use_decl(use_decl)
                     && let Err(message) = validate_module_path(&use_decl.source)
                 {
-                    self.logger.error(AnalyzeError::InvalidModulePath {
+                    self.logger.error_in(from_module_source, AnalyzeError::InvalidModulePath {
                         path: use_decl.source.clone(),
                         message,
                         span: use_decl.span,
@@ -914,7 +911,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                     Some(&self.entry_module_source),
                     &self.invocations,
                 ) else {
-                    self.logger.error(AnalyzeError::InvalidModulePath {
+                    self.logger.error_in(from_module_source, AnalyzeError::InvalidModulePath {
                         path: use_decl.source.clone(),
                         message: "wasm asset paths must be relative (`./` or `../`); \
                              absolute namespace-qualified paths are not supported here"
@@ -926,7 +923,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
 
                 // Check the module exists in pre-loaded modules
                 if !all_modules.contains_key(&module_source) {
-                    self.logger.error(AnalyzeError::ModuleNotFound {
+                    self.logger.error_in(from_module_source, AnalyzeError::ModuleNotFound {
                         module_source: module_source.clone(),
                         span: use_decl.span,
                     })?;
@@ -951,7 +948,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                                 self.symbols
                                     .register_import(from_module_source, import_name, key);
                             } else {
-                                self.logger.error(AnalyzeError::ImportNotFound {
+                                self.logger.error_in(from_module_source, AnalyzeError::ImportNotFound {
                                     module_source: module_source.clone(),
                                     name: name.clone(),
                                     span: use_decl.span,
@@ -982,7 +979,7 @@ impl<'a, H: CompilerHost> Analyzer<'a, H> {
                                         key,
                                     );
                                 } else {
-                                    self.logger.error(AnalyzeError::ImportNotFound {
+                                    self.logger.error_in(from_module_source, AnalyzeError::ImportNotFound {
                                         module_source: module_source.clone(),
                                         name: lookup_name,
                                         span: use_decl.span,

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -377,6 +377,9 @@ fn collect_top_level_bare_idents(pattern: &crate::ast::Pattern) -> Vec<String> {
 pub struct Binder<'a, H: CompilerHost> {
     scopes: Vec<Scope>,
     logger: &'a Logger<'a, H>,
+    /// Module whose bodies are being bound; every diagnostic is attributed to
+    /// its source file.
+    module_source: &'a crate::module_source::ModuleSource,
     current_depth: u32,
     /// All local variable names defined in the current function
     /// Used to distinguish "out of scope" errors from "global reference"
@@ -389,14 +392,23 @@ pub struct Binder<'a, H: CompilerHost> {
 
 impl<'a, H: CompilerHost> Binder<'a, H> {
     /// Create a new binder
-    pub fn new(logger: &'a Logger<'a, H>) -> Self {
+    pub fn new(
+        logger: &'a Logger<'a, H>,
+        module_source: &'a crate::module_source::ModuleSource,
+    ) -> Self {
         Self {
             scopes: vec![Scope::new()], // Global scope
             logger,
+            module_source,
             current_depth: 0,
             local_names_in_function: IndexSet::default(),
             possibly_uninit: IndexSet::default(),
         }
+    }
+
+    /// Emit a bind error attributed to the module being bound.
+    fn emit(&self, err: impl Into<crate::compiler_host::Diagnostic>) -> Result<(), Bail> {
+        self.logger.error_in(self.module_source, err)
     }
 
     /// Returns true if the innermost binding for `name` is possibly uninitialized.
@@ -801,13 +813,13 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
                     // Unknown names might be global functions/constants - those are
                     // resolved later by the analyzer.
                     if self.local_names_in_function.contains(&ident.name) {
-                        self.logger.error(BindError::UseBeforeDefine {
+                        self.emit(BindError::UseBeforeDefine {
                             name: ident.name.clone(),
                             used_at: ident.span,
                         })?;
                     }
                 } else if self.is_possibly_uninit(&ident.name) {
-                    self.logger.error(BindError::UseBeforeInit {
+                    self.emit(BindError::UseBeforeInit {
                         name: ident.name.clone(),
                         span: ident.span,
                     })?;
@@ -831,7 +843,7 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
                     && let Some(binding) = self.lookup(&ident.name)
                     && !binding.is_mut
                 {
-                    self.logger.error(BindError::AssignToImmutable {
+                    self.emit(BindError::AssignToImmutable {
                         name: ident.name.clone(),
                         span: assign.span,
                     })?;
@@ -846,7 +858,7 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
                     && let Some(binding) = self.lookup(&ident.name)
                     && !binding.is_mut
                 {
-                    self.logger.error(BindError::AssignToImmutable {
+                    self.emit(BindError::AssignToImmutable {
                         name: ident.name.clone(),
                         span: compound.span,
                     })?;
@@ -1200,13 +1212,19 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
         is_reactive: bool,
         span: Span,
     ) -> Result<(), Bail> {
-        let scope = self.scopes.last_mut().unwrap();
-
-        // Check for duplicate in the same scope
-        if let Some(existing) = scope.bindings.get(name) {
-            self.logger.error(BindError::DuplicateInScope {
+        // Check for duplicate in the same scope. Read the prior span through a
+        // shared borrow so it ends before `emit` takes `&self`.
+        if let Some(first) = self
+            .scopes
+            .last()
+            .unwrap()
+            .bindings
+            .get(name)
+            .map(|b| b.defined_at)
+        {
+            self.emit(BindError::DuplicateInScope {
                 name: name.to_string(),
-                first: existing.defined_at,
+                first,
                 second: span,
             })?;
             return Ok(());
@@ -1215,6 +1233,7 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
         // Track this name as a local variable in the current function
         self.local_names_in_function.insert(name.to_string());
 
+        let scope = self.scopes.last_mut().unwrap();
         scope.bindings.insert(
             name.to_string(),
             BindingInfo {
@@ -1256,8 +1275,12 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
 }
 
 /// Convenience function to bind a module
-pub fn bind_module<H: CompilerHost>(module: &Module, logger: &Logger<H>) -> Result<(), Bail> {
-    let mut binder = Binder::new(logger);
+pub fn bind_module<H: CompilerHost>(
+    module: &Module,
+    module_source: &crate::module_source::ModuleSource,
+    logger: &Logger<H>,
+) -> Result<(), Bail> {
+    let mut binder = Binder::new(logger, module_source);
     binder.bind_module(module)
 }
 
@@ -1278,7 +1301,7 @@ mod tests {
     fn bind_and_check(module: &Module) -> (bool, Vec<crate::compiler_host::Diagnostic>) {
         let host = InMemoryCompilerHost::new();
         let logger = Logger::new(&host, LogLevel::Error);
-        let result = bind_module(module, &logger);
+        let result = bind_module(module, &crate::module_source::ModuleSource::default(), &logger);
         (result.is_ok(), host.diagnostics())
     }
 

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -1212,8 +1212,7 @@ impl<'a, H: CompilerHost> Binder<'a, H> {
         is_reactive: bool,
         span: Span,
     ) -> Result<(), Bail> {
-        // Check for duplicate in the same scope. Read the prior span through a
-        // shared borrow so it ends before `emit` takes `&self`.
+        // Shared borrow (not `last_mut`) so it ends before `emit` takes `&self`.
         if let Some(first) = self
             .scopes
             .last()

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -1300,7 +1300,11 @@ mod tests {
     fn bind_and_check(module: &Module) -> (bool, Vec<crate::compiler_host::Diagnostic>) {
         let host = InMemoryCompilerHost::new();
         let logger = Logger::new(&host, LogLevel::Error);
-        let result = bind_module(module, &crate::module_source::ModuleSource::default(), &logger);
+        let result = bind_module(
+            module,
+            &crate::module_source::ModuleSource::default(),
+            &logger,
+        );
         (result.is_ok(), host.diagnostics())
     }
 

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -167,6 +167,19 @@ pub struct Elaborator<'a, H: CompilerHost> {
 }
 
 impl<'a, H: CompilerHost> Elaborator<'a, H> {
+    /// Emit a compilation error attributed to the module currently being
+    /// resolved. This is the single channel for `TypeError`s raised during
+    /// item/body resolution: the file comes from `current_module_source`,
+    /// which is maintained structurally (including across
+    /// [`Self::with_module_perspective`]), so there is no ambient file
+    /// context for a phase to forget to set.
+    pub(super) fn emit(
+        &self,
+        err: impl Into<crate::compiler_host::Diagnostic>,
+    ) -> Result<(), crate::logger::Bail> {
+        self.logger.error_in(&self.current_module_source, err)
+    }
+
     /// Construct a [`TypeLookup`] view over the elaborator's current import
     /// context and shared `all_*` tables. Use this for any type-name
     /// resolution; never reach into `all_*` directly.

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -167,12 +167,8 @@ pub struct Elaborator<'a, H: CompilerHost> {
 }
 
 impl<'a, H: CompilerHost> Elaborator<'a, H> {
-    /// Emit a compilation error attributed to the module currently being
-    /// resolved. This is the single channel for `TypeError`s raised during
-    /// item/body resolution: the file comes from `current_module_source`,
-    /// which is maintained structurally (including across
-    /// [`Self::with_module_perspective`]), so there is no ambient file
-    /// context for a phase to forget to set.
+    /// Emit a `TypeError` attributed to `current_module_source` — the channel
+    /// for every diagnostic raised during item/body resolution.
     pub(super) fn emit(
         &self,
         err: impl Into<crate::compiler_host::Diagnostic>,

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -214,7 +214,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if is_mut_ref {
             return;
         }
-        let _ = self.logger.error(TypeError::ClosureMutBindingRequired {
+        let _ = self.emit(TypeError::ClosureMutBindingRequired {
             name: root.name.clone(),
             span: root.span,
         });
@@ -334,7 +334,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // not-callable diagnostic, not the misleading "unknown
                 // function 'x'" from the named-function lookup below.
                 let type_name = self.tysys.type_table.borrow().type_name(value_ty);
-                let _ = self.logger.error(TypeError::CalleeNotCallable {
+                let _ = self.emit(TypeError::CalleeNotCallable {
                     type_name,
                     span: call.callee.span(),
                 });
@@ -381,7 +381,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // don't pile a second diagnostic on top of the first.
             if callee_type != TypeTable::ERROR {
                 let type_name = self.tysys.type_table.borrow().type_name(callee_type);
-                let _ = self.logger.error(TypeError::CalleeNotCallable {
+                let _ = self.emit(TypeError::CalleeNotCallable {
                     type_name,
                     span: call.callee.span(),
                 });
@@ -791,7 +791,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let expected_args = usize::from(!payload_is_unit);
 
                     if args.len() != expected_args {
-                        let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+                        let _ = self.emit(TypeError::ArgumentCountMismatch {
                             expected: expected_args,
                             found: args.len(),
                             span: call.span,
@@ -882,14 +882,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             )
                             .type_id;
                     }
-                    let _ = self.logger.error(TypeError::UnknownFunction {
+                    let _ = self.emit(TypeError::UnknownFunction {
                         name: format!("{prefix}::{suffix}"),
                         span: call.span,
                     });
                     return TypeTable::ERROR;
                 } else {
                     // Unknown case name
-                    let _ = self.logger.error(TypeError::UnknownFunction {
+                    let _ = self.emit(TypeError::UnknownFunction {
                         name: format!("{prefix}::{suffix}"),
                         span: call.span,
                     });
@@ -899,7 +899,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // If prefix is a known type (struct/enum/newtype/flags) with no matching
             // static method, emit a compile error.
             else if self.tysys.is_known_type_name(prefix) {
-                let _ = self.logger.error(TypeError::UnknownFunction {
+                let _ = self.emit(TypeError::UnknownFunction {
                     name: format!("{prefix}::{suffix}"),
                     span: call.span,
                 });
@@ -936,7 +936,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             );
                             let expected_args = usize::from(!payload_is_unit);
                             if args.len() != expected_args {
-                                let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+                                let _ = self.emit(TypeError::ArgumentCountMismatch {
                                     expected: expected_args,
                                     found: args.len(),
                                     span: call.span,
@@ -1207,7 +1207,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let callee = if let Some(c) = callee_opt {
             c
         } else {
-            let _ = self.logger.error(TypeError::UnknownFunction {
+            let _ = self.emit(TypeError::UnknownFunction {
                 name: display_name.clone(),
                 span: call.span,
             });
@@ -1300,7 +1300,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             );
         }
         if !check_param_types.is_empty() && args.len() != check_param_types.len() {
-            let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+            let _ = self.emit(TypeError::ArgumentCountMismatch {
                 expected: check_param_types.len(),
                 found: args.len(),
                 span: call.span,
@@ -1397,7 +1397,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         if args.len() != fn_params.len() {
-            let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+            let _ = self.emit(TypeError::ArgumentCountMismatch {
                 expected: fn_params.len(),
                 found: args.len(),
                 span: call.span,
@@ -1936,7 +1936,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .collect::<Vec<_>>()
             .join(", ");
         let func_name = callee.name.as_str();
-        let _ = self.logger.error(TypeError::CannotInferType {
+        let _ = self.emit(TypeError::CannotInferType {
             message: format!(
                 "cannot infer type parameter {names} of function `{func_name}`; \
                  add a turbofish (`{func_name}::<...>()`) or a type annotation"
@@ -2055,7 +2055,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         } else {
             format!("`{prefix}::{suffix}::<...>()`")
         };
-        let _ = self.logger.error(TypeError::CannotInferType {
+        let _ = self.emit(TypeError::CannotInferType {
             message: format!(
                 "cannot infer type parameter {joined} of `{prefix}::{suffix}`; \
                  add a turbofish ({turbofish}) or a type annotation"
@@ -2774,7 +2774,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return final_return_type;
         }
 
-        let _ = self.logger.error(TypeError::UnknownFunction {
+        let _ = self.emit(TypeError::UnknownFunction {
             name: format!("{type_param_name}::{method_name}"),
             span: call.span,
         });

--- a/wado-compiler/src/elaborator/closure.rs
+++ b/wado-compiler/src/elaborator/closure.rs
@@ -73,7 +73,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     fn reject_closure_defaults(&mut self, closure: &ast::ClosureExpr) {
         for param in &closure.params {
             if let Some(default) = &param.default {
-                let _ = self.logger.error(TypeError::DefaultInClosure {
+                let _ = self.emit(TypeError::DefaultInClosure {
                     param: param.name.clone(),
                     span: default.span(),
                 });
@@ -201,7 +201,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         && body_type != t
                         && body_type != TypeTable::NEVER
                     {
-                        let _ = self.logger.error(TypeError::MissingReturn {
+                        let _ = self.emit(TypeError::MissingReturn {
                             return_type: self.tysys.type_table.borrow().type_name(t),
                             span: closure.span,
                         });
@@ -210,7 +210,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
                 None if body_type == TypeTable::UNIT || body_type == TypeTable::NEVER => body_type,
                 None => {
-                    let _ = self.logger.error(TypeError::MissingReturn {
+                    let _ = self.emit(TypeError::MissingReturn {
                         return_type: self.tysys.type_table.borrow().type_name(body_type),
                         span: closure.span,
                     });

--- a/wado-compiler/src/elaborator/coercion.rs
+++ b/wado-compiler/src/elaborator/coercion.rs
@@ -56,7 +56,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && self.tysys.type_table.borrow().is_integer(target_type)
         {
             if util::is_float_only_literal(repr) {
-                let _ = self.logger.error(TypeError::InvalidLiteral {
+                let _ = self.emit(TypeError::InvalidLiteral {
                     message: format!(
                         "cannot use float literal '{repr}' as integer (has decimal point or negative exponent)"
                     ),
@@ -72,7 +72,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         &self.tysys.type_table.borrow(),
                         repr,
                     ) {
-                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                        let _ = self.emit(TypeError::InvalidLiteral {
                             message: err_msg,
                             span: lit.span,
                         });
@@ -80,7 +80,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     placeholder(target_type, lit.span)
                 }
                 Err(message) => {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message,
                         span: lit.span,
                     });
@@ -97,7 +97,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && self.tysys.type_table.borrow().is_integer(target_type)
         {
             if util::is_float_only_literal(repr) {
-                let _ = self.logger.error(TypeError::InvalidLiteral {
+                let _ = self.emit(TypeError::InvalidLiteral {
                     message: format!(
                         "cannot use float literal '-{repr}' as integer (has decimal point or negative exponent)"
                     ),
@@ -113,7 +113,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         &self.tysys.type_table.borrow(),
                         repr,
                     ) {
-                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                        let _ = self.emit(TypeError::InvalidLiteral {
                             message: err_msg,
                             span: unary.span,
                         });
@@ -121,7 +121,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     placeholder(target_type, unary.span)
                 }
                 Err(message) => {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message,
                         span: lit.span,
                     });
@@ -138,7 +138,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return Some(match util::parse_float_literal(repr) {
                 Ok(_) => placeholder(target_type, lit.span),
                 Err(message) => {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message,
                         span: lit.span,
                     });
@@ -157,7 +157,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return Some(match util::parse_float_literal(repr) {
                 Ok(_) => placeholder(target_type, unary.span),
                 Err(message) => {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message,
                         span: lit.span,
                     });
@@ -190,7 +190,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         return Some(placeholder(target_type, lit.span));
                     }
                     Err(_) => {
-                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                        let _ = self.emit(TypeError::InvalidLiteral {
                             message: format!("invalid {name} literal: {repr}"),
                             span: lit.span,
                         });
@@ -218,7 +218,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if util::parse_i128_literal(&negated_repr).is_ok() {
                     return Some(placeholder(target_type, unary.span));
                 }
-                let _ = self.logger.error(TypeError::InvalidLiteral {
+                let _ = self.emit(TypeError::InvalidLiteral {
                     message: format!("invalid i128 literal: -{repr}"),
                     span: unary.span,
                 });
@@ -411,7 +411,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             )
         {
             let type_name = self.tysys.type_table.borrow().type_name(target_type);
-            let _ = self.logger.error(TypeError::MissingTraitImpl {
+            let _ = self.emit(TypeError::MissingTraitImpl {
                 type_name,
                 trait_name: "KeyValueLiteral".to_string(),
                 span: expr.span(),
@@ -598,7 +598,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let mut seen_fields: IndexSet<&str> = IndexSet::default();
         for field in &struct_lit.fields {
             if !seen_fields.insert(field.name.as_str()) {
-                let _ = self.logger.error(TypeError::DuplicateField {
+                let _ = self.emit(TypeError::DuplicateField {
                     name: field.name.clone(),
                     span: field.span,
                 });
@@ -608,7 +608,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         for field in &struct_lit.fields {
             let value = self.resolve_expr(&field.value, ctx, Some(value_type));
             if value != value_type && value != TypeTable::UNKNOWN && value != TypeTable::NEVER {
-                let _ = self.logger.error(TypeError::TypeMismatch {
+                let _ = self.emit(TypeError::TypeMismatch {
                     expected: self.tysys.type_table.borrow().type_name(value_type),
                     found: self.tysys.type_table.borrow().type_name(value),
                     span: field.value.span(),
@@ -774,7 +774,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .borrow()
                     .contains_type_param(element_type)
             {
-                let _ = self.logger.error(TypeError::TypeMismatch {
+                let _ = self.emit(TypeError::TypeMismatch {
                     expected: format!(
                         "homogeneous elements of type '{}'",
                         self.tysys.type_table.borrow().type_name(element_type)

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -3992,13 +3992,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         // per field.
                         elem_types.extend(inner_elems);
                     } else {
-                        let _ = self.emit(
-                            crate::elaborator::types::TypeError::InvalidLiteral {
-                                message: "spread operator `..` can only be used with tuple types"
-                                    .to_string(),
-                                span: elem.span(),
-                            },
-                        );
+                        let _ = self.emit(crate::elaborator::types::TypeError::InvalidLiteral {
+                            message: "spread operator `..` can only be used with tuple types"
+                                .to_string(),
+                            span: elem.span(),
+                        });
                         elem_types.push(spread_type_id);
                     }
                 }

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -346,7 +346,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if util::is_float_only_literal(repr) {
                     // Must be float (has decimal point or negative exponent)
                     if let Err(message) = util::parse_float_literal(repr) {
-                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                        let _ = self.emit(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -355,7 +355,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 } else {
                     // Can be integer (default to i32)
                     if let Err(message) = util::parse_u128_literal(repr) {
-                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                        let _ = self.emit(TypeError::InvalidLiteral {
                             message,
                             span: lit.span,
                         });
@@ -366,7 +366,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             Literal::Bool(_) => TypeTable::BOOL,
             Literal::Char(raw) => {
                 if let Err(message) = util::unescape_char(raw) {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message,
                         span: lit.span,
                     });
@@ -376,7 +376,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             Literal::String(raw) => {
                 let string_type = self.get_string_struct_type();
                 if let Err(message) = util::unescape_string(raw) {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message,
                         span: lit.span,
                     });
@@ -386,7 +386,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             Literal::Bytes(raw) => {
                 let array_u8_type = self.tysys.type_table.borrow_mut().make_list(TypeTable::U8);
                 if let Err(message) = util::unescape_bytes(raw) {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message,
                         span: lit.span,
                     });
@@ -420,7 +420,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .cloned();
                 let string_type = self.get_string_struct_type();
                 if data.is_none() {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message: "`#data` requires a `__DATA__` section in the source file"
                             .to_owned(),
                         span: lit.span,
@@ -433,13 +433,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let string_type = self.get_string_struct_type();
                 if let Some(bytes) = self.tysys.included_files.get(&key) {
                     if std::str::from_utf8(bytes).is_err() {
-                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                        let _ = self.emit(TypeError::InvalidLiteral {
                             message: format!("file is not valid UTF-8: \"{raw_path}\""),
                             span: lit.span,
                         });
                     }
                 } else {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message: format!("file not found: \"{raw_path}\""),
                         span: lit.span,
                     });
@@ -450,7 +450,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let key = [self.current_module_source.to_string(), raw_path.clone()];
                 let array_u8_type = self.tysys.type_table.borrow_mut().make_list(TypeTable::U8);
                 if !self.tysys.included_files.contains_key(&key) {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message: format!("file not found: \"{raw_path}\""),
                         span: lit.span,
                     });
@@ -636,7 +636,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // Unknown variable - report error
-        let _ = self.logger.error(TypeError::UnknownIdentifier {
+        let _ = self.emit(TypeError::UnknownIdentifier {
             name: ident.name.clone(),
             span: ident.span,
         });
@@ -739,7 +739,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     ResolvedType::Unit
                 );
                 if !payload_is_unit {
-                    let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+                    let _ = self.emit(TypeError::ArgumentCountMismatch {
                         expected: 1,
                         found: 0,
                         span: ident.span,
@@ -948,7 +948,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
 
         // (c) Generic, no usable type context: dedicated diagnostic.
-        let _ = self.logger.error(TypeError::BareGenericFunctionRef {
+        let _ = self.emit(TypeError::BareGenericFunctionRef {
             name: ident.name.clone(),
             span: ident.span,
         });
@@ -1184,7 +1184,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if index < type_args.len() {
                         return (index as u32, type_args[index]);
                     }
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message: format!(
                             "tuple index {} out of bounds, tuple has {} elements",
                             index,
@@ -1249,7 +1249,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some(struct_info) = self.lookup_struct_fields_in(&struct_name, &module_source) {
             for (fname, _, vis) in &struct_info.fields {
                 if fname == field_name && !vis.reachable_from(same_package) {
-                    let _ = self.logger.error(TypeError::PrivateFieldAccess {
+                    let _ = self.emit(TypeError::PrivateFieldAccess {
                         struct_name: struct_name.clone(),
                         field_name: field_name.to_string(),
                         visibility: *vis,
@@ -1389,7 +1389,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let field_type = elements[idx];
                     return field_type;
                 } else {
-                    let _ = self.logger.error(TypeError::InvalidLiteral {
+                    let _ = self.emit(TypeError::InvalidLiteral {
                         message: format!(
                             "tuple index {} out of bounds, tuple has {} elements",
                             idx,
@@ -1401,7 +1401,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
             }
             // Non-constant index on tuple
-            let _ = self.logger.error(TypeError::InvalidLiteral {
+            let _ = self.emit(TypeError::InvalidLiteral {
                 message: "tuple index must be a constant integer".to_string(),
                 span: index.span,
             });
@@ -1539,7 +1539,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Fallback: report error for unsupported indexing
         let type_name = self.tysys.type_table.borrow().type_name(expr_type);
-        let _ = self.logger.error(TypeError::MissingTraitImpl {
+        let _ = self.emit(TypeError::MissingTraitImpl {
             type_name,
             trait_name: "Index or IndexValue".to_string(),
             span: index.span,
@@ -1607,7 +1607,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else {
                         let chain_name = self.tysys.type_table.borrow().type_name(chain_type);
                         let else_name = self.tysys.type_table.borrow().type_name(else_type);
-                        let _ = self.logger.error(TypeError::TypeMismatch {
+                        let _ = self.emit(TypeError::TypeMismatch {
                             expected: chain_name,
                             found: else_name,
                             span: if_expr.else_block.as_ref().unwrap().span,
@@ -1729,7 +1729,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else if if_expr.else_block.is_none() {
                         if then_type != TypeTable::UNIT {
                             let type_name = self.tysys.type_table.borrow().type_name(then_type);
-                            let _ = self.logger.error(TypeError::TypeMismatch {
+                            let _ = self.emit(TypeError::TypeMismatch {
                                 expected: "()".to_string(),
                                 found: type_name,
                                 span: if_expr.then_block.span,
@@ -1739,7 +1739,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else {
                         let then_name = self.tysys.type_table.borrow().type_name(then_type);
                         let else_name = self.tysys.type_table.borrow().type_name(else_type);
-                        let _ = self.logger.error(TypeError::TypeMismatch {
+                        let _ = self.emit(TypeError::TypeMismatch {
                             expected: then_name,
                             found: else_name,
                             span: if_expr.else_block.as_ref().unwrap().span,
@@ -1830,7 +1830,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if matches!(result, TypeCheckResult::Incompatible) {
             let expected_name = self.tysys.type_table.borrow().type_name(expected);
             let found_name = self.tysys.type_table.borrow().type_name(actual);
-            let _ = self.logger.error(TypeError::TypeMismatch {
+            let _ = self.emit(TypeError::TypeMismatch {
                 expected: expected_name,
                 found: found_name,
                 span,
@@ -1852,7 +1852,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if !self.tysys.type_table.borrow().contains_unknown(result_type) {
             return false;
         }
-        let _ = self.logger.error(TypeError::CannotInferType {
+        let _ = self.emit(TypeError::CannotInferType {
             message: format!("cannot infer the type of this {construct}; add a type annotation"),
             span,
         });
@@ -1866,7 +1866,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     fn report_unresolved_nulls(&mut self, unresolved: &[Span], result_type: TypeId) {
         for &span in unresolved {
             let expected = self.tysys.type_table.borrow().type_name(result_type);
-            let _ = self.logger.error(TypeError::TypeMismatch {
+            let _ = self.emit(TypeError::TypeMismatch {
                 expected,
                 found: "null".to_string(),
                 span,
@@ -2099,7 +2099,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if matches!(result, TypeCheckResult::Incompatible) {
                     let expected_name = self.tysys.type_table.borrow().type_name(type_id);
                     let found_name = self.tysys.type_table.borrow().type_name(arm_type);
-                    let _ = self.logger.error(TypeError::TypeMismatch {
+                    let _ = self.emit(TypeError::TypeMismatch {
                         expected: expected_name,
                         found: found_name,
                         span: arm_span,
@@ -2199,7 +2199,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if !missing.is_empty() {
                         let missing_names: Vec<String> =
                             missing.iter().map(|s| (*s).to_string()).collect();
-                        let _ = self.logger.error(TypeError::InvalidPattern {
+                        let _ = self.emit(TypeError::InvalidPattern {
                             message: format!(
                                 "non-exhaustive match: missing {}",
                                 Self::format_missing_cases(&missing_names),
@@ -2239,7 +2239,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if !has_false {
                         missing.push("false".to_string());
                     }
-                    let _ = self.logger.error(TypeError::InvalidPattern {
+                    let _ = self.emit(TypeError::InvalidPattern {
                         message: format!(
                             "non-exhaustive match: missing {}",
                             Self::format_missing_cases(&missing),
@@ -2584,7 +2584,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let missing: Vec<&&str> = all_cases.difference(&covered).collect();
             if !missing.is_empty() {
                 let missing_names: Vec<String> = missing.iter().map(|s| (*s).to_string()).collect();
-                let _ = self.logger.error(TypeError::InvalidPattern {
+                let _ = self.emit(TypeError::InvalidPattern {
                     message: format!(
                         "non-exhaustive match: missing {}",
                         Self::format_missing_cases(&missing_names),
@@ -2711,7 +2711,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check exhaustiveness: sort ranges and verify they cover [type_min, type_max]
         if all_ranges.is_empty() {
-            let _ = self.logger.error(TypeError::InvalidPattern {
+            let _ = self.emit(TypeError::InvalidPattern {
                 message: "non-exhaustive match: integer type requires a wildcard `_` or full range coverage".to_string(),
                 span,
             });
@@ -2736,7 +2736,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Check if merged ranges cover [type_min, type_max]
         let covers = merged.len() == 1 && merged[0].0 <= type_min && merged[0].1 >= type_max;
         if !covers {
-            let _ = self.logger.error(TypeError::InvalidPattern {
+            let _ = self.emit(TypeError::InvalidPattern {
                 message: "non-exhaustive match: not all values in the integer range are covered"
                     .to_string(),
                 span,
@@ -2763,7 +2763,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 for &(a_lo, a_hi) in &arm_ranges[i] {
                     for &(b_lo, b_hi) in &arm_ranges[j] {
                         if a_lo <= b_hi && b_lo <= a_hi {
-                            let _ = self.logger.error(TypeError::InvalidPattern {
+                            let _ = self.emit(TypeError::InvalidPattern {
                                 message: "overlapping range patterns in match arms".to_string(),
                                 span,
                             });
@@ -2840,7 +2840,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .type_id;
                     }
                     Err(_) => {
-                        let _ = self.logger.error(TypeError::InvalidLiteral {
+                        let _ = self.emit(TypeError::InvalidLiteral {
                             message: format!("invalid {name} literal: {repr}"),
                             span: lit.span,
                         });
@@ -2869,7 +2869,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     )
                     .type_id;
                 }
-                let _ = self.logger.error(TypeError::InvalidLiteral {
+                let _ = self.emit(TypeError::InvalidLiteral {
                     message: format!("invalid i128 literal: -{repr}"),
                     span: unary.span,
                 });
@@ -2953,7 +2953,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let from_name = tt.type_name(source_type);
                 let to_name = tt.type_name(target_type);
                 drop(tt);
-                let _ = self.logger.error(TypeError::InvalidCast {
+                let _ = self.emit(TypeError::InvalidCast {
                     from: from_name,
                     to: to_name,
                     hint: "i128/u128 can only be cast to numeric types".to_string(),
@@ -2979,7 +2979,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && source_base != TypeTable::U8
         {
             let from_name = self.tysys.type_table.borrow().type_name(source_type);
-            let _ = self.logger.error(TypeError::InvalidCast {
+            let _ = self.emit(TypeError::InvalidCast {
                 from: from_name,
                 to: "char".to_string(),
                 hint: "use char::from_u32() or char::from_i32() for checked conversion".to_string(),
@@ -2992,7 +2992,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && !self.tysys.type_table.borrow().is_integer(target_base)
         {
             let to_name = self.tysys.type_table.borrow().type_name(target_type);
-            let _ = self.logger.error(TypeError::InvalidCast {
+            let _ = self.emit(TypeError::InvalidCast {
                 from: "char".to_string(),
                 to: to_name,
                 hint: "char can only be cast to integer types".to_string(),
@@ -3046,7 +3046,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if let crate::symbol::SymbolKind::Struct(_) = &symbol.kind {
                 (symbol.name.clone(), symbol.module_source().clone())
             } else {
-                let _ = self.logger.error(TypeError::UnknownType {
+                let _ = self.emit(TypeError::UnknownType {
                     name: name.clone(),
                     span: struct_lit.span,
                 });
@@ -3068,7 +3068,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // `StructLiteral expected Ref WirType` panic. The fallback
             // module_source is still returned so subsequent passes have a
             // best-effort type; the error has already been logged.
-            let _ = self.logger.error(TypeError::UnknownType {
+            let _ = self.emit(TypeError::UnknownType {
                 name: name.clone(),
                 span: struct_lit.span,
             });
@@ -3101,7 +3101,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // (or a second spread) is fully overwritten and unused.
         let named_spread = struct_lit.spreads.first();
         if let Some(second) = struct_lit.spreads.get(1) {
-            let _ = self.logger.error(TypeError::InvalidLiteral {
+            let _ = self.emit(TypeError::InvalidLiteral {
                 message: "a named struct literal allows at most one `..base` spread".to_string(),
                 span: second.span,
             });
@@ -3109,7 +3109,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some(spread) = named_spread
             && spread.field_pos > 0
         {
-            let _ = self.logger.error(TypeError::InvalidLiteral {
+            let _ = self.emit(TypeError::InvalidLiteral {
                 message: "a field before `..base` is overwritten and never used; \
                           put `..base` first"
                     .to_string(),
@@ -3120,7 +3120,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some(spread) = named_spread
             && struct_lit.fields.is_empty()
         {
-            let _ = self.logger.error(TypeError::InvalidLiteral {
+            let _ = self.emit(TypeError::InvalidLiteral {
                 message: "`{ ..base }` with no other fields just copies `base`; \
                           use `base` directly"
                     .to_string(),
@@ -3239,7 +3239,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if !struct_field_types.iter().any(|(n, _)| n == &field.name)
                     && !struct_field_types.is_empty()
                 {
-                    let _ = self.logger.error(TypeError::ExtraField {
+                    let _ = self.emit(TypeError::ExtraField {
                         struct_name: struct_name.clone(),
                         field_name: field.name.clone(),
                         span: field.span,
@@ -3311,7 +3311,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         field_index: idx as u32,
                     });
                 } else {
-                    let _ = self.logger.error(TypeError::MissingField {
+                    let _ = self.emit(TypeError::MissingField {
                         struct_name: struct_name.clone(),
                         field_name: expected_name.clone(),
                         span: struct_lit.span,
@@ -3336,7 +3336,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let set_explicitly = provided_names.contains(fname);
                 let read_via_spread = !struct_lit.spreads.is_empty() && !set_explicitly;
                 if !vis.reachable_from(same_package) && (set_explicitly || read_via_spread) {
-                    let _ = self.logger.error(TypeError::PrivateFieldAccess {
+                    let _ = self.emit(TypeError::PrivateFieldAccess {
                         struct_name: struct_name.clone(),
                         field_name: fname.clone(),
                         visibility: *vis,
@@ -3451,7 +3451,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                     type_arg,
                                     bound,
                                 );
-                                let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
+                                let _ = self.emit(TypeError::TraitBoundNotSatisfied {
                                     type_name,
                                     trait_name: bound.clone(),
                                     param_name: param_name.clone(),
@@ -3581,7 +3581,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .iter()
                 .all(|n| members[i + 1..].iter().any(|(_, later)| later.contains(n)));
             if fully_shadowed {
-                let _ = self.logger.error(TypeError::InvalidLiteral {
+                let _ = self.emit(TypeError::InvalidLiteral {
                     message: "this member is fully overwritten by a later spread/field \
                               and has no effect"
                         .to_string(),
@@ -3617,7 +3617,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 continue;
             };
             if !vis.reachable_from(same_package) {
-                let _ = self.logger.error(TypeError::PrivateFieldAccess {
+                let _ = self.emit(TypeError::PrivateFieldAccess {
                     struct_name: self.tysys.type_id_to_string(base_types[base_idx]),
                     field_name: name.clone(),
                     visibility: *vis,
@@ -3685,14 +3685,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         if !base_errored {
             if is_copy {
-                let _ = self.logger.error(TypeError::InvalidLiteral {
+                let _ = self.emit(TypeError::InvalidLiteral {
                     message: "`{ ..base }` with no other members just copies `base`; \
                               use `base` directly"
                         .to_string(),
                     span: struct_lit.spreads[0].span,
                 });
             } else if has_spread && !compose_union && !is_kv_merge {
-                let _ = self.logger.error(TypeError::InvalidLiteral {
+                let _ = self.emit(TypeError::InvalidLiteral {
                     message: "a `..base` spread must be a struct value (composition) or a \
                               key-value map with a map-typed target; a non-struct base or a \
                               mix of struct and map spreads is not allowed"
@@ -3992,7 +3992,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         // per field.
                         elem_types.extend(inner_elems);
                     } else {
-                        let _ = self.logger.error(
+                        let _ = self.emit(
                             crate::elaborator::types::TypeError::InvalidLiteral {
                                 message: "spread operator `..` can only be used with tuple types"
                                     .to_string(),
@@ -4081,7 +4081,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         drop(tt);
 
         if !is_option && !is_result {
-            let _ = self.logger.error(TypeError::InvalidQuestionMark {
+            let _ = self.emit(TypeError::InvalidQuestionMark {
                 message: format!("cannot use ? on type {type_name}"),
                 span: qm.span,
             });
@@ -4099,7 +4099,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         drop(tt);
 
         if is_option && !ret_is_option {
-            let _ = self.logger.error(TypeError::InvalidQuestionMark {
+            let _ = self.emit(TypeError::InvalidQuestionMark {
                 message: "cannot use ? on Option in a function returning Result".to_string(),
                 span: qm.span,
             });
@@ -4107,12 +4107,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
         if is_result && !ret_is_result {
             if ret_is_option {
-                let _ = self.logger.error(TypeError::InvalidQuestionMark {
+                let _ = self.emit(TypeError::InvalidQuestionMark {
                     message: "cannot use ? on Result in a function returning Option".to_string(),
                     span: qm.span,
                 });
             } else {
-                let _ = self.logger.error(TypeError::InvalidQuestionMark {
+                let _ = self.emit(TypeError::InvalidQuestionMark {
                     message: "? requires function to return Result or Option".to_string(),
                     span: qm.span,
                 });
@@ -4432,7 +4432,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     RangeKind::Exclusive => "..<",
                     RangeKind::Inclusive => "..=",
                 };
-                let _ = self.logger.error(TypeError::TypeMismatch {
+                let _ = self.emit(TypeError::TypeMismatch {
                     expected: start_name,
                     found: format!(
                         "{end_name} (range `{op_str}` requires both operands to have the same type)"
@@ -4467,7 +4467,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 element_type,
                 &ord_trait_name,
             );
-            let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
+            let _ = self.emit(TypeError::TraitBoundNotSatisfied {
                 type_name,
                 trait_name: ord_trait_name,
                 param_name: "T".to_string(),
@@ -4487,7 +4487,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     RangeKind::Exclusive => "..<",
                     RangeKind::Inclusive => "..=",
                 };
-                let _ = self.logger.error(TypeError::InvalidLiteral {
+                let _ = self.emit(TypeError::InvalidLiteral {
                     message: format!(
                         "reversed range `{op_str}` is not supported (start must be less than end)"
                     ),

--- a/wado-compiler/src/elaborator/handlers.rs
+++ b/wado-compiler/src/elaborator/handlers.rs
@@ -149,7 +149,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let is_known_resource =
                         self.tysys.trait_env.resource_decl_index.contains_key(&key);
                     if !is_known_effect && !is_known_resource {
-                        let _ = self.logger.error(TypeError::NotAnEffect {
+                        let _ = self.emit(TypeError::NotAnEffect {
                             name: name.clone(),
                             span: effect_ty.span(),
                         });
@@ -202,7 +202,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     ))
             {
                 let type_name = self.tysys.type_table.borrow().type_name(handler_type);
-                let _ = self.logger.error(TypeError::HandlerEffectNotImplemented {
+                let _ = self.emit(TypeError::HandlerEffectNotImplemented {
                     type_name,
                     interface_name: interface_name.clone(),
                     span: binding.span,

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -28,14 +28,18 @@ use super::types::{FunctionContext, TypeError};
 pub(super) fn extract_compiler_item<H: CompilerHost>(
     attrs: &[crate::ast::Attribute],
     decl_span: Span,
+    module_source: &ModuleSource,
     logger: &Logger<'_, H>,
 ) -> Option<CompilerItem> {
     let (items, unknown) = parse_compiler_item_attrs(attrs);
     for raw in unknown {
-        let _ = logger.error(TypeError::CompilerItemAttr {
-            message: format!("unknown compiler item `{raw}`"),
-            span: decl_span,
-        });
+        let _ = logger.error_in(
+            module_source,
+            TypeError::CompilerItemAttr {
+                message: format!("unknown compiler item `{raw}`"),
+                span: decl_span,
+            },
+        );
     }
     items.into_iter().next()
 }
@@ -89,11 +93,19 @@ fn placeholder_function(name: String, span: Span) -> TirFunction {
 /// stdlib bug (two declarations claiming the same anchor); kind
 /// mismatches are reported by [`check_kind`] before reaching this
 /// path, so the error surface here is small.
-fn report_register_error<H: CompilerHost>(err: RegisterError, span: Span, logger: &Logger<'_, H>) {
-    let _ = logger.error(TypeError::CompilerItemAttr {
-        message: err.to_string(),
-        span,
-    });
+fn report_register_error<H: CompilerHost>(
+    err: RegisterError,
+    span: Span,
+    module_source: &ModuleSource,
+    logger: &Logger<'_, H>,
+) {
+    let _ = logger.error_in(
+        module_source,
+        TypeError::CompilerItemAttr {
+            message: err.to_string(),
+            span,
+        },
+    );
 }
 
 /// Run the per-attribute validation that applies to every kind:
@@ -112,25 +124,31 @@ fn check_compiler_item_placement<H: CompilerHost>(
     logger: &Logger<'_, H>,
 ) -> bool {
     if !module_source.is_core() {
-        let _ = logger.error(TypeError::CompilerItemAttr {
-            message: format!(
-                "`#[compiler_item(\"{name}\")]` is only valid inside `core::*` modules",
-                name = item.attr_name(),
-            ),
-            span,
-        });
+        let _ = logger.error_in(
+            module_source,
+            TypeError::CompilerItemAttr {
+                message: format!(
+                    "`#[compiler_item(\"{name}\")]` is only valid inside `core::*` modules",
+                    name = item.attr_name(),
+                ),
+                span,
+            },
+        );
         return false;
     }
     if item.expected_kind() != actual_kind {
-        let _ = logger.error(TypeError::CompilerItemAttr {
-            message: format!(
-                "`#[compiler_item(\"{name}\")]` expects a {expected}, but it is attached to a {actual}",
-                name = item.attr_name(),
-                expected = item.expected_kind(),
-                actual = actual_kind,
-            ),
-            span,
-        });
+        let _ = logger.error_in(
+            module_source,
+            TypeError::CompilerItemAttr {
+                message: format!(
+                    "`#[compiler_item(\"{name}\")]` expects a {expected}, but it is attached to a {actual}",
+                    name = item.attr_name(),
+                    expected = item.expected_kind(),
+                    actual = actual_kind,
+                ),
+                span,
+            },
+        );
         return false;
     }
     true
@@ -145,7 +163,7 @@ pub(super) fn register_struct_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(item, CompilerItemKind::Struct, module_source, span, logger) {
@@ -160,7 +178,7 @@ pub(super) fn register_struct_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -173,7 +191,7 @@ pub(super) fn register_variant_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(item, CompilerItemKind::Variant, module_source, span, logger)
@@ -189,7 +207,7 @@ pub(super) fn register_variant_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -202,7 +220,7 @@ pub(super) fn register_enum_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(item, CompilerItemKind::Enum, module_source, span, logger) {
@@ -217,7 +235,7 @@ pub(super) fn register_enum_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -238,7 +256,7 @@ pub(super) fn register_trait_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(item, CompilerItemKind::Trait, module_source, span, logger) {
@@ -275,7 +293,7 @@ pub(super) fn register_trait_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -289,7 +307,7 @@ pub(super) fn register_method_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(item, CompilerItemKind::Method, module_source, span, logger) {
@@ -305,7 +323,7 @@ pub(super) fn register_method_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -325,7 +343,7 @@ pub(super) fn register_variant_case_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(
@@ -348,7 +366,7 @@ pub(super) fn register_variant_case_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -365,7 +383,7 @@ pub(super) fn register_enum_case_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(
@@ -388,7 +406,7 @@ pub(super) fn register_enum_case_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -400,7 +418,7 @@ pub(super) fn register_tuple_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(
@@ -420,7 +438,7 @@ pub(super) fn register_tuple_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -436,7 +454,7 @@ pub(super) fn register_builtin_type_compiler_item<H: CompilerHost>(
     span: Span,
     logger: &Logger<'_, H>,
 ) {
-    let Some(item) = extract_compiler_item(attrs, span, logger) else {
+    let Some(item) = extract_compiler_item(attrs, span, module_source, logger) else {
         return;
     };
     if !check_compiler_item_placement(
@@ -457,7 +475,7 @@ pub(super) fn register_builtin_type_compiler_item<H: CompilerHost>(
         .compiler_items_mut()
         .register(item, resolved)
     {
-        report_register_error(err, span, logger);
+        report_register_error(err, span, module_source, logger);
     }
 }
 
@@ -559,7 +577,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .iter()
                 .find(|a| a.name == "serde" && a.has_arg("default"))
             {
-                let _ = scope.logger.error(TypeError::SerdeDefaultAttr {
+                let _ = scope.emit(TypeError::SerdeDefaultAttr {
                     field: field.name.clone(),
                     span: serde_default.span,
                 });
@@ -748,7 +766,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .as_async_call(return_type)
                     .is_none()
             {
-                let _ = scope.logger.error(TypeError::AsyncOpMustReturnAsyncCall {
+                let _ = scope.emit(TypeError::AsyncOpMustReturnAsyncCall {
                     op_name: method.name.clone(),
                     span: method.span,
                 });
@@ -914,7 +932,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         | crate::tir::ResolvedType::TypeParam { .. }
                 ) {
                     let type_name = tt.type_name(param.type_id);
-                    let _ = self.logger.error(TypeError::InvalidStores {
+                    let _ = self.emit(TypeError::InvalidStores {
                         message: format!(
                             "stores[{store_name}]: parameter '{store_name}' has type '{type_name}', \
                              but only reference parameters (&T or &mut T) or type parameters can be stored"
@@ -923,7 +941,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     });
                 }
             } else {
-                let _ = self.logger.error(TypeError::InvalidStores {
+                let _ = self.emit(TypeError::InvalidStores {
                     message: format!("stores[{store_name}]: no parameter named '{store_name}'"),
                     span,
                 });
@@ -1066,7 +1084,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // to a phantom `EffectRef::Concrete`.
         let effect_params: Vec<_> = func.type_params.iter().filter(|p| p.is_effect).collect();
         if effect_params.len() > 1 {
-            let _ = scope.logger.error(TypeError::InvalidLiteral {
+            let _ = scope.emit(TypeError::InvalidLiteral {
                 message: "multiple effect parameters are not allowed; use a single effect parameter instead".to_string(),
                 span: effect_params[1].span,
             });
@@ -1146,7 +1164,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let type_id = scope.resolve_type(&param.ty);
             // Closures cannot cross the Component Model boundary.
             if crosses_cm_boundary && scope.type_contains_closure(type_id) {
-                let _ = scope.logger.error(TypeError::ClosureAtCmBoundary {
+                let _ = scope.emit(TypeError::ClosureAtCmBoundary {
                     function: func.name.clone(),
                     position: format!("parameter '{}'", param.name),
                     span: param.span,
@@ -1157,7 +1175,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // resolved TIR is discarded — reify re-emits it from the AST.
             if let Some(default_ast) = &param.default {
                 if func.is_export {
-                    let _ = scope.logger.error(TypeError::DefaultInExportFn {
+                    let _ = scope.emit(TypeError::DefaultInExportFn {
                         function: func.name.clone(),
                         param: param.name.clone(),
                         span: default_ast.span(),
@@ -1188,7 +1206,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Closures cannot cross the CM boundary in return position either.
         if crosses_cm_boundary && scope.type_contains_closure(return_type) {
-            let _ = scope.logger.error(TypeError::ClosureAtCmBoundary {
+            let _ = scope.emit(TypeError::ClosureAtCmBoundary {
                 function: func.name.clone(),
                 position: "return type".to_string(),
                 span: func.span,
@@ -1594,7 +1612,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Set effect params in scope (for resolving effect names in function types)
         let effect_params: Vec<_> = func.type_params.iter().filter(|p| p.is_effect).collect();
         if effect_params.len() > 1 {
-            let _ = scope.logger.error(TypeError::InvalidLiteral {
+            let _ = scope.emit(TypeError::InvalidLiteral {
                 message: "multiple effect parameters are not allowed; use a single effect parameter instead".to_string(),
                 span: effect_params[1].span,
             });
@@ -1819,7 +1837,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // aggregates resolve to `GenericInstance`, not a concrete
                     // value type, so they are already permitted here.
                     if is_concrete_value && !is_resource && !scope.tysys.carries_resource(self_ty) {
-                        let _ = scope.logger.error(TypeError::SelfByValueOnNonResource {
+                        let _ = scope.emit(TypeError::SelfByValueOnNonResource {
                             type_name,
                             span: param.span,
                         });
@@ -1846,7 +1864,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             if trait_name.is_some()
                 && let Some(default_ast) = &param.default
             {
-                let _ = scope.logger.error(TypeError::DefaultInTraitImpl {
+                let _ = scope.emit(TypeError::DefaultInTraitImpl {
                     method: func.name.clone(),
                     param: param.name.clone(),
                     span: default_ast.span(),

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -390,7 +390,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             info
         } else {
             let type_name = self.tysys.type_table.borrow().type_name(base_type_id);
-            let _ = self.logger.error(TypeError::MethodNotFound {
+            let _ = self.emit(TypeError::MethodNotFound {
                 type_name,
                 method_name: method_name.to_string(),
                 hint: String::new(),
@@ -519,7 +519,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // e.g., `obj.static_method()` should be `Type::static_method()` instead.
         if self_kind == ast::SelfKind::None {
             let type_name = self.tysys.type_table.borrow().type_name(base_type_id);
-            let _ = self.logger.error(TypeError::MethodNotFound {
+            let _ = self.emit(TypeError::MethodNotFound {
                 type_name: type_name.clone(),
                 method_name: method_name.to_string(),
                 hint: format!(
@@ -1250,7 +1250,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 match static_call.method.as_str() {
                     "none" => {
                         if !args.is_empty() {
-                            let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+                            let _ = self.emit(TypeError::ArgumentCountMismatch {
                                 expected: 0,
                                 found: args.len(),
                                 span: static_call.span,
@@ -1261,7 +1261,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     }
                     "all" => {
                         if !args.is_empty() {
-                            let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+                            let _ = self.emit(TypeError::ArgumentCountMismatch {
                                 expected: 0,
                                 found: args.len(),
                                 span: static_call.span,
@@ -1298,7 +1298,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let expected_args = usize::from(!payload_is_unit);
 
                     if args.len() != expected_args {
-                        let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+                        let _ = self.emit(TypeError::ArgumentCountMismatch {
                             expected: expected_args,
                             found: args.len(),
                             span: static_call.span,
@@ -1351,7 +1351,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let expected_args = usize::from(!payload_is_unit);
 
                     if args.len() != expected_args {
-                        let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+                        let _ = self.emit(TypeError::ArgumentCountMismatch {
                             expected: expected_args,
                             found: args.len(),
                             span: static_call.span,
@@ -1668,7 +1668,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Emit a compile error if the static method was not found anywhere
         if return_type == TypeTable::UNKNOWN {
-            let _ = self.logger.error(TypeError::UnknownFunction {
+            let _ = self.emit(TypeError::UnknownFunction {
                 name: format!("{}::{}", struct_name, static_call.method),
                 span: static_call.span,
             });
@@ -2992,7 +2992,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let self_name = self.tysys.type_table.borrow().type_name(self_ty);
 
         if self.type_lookup().struct_fields(&self_name).is_none() {
-            let _ = self.logger.error(TypeError::UnknownFunction {
+            let _ = self.emit(TypeError::UnknownFunction {
                 name: format!("Reflect::<{self_name}>::{method}"),
                 span: static_call.span,
             });
@@ -3007,7 +3007,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             for arg in &static_call.args {
                 self.resolve_expr(arg, ctx, None);
             }
-            let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+            let _ = self.emit(TypeError::ArgumentCountMismatch {
                 expected: 0,
                 found: static_call.args.len(),
                 span: static_call.span,

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -280,7 +280,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let left_name = type_table.type_name(left.type_id);
                     let right_name = type_table.type_name(right.type_id);
                     if left_name != right_name {
-                        let _ = self.logger.error(TypeError::TypeMismatch {
+                        let _ = self.emit(TypeError::TypeMismatch {
                             expected: left_name,
                             found: right_name,
                             span,
@@ -312,7 +312,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     BinaryOp::Or => "||",
                     _ => unreachable!(),
                 };
-                let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                let _ = self.emit(TypeError::OperatorNotApplicable {
                     op: op_str.to_string(),
                     operands: vec![type_name],
                     note: None,
@@ -396,7 +396,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     ) else {
                         let type_name = self.tysys.type_table.borrow().type_name(left.type_id);
                         let op_str = if op == BinaryOp::Eq { "==" } else { "!=" };
-                        let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                        let _ = self.emit(TypeError::OperatorNotApplicable {
                             op: op_str.to_string(),
                             operands: vec![type_name],
                             note: Some("type does not implement `Eq`".to_string()),
@@ -444,7 +444,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             BinaryOp::GtEq => ">=",
                             _ => unreachable!(),
                         };
-                        let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                        let _ = self.emit(TypeError::OperatorNotApplicable {
                             op: op_str.to_string(),
                             operands: vec![type_name],
                             note: Some("type does not implement `Ord`".to_string()),
@@ -764,7 +764,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     _ => unreachable!(),
                 };
                 let type_name = self.tysys.type_table.borrow().type_name(left.type_id);
-                let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                let _ = self.emit(TypeError::OperatorNotApplicable {
                     op: op_char.to_string(),
                     operands: vec![type_name],
                     note: Some(
@@ -790,7 +790,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     ResolvedType::Primitive(PrimitiveType::F32) => "f32",
                     _ => "f64",
                 };
-                let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                let _ = self.emit(TypeError::OperatorNotApplicable {
                     op: "%".to_string(),
                     operands: vec![type_name.to_string()],
                     note: Some(format!("use `{type_name}::fmod(a, b)` instead")),
@@ -868,7 +868,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .to_string(),
                         _ => "?".to_string(),
                     };
-                    let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                    let _ = self.emit(TypeError::OperatorNotApplicable {
                         op: op_char.to_string(),
                         operands: vec![left_name],
                         note: Some(format!("type does not implement `{trait_name}`")),
@@ -878,7 +878,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     // Mixed operand types that cannot combine under this
                     // operator (e.g. `i32 - List<i32>`). Reported the same
                     // way regardless of which operand is non-primitive.
-                    let _ = self.logger.error(TypeError::OperatorNotApplicable {
+                    let _ = self.emit(TypeError::OperatorNotApplicable {
                         op: op_char.to_string(),
                         operands: vec![left_name, right_name],
                         note: None,
@@ -906,7 +906,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let left_name = type_table.type_name(left.type_id);
             let right_name = type_table.type_name(right.type_id);
             if left_name != right_name {
-                let _ = self.logger.error(TypeError::TypeMismatch {
+                let _ = self.emit(TypeError::TypeMismatch {
                     expected: left_name,
                     found: right_name,
                     span,
@@ -959,7 +959,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             && let Some(local) = ctx.lookup(&id.name)
             && !local.is_mut
         {
-            let _ = self.logger.error(TypeError::CannotAssign {
+            let _ = self.emit(TypeError::CannotAssign {
                 message: format!("cannot take &mut of immutable variable '{}'", id.name),
                 span: unary.span,
             });
@@ -982,7 +982,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 matches!(ty, ResolvedType::Primitive(_) | ResolvedType::Enum { .. })
             };
             if is_scalar_field(&field_type) || is_scalar_field(&base_type) {
-                let _ = self.logger.error(TypeError::CannotAssign {
+                let _ = self.emit(TypeError::CannotAssign {
                     message: "cannot take mutable reference to primitive struct field; use the struct reference directly".to_string(),
                     span: unary.span,
                 });
@@ -1065,7 +1065,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         }
                     }
                     _ => {
-                        let _ = self.logger.error(TypeError::TypeMismatch {
+                        let _ = self.emit(TypeError::TypeMismatch {
                             expected: "reference type".to_string(),
                             found: self.tysys.type_table.borrow().type_name(expr_type),
                             span: unary.span,
@@ -1115,7 +1115,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .map(|d| d.needs_deref);
         if let Some(needs_deref) = needs_deref {
             if needs_deref {
-                let _ = self.logger.error(TypeError::CannotAssign {
+                let _ = self.emit(TypeError::CannotAssign {
                     message: "cannot assign through immutable reference".to_string(),
                     span: index_expr.span,
                 });
@@ -1168,7 +1168,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             ResolvedType::Ref(_)
         );
         if is_immutable_ref {
-            let _ = self.logger.error(TypeError::CannotAssign {
+            let _ = self.emit(TypeError::CannotAssign {
                 message: "cannot assign through immutable reference".to_string(),
                 span,
             });
@@ -1202,7 +1202,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 ResolvedType::Ref(_)
             ) || self.place_roots_at_immutable_ref(&index_expr.expr);
             if indexed_immutable {
-                let _ = self.logger.error(TypeError::CannotAssign {
+                let _ = self.emit(TypeError::CannotAssign {
                     message: "cannot assign through immutable reference".to_string(),
                     span: target_ast.span(),
                 });
@@ -1340,7 +1340,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
         if let Some((name, is_mut)) = global_assign {
             if !is_mut {
-                let _ = self.logger.error(TypeError::CannotAssign {
+                let _ = self.emit(TypeError::CannotAssign {
                     message: format!("cannot assign to immutable global variable '{name}'"),
                     span: target_ast.span(),
                 });
@@ -1359,7 +1359,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // at an immutable reference.
             ast::Expr::FieldAccess(_) => {
                 if self.place_roots_at_immutable_ref(target_ast) {
-                    let _ = self.logger.error(TypeError::CannotAssign {
+                    let _ = self.emit(TypeError::CannotAssign {
                         message: "cannot assign through immutable reference".to_string(),
                         span: target_ast.span(),
                     });
@@ -1394,7 +1394,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         if through_mut_ref {
                             true
                         } else {
-                            let _ = self.logger.error(TypeError::CannotAssign {
+                            let _ = self.emit(TypeError::CannotAssign {
                                 message: "cannot assign through immutable reference".to_string(),
                                 span: target_ast.span(),
                             });
@@ -1409,7 +1409,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         if !is_valid_lvalue {
             // Report error for invalid assignment target
-            let _ = self.logger.error(TypeError::CannotAssign {
+            let _ = self.emit(TypeError::CannotAssign {
                 message: "expression is not assignable".to_string(),
                 span: target_ast.span(),
             });
@@ -1634,7 +1634,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // resolve-site should always line up operand count with the
             // trait's arity.  Return ERROR so the rest of resolve recovers
             // gracefully, but flag it as a mismatch too so tests notice.
-            let _ = self.logger.error(TypeError::TypeMismatch {
+            let _ = self.emit(TypeError::TypeMismatch {
                 expected: format!("{} arg(s)", resolved.param_types.len()),
                 found: format!("{} arg(s)", args.len()),
                 span,

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -32,7 +32,7 @@ use crate::ast::{self, Item, Module, Type};
 use crate::builtin_registry::BuiltinRegistry;
 use crate::compiler_host::CompilerHost;
 use crate::component_model::CmInterfaceRegistry;
-use crate::logger::{Bail, Logger};
+use crate::logger::{Bail, Logger, ModuleDiag};
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::symbol::SymbolTable;
 use crate::tir::{ResolvedType, TirModule, TypeId, TypeTable};
@@ -855,29 +855,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 &invocations,
             )
         };
-        // These diagnostics are raised at the phase boundary (before the
-        // per-module resolution loop establishes a file context), and each
-        // `TypeError` carries only a bare `Span` with no owning-module
-        // identity. Derive the file from the offending impl block's `AstId`
-        // via the `AstIdSpace → ModuleSource` registry — the same mapping
-        // `Semantics::module_of_id` uses — so the printer attributes the
-        // location to the user's file instead of a stdlib module (#1596).
-        let space_modules: IndexMap<crate::ast::AstIdSpace, &ModuleSource> = modules
-            .iter()
-            .map(|(ms, m)| (m.ast_id_space(), ms))
-            .collect();
-        let emit_phase_diagnostic = |id: crate::ast::AstId, err: TypeError| {
-            let mut diag: crate::compiler_host::Diagnostic = err.into();
-            if let Some(module_source) = space_modules.get(&id.space())
-                && let Some(span) = diag.span.as_mut()
-                && span.file.is_empty()
-            {
-                span.file = module_source.source_path();
-            }
-            let _ = logger.error(diag);
-        };
-        for (id, violation) in orphan_violations {
-            emit_phase_diagnostic(id, violation);
+        // Each violation is attributed to the module of the offending impl
+        // block, which `check_all_orphan_rules` pairs with the error (#1596).
+        for (module_source, violation) in orphan_violations {
+            let _ = logger.error_in(&module_source, violation);
         }
 
         // Seal `Reflect`: compiler-synthesized, it may not be implemented in
@@ -908,10 +889,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             && let Some(trait_type) = &impl_block.trait_type
                             && super::trait_env::get_type_name_static(trait_type) == reflect_name
                         {
-                            // Same phase-boundary file attribution as the
-                            // orphan/coherence diagnostics above (#1596).
-                            emit_phase_diagnostic(
-                                impl_block.id,
+                            let _ = logger.error_in(
+                                module_source,
                                 TypeError::SealedTraitImpl {
                                     trait_name: reflect_name.clone(),
                                     span: impl_block.span,
@@ -1452,10 +1431,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             let mut elaborator =
                 Self::module_elaborator(state, sem, symbols, modules, logger, &entry_module_source);
 
-            // Set file context so diagnostics emitted during resolution
-            // carry the correct module filename (not the entry module).
-            logger.set_file(module_source.source_path());
-
             let errors_before = logger.error_count();
             elaborator.annotate_module_decls(module, module_source.clone());
             if logger.error_count() > errors_before {
@@ -1521,7 +1496,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 .expect("module_semantics is pre-populated by annotate_modules");
             let mut elaborator =
                 Self::module_elaborator(state, sem, symbols, modules, logger, &entry_module_source);
-            logger.set_file(module_source.source_path());
 
             let errors_before = logger.error_count();
             elaborator.annotate_module_bodies(module, module_source.clone());
@@ -1590,7 +1564,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     );
                 } else if reify_eligible.contains(module_source) {
                     let module = modules.get(module_source).expect("module should exist");
-                    logger.set_file(module_source.source_path());
                     let sem_ref = state
                         .module_semantics
                         .get(module_source)
@@ -1906,7 +1879,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             if stdlib_set.contains(module_source) {
                 continue;
             }
-            logger.set_file(module_source.source_path());
+            // Bind the logger to this module so every validator diagnostic is
+            // attributed to its file; shadows the raw logger for the loop body.
+            let logger = &logger.in_module(module_source);
 
             // Build per-module known names: global names + import aliases + trait names
             let mut module_known_names = known_type_names.clone();
@@ -2126,7 +2101,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 }
             }
         }
-        logger.clear_file();
         Ok(())
     }
 
@@ -2136,7 +2110,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         known_type_names: &IndexSet<String>,
         resource_type_names: &IndexSet<String>,
         type_params: &[&str],
-        logger: &Logger<'_, H>,
+        logger: &ModuleDiag<'_, '_, H>,
     ) -> Result<(), Bail> {
         // Local item declarations (`Stmt::Item`) are not in `known_type_names`
         // (a module-wide set built before any function body is walked), so a
@@ -2228,7 +2202,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         known_type_names: &IndexSet<String>,
         resource_type_names: &IndexSet<String>,
         type_params: &[&str],
-        logger: &Logger<'_, H>,
+        logger: &ModuleDiag<'_, '_, H>,
     ) -> Result<(), Bail> {
         match stmt {
             ast::Stmt::Let(let_stmt) => {
@@ -2438,7 +2412,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         known_type_names: &IndexSet<String>,
         resource_type_names: &IndexSet<String>,
         type_params: &[&str],
-        logger: &Logger<'_, H>,
+        logger: &ModuleDiag<'_, '_, H>,
     ) -> Result<(), Bail> {
         match condition {
             ast::Condition::Expr(expr) => {
@@ -2484,7 +2458,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         known_type_names: &IndexSet<String>,
         resource_type_names: &IndexSet<String>,
         type_params: &[&str],
-        logger: &Logger<'_, H>,
+        logger: &ModuleDiag<'_, '_, H>,
     ) -> Result<(), Bail> {
         match expr {
             ast::Expr::Cast(cast) => {
@@ -2954,7 +2928,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         known_type_names: &IndexSet<String>,
         resource_type_names: &IndexSet<String>,
         type_params: &[&str],
-        logger: &Logger<'_, H>,
+        logger: &ModuleDiag<'_, '_, H>,
     ) -> Result<(), Bail> {
         Self::validate_ast_type_names_inner(
             ty,
@@ -2971,7 +2945,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         known_type_names: &IndexSet<String>,
         resource_type_names: &IndexSet<String>,
         type_params: &[&str],
-        logger: &Logger<'_, H>,
+        logger: &ModuleDiag<'_, '_, H>,
         allow_infer: bool,
     ) -> Result<(), Bail> {
         match ty {
@@ -3081,7 +3055,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         known_type_names: &IndexSet<String>,
         resource_type_names: &IndexSet<String>,
         type_params: &[&str],
-        logger: &Logger<'_, H>,
+        logger: &ModuleDiag<'_, '_, H>,
     ) -> Result<(), Bail> {
         match ty {
             Type::Infer(_) => Ok(()),

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -855,8 +855,29 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 &invocations,
             )
         };
-        for violation in orphan_violations {
-            let _ = logger.error(violation);
+        // These diagnostics are raised at the phase boundary (before the
+        // per-module resolution loop establishes a file context), and each
+        // `TypeError` carries only a bare `Span` with no owning-module
+        // identity. Derive the file from the offending impl block's `AstId`
+        // via the `AstIdSpace → ModuleSource` registry — the same mapping
+        // `Semantics::module_of_id` uses — so the printer attributes the
+        // location to the user's file instead of a stdlib module (#1596).
+        let space_modules: IndexMap<crate::ast::AstIdSpace, &ModuleSource> = modules
+            .iter()
+            .map(|(ms, m)| (m.ast_id_space(), ms))
+            .collect();
+        let emit_phase_diagnostic = |id: crate::ast::AstId, err: TypeError| {
+            let mut diag: crate::compiler_host::Diagnostic = err.into();
+            if let Some(module_source) = space_modules.get(&id.space())
+                && let Some(span) = diag.span.as_mut()
+                && span.file.is_empty()
+            {
+                span.file = module_source.source_path();
+            }
+            let _ = logger.error(diag);
+        };
+        for (id, violation) in orphan_violations {
+            emit_phase_diagnostic(id, violation);
         }
 
         // Seal `Reflect`: compiler-synthesized, it may not be implemented in
@@ -887,10 +908,15 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                             && let Some(trait_type) = &impl_block.trait_type
                             && super::trait_env::get_type_name_static(trait_type) == reflect_name
                         {
-                            let _ = logger.error(TypeError::SealedTraitImpl {
-                                trait_name: reflect_name.clone(),
-                                span: impl_block.span,
-                            });
+                            // Same phase-boundary file attribution as the
+                            // orphan/coherence diagnostics above (#1596).
+                            emit_phase_diagnostic(
+                                impl_block.id,
+                                TypeError::SealedTraitImpl {
+                                    trait_name: reflect_name.clone(),
+                                    span: impl_block.span,
+                                },
+                            );
                         }
                     }
                 }

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -855,8 +855,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 &invocations,
             )
         };
-        // Each violation is attributed to the module of the offending impl
-        // block, which `check_all_orphan_rules` pairs with the error (#1596).
         for (module_source, violation) in orphan_violations {
             let _ = logger.error_in(&module_source, violation);
         }
@@ -1879,8 +1877,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             if stdlib_set.contains(module_source) {
                 continue;
             }
-            // Bind the logger to this module so every validator diagnostic is
-            // attributed to its file; shadows the raw logger for the loop body.
+            // Shadow with a module-bound logger so validator diagnostics
+            // attribute to this module.
             let logger = &logger.in_module(module_source);
 
             // Build per-module known names: global names + import aliases + trait names

--- a/wado-compiler/src/elaborator/reify.rs
+++ b/wado-compiler/src/elaborator/reify.rs
@@ -1212,6 +1212,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             compiler_item: crate::elaborator::item::extract_compiler_item(
                 &func.attrs,
                 func.span,
+                &self.current_module_source,
                 self.logger,
             ),
             export_name: extract_export_name_attr(&func.attrs),
@@ -1640,6 +1641,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             compiler_item: crate::elaborator::item::extract_compiler_item(
                 &func.attrs,
                 func.span,
+                &self.current_module_source,
                 self.logger,
             ),
             export_name: extract_export_name_attr(&func.attrs),
@@ -1778,12 +1780,15 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         let attr = global_decl.attributes.iter().find(|a| a.name == "param")?;
         let emit = |message: String| {
-            let _ = self.logger.error(Diagnostic {
-                severity: Severity::Error,
-                code: Code::ParamAttr,
-                message,
-                span: Some(DiagnosticSpan::from_span(&attr.span, None)),
-            });
+            let _ = self.logger.error_in(
+                &self.current_module_source,
+                Diagnostic {
+                    severity: Severity::Error,
+                    code: Code::ParamAttr,
+                    message,
+                    span: Some(DiagnosticSpan::from_span(&attr.span, None)),
+                },
+            );
         };
 
         let mut ok = true;

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -398,7 +398,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                         // Also check length mismatch
                         if tuple_lit.elements.len() != expected_elem_types.len() {
-                            let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                            let _ = self.emit(TypeError::PatternTypeMismatch {
                                 expected: format!(
                                     "tuple with {} elements",
                                     expected_elem_types.len()
@@ -447,7 +447,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 if !vis.reachable_from(same_package)
                                     && struct_lit.fields.iter().any(|f| f.name == *fname)
                                 {
-                                    let _ = self.logger.error(TypeError::PrivateFieldAccess {
+                                    let _ = self.emit(TypeError::PrivateFieldAccess {
                                         struct_name: name.clone(),
                                         field_name: fname.clone(),
                                         visibility: *vis,
@@ -462,7 +462,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             if !struct_field_types.iter().any(|(n, _)| n == &field.name)
                                 && !struct_field_types.is_empty()
                             {
-                                let _ = self.logger.error(TypeError::ExtraField {
+                                let _ = self.emit(TypeError::ExtraField {
                                     struct_name: name.clone(),
                                     field_name: field.name.clone(),
                                     span: field.span,
@@ -495,7 +495,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     } else {
                         // Target type does not implement KeyValueLiteral
                         let type_name = self.tysys.type_table.borrow().type_name(target_type);
-                        let _ = self.logger.error(TypeError::MissingTraitImpl {
+                        let _ = self.emit(TypeError::MissingTraitImpl {
                             type_name,
                             trait_name: "KeyValueLiteral".to_string(),
                             span: struct_lit.span,
@@ -582,7 +582,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 }
             };
             if !is_null_to_option && !is_compatible_fn_type {
-                let _ = self.logger.error(TypeError::TypeMismatch {
+                let _ = self.emit(TypeError::TypeMismatch {
                     expected: self.tysys.type_table.borrow().type_name(type_id),
                     found: self.tysys.type_table.borrow().type_name(value_type),
                     span: ast_value.span(),
@@ -709,28 +709,28 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .iter()
                 .all(|f| self.check_irrefutable_pattern(&f.pattern, span)),
             Pattern::Literal(_) => {
-                let _ = self.logger.error(TypeError::InvalidPattern {
+                let _ = self.emit(TypeError::InvalidPattern {
                     message: "refutable pattern in `let` binding: literal patterns may not match; use `if let` instead".to_string(),
                     span,
                 });
                 false
             }
             Pattern::Variant { variant_name, .. } => {
-                let _ = self.logger.error(TypeError::InvalidPattern {
+                let _ = self.emit(TypeError::InvalidPattern {
                     message: format!("refutable pattern in `let` binding: `{variant_name}` may not match; use `if let` instead"),
                     span,
                 });
                 false
             }
             Pattern::Or(_) => {
-                let _ = self.logger.error(TypeError::InvalidPattern {
+                let _ = self.emit(TypeError::InvalidPattern {
                     message: "refutable pattern in `let` binding: or-patterns may not match; use `if let` or `match` instead".to_string(),
                     span,
                 });
                 false
             }
             Pattern::Range { .. } => {
-                let _ = self.logger.error(TypeError::InvalidPattern {
+                let _ = self.emit(TypeError::InvalidPattern {
                     message: "refutable pattern in `let` binding: range patterns may not match; use `if let` instead".to_string(),
                     span,
                 });
@@ -954,7 +954,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         elem_types
                     } else {
                         // Error: expected tuple type
-                        let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                        let _ = self.emit(TypeError::PatternTypeMismatch {
                             expected: "tuple type".to_string(),
                             found: type_table.type_name(type_id),
                             span,
@@ -966,14 +966,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // Check length
                 if *has_rest {
                     if patterns.len() > elem_types.len() {
-                        let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                        let _ = self.emit(TypeError::PatternTypeMismatch {
                             expected: format!("tuple with at least {} elements", patterns.len()),
                             found: format!("tuple with {} elements", elem_types.len()),
                             span,
                         });
                     }
                 } else if patterns.len() != elem_types.len() {
-                    let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                    let _ = self.emit(TypeError::PatternTypeMismatch {
                         expected: format!("tuple with {} elements", elem_types.len()),
                         found: format!("pattern with {} elements", patterns.len()),
                         span,
@@ -1016,7 +1016,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let actual_short = actual_name.rsplit("::").next().unwrap_or(actual_name);
                     let matches = actual_short == expected_short;
                     if !matches {
-                        let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                        let _ = self.emit(TypeError::PatternTypeMismatch {
                             expected: expected_name.clone(),
                             found: self.tysys.type_table.borrow().type_name(type_id),
                             span: *pat_span,
@@ -1028,7 +1028,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 };
 
                 if struct_name.is_none() {
-                    let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                    let _ = self.emit(TypeError::PatternTypeMismatch {
                         expected: "struct type".to_string(),
                         found: self.tysys.type_table.borrow().type_name(type_id),
                         span: *pat_span,
@@ -1067,7 +1067,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .map(|(name, _, _)| name.clone())
                             .collect();
                         if !missing.is_empty() {
-                            let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                            let _ = self.emit(TypeError::PatternTypeMismatch {
                                         expected: format!(
                                             "all fields (missing: {}), or use `..` to ignore remaining fields",
                                             missing.join(", ")
@@ -1108,7 +1108,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     pub(super) fn resolve_return(&mut self, ret_stmt: &ReturnStmt, ctx: &mut FunctionContext) {
         // In async functions, `return expr` (with a value) is forbidden; use `task return expr`
         if ctx.is_async && ret_stmt.value.is_some() {
-            let _ = self.logger.error(TypeError::InvalidLiteral {
+            let _ = self.emit(TypeError::InvalidLiteral {
                 message:
                     "cannot use `return expr` in `export async fn`; use `task return expr` instead"
                         .to_string(),
@@ -1137,7 +1137,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ctx: &mut FunctionContext,
     ) {
         if !ctx.is_async {
-            let _ = self.logger.error(TypeError::InvalidLiteral {
+            let _ = self.emit(TypeError::InvalidLiteral {
                 message: "`task return` is only valid inside `export async fn`".to_string(),
                 span: tr_stmt.span,
             });
@@ -1393,7 +1393,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     Literal::Number(repr) => {
                         // Float literals cannot be used in match patterns
                         if util::is_float_only_literal(repr) {
-                            let _ = self.logger.error(TypeError::InvalidPattern {
+                            let _ = self.emit(TypeError::InvalidPattern {
                                 message: "float literals cannot be used in match patterns"
                                     .to_string(),
                                 span,
@@ -1415,7 +1415,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if let Some(types) = self.tysys.type_table.borrow().as_tuple(scrutinee_type) {
                         types
                     } else {
-                        let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                        let _ = self.emit(TypeError::PatternTypeMismatch {
                             expected: "tuple type".to_string(),
                             found: self.tysys.type_table.borrow().type_name(scrutinee_type),
                             span,
@@ -1516,7 +1516,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         }
                         _ => "variant or enum case".to_string(),
                     };
-                    let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                    let _ = self.emit(TypeError::PatternTypeMismatch {
                         expected,
                         found: qualified_variant_name,
                         span: *span,
@@ -1531,7 +1531,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 } = &resolved_type
                 {
                     if !bindings.is_empty() {
-                        let _ = self.logger.error(TypeError::InvalidPattern {
+                        let _ = self.emit(TypeError::InvalidPattern {
                             message: format!("enum case `{variant_name}` does not have a payload"),
                             span: *span,
                         });
@@ -1549,7 +1549,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             // Enum case carries no payload — no binding.
                             return Vec::new();
                         }
-                        let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                        let _ = self.emit(TypeError::PatternTypeMismatch {
                             expected: format!(
                                 "one of: {}",
                                 enum_info
@@ -1565,7 +1565,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         });
                         return Vec::new();
                     }
-                    let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                    let _ = self.emit(TypeError::PatternTypeMismatch {
                         expected: format!("enum type `{name}`"),
                         found: "unknown enum".to_string(),
                         span: *span,
@@ -1631,7 +1631,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 *span,
                             )
                         } else {
-                            let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                            let _ = self.emit(TypeError::PatternTypeMismatch {
                                 expected: "variant type".to_string(),
                                 found: name.clone(),
                                 span: *span,
@@ -1640,7 +1640,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         }
                     }
                     _ => {
-                        let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                        let _ = self.emit(TypeError::PatternTypeMismatch {
                             expected: "variant or enum type".to_string(),
                             found: format!("{resolved_type:?}"),
                             span: *span,
@@ -1694,7 +1694,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             .unwrap_or(expected_name.as_str());
                         let actual_short = name.rsplit("::").next().unwrap_or(name);
                         if actual_short != expected_short {
-                            let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                            let _ = self.emit(TypeError::PatternTypeMismatch {
                                 expected: expected_name.clone(),
                                 found: self.tysys.type_table.borrow().type_name(scrutinee_type),
                                 span: *pat_span,
@@ -1743,7 +1743,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                 .map(|(name, _, _)| name.clone())
                                 .collect();
                             if !missing.is_empty() {
-                                let _ = self.logger.error(TypeError::PatternTypeMismatch {
+                                let _ = self.emit(TypeError::PatternTypeMismatch {
                                         expected: format!(
                                             "all fields (missing: {}), or use `..` to ignore remaining fields",
                                             missing.join(", ")
@@ -1803,7 +1803,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if first_names != alt_names {
                         let fn_: Vec<&str> = first_names.iter().map(|(n, _)| *n).collect();
                         let an: Vec<&str> = alt_names.iter().map(|(n, _)| *n).collect();
-                        let _ = self.logger.error(TypeError::InvalidPattern {
+                        let _ = self.emit(TypeError::InvalidPattern {
                             message: format!(
                                 "or-pattern alternatives must bind the same names with the same types: \
                                  alternative 1 binds {:?}, but alternative {} binds {:?}",
@@ -1917,7 +1917,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         let end_val = self.pattern_to_i128(end, is_unsigned);
 
         let (Some(start_val), Some(end_val)) = (start_val, end_val) else {
-            let _ = self.logger.error(TypeError::InvalidPattern {
+            let _ = self.emit(TypeError::InvalidPattern {
                 message: "range pattern bounds must be integer or char literals".to_string(),
                 span,
             });
@@ -1927,14 +1927,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Check for reversed or empty range
         let inclusive = matches!(kind, crate::ast::RangeKind::Inclusive);
         if start_val > end_val {
-            let _ = self.logger.error(TypeError::InvalidPattern {
+            let _ = self.emit(TypeError::InvalidPattern {
                 message: "reversed range pattern".to_string(),
                 span,
             });
             return;
         }
         if !inclusive && start_val >= end_val {
-            let _ = self.logger.error(TypeError::InvalidPattern {
+            let _ = self.emit(TypeError::InvalidPattern {
                 message: "empty range pattern".to_string(),
                 span,
             });
@@ -2000,13 +2000,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Check if variant exists but case not found
         if self.contains_variant(variant_name) {
-            let _ = self.logger.error(TypeError::PatternTypeMismatch {
+            let _ = self.emit(TypeError::PatternTypeMismatch {
                 expected: format!("valid case of variant {variant_name}"),
                 found: case_name.to_string(),
                 span,
             });
         } else {
-            let _ = self.logger.error(TypeError::PatternTypeMismatch {
+            let _ = self.emit(TypeError::PatternTypeMismatch {
                 expected: "known variant type".to_string(),
                 found: variant_name.to_string(),
                 span,
@@ -2124,7 +2124,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             );
             if !implements_into_iter {
                 let type_name = self.tysys.type_table.borrow().type_name(iterable_type_id);
-                let _ = self.logger.error(TypeError::MissingTraitImpl {
+                let _ = self.emit(TypeError::MissingTraitImpl {
                     type_name,
                     trait_name: "IntoIterator".to_string(),
                     span: for_of.span,
@@ -2169,7 +2169,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     ) {
         // Validate: no break/continue/return in variadic for-of
         if let Some((kind, bad_span)) = Self::find_control_flow_in_block(&for_of.body) {
-            let _ = self.logger.error(TypeError::InvalidPattern {
+            let _ = self.emit(TypeError::InvalidPattern {
                 message: format!(
                     "`{kind}` is not allowed inside a variadic for-of loop (the loop is expanded at compile time)"
                 ),
@@ -2278,7 +2278,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Validate: break, continue, and return are not allowed inside tuple for-of
         // because the loop is expanded at compile time into sequential blocks.
         if let Some((kind, bad_span)) = Self::find_control_flow_in_block(&for_of.body) {
-            let _ = self.logger.error(TypeError::InvalidPattern {
+            let _ = self.emit(TypeError::InvalidPattern {
                 message: format!(
                     "`{kind}` is not allowed inside a tuple for-of loop (the loop is expanded at compile time)"
                 ),
@@ -2367,7 +2367,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         // Discard the element; nothing to bind.
                     }
                     _ => {
-                        let _ = self.logger.error(TypeError::InvalidPattern {
+                        let _ = self.emit(TypeError::InvalidPattern {
                             message: "invalid binding pattern in for-of loop".to_string(),
                             span,
                         });
@@ -2483,7 +2483,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             ResolvedType::Unknown | ResolvedType::TypeParam { .. }
         ) {
             let type_name = self.tysys.type_table.borrow().type_name(iter_type);
-            let _ = self.logger.error(TypeError::MissingTraitImpl {
+            let _ = self.emit(TypeError::MissingTraitImpl {
                 type_name,
                 trait_name: "Iterator".to_string(),
                 span,
@@ -2576,7 +2576,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             let elem_resolved = self.tysys.type_table.borrow().get(elem).clone();
             let elem_name = self.tysys.type_table.borrow().type_name(elem);
             if matches!(elem_resolved, ResolvedType::TypeParam { .. }) {
-                let _ = self.logger.error(TypeError::CannotMutate {
+                let _ = self.emit(TypeError::CannotMutate {
                     message: format!(
                         "cannot iterate `&mut` over a list of generic type `{elem_name}`: the \
                          element type is not known to support in-place mutation. Constrain it to \
@@ -2585,7 +2585,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     span,
                 });
             } else if self.is_replace_on_assign_element(elem) {
-                let _ = self.logger.error(TypeError::CannotMutate {
+                let _ = self.emit(TypeError::CannotMutate {
                     message: format!(
                         "cannot iterate `&mut` over a list of `{elem_name}`: a write through \
                          `&mut {elem_name}` would be lost (no in-place interior). Assign by index \
@@ -2706,7 +2706,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         if let Some(label) = &break_stmt.label
             && !ctx.active_labels.iter().any(|l| l == label)
         {
-            let _ = self.logger.error(TypeError::UnknownIdentifier {
+            let _ = self.emit(TypeError::UnknownIdentifier {
                 name: format!("labeled break target not found: {label}"),
                 span: break_stmt.span,
             });
@@ -2895,7 +2895,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     None
                 };
                 let Some((pattern, expr, elem_span)) = single_let else {
-                    let _ = self.logger.error(TypeError::InvalidPattern {
+                    let _ = self.emit(TypeError::InvalidPattern {
                         message: "for-header let-chain must consist of a single \
                                   `let pattern = expr` element"
                             .to_string(),

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -526,7 +526,7 @@ impl TraitEnv {
         interner: &mut ModuleSourceInterner,
         entry_module: Option<&ModuleSource>,
         invocations: &InvocationIndex,
-    ) -> (Arc<Self>, Vec<TypeError>) {
+    ) -> (Arc<Self>, Vec<(AstId, TypeError)>) {
         // Pre-compute every module's `use`-derived import scope so dispatch
         // queries read it instead of rebuilding from the module AST.
         let mut module_import_scopes: IndexMap<ModuleSource, ModuleImportScope> =
@@ -1256,11 +1256,17 @@ fn check_orphan_rfc2451(impl_block: &ast::ImplBlock, local_type_names: &IndexSet
 
 /// Check orphan rules for all trait impl blocks across all modules.
 /// Only impl blocks in local (user) modules are checked.
+///
+/// Each violation is paired with the offending impl block's [`AstId`]. The
+/// `TypeError`s carry only a bare `Span` (byte offsets + line/column), which
+/// has no owning-module identity; the `AstId` lets the emitter derive the file
+/// via the `AstIdSpace → ModuleSource` registry, so the printer attributes the
+/// location to the user's file instead of a stdlib module (issue #1596).
 fn check_all_orphan_rules(
     modules: &IndexMap<ModuleSource, Module>,
     decl_index: &TraitDeclIndex,
     type_decl_index: &IndexMap<DeclKey, ModuleSource>,
-) -> Vec<TypeError> {
+) -> Vec<(AstId, TypeError)> {
     let mut violations = Vec::new();
 
     // Project all (`DeclKey`, `ModuleSource`) entries down to bare names of
@@ -1309,10 +1315,13 @@ fn check_all_orphan_rules(
                 if let PositionKind::ForeignType =
                     classify_position(&impl_block.ty, &type_params, &local_type_names)
                 {
-                    violations.push(TypeError::InherentImplOnForeignType {
-                        self_type_name: get_type_name_static(&impl_block.ty),
-                        span: impl_block.span,
-                    });
+                    violations.push((
+                        impl_block.id,
+                        TypeError::InherentImplOnForeignType {
+                            self_type_name: get_type_name_static(&impl_block.ty),
+                            span: impl_block.span,
+                        },
+                    ));
                 }
                 continue;
             };
@@ -1327,11 +1336,14 @@ fn check_all_orphan_rules(
             // Foreign trait: apply RFC 2451 sequence check
             if !check_orphan_rfc2451(impl_block, &local_type_names) {
                 let self_type_name = get_type_name_static(&impl_block.ty);
-                violations.push(TypeError::OrphanViolation {
-                    trait_name,
-                    self_type_name,
-                    span: impl_block.span,
-                });
+                violations.push((
+                    impl_block.id,
+                    TypeError::OrphanViolation {
+                        trait_name,
+                        self_type_name,
+                        span: impl_block.span,
+                    },
+                ));
             }
         }
     }

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -1255,11 +1255,8 @@ fn check_orphan_rfc2451(impl_block: &ast::ImplBlock, local_type_names: &IndexSet
 }
 
 /// Check orphan rules for all trait impl blocks across all modules.
-/// Only impl blocks in local (user) modules are checked.
-///
-/// Each violation is paired with the [`ModuleSource`] of the offending impl
-/// block: the `TypeError` carries only a bare `Span`, so the emitter needs the
-/// owning module to attribute the diagnostic to the user's file (issue #1596).
+/// Only impl blocks in local (user) modules are checked. Each violation is
+/// paired with the offending impl's [`ModuleSource`] for file attribution.
 fn check_all_orphan_rules(
     modules: &IndexMap<ModuleSource, Module>,
     decl_index: &TraitDeclIndex,

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -526,7 +526,7 @@ impl TraitEnv {
         interner: &mut ModuleSourceInterner,
         entry_module: Option<&ModuleSource>,
         invocations: &InvocationIndex,
-    ) -> (Arc<Self>, Vec<(AstId, TypeError)>) {
+    ) -> (Arc<Self>, Vec<(ModuleSource, TypeError)>) {
         // Pre-compute every module's `use`-derived import scope so dispatch
         // queries read it instead of rebuilding from the module AST.
         let mut module_import_scopes: IndexMap<ModuleSource, ModuleImportScope> =
@@ -1257,16 +1257,14 @@ fn check_orphan_rfc2451(impl_block: &ast::ImplBlock, local_type_names: &IndexSet
 /// Check orphan rules for all trait impl blocks across all modules.
 /// Only impl blocks in local (user) modules are checked.
 ///
-/// Each violation is paired with the offending impl block's [`AstId`]. The
-/// `TypeError`s carry only a bare `Span` (byte offsets + line/column), which
-/// has no owning-module identity; the `AstId` lets the emitter derive the file
-/// via the `AstIdSpace → ModuleSource` registry, so the printer attributes the
-/// location to the user's file instead of a stdlib module (issue #1596).
+/// Each violation is paired with the [`ModuleSource`] of the offending impl
+/// block: the `TypeError` carries only a bare `Span`, so the emitter needs the
+/// owning module to attribute the diagnostic to the user's file (issue #1596).
 fn check_all_orphan_rules(
     modules: &IndexMap<ModuleSource, Module>,
     decl_index: &TraitDeclIndex,
     type_decl_index: &IndexMap<DeclKey, ModuleSource>,
-) -> Vec<(AstId, TypeError)> {
+) -> Vec<(ModuleSource, TypeError)> {
     let mut violations = Vec::new();
 
     // Project all (`DeclKey`, `ModuleSource`) entries down to bare names of
@@ -1316,7 +1314,7 @@ fn check_all_orphan_rules(
                     classify_position(&impl_block.ty, &type_params, &local_type_names)
                 {
                     violations.push((
-                        impl_block.id,
+                        module_source.clone(),
                         TypeError::InherentImplOnForeignType {
                             self_type_name: get_type_name_static(&impl_block.ty),
                             span: impl_block.span,
@@ -1337,7 +1335,7 @@ fn check_all_orphan_rules(
             if !check_orphan_rfc2451(impl_block, &local_type_names) {
                 let self_type_name = get_type_name_static(&impl_block.ty);
                 violations.push((
-                    impl_block.id,
+                    module_source.clone(),
                     TypeError::OrphanViolation {
                         trait_name,
                         self_type_name,

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -1483,7 +1483,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 type_arg,
                 trait_name,
             );
-            let _ = self.logger.error(TypeError::TraitBoundNotSatisfied {
+            let _ = self.emit(TypeError::TraitBoundNotSatisfied {
                 type_name,
                 trait_name: trait_name.to_string(),
                 param_name: param_name.to_string(),

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -108,7 +108,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_type_pack(name.clone(), *index)
                 } else {
-                    let _ = self.logger.error(TypeError::UnknownType {
+                    let _ = self.emit(TypeError::UnknownType {
                         name: format!("..{name}"),
                         span: *span,
                     });
@@ -143,7 +143,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 return type_id;
             }
             // If not found, it's an unknown associated type
-            let _ = self.logger.error(TypeError::UnknownType {
+            let _ = self.emit(TypeError::UnknownType {
                 name: format!("Self::{}", namespaced.name),
                 span: namespaced.span,
             });
@@ -241,7 +241,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 self.resolve_generic_type(&alias, &namespaced.args, namespaced.span)
             }
         } else {
-            let _ = self.logger.error(TypeError::UnknownType {
+            let _ = self.emit(TypeError::UnknownType {
                 name: format!("{}::{}", namespaced.namespace, namespaced.name),
                 span: namespaced.span,
             });
@@ -291,7 +291,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // Check newtypes, struct definitions, and variants
             _ => {
                 if enforce_arity && let Some(expected) = self.bare_generic_type_arity(name) {
-                    let _ = self.logger.error(TypeError::MissingTypeArguments {
+                    let _ = self.emit(TypeError::MissingTypeArguments {
                         name: name.to_string(),
                         expected,
                         span,
@@ -384,7 +384,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 if !found_as_variant {
                     // Option not found as a variant - likely #![no_prelude] without explicit import
-                    let _ = self.logger.error(TypeError::UnknownType {
+                    let _ = self.emit(TypeError::UnknownType {
                         name: "Option".to_string(),
                         span,
                     });
@@ -439,7 +439,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             // populated.
             _ if name == TypeTable::ARRAY_TYPE_NAME => {
                 if args.len() != 1 {
-                    let _ = self.logger.error(TypeError::ArgumentCountMismatch {
+                    let _ = self.emit(TypeError::ArgumentCountMismatch {
                         expected: 1,
                         found: args.len(),
                         span,
@@ -506,7 +506,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                             bound,
                                         );
                                         let _ =
-                                            self.logger.error(TypeError::TraitBoundNotSatisfied {
+                                            self.emit(TypeError::TraitBoundNotSatisfied {
                                                 type_name,
                                                 trait_name: bound.clone(),
                                                 param_name: param_name.clone(),

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -505,14 +505,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                                             type_arg,
                                             bound,
                                         );
-                                        let _ =
-                                            self.emit(TypeError::TraitBoundNotSatisfied {
-                                                type_name,
-                                                trait_name: bound.clone(),
-                                                param_name: param_name.clone(),
-                                                reason,
-                                                span,
-                                            });
+                                        let _ = self.emit(TypeError::TraitBoundNotSatisfied {
+                                            type_name,
+                                            trait_name: bound.clone(),
+                                            param_name: param_name.clone(),
+                                            reason,
+                                            span,
+                                        });
                                     }
                                 }
                             }

--- a/wado-compiler/src/elaborator/typecheck.rs
+++ b/wado-compiler/src/elaborator/typecheck.rs
@@ -302,7 +302,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// `TypeSystem` itself stays host-agnostic.
     pub(super) fn typecheck(&self, actual: TypeId, expected: TypeId, span: Span) {
         if let Err(payload) = self.tysys.typecheck(actual, expected) {
-            let _ = self.logger.error(TypeError::TypeMismatch {
+            let _ = self.emit(TypeError::TypeMismatch {
                 expected: payload.expected,
                 found: payload.found,
                 span,
@@ -316,7 +316,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// delegates to [`Self::typecheck`]'s emit path.
     pub(super) fn typecheck_return(&self, actual: TypeId, expected: TypeId, span: Span) {
         if let Err(payload) = self.tysys.typecheck_return(actual, expected) {
-            let _ = self.logger.error(TypeError::TypeMismatch {
+            let _ = self.emit(TypeError::TypeMismatch {
                 expected: payload.expected,
                 found: payload.found,
                 span,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -1446,8 +1446,8 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
 ) -> Result<DumpResult, Bail> {
     let logger = Logger::new(host, compiler_host::LogLevel::default());
     let filename = filename.map(String::from);
-    // The entry module the standalone bind/lex/parse phases below attribute
-    // their diagnostics to (load_all mints the real one only at Phase 4).
+    // Attribution target for the standalone bind/lex/parse phases below;
+    // load_all mints the real entry source only at Phase 4.
     let entry_source = {
         let mut interner = module_source::ModuleSourceInterner::new();
         match &filename {

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -700,9 +700,6 @@ pub async fn compile_with_options<H: CompilerHost>(
     let log_level = options.log_level.unwrap_or_default();
     let logger = Logger::new(host, log_level);
     let filename = filename.map(String::from);
-    if let Some(ref f) = filename {
-        logger.set_file(f);
-    }
 
     // === Phase 1: Load all modules ===
     // Loader performs: lex → parse → bind for each module, and preserves
@@ -1242,6 +1239,7 @@ fn compile_after_load<H: CompilerHost>(
             &mut flat,
             &options.param_overrides,
             &options.param_policy,
+            &entry_filename,
             logger,
         )?;
     }
@@ -1448,9 +1446,15 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
 ) -> Result<DumpResult, Bail> {
     let logger = Logger::new(host, compiler_host::LogLevel::default());
     let filename = filename.map(String::from);
-    if let Some(ref f) = filename {
-        logger.set_file(f);
-    }
+    // The entry module the standalone bind/lex/parse phases below attribute
+    // their diagnostics to (load_all mints the real one only at Phase 4).
+    let entry_source = {
+        let mut interner = module_source::ModuleSourceInterner::new();
+        match &filename {
+            Some(f) => interner.entry_point(f),
+            None => ModuleSource::entry_point_stdin(),
+        }
+    };
 
     // === Phase 1: Lexer ===
     let mut lex_result = {
@@ -1461,7 +1465,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
     // Batch path is fail-fast: report any recovered lex error before parsing
     // so the wire format keeps the `lexer error: …` prefix.
     if !lex_result.errors.is_empty() {
-        let _ = logger.error(lex_result.errors.remove(0));
+        let _ = logger.error_in(&entry_source, lex_result.errors.remove(0));
         return Err(Bail);
     }
 
@@ -1471,7 +1475,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
         let mut parser = Parser::from_lex(lex_result);
         let ast = parser.parse();
         if let Some(e) = parser.take_errors().into_iter().next() {
-            let _ = logger.error(e);
+            let _ = logger.error_in(&entry_source, e);
             return Err(Bail);
         }
         let mut trivia = parser.take_trivia();
@@ -1483,7 +1487,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
     // === Phase 3: Bind ===
     {
         let _span = logger.span("bind");
-        let mut binder = Binder::new(&logger);
+        let mut binder = Binder::new(&logger, &entry_source);
         binder.bind_module(&ast)?;
     }
 
@@ -1679,6 +1683,7 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
                     &mut flat,
                     param_overrides,
                     &param_policy,
+                    &entry_source.source_path(),
                     &logger,
                 )?;
             }

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -838,7 +838,11 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
     {
         let bind_host = crate::compiler_host::InMemoryCompilerHost::new();
         let bind_logger = Logger::new(&bind_host, LogLevel::Off);
-        bind::bind_module(&ast, &bind_logger).unwrap_or_else(|_| {
+        // A bind failure here is a bundled-stdlib bug: the panic message below
+        // formats each diagnostic against `label`, so the source's file
+        // attribution is never read — a label-named source keeps it honest.
+        let module_source = crate::module_source::ModuleSourceInterner::new().entry_point(label);
+        bind::bind_module(&ast, &module_source, &bind_logger).unwrap_or_else(|_| {
             let diags = bind_host.diagnostics();
             let mut msg = format!("bind error in {label}:\n");
             for d in &diags {
@@ -1842,8 +1846,7 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         // Bind errors are emitted directly to the host via Logger.
         // We use a temporary logger per module so error counting is per-module.
         let logger = Logger::new(self.host, self.log_level);
-        logger.set_file(module_source.source_path());
-        bind::bind_module(module, &logger).map_err(|_bail| {
+        bind::bind_module(module, module_source, &logger).map_err(|_bail| {
             let error_count = logger.error_count();
             LoadError::BindError {
                 module_source: module_source.clone(),

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -838,9 +838,8 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
     {
         let bind_host = crate::compiler_host::InMemoryCompilerHost::new();
         let bind_logger = Logger::new(&bind_host, LogLevel::Off);
-        // A bind failure here is a bundled-stdlib bug: the panic message below
-        // formats each diagnostic against `label`, so the source's file
-        // attribution is never read — a label-named source keeps it honest.
+        // Only used for (unread) file attribution: a bind failure here is a
+        // bundled-stdlib bug and the panic below formats against `label`.
         let module_source = crate::module_source::ModuleSourceInterner::new().entry_point(label);
         bind::bind_module(&ast, &module_source, &bind_logger).unwrap_or_else(|_| {
             let diags = bind_host.diagnostics();

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -138,11 +138,7 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     }
 
     /// Report a compilation error attributed to `module`'s source file.
-    pub fn error_in(
-        &self,
-        module: &ModuleSource,
-        err: impl Into<Diagnostic>,
-    ) -> Result<(), Bail> {
+    pub fn error_in(&self, module: &ModuleSource, err: impl Into<Diagnostic>) -> Result<(), Bail> {
         self.error_at(&module.source_path(), err)
     }
 

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -16,18 +16,19 @@
 //!                              error counting + bail
 //! ```
 //!
-//! Each phase calls `logger.error(typed_error)?` which:
+//! Each phase calls `logger.error_in(module, typed_error)?` which:
 //! 1. Converts the typed error to a `Diagnostic` via `Into<Diagnostic>`
-//! 2. Applies file context (if set) to the diagnostic span
+//! 2. Stamps the module's file onto the span when it carries none
 //! 3. Emits the diagnostic to `CompilerHost::emit_diagnostic()`
 //! 4. Increments the error count
 //! 5. Returns `Err(Bail)` if the error limit is reached
 
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 
 use crate::compiler_host::{
     Code, CompilerHost, Diagnostic, DiagnosticSpan, LogLevel, Severity, SpanEmitter,
 };
+use crate::module_source::ModuleSource;
 
 /// Maximum number of errors before compilation is aborted
 pub const MAX_ERRORS: usize = 100;
@@ -60,21 +61,22 @@ impl std::error::Error for Bail {}
 /// The logger tracks how many errors have been emitted. When the count reaches
 /// `MAX_ERRORS`, `error()` returns `Err(Bail)` to stop compilation.
 ///
-/// # File Context
+/// # File Attribution
 ///
-/// Phases can set a file context via `set_file()`. This file name is
-/// automatically applied to diagnostic spans that don't already have one.
+/// A diagnostic's file is stamped at emit time from the module the caller
+/// already holds — `error_in(module, err)` / `error_at(file, err)` — never
+/// from ambient logger state. The logger keeps no "current file": there is
+/// nothing a phase can forget to set, so a diagnostic can't be silently
+/// mis-attributed to a stale module. `error(err)` emits a diagnostic that
+/// already carries its own location (parser/lexer errors) or has none.
 ///
 /// # Example
 ///
 /// ```ignore
 /// let logger = Logger::new(&host, LogLevel::Debug);
 ///
-/// // Set file context for diagnostics
-/// logger.set_file("main.wado");
-///
-/// // Report compilation errors (counted, may bail)
-/// logger.error(TypeError::TypeMismatch { expected, found, span })?;
+/// // Report compilation errors attributed to a module (counted, may bail)
+/// logger.error_in(&module_source, TypeError::TypeMismatch { expected, found, span })?;
 ///
 /// // Fatal errors always bail
 /// logger.fatal(TypeError::TypeMismatch { ... })?; // always Err(Bail)
@@ -93,7 +95,6 @@ pub struct Logger<'a, H: CompilerHost> {
     host: &'a H,
     level: LogLevel,
     error_count: Cell<usize>,
-    current_file: RefCell<Option<String>>,
 }
 
 impl<'a, H: CompilerHost> Logger<'a, H> {
@@ -103,7 +104,6 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
             host,
             level,
             error_count: Cell::new(0),
-            current_file: RefCell::new(None),
         }
     }
 
@@ -114,29 +114,10 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
         self.host
     }
 
-    // === File context ===
-
-    /// Set the current file context for diagnostics
-    ///
-    /// All subsequent diagnostics will have this file name in their span
-    /// (unless the span already has a file set).
-    pub fn set_file(&self, file: impl Into<String>) {
-        *self.current_file.borrow_mut() = Some(file.into());
-    }
-
-    /// Clear the current file context
-    pub fn clear_file(&self) {
-        *self.current_file.borrow_mut() = None;
-    }
-
     // === Compilation error methods (counted, may bail) ===
 
-    /// Report a compilation error.
-    ///
-    /// The error is immediately emitted to the `CompilerHost`.
-    /// Returns `Err(Bail)` if the error count reaches `MAX_ERRORS`.
-    pub fn error(&self, err: impl Into<Diagnostic>) -> Result<(), Bail> {
-        let diag = self.apply_file_context(err.into());
+    /// Count the diagnostic, emit it, and signal `Bail` at `MAX_ERRORS`.
+    fn emit_error(&self, diag: Diagnostic) -> Result<(), Bail> {
         let count = self.error_count.get() + 1;
         self.error_count.set(count);
         self.host.emit_diagnostic(diag);
@@ -147,13 +128,49 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
         }
     }
 
+    /// Stamp `file` onto a diagnostic's span when the span carries no file of
+    /// its own, so a caller that knows its module wins over a bare `Span`.
+    fn with_file(mut diag: Diagnostic, file: &str) -> Diagnostic {
+        if let Some(span) = diag.span.as_mut()
+            && span.file.is_empty()
+        {
+            span.file = file.to_string();
+        }
+        diag
+    }
+
+    /// Report a compilation error attributed to `module`'s source file.
+    ///
+    /// The file is taken from the module the caller already holds — the
+    /// only supported way to attribute a `Span`-carrying diagnostic to a
+    /// file. Returns `Err(Bail)` if the error count reaches `MAX_ERRORS`.
+    pub fn error_in(
+        &self,
+        module: &ModuleSource,
+        err: impl Into<Diagnostic>,
+    ) -> Result<(), Bail> {
+        self.error_at(&module.source_path(), err)
+    }
+
+    /// Report a compilation error attributed to the file path `file`. Prefer
+    /// [`Self::error_in`] when a [`ModuleSource`] is in hand; this variant is
+    /// for callers that only have a display filename (the entry driver).
+    pub fn error_at(&self, file: &str, err: impl Into<Diagnostic>) -> Result<(), Bail> {
+        self.emit_error(Self::with_file(err.into(), file))
+    }
+
+    /// Report a compilation error whose diagnostic already carries its own
+    /// location (parser/lexer errors) or has none. No file is stamped.
+    pub fn error(&self, err: impl Into<Diagnostic>) -> Result<(), Bail> {
+        self.emit_error(err.into())
+    }
+
     /// Report a fatal compilation error. Always returns `Err(Bail)`.
     ///
     /// Use for errors that make it impossible to continue the current phase.
     pub fn fatal(&self, err: impl Into<Diagnostic>) -> Result<(), Bail> {
-        let diag = self.apply_file_context(err.into());
         self.error_count.set(self.error_count.get() + 1);
-        self.host.emit_diagnostic(diag);
+        self.host.emit_diagnostic(err.into());
         Err(Bail)
     }
 
@@ -232,18 +249,17 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
 
     /// Log a warning carrying a source span.
     ///
-    /// Used by span-bearing lints (unused diagnostics). The span's `file`
-    /// is taken as-is when set; otherwise the logger's current-file context
-    /// is applied, matching [`Self::error`].
+    /// Used by span-bearing lints (unused diagnostics). The caller builds the
+    /// `DiagnosticSpan` with its own file (`DiagnosticSpan::from_span(span,
+    /// Some(file))`); no file is stamped here.
     pub fn warn_at(&self, code: Code, message: impl Into<String>, span: DiagnosticSpan) {
         if self.should_log(Severity::Warning) {
-            let diag = self.apply_file_context(Diagnostic {
+            self.host.emit_diagnostic(Diagnostic {
                 severity: Severity::Warning,
                 code,
                 message: message.into(),
                 span: Some(span),
             });
-            self.host.emit_diagnostic(diag);
         }
     }
 
@@ -269,13 +285,12 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     /// message.
     pub fn remark(&self, message: impl Into<String>, span: DiagnosticSpan) {
         if self.should_log(Severity::Info) {
-            let diag = self.apply_file_context(Diagnostic {
+            self.host.emit_diagnostic(Diagnostic {
                 severity: Severity::Info,
                 code: Code::Remark,
                 message: format!("remark: {}", message.into()),
                 span: Some(span),
             });
-            self.host.emit_diagnostic(diag);
         }
     }
 
@@ -335,19 +350,6 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
             });
         }
     }
-
-    // === Internal helpers ===
-
-    /// Apply file context to a diagnostic's span if the span has no file set
-    fn apply_file_context(&self, mut diag: Diagnostic) -> Diagnostic {
-        if let Some(ref mut span) = diag.span
-            && span.file.is_empty()
-            && let Some(ref file) = *self.current_file.borrow()
-        {
-            span.file.clone_from(file);
-        }
-        diag
-    }
 }
 
 /// RAII guard for span tracking
@@ -374,6 +376,35 @@ impl<H: CompilerHost> SpanEmitter for Logger<'_, H> {
     }
     fn debug(&self, message: &str) {
         Logger::debug(self, message);
+    }
+}
+
+/// A [`Logger`] bound to one module's source file.
+///
+/// Diagnostics emitted through it are attributed to that module, so a
+/// recursive validator family that threads a single `logger` value never
+/// also has to thread a [`ModuleSource`]. Obtain one with
+/// [`Logger::in_module`].
+pub struct ModuleDiag<'l, 'a, H: CompilerHost> {
+    logger: &'l Logger<'a, H>,
+    module: &'l ModuleSource,
+}
+
+impl<H: CompilerHost> ModuleDiag<'_, '_, H> {
+    /// Report a compilation error attributed to the bound module's file.
+    pub fn error(&self, err: impl Into<Diagnostic>) -> Result<(), Bail> {
+        self.logger.error_in(self.module, err)
+    }
+}
+
+impl<'a, H: CompilerHost> Logger<'a, H> {
+    /// Bind this logger to `module`, so diagnostics emitted through the
+    /// returned [`ModuleDiag`] are attributed to `module`'s file.
+    pub fn in_module<'l>(&'l self, module: &'l ModuleSource) -> ModuleDiag<'l, 'a, H> {
+        ModuleDiag {
+            logger: self,
+            module,
+        }
     }
 }
 
@@ -499,26 +530,53 @@ mod tests {
     }
 
     #[test]
-    fn test_file_context() {
+    fn test_error_at_stamps_empty_span_file() {
         let host = InMemoryCompilerHost::new();
         let logger = Logger::new(&host, LogLevel::Error);
 
-        logger.set_file("test.wado");
-        let _ = logger.error(Diagnostic {
-            severity: Severity::Error,
-            code: Code::TypeMismatch,
-            message: "error".to_string(),
-            span: Some(crate::compiler_host::DiagnosticSpan {
-                file: String::new(),
-                line: 10,
-                column: 5,
-                end_line: None,
-                end_column: None,
-            }),
-        });
+        let _ = logger.error_at(
+            "test.wado",
+            Diagnostic {
+                severity: Severity::Error,
+                code: Code::TypeMismatch,
+                message: "error".to_string(),
+                span: Some(crate::compiler_host::DiagnosticSpan {
+                    file: String::new(),
+                    line: 10,
+                    column: 5,
+                    end_line: None,
+                    end_column: None,
+                }),
+            },
+        );
 
         let diags = host.diagnostics();
         assert_eq!(diags[0].span.as_ref().unwrap().file, "test.wado");
+    }
+
+    #[test]
+    fn test_error_at_does_not_override_existing_file() {
+        let host = InMemoryCompilerHost::new();
+        let logger = Logger::new(&host, LogLevel::Error);
+
+        let _ = logger.error_at(
+            "outer.wado",
+            Diagnostic {
+                severity: Severity::Error,
+                code: Code::TypeMismatch,
+                message: "error".to_string(),
+                span: Some(crate::compiler_host::DiagnosticSpan {
+                    file: "inner.wado".to_string(),
+                    line: 10,
+                    column: 5,
+                    end_line: None,
+                    end_column: None,
+                }),
+            },
+        );
+
+        let diags = host.diagnostics();
+        assert_eq!(diags[0].span.as_ref().unwrap().file, "inner.wado");
     }
 
     #[test]

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -63,12 +63,10 @@ impl std::error::Error for Bail {}
 ///
 /// # File Attribution
 ///
-/// A diagnostic's file is stamped at emit time from the module the caller
-/// already holds — `error_in(module, err)` / `error_at(file, err)` — never
-/// from ambient logger state. The logger keeps no "current file": there is
-/// nothing a phase can forget to set, so a diagnostic can't be silently
-/// mis-attributed to a stale module. `error(err)` emits a diagnostic that
-/// already carries its own location (parser/lexer errors) or has none.
+/// A diagnostic's file is stamped from the module the caller holds
+/// (`error_in` / `error_at`), never from ambient logger state — so no phase
+/// can forget to set it. `error(err)` is for diagnostics that already carry
+/// their own location.
 ///
 /// # Example
 ///
@@ -140,10 +138,6 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
     }
 
     /// Report a compilation error attributed to `module`'s source file.
-    ///
-    /// The file is taken from the module the caller already holds — the
-    /// only supported way to attribute a `Span`-carrying diagnostic to a
-    /// file. Returns `Err(Bail)` if the error count reaches `MAX_ERRORS`.
     pub fn error_in(
         &self,
         module: &ModuleSource,
@@ -152,15 +146,14 @@ impl<'a, H: CompilerHost> Logger<'a, H> {
         self.error_at(&module.source_path(), err)
     }
 
-    /// Report a compilation error attributed to the file path `file`. Prefer
-    /// [`Self::error_in`] when a [`ModuleSource`] is in hand; this variant is
-    /// for callers that only have a display filename (the entry driver).
+    /// Like [`Self::error_in`], for callers that hold a display filename
+    /// rather than a [`ModuleSource`].
     pub fn error_at(&self, file: &str, err: impl Into<Diagnostic>) -> Result<(), Bail> {
         self.emit_error(Self::with_file(err.into(), file))
     }
 
-    /// Report a compilation error whose diagnostic already carries its own
-    /// location (parser/lexer errors) or has none. No file is stamped.
+    /// Report an error whose diagnostic already carries its own location
+    /// (parser/lexer errors) or has none.
     pub fn error(&self, err: impl Into<Diagnostic>) -> Result<(), Bail> {
         self.emit_error(err.into())
     }
@@ -379,12 +372,9 @@ impl<H: CompilerHost> SpanEmitter for Logger<'_, H> {
     }
 }
 
-/// A [`Logger`] bound to one module's source file.
-///
-/// Diagnostics emitted through it are attributed to that module, so a
-/// recursive validator family that threads a single `logger` value never
-/// also has to thread a [`ModuleSource`]. Obtain one with
-/// [`Logger::in_module`].
+/// A [`Logger`] bound to one module, so code threading a single `logger`
+/// value (recursive validators) need not also thread a [`ModuleSource`].
+/// Obtain one with [`Logger::in_module`].
 pub struct ModuleDiag<'l, 'a, H: CompilerHost> {
     logger: &'l Logger<'a, H>,
     module: &'l ModuleSource,

--- a/wado-compiler/src/param_resolution.rs
+++ b/wado-compiler/src/param_resolution.rs
@@ -81,6 +81,7 @@ pub fn resolve_params<H: CompilerHost>(
     flat: &mut FlatPackage,
     overrides: &IndexMap<String, String>,
     policy: &ParamPolicy,
+    file: &str,
     logger: &Logger<'_, H>,
 ) -> Result<(), Bail> {
     // Nothing to resolve and no stray `-D` to flag — skip the type-table work.
@@ -110,7 +111,7 @@ pub fn resolve_params<H: CompilerHost>(
 
     let mut had_error = false;
     let mut emit = |level: ParamPolicyLevel, code: Code, message: String, span: Option<Span>| {
-        let diag_span = span.map(|s| DiagnosticSpan::from_span(&s, None));
+        let diag_span = span.map(|s| DiagnosticSpan::from_span(&s, Some(file)));
         match level {
             ParamPolicyLevel::Error => {
                 had_error = true;

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -1023,10 +1023,14 @@ pub async fn semantics_for_world<H: CompilerHost>(
         }
         Err(e) => {
             let logger = Logger::new(host, LogLevel::default());
-            if let Some(f) = filename {
-                logger.set_file(f);
+            match filename {
+                Some(f) => {
+                    let _ = logger.error_at(f, e);
+                }
+                None => {
+                    let _ = logger.error(e);
+                }
             }
-            let _ = logger.error(e);
             Semantics::empty()
         }
     }
@@ -1138,10 +1142,6 @@ pub fn semantics_of<H: CompilerHost>(
     build_tir: bool,
 ) -> Semantics {
     let logger = Logger::new(host, log_level);
-    let entry_filename = loaded.entry_module_source.source_path();
-    if !entry_filename.is_empty() {
-        logger.set_file(&entry_filename);
-    }
     semantics_with_logger(loaded, &logger, build_tir)
 }
 

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -587,6 +587,29 @@ fn test_orphan_error_attributed_to_user_file() {
 }
 
 #[test]
+fn test_orphan_error_attributed_to_the_submodule_that_defines_it() {
+    // The offending impl lives in ./sub/orphan_xmod_lib.wado, imported by the
+    // entry fixture. The diagnostic's file must be that submodule — a result
+    // the entry-filename fallback in `bail_to_compile_error` could never
+    // produce — so this pins per-module attribution (#1596).
+    let path = Path::new("tests/fixtures/orphan_xmod_entry.wado");
+    let err = common::compile_file(path).expect_err("expected a compile error");
+    match err {
+        CompileError::Analyzer {
+            filename, message, ..
+        } => {
+            assert!(message.contains("orphan rule"), "unexpected: {message}");
+            let filename = filename.expect("diagnostic must carry a source file");
+            assert!(
+                filename.ends_with("orphan_xmod_lib.wado"),
+                "expected the submodule that defines the impl, got: {filename}"
+            );
+        }
+        other => panic!("expected Analyzer error, got: {other}"),
+    }
+}
+
+#[test]
 fn test_sealed_reflect_error_attributed_to_user_file() {
     let filename = analyzer_filename(
         "struct Point { x: i32, y: i32 }\n\nimpl Reflect for Point {\n    type Fields = [i32, i32];\n    fn fields(&self) -> Self::Fields { return [self.x, self.y]; }\n    fn field_names() -> List<String> { return [\"a\", \"b\"]; }\n    fn type_name() -> String { return \"forged\"; }\n}\n\nexport fn run() {}\n",

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -553,11 +553,8 @@ fn test_error_display_analyzer_without_filename() {
     assert!(display.contains("analysis error"));
 }
 
-/// Diagnostics emitted at the `trait_env` build phase (orphan / coherence /
-/// sealed-`Reflect`) carry a bare `Span` with no owning-module identity, so
-/// before the fix the printer mis-attributed the source file to a stdlib
-/// module (`core:libm.wat`). The offending impl block is in the user's file,
-/// and the diagnostic must point there. Regression test for issue #1596.
+/// Orphan / coherence / sealed-`Reflect` errors must point at the user's file,
+/// not a stdlib module (`core:libm.wat` before the fix). Regression for #1596.
 fn analyzer_filename(source: &str) -> String {
     let path = Path::new("orphan_phase_diag.wado");
     let err = common::compile_source_with_opts(path, source, OptLevel::default())
@@ -588,10 +585,8 @@ fn test_orphan_error_attributed_to_user_file() {
 
 #[test]
 fn test_orphan_error_attributed_to_the_submodule_that_defines_it() {
-    // The offending impl lives in ./sub/orphan_xmod_lib.wado, imported by the
-    // entry fixture. The diagnostic's file must be that submodule — a result
-    // the entry-filename fallback in `bail_to_compile_error` could never
-    // produce — so this pins per-module attribution (#1596).
+    // The impl lives in the imported submodule, so the file must be that
+    // submodule — never the entry — which pins per-module attribution (#1596).
     let path = Path::new("tests/fixtures/orphan_xmod_entry.wado");
     let err = common::compile_file(path).expect_err("expected a compile error");
     match err {

--- a/wado-compiler/tests/compile_errors.rs
+++ b/wado-compiler/tests/compile_errors.rs
@@ -6,7 +6,7 @@
 mod common;
 
 use std::path::Path;
-use wado_compiler::CompileError;
+use wado_compiler::{CompileError, OptLevel};
 
 #[test]
 fn test_io_error_file_not_found() {
@@ -551,4 +551,45 @@ fn test_error_display_analyzer_without_filename() {
     let display = format!("{err}");
     assert!(display.contains("type mismatch"));
     assert!(display.contains("analysis error"));
+}
+
+/// Diagnostics emitted at the `trait_env` build phase (orphan / coherence /
+/// sealed-`Reflect`) carry a bare `Span` with no owning-module identity, so
+/// before the fix the printer mis-attributed the source file to a stdlib
+/// module (`core:libm.wat`). The offending impl block is in the user's file,
+/// and the diagnostic must point there. Regression test for issue #1596.
+fn analyzer_filename(source: &str) -> String {
+    let path = Path::new("orphan_phase_diag.wado");
+    let err = common::compile_source_with_opts(path, source, OptLevel::default())
+        .expect_err("expected a compile error");
+    match err {
+        CompileError::Analyzer { filename, .. } => {
+            filename.expect("diagnostic must carry a source file")
+        }
+        other => panic!("expected Analyzer error, got: {other}"),
+    }
+}
+
+#[test]
+fn test_coherence_error_attributed_to_user_file() {
+    let filename = analyzer_filename(
+        "impl i32 {\n    fn my_foo(&self) -> i32 { return 1; }\n}\n\nexport fn run() {}\n",
+    );
+    assert_eq!(filename, "orphan_phase_diag.wado");
+}
+
+#[test]
+fn test_orphan_error_attributed_to_user_file() {
+    let filename = analyzer_filename(
+        "impl Eq for String {\n    fn eq(&self, other: &Self) -> bool { return true; }\n}\n\nexport fn run() {}\n",
+    );
+    assert_eq!(filename, "orphan_phase_diag.wado");
+}
+
+#[test]
+fn test_sealed_reflect_error_attributed_to_user_file() {
+    let filename = analyzer_filename(
+        "struct Point { x: i32, y: i32 }\n\nimpl Reflect for Point {\n    type Fields = [i32, i32];\n    fn fields(&self) -> Self::Fields { return [self.x, self.y]; }\n    fn field_names() -> List<String> { return [\"a\", \"b\"]; }\n    fn type_name() -> String { return \"forged\"; }\n}\n\nexport fn run() {}\n",
+    );
+    assert_eq!(filename, "orphan_phase_diag.wado");
 }

--- a/wado-compiler/tests/fixtures/orphan_xmod_entry.wado
+++ b/wado-compiler/tests/fixtures/orphan_xmod_entry.wado
@@ -1,0 +1,12 @@
+// The offending `impl Eq for String` lives in the imported submodule, so the
+// orphan-rule diagnostic must point at the submodule file — a per-module
+// attribution the entry-filename fallback could never produce (#1596).
+
+use { helper } from "./sub/orphan_xmod_lib.wado";
+
+export fn run() {
+    let _ = helper();
+}
+
+__DATA__
+{"compile_error": "orphan rule"}

--- a/wado-compiler/tests/fixtures/sub/orphan_xmod_lib.wado
+++ b/wado-compiler/tests/fixtures/sub/orphan_xmod_lib.wado
@@ -1,0 +1,14 @@
+// Helper module carrying an orphan-rule violation, imported by
+// `orphan_xmod_entry.wado`. The `impl Eq for String` lives HERE, so the
+// diagnostic must be attributed to this submodule — not the importing entry
+// module (#1596: phase-boundary diagnostics are attributed per-module).
+
+pub fn helper() -> i32 {
+    return 1;
+}
+
+impl Eq for String {
+    fn eq(&self, other: &Self) -> bool {
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

Compile errors raised at the `trait_env` build phase — orphan-rule
(`OrphanViolation`), coherence (`InherentImplOnForeignType`), and
sealed-`Reflect` (`SealedTraitImpl`) — printed the **wrong source file**,
attributing the location to a stdlib module (`core:libm.wat`) instead of the
user file the offending `impl` lives in. The message and line/column were
correct; only the file was wrong. Closes #1596.

## Root cause

`Logger` carried a mutable `current_file`, set via `set_file()` at each phase
boundary and stamped onto any span with an empty file. The `trait_env` phase
never set it, so these diagnostics inherited a stale value left over from the
previous phase. This was one instance of a recurring "forgot to `set_file`"
bug class — ambient mutable state that every phase must remember to maintain.

## What changed

Rather than patch the one call site, the ambient file context is removed
entirely and a diagnostic's file is now stamped at emit time from the module
the caller already holds:

- `Logger::error_in(module, err)` / `error_at(file, err)` replace the ambient
  path; `error(err)` emits a diagnostic that already carries its own location
  (parser/lexer errors) or has none. `ModuleDiag` (via `Logger::in_module`)
  binds a logger to one module so recursive validators thread a single value.
- The `Elaborator` and `Binder` stamp their own `current_module_source` /
  `module_source` through a small `emit` helper — state they already maintain
  structurally, so there is nothing for a phase to forget.
- `set_file` / `clear_file` / `apply_file_context` / `current_file` are gone.

With the mechanism corrected, the #1596 fix falls out: `check_all_orphan_rules`
pairs each violation with its module and the emitter uses `error_in`.

Regression coverage pins both single-file attribution and — via an imported
submodule whose `impl` triggers the orphan rule — genuine per-module
attribution that the entry-filename fallback could never produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sSSMu1a7EiV5fqAbWJuuq

---
_Generated by [Claude Code](https://claude.ai/code/session_013sSSMu1a7EiV5fqAbWJuuq)_