### PR TITLE
chore: cache compiled dependencies via sccache for the web container

### DIFF
--- a/.claude/hooks/cargo-cache-restore.mts
+++ b/.claude/hooks/cargo-cache-restore.mts
@@ -1,15 +1,21 @@
 #!/usr/bin/env node
-// SessionStart hook: restore the shared cargo registry cache from GCS.
+// SessionStart hook: restore the shared cargo caches from GCS.
+//
+// Two objects are restored (both produced by .github/workflows/cargo-cache.yml):
+//   registry  -> $CARGO_HOME (registry/index + registry/cache; saves the download)
+//   sccache   -> $SCCACHE_DIR (content-addressed compile cache; the `warm-cache`
+//                mise task turns it into a warm target/ in ~80s instead of ~8min)
+// Neither object contains credentials.
 //
 // Best-effort: any failure (no key, no object yet, network) is logged and the
-// session continues. The object is produced by .github/workflows/cargo-cache.yml
-// and contains only registry/index + registry/cache (never credentials).
+// session continues.
 //
 // Auth uses a read-only service-account key provided via the environment:
 //   WADO_CACHE_SA_KEY_B64   base64 of the JSON key (for stores that reject raw JSON), or
 //   WADO_CACHE_SA_KEY       inline service-account JSON, or
 //   WADO_CACHE_SA_KEY_FILE  path to the JSON key file
-// Optional overrides: WADO_CACHE_BUCKET, WADO_CACHE_OBJECT.
+// Optional overrides: WADO_CACHE_BUCKET, WADO_CACHE_OBJECT (registry),
+//   WADO_CACHE_SCCACHE_OBJECT, SCCACHE_DIR.
 
 import { createSign } from "node:crypto";
 import { createWriteStream, readFileSync, mkdirSync } from "node:fs";
@@ -22,7 +28,10 @@ import { join } from "node:path";
 process.env.NODE_USE_ENV_PROXY ??= "1";
 
 const BUCKET = process.env.WADO_CACHE_BUCKET ?? "wado-lang-cache";
-const OBJECT = process.env.WADO_CACHE_OBJECT ?? "cargo/registry/linux-x86_64.tar.gz";
+const REGISTRY_OBJECT = process.env.WADO_CACHE_OBJECT ?? "cargo/registry/linux-x86_64.tar.gz";
+const SCCACHE_OBJECT = process.env.WADO_CACHE_SCCACHE_OBJECT ?? "cargo/sccache/linux-x86_64.tar.gz";
+const CARGO_HOME = process.env.CARGO_HOME ?? join(homedir(), ".cargo");
+const SCCACHE_DIR = process.env.SCCACHE_DIR ?? join(CARGO_HOME, "sccache");
 const SCOPE = "https://www.googleapis.com/auth/devstorage.read_only";
 const TIMEOUT_MS = 60_000;
 
@@ -65,6 +74,27 @@ async function accessToken({ client_email, private_key, token_uri }: ServiceAcco
   return (await res.json()).access_token;
 }
 
