### PR TITLE
perf(build): opt-level 2 for all deps in the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,18 +107,15 @@ dprint-plugin-markdown = { version = "0.22" }
 debug = "line-tables-only"
 split-debuginfo = "unpacked"
 
-# Drop `debug_assert!`s and integer-overflow checks in *all third-party
-# dependencies* for dev/test builds. The `"*"` glob applies to every
-# dependency but never to our own workspace members, so the wado-* crates
-# keep their assertions (a compiler bug is always P0 — we want those
-# checks during development). The vendored runtime/codegen stack —
-# wasmtime, cranelift, regalloc2, wasmparser, … — runs with these checks
-# off in release anyway, and they dominate the dev-build cost of
-# `wado test`/`run`: wasmtime's copying GC and the cranelift JIT are
-# riddled with bounds/precondition `debug_assert!`s. Measured on
-# `wado test --no-cache example/wado_syntax_highlight.wado` this cut the
-# guest-execution (test) phase by ~45% with no change to our own code.
+# All third-party deps at opt-level 2, with debug-assertions/overflow-checks off.
+# The `"*"` glob skips workspace members (they keep their own opt-level). Deps are
+# cached, so this only costs a one-time clean/CI build; incremental dev builds are
+# unaffected while every run gets faster — both compile (mimalloc, indexmap,
+# hashbrown) and test/run (wasmtime/wasmparser, previously opt-level 0).
+# `debug-assertions = false` is also load-bearing: dprint-core trips a
+# `debug_assert!` on some markdown, panicking `wado doc` / `format-md`.
 [profile.dev.package."*"]
+opt-level = 2
 debug-assertions = false
 overflow-checks = false
 
@@ -127,30 +124,6 @@ opt-level = 1
 
 [profile.dev.package.wado-dev-tools]
 opt-level = 1
-
-# Upstream bug, unavoidable from our side: dprint-plugin-markdown
-# hands multi-line inline code spans (e.g. a backtick fragment that
-# wraps across two source lines) straight to dprint-core's printer,
-# which then trips a `debug_assert!` at
-# dprint-core/src/formatting/printer.rs — "Found a newline in the
-# string." The bundled `dprint` CLI is shipped in release, where
-# `debug_assert!`s are stripped, so the bug never surfaces there. We
-# mirror that here so `wado-dev-tools format-md` works in dev too.
-# Remove these stanzas once the upstream is fixed.
-[profile.dev.package.dprint-core]
-debug-assertions = false
-
-[profile.dev.package.dprint-plugin-markdown]
-debug-assertions = false
-
-# Optimize Cranelift in dev/test builds for faster E2E tests.
-# Cranelift compiles Wasm→native for every test; without this it runs in debug mode.
-# A package with its own override does not inherit the `"*"` glob above, so the
-# debug-assertions/overflow-checks opt-outs are repeated here explicitly.
-[profile.dev.package.cranelift-codegen]
-opt-level = 2
-debug-assertions = false
-overflow-checks = false
 
 # `release` is the profile for distributed `wado` binaries. `thin` LTO
 # captures most of fat LTO's size/perf benefit at a fraction of the


### PR DESCRIPTION
## Summary

The dev profile compiled all third-party dependencies at `opt-level = 0` — the `[profile.dev.package."*"]` glob only turned off their debug-assertions/overflow-checks, and `cranelift-codegen` was the sole optimized runtime crate. This adds `opt-level = 2` to that glob so the whole dependency tree is optimized, and removes the now-redundant per-crate overrides (`cranelift-codegen`, and the `dprint-core` / `dprint-plugin-markdown` debug-assertions opt-outs the glob now covers).

Net change is `Cargo.toml` only; no source or codegen changes.

## Why it's cheap

Dependencies are compiled once and cached — editing a workspace crate never rebuilds them — so incremental dev builds are unaffected. Only clean/CI builds pay a one-time cost (the full tree rebuilt at opt-level 2 in ~7m45s here). Workspace members keep their own opt-level (the glob never matches them).

## Impact

Both halves of the dev loop get faster, where the prior config only reached cranelift:

- **compile**: allocator (mimalloc), ordered maps (indexmap/hashbrown), hasher, and the wasm encoder/parser sit on the compiler's hot paths.
- **test/run**: the runtime stack — wasmtime (loader/GC/executor) and wasmparser (validation) — previously sat at opt-level 0 and dominated guest execution.

Measured on `package-gale/tests/driver_cst_rust_test.wado` (CPU time, load-independent):

| phase | before | after |
| --- | --- | --- |
| `wado compile` | ~12.9s | ~5.7s (~2.2×) |
| `wado test` load | ~1.1s | ~0.36s (3×) |
| `wado test` test | ~1.0s | ~0.19s (5×) |

## Note

`debug-assertions = false` on the glob stays load-bearing for correctness, not just speed: `dprint-plugin-markdown` trips a `debug_assert!` in dprint-core's printer on some markdown, which would panic `wado doc` / `wado-dev-tools format-md` were assertions on. This is documented in the glob comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTB3uiZuGnhBh517EZYKQF)_