### PR TITLE
ci: add Dependabot for GitHub Actions and cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
       github-actions:
         patterns:
           - "*"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      cargo:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to keep dependencies up to date.

## Config

Two ecosystems, both configured identically:

| Setting | Value |
|---------|-------|
| Ecosystems | `github-actions` and `cargo` |
| Schedule | monthly |
| Cooldown | 7 days |
| Grouping | all updates within an ecosystem land in a single grouped PR (`patterns: ["*"]`) |

Grouping is per-ecosystem, so at most two PRs a month (one for actions, one for cargo) rather than one PR per dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXZsASpR3cmbXiZN6wAdMB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXZsASpR3cmbXiZN6wAdMB)_