+async function restore(token: string, object: string, destDir: string, tarName: string): Promise<void> {
+  const url =
+    `https://storage.googleapis.com/storage/v1/b/${BUCKET}` +
+    `/o/${encodeURIComponent(object)}?alt=media`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (res.status === 404) {
+    log(`no cache object yet (gs://${BUCKET}/${object}); skipping`);
+    return;
+  }
+  if (!res.ok) throw new Error(`download failed: HTTP ${res.status} ${await res.text()}`);
+
+  mkdirSync(destDir, { recursive: true });
+  const tarPath = join(tmpdir(), tarName);
+  await pipeline(Readable.fromWeb(res.body!), createWriteStream(tarPath));
+  execFileSync("tar", ["-xzf", tarPath, "-C", destDir]);
+  log(`restored gs://${BUCKET}/${object} into ${destDir}`);
+}
+
 async function main(): Promise<void> {
   const key = loadKey();
   if (!key) {
@@ -73,25 +103,15 @@ async function main(): Promise<void> {
   }
 
   const token = await accessToken(key);
-  const url =
-    `https://storage.googleapis.com/storage/v1/b/${BUCKET}` +
-    `/o/${encodeURIComponent(OBJECT)}?alt=media`;
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(TIMEOUT_MS),
-  });
-  if (res.status === 404) {
-    log(`no cache object yet (gs://${BUCKET}/${OBJECT}); skipping`);
-    return;
+  // Independent and best-effort: a missing sccache object must not stop the
+  // registry restore, and vice versa.
+  const results = await Promise.allSettled([
+    restore(token, REGISTRY_OBJECT, CARGO_HOME, "cargo-registry-cache.tar.gz"),
+    restore(token, SCCACHE_OBJECT, SCCACHE_DIR, "cargo-sccache-cache.tar.gz"),
+  ]);
+  for (const r of results) {
+    if (r.status === "rejected") log(`skipped: ${(r.reason as Error).message}`);
   }
-  if (!res.ok) throw new Error(`download failed: HTTP ${res.status} ${await res.text()}`);
-
-  const cargoHome = process.env.CARGO_HOME ?? join(homedir(), ".cargo");
-  mkdirSync(cargoHome, { recursive: true });
-  const tarPath = join(tmpdir(), "cargo-registry-cache.tar.gz");
-  await pipeline(Readable.fromWeb(res.body!), createWriteStream(tarPath));
-  execFileSync("tar", ["-xzf", tarPath, "-C", cargoHome]);
-  log(`restored gs://${BUCKET}/${OBJECT} into ${cargoHome}`);
 }
 
 main().catch((e: Error) => log(`skipped: ${e.message}`));

--- a/.claude/hooks/mise-setup.sh
+++ b/.claude/hooks/mise-setup.sh
@@ -18,6 +18,19 @@ fi
 
 log "Remote session detected, setting up mise..."
 
+# Install sccache so `mise run warm-cache` can turn the restored sccache cache
+# into a warm target/ (see .claude/hooks/cargo-cache-restore.mts). Best-effort:
+# if it fails, warm-cache no-ops and a normal cold build applies.
+if ! command -v sccache >/dev/null 2>&1; then
+    log "Installing sccache..."
+    if DEBIAN_FRONTEND=noninteractive apt-get install -y sccache >/dev/null 2>&1 \
+        || DEBIAN_FRONTEND=noninteractive sudo apt-get install -y sccache >/dev/null 2>&1; then
+        log "sccache installed: $(sccache --version 2>/dev/null)"
+    else
+        log "Warning: sccache install failed; warm-cache will be skipped"
+    fi
+fi
+
 # Setup local bin directory
 LOCAL_BIN="$HOME/.local/bin"
 mkdir -p "$LOCAL_BIN"

--- a/.github/workflows/cargo-cache.yml
+++ b/.github/workflows/cargo-cache.yml
@@ -1,12 +1,28 @@
-# Publishes the shared cargo registry cache to GCS so non-GitHub environments
-# (e.g. the Claude Code web container) can restore it. See
-# .claude/hooks/cargo-cache-restore.mjs for the consumer side.
+# Publishes shared cargo caches to GCS so non-GitHub environments (e.g. the
+# Claude Code web container) can restore them. Two objects are produced:
+#
+#   cargo/registry/linux-x86_64.tar.gz  registry index + downloaded .crate files
+#   cargo/sccache/linux-x86_64.tar.gz   sccache content-addressed compile cache
+#
+# The registry cache saves the download; the sccache cache saves the compile of
+# the ~440 dependencies (an ~8 min cold build becomes an ~80s sccache-backed
+# rebuild in the container). See .claude/hooks/cargo-cache-restore.mts (consumer)
+# and the `warm-cache` task in mise.toml (which uses it, then hands off to
+# incremental for the dev loop).
+#
+# PATH PARITY IS LOAD-BEARING. sccache's Rust cache key is sensitive to the
+# absolute build paths (build-script OUT_DIR and dependency paths bake into it),
+# so the runner MUST compile under the exact same absolute paths the container
+# uses, or every entry misses. Keep these env values in lockstep with the
+# container: repo at /home/user/wado, CARGO_HOME at /root/.cargo, target at
+# /home/user/wado/target. sccache itself is the distro build on both sides
+# (Ubuntu 24.04 `apt` sccache) so the on-disk cache format matches.
 #
 # Required repo variables (none are secret — all are plain identifiers):
 #   vars.GCP_WIF_PROVIDER    workload identity provider resource name
 #   vars.GCP_CACHE_WRITER_SA writer service-account email (roles/storage.objectAdmin on the bucket)
