### PR TITLE
ci: keep Dependabot cargo updates within Cargo.toml constraints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Only update within the version constraints declared in Cargo.toml, never
+    # widen them. Keeps the wasm-tools crates pinned to wasmtime's generation
+    # (see the workspace Cargo.toml note and `mise run check-deps`).
+    versioning-strategy: "lockfile-only"
     cooldown:
       default-days: 7
     groups:


### PR DESCRIPTION
Follow-up to #1610. Dependabot's default `versioning-strategy` rewrites the version requirement in `Cargo.toml` to reach a new release, so the intentionally pinned wasm-tools crates got bumped anyway (see the closed #1613, which moved `wat`/`wasm-encoder`/`wasmparser`/… from `0.251` to `0.253`).

## Change

Set `versioning-strategy: lockfile-only` on the cargo ecosystem so Dependabot updates only **within** the constraints already declared in `Cargo.toml`, never widening them.

- `wasmparser = "0.251"` → `>=0.251.0, <0.252.0`, so `0.253` is out of range and will not be proposed.
- The wasm-tools crates stay pinned to wasmtime's generation, which `mise run check-deps` enforces.

## Trade-off

`lockfile-only` applies to the whole cargo ecosystem, so loosely-constrained deps (e.g. `tokio = "1"`) also update only within their range via the lock file — no manifest-widening PRs. Updates within range continue as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXZsASpR3cmbXiZN6wAdMB

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXZsASpR3cmbXiZN6wAdMB)_