### PR TITLE
refactor(lsp): source the unused-lint tag from Code::is_unused_lint

### DIFF
--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -193,6 +193,19 @@ pub enum Code {
     ParamMissing,
 }
 
+impl Code {
+    /// Whether this code is an unused / dead-code lint — the diagnostic marks
+    /// code that is never reached, so a client may fade the range. Kept next to
+    /// the enum as the single source of truth; `wado-lsp` maps this to the LSP
+    /// `DiagnosticTag::Unnecessary` rather than re-listing the codes itself.
+    pub fn is_unused_lint(&self) -> bool {
+        matches!(
+            self,
+            Code::DeadFunction | Code::DeadGlobal | Code::TestOnlyFunction | Code::TestOnlyGlobal
+        )
+    }
+}
+
 impl std::fmt::Display for Code {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = match self {
@@ -734,5 +747,20 @@ mod tests {
         assert!(display.contains("test.wado:10:5"));
         assert!(display.contains("error"));
         assert!(display.contains("expected ';'"));
+    }
+
+    #[test]
+    fn unused_lint_codes_are_classified() {
+        for code in [
+            Code::DeadFunction,
+            Code::DeadGlobal,
+            Code::TestOnlyFunction,
+            Code::TestOnlyGlobal,
+        ] {
+            assert!(code.is_unused_lint(), "{code} should be an unused lint");
+        }
+        for code in [Code::TypeMismatch, Code::UnexpectedToken, Code::Log] {
+            assert!(!code.is_unused_lint(), "{code} is not an unused lint");
+        }
     }
 }

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -194,10 +194,6 @@ pub enum Code {
 }
 
 impl Code {
-    /// Whether this code is an unused / dead-code lint — the diagnostic marks
-    /// code that is never reached, so a client may fade the range. Kept next to
-    /// the enum as the single source of truth; `wado-lsp` maps this to the LSP
-    /// `DiagnosticTag::Unnecessary` rather than re-listing the codes itself.
     pub fn is_unused_lint(&self) -> bool {
         matches!(
             self,

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -83,11 +83,7 @@ pub fn from_compiler_diagnostic(
         CompilerSeverity::Debug => return None,
     };
 
-    let is_unused_lint = matches!(
-        diag.code,
-        Code::DeadFunction | Code::DeadGlobal | Code::TestOnlyFunction | Code::TestOnlyGlobal
-    );
-    let tags = if is_unused_lint {
+    let tags = if diag.code.is_unused_lint() {
         vec![DiagnosticTag::Unnecessary]
     } else {
         Vec::new()


### PR DESCRIPTION
wado-lsp decided which diagnostics get the LSP `DiagnosticTag::Unnecessary` (the tag that lets a client fade unused code) via a hardcoded allowlist of `Code` variants. That duplicated knowledge the compiler already owns — the dead-code analysis emits exactly those codes — across a crate boundary, with nothing to catch drift: adding a new unused lint would silently miss the fade until someone remembered to update the allowlist in `wado-lsp`.

## Change

- Add `Code::is_unused_lint()` next to the `Code` enum (`wado-compiler`) as the single source of truth for "this diagnostic marks unreachable code."
- `wado-lsp` calls it instead of re-listing the codes. The LSP-specific mapping (`is_unused_lint() → DiagnosticTag::Unnecessary`) still lives in `wado-lsp`; the compiler stays free of LSP concepts.

No behavior change: the same four codes emit the same tag on the wire. This is purely a maintainability change so a future unused lint has a single place to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T68AKL4Q4evcifSzRG6ZUq

---
_Generated by [Claude Code](https://claude.ai/code/session_01T68AKL4Q4evcifSzRG6ZUq)_