-#   vars.GCP_CACHE_BUCKET  GCS bucket name (e.g. wado-lang-cache)
-name: Cargo registry cache
+#   vars.GCP_CACHE_BUCKET    GCS bucket name (e.g. wado-lang-cache)
+name: Cargo caches (registry + sccache)
 
 on:
   push:
@@ -24,21 +40,48 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  # Mirror the container's absolute paths (see the parity note above).
+  CONTAINER_REPO: /home/user/wado
+  CARGO_HOME: /root/.cargo
+  SCCACHE_DIR: /root/.cargo/sccache
+  CARGO_TARGET_DIR: /home/user/wado/target
+  RUSTC_WRAPPER: sccache
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: -D warnings # must match the container's mise [env]
+
 jobs:
   upload:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
+        with:
+          submodules: false
 
-      # Populates ~/.cargo/registry/{index,cache} without compiling.
-      - run: cargo fetch --locked
+      - name: Install sccache (distro build — same version as the container)
+        run: sudo apt-get update && sudo apt-get install -y sccache
 
-      # Pack only public registry data — never credentials.toml / config.toml.
-      - name: Pack registry cache
+      - name: Mirror the container's absolute build paths
         run: |
-          tar -C "$HOME/.cargo" -czf linux-x86_64.tar.gz registry/index registry/cache
-          ls -lh linux-x86_64.tar.gz
+          sudo mkdir -p "$CONTAINER_REPO" "$CARGO_HOME"
+          sudo cp -a "$GITHUB_WORKSPACE/." "$CONTAINER_REPO/"
+          sudo chown -R "$(id -u):$(id -g)" "$CONTAINER_REPO" "$CARGO_HOME"
+
+      - name: Fetch registry, then compile through sccache
+        working-directory: /home/user/wado
+        run: |
+          cargo fetch --locked
+          cargo build --workspace --locked
+          sccache --show-stats
+
+      - name: Pack caches (public data only — never credentials.toml / config.toml)
+        run: |
+          sccache --stop-server || true
+          mkdir -p out/registry out/sccache
+          tar -C "$CARGO_HOME" -czf out/registry/linux-x86_64.tar.gz registry/index registry/cache
+          tar -C "$SCCACHE_DIR" -czf out/sccache/linux-x86_64.tar.gz .
+          ls -lh out/registry/linux-x86_64.tar.gz out/sccache/linux-x86_64.tar.gz
 
       - id: auth
         uses: google-github-actions/auth@v2
@@ -46,8 +89,16 @@ jobs:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER }}
           service_account: ${{ vars.GCP_CACHE_WRITER_SA }}
 
-      - uses: google-github-actions/upload-cloud-storage@v2
+      - name: Upload registry cache
+        uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: linux-x86_64.tar.gz
+          path: out/registry/linux-x86_64.tar.gz
           destination: ${{ vars.GCP_CACHE_BUCKET }}/cargo/registry
+          parent: false
+
+      - name: Upload sccache cache
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: out/sccache/linux-x86_64.tar.gz
+          destination: ${{ vars.GCP_CACHE_BUCKET }}/cargo/sccache
           parent: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 target/
 build/
 
+# sccache local cache (restored from GCS by the cargo-cache-restore hook)
+.sccache/
+
 *.wasm
 
 # mise

