### PR TITLE
fix(cargo-cache): make the web container reuse CI's sccache compile cache

### DIFF
--- a/.claude/skills/rust/SKILL.md
+++ b/.claude/skills/rust/SKILL.md
@@ -6,5 +6,5 @@ description: Workspace-specific Rust rules that override common habits: panic in
 - Manage dependencies in the workspace `Cargo.toml`.
 - Use the `panic!` macro instead of falling back to meaningless dummy values or no-op implementations.
 - Use the `2024` edition.
-- Keep the code free of compiler warnings and Clippy lints.
+- Keep the code free of compiler warnings and Clippy lints. CI runs `clippy -D warnings`, so any warning or lint fails CI.
 - Avoid wildcard match arms (`_ => ...`) unless absolutely necessary.

--- a/.github/workflows/cargo-cache.yml
+++ b/.github/workflows/cargo-cache.yml
@@ -18,6 +18,11 @@
 # /home/user/wado/target. sccache itself is the distro build on both sides
 # (Ubuntu 24.04 `apt` sccache) so the on-disk cache format matches.
 #
+# CARGO_* ENV PARITY IS ALSO LOAD-BEARING. sccache hashes every CARGO_* env var
+# into the Rust cache key, so this job's CARGO_* set (CARGO_HOME,
+# CARGO_TARGET_DIR, CARGO_INCREMENTAL) must match the container's warm-cache
+# build (mise.toml) exactly.
+#
 # Required repo variables (none are secret — all are plain identifiers):
 #   vars.GCP_WIF_PROVIDER    workload identity provider resource name
 #   vars.GCP_CACHE_WRITER_SA writer service-account email (roles/storage.objectAdmin on the bucket)
@@ -48,7 +53,8 @@ env:
   CARGO_TARGET_DIR: /home/user/wado/target
   RUSTC_WRAPPER: sccache
   CARGO_INCREMENTAL: "0"
-  RUSTFLAGS: -D warnings # must match the container's mise [env]
+  # RUSTFLAGS is a sccache cache-key input; keep it identical to the container's
+  # mise [env] (both unset).
 
 jobs:
   upload:
@@ -67,6 +73,9 @@ jobs:
           sudo mkdir -p "$CONTAINER_REPO" "$CARGO_HOME"
           sudo cp -a "$GITHUB_WORKSPACE/." "$CONTAINER_REPO/"
           sudo chown -R "$(id -u):$(id -g)" "$CONTAINER_REPO" "$CARGO_HOME"
+          # cargo runs as the unprivileged runner user but writes $CARGO_HOME
+          # under /root (0700); make /root traversable so it can.
+          sudo chmod o+x /root
 
       - name: Fetch registry, then compile through sccache
         working-directory: /home/user/wado

--- a/mise.toml
+++ b/mise.toml
@@ -22,7 +22,6 @@ lockfile = true
 verbose = false
 
 [env]
-RUSTFLAGS = "-D warnings"
 _.path = ["vendor/wasmtime/target/release"]
 
 [tasks.on-task-started]
@@ -54,8 +53,13 @@ if [ ! -d "$SCCACHE_DIR" ] || [ -z "$(ls -A "$SCCACHE_DIR" 2>/dev/null)" ]; then
   echo "no restored sccache cache at $SCCACHE_DIR; skipping warm-cache"
   exit 0
 fi
-# 1) Reconstruct dependency artifacts fast from the content-addressed cache.
-RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 cargo build --workspace --locked
+# 1) Reconstruct dependency artifacts from the content-addressed cache.
+#    sccache hashes every CARGO_* env var into the Rust cache key, so expose
+#    exactly the CARGO_* set the cargo-cache.yml runner used — this container
+#    otherwise leaks CARGO_HTTP_CAINFO and drops the runner's three.
+unset $(compgen -e | grep '^CARGO_' || true)
+env CARGO_HOME="$HOME/.cargo" CARGO_TARGET_DIR="$PWD/target" CARGO_INCREMENTAL=0 \
+  RUSTC_WRAPPER=sccache cargo build --workspace --locked
 sccache --show-stats || true
 # 2) Hand off to incremental so the first real edit is a fast relink rather
 #    than a full non-incremental recompile (sccache and incremental are
@@ -184,7 +188,8 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 # vendor/wasmtime is a separate workspace tracking upstream dev; its source is
-# not warning-clean, so drop the repo-wide `-D warnings` for this build.
+# not warning-clean, so build it with an empty RUSTFLAGS to ignore any
+# deny-warnings flags inherited from the environment.
 RUSTFLAGS= cargo build --release -p wasmtime-cli --manifest-path vendor/wasmtime/Cargo.toml
 """
 


### PR DESCRIPTION
## Summary

The `cargo-cache` workflow publishes an sccache compile cache to GCS that the web container restores (via `.claude/hooks/cargo-cache-restore.mts` + the `warm-cache` mise task). It was never producing cross-environment hits, so every web session paid a full cold build. Two independent causes, both fixed here:

**1. The upload job failed before uploading.** It runs as the unprivileged runner user but builds with `CARGO_HOME` under `/root` (mode `0700`), which the runner cannot traverse — so `cargo` hit `EACCES` and the job died at `cargo fetch`. The sccache object was therefore never produced. → make `/root` traversable.

**2. Cross-environment sccache keys diverged.** sccache folds every `CARGO_*`-prefixed environment variable into the Rust cache key. The runner and the container exposed different `CARGO_*` sets — the container adds `CARGO_HTTP_CAINFO` (the agent-proxy CA bundle) and doesn't export `CARGO_HOME` / `CARGO_TARGET_DIR` / `CARGO_INCREMENTAL`. Every Rust key differed, so only `C/C++` entries hit and the whole Rust half missed. → `warm-cache` now reproduces the runner's exact `CARGO_*` set (scrub all `CARGO_*`, re-set the three the runner uses).

Measured on the web container: cold `~519s` → sccache-backed reconstruct `~90s`, **Rust cache hits 333/334 (~99.7%)**.

## Also

Drop the repo-wide `RUSTFLAGS=-D warnings` from mise `[env]`. It forced every local build to fail on warnings and is redundant with CI's `clippy -D warnings` (run via `tidy`). The `rust` skill now notes that CI still enforces warnings/lints even though local builds no longer deny them. (`RUSTFLAGS` is a sccache cache-key input, so it stays in lockstep with the workflow — both unset.)

## Changes

- `.github/workflows/cargo-cache.yml` — make `/root` traversable; drop `RUSTFLAGS`; document the `CARGO_*` env-parity requirement.
- `mise.toml` — `warm-cache` reproduces the runner's exact `CARGO_*` set; remove `RUSTFLAGS=-D warnings` from `[env]`.
- `.claude/skills/rust/SKILL.md` — note CI denies warnings/lints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014V3uoVj2bJtfpTbq2Zvo7D)_