--- a/mise.toml
+++ b/mise.toml
@@ -31,6 +31,37 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 mise install
+mise run warm-cache
+"""
+
+[tasks.warm-cache]
+description = "Reconstruct target/ from the restored sccache cache, then warm the incremental dev loop"
+run = """
+#!/usr/bin/env bash
+# Turns the restored sccache cache (see .claude/hooks/cargo-cache-restore.mts)
+# into a warm target/: an ~8 min cold dependency build becomes an ~80s
+# sccache-backed rebuild. sccache is used ONLY here — it disables incremental,
+# which cripples the edit/rebuild inner loop (measured ~12x slower on
+# wado-compiler edits), so we hand off to incremental immediately after.
+# No-ops cleanly when sccache or the cache is absent (e.g. local dev).
+set -e -o pipefail
+export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cargo/sccache}"
+if ! command -v sccache >/dev/null 2>&1; then
+  echo "sccache not installed; skipping warm-cache (normal cold build applies)"
+  exit 0
+fi
+if [ ! -d "$SCCACHE_DIR" ] || [ -z "$(ls -A "$SCCACHE_DIR" 2>/dev/null)" ]; then
+  echo "no restored sccache cache at $SCCACHE_DIR; skipping warm-cache"
+  exit 0
+fi
+# 1) Reconstruct dependency artifacts fast from the content-addressed cache.
+RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 cargo build --workspace --locked
+sccache --show-stats || true
+# 2) Hand off to incremental so the first real edit is a fast relink rather
+#    than a full non-incremental recompile (sccache and incremental are
+#    mutually exclusive). Only the workspace crates rebuild here; the cached
+#    dependencies are reused.
+CARGO_INCREMENTAL=1 cargo build --workspace --locked
 """
 
 [tasks.on-task-done]


### PR DESCRIPTION
## Summary

The cargo-cache pipeline shipped only the **registry** (downloaded `.crate` files) to non-GitHub environments, so the ~440 dependencies were recompiled from scratch every web session (~8 min cold build): `target/` is re-cloned away while `CARGO_HOME` persists, so nothing carried the compiled artifacts across sessions.

This adds a content-addressed **sccache** layer to the same Actions-writes / container-reads GCS pipeline, cutting the first build from ~8 min to ~80s while keeping the fast incremental inner loop for development.

## Changes

- **`.github/workflows/cargo-cache.yml`** — compiles the workspace through sccache and uploads the cache alongside the registry (`cargo/sccache/linux-x86_64.tar.gz`). sccache's Rust cache key is path-sensitive (build-script `OUT_DIR` and dependency paths bake in), so the runner mirrors the container's absolute paths (`/home/user/wado`, `CARGO_HOME=/root/.cargo`, `target/`) — otherwise every entry misses.
- **`.claude/hooks/cargo-cache-restore.mts`** — restores both objects, independently and best-effort (read-only service account); a missing sccache object never blocks the registry restore.
- **`mise.toml`** — new `warm-cache` task (run by `on-task-started`) reconstructs `target/` from the restored cache, then hands off to incremental. sccache is used **only** for that one-shot warm-up because it disables incremental, which measured ~12× slower on `wado-compiler` edits. No-ops cleanly when the cache or sccache is absent (e.g. local dev).
- **`.claude/hooks/mise-setup.sh`** — installs sccache (distro build, matching the runner).
- **`.gitignore`** — covers `.sccache/`.

## Security boundary

Write access stays Actions-only (WIF + writer SA); the container reads with a read-only SA. This preserves the existing registry-cache trust boundary — the container never has cache-write credentials.

## Measured (in-container, path parity, `RUSTFLAGS=-D warnings`)

| Step | Result |
|------|--------|
| Cold `cargo build --workspace` | 491s |
| sccache warm rebuild (target dropped) | **90s**, 99.7% hit (609/611) |
| Incremental handoff (one-time) | 119s |
| Real edit to `wado-compiler` afterward | **10s** |

Path-sensitivity was confirmed by a controlled contrast (new target path: 471s full miss vs. matching path: 80s hit), which is why absolute-path parity is enforced in the workflow.

## Follow-up

The in-container producer→consumer path is fully validated. The cross-machine (runner→container) hit rate can only be confirmed after this workflow runs on `main`; both sides use rustup 1.96.1, so the compiler digest should match — worth a `sccache --show-stats` check on the first warmed session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121pFbvK95LHAMZM9YKnDAq

---
_Generated by [Claude Code](https://claude.ai/code/session_0121pFbvK95LHAMZM9YKnDAq)_