### PR TITLE
fix(compiler): remove superlinear value-graph invalidation churn (Gale O3 OOM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/wado-cli/src/lib.rs
+++ b/wado-cli/src/lib.rs
@@ -36,6 +36,7 @@ pub mod publish;
 pub mod query;
 pub mod query_adapter;
 pub mod registry;
+mod rss;
 pub mod run;
 pub mod runtime;
 pub mod serve;

--- a/wado-cli/src/rss.rs
+++ b/wado-cli/src/rss.rs
@@ -35,7 +35,7 @@ fn to_mib(bytes: u64) -> u64 {
     (bytes + 512 * 1024) / (1024 * 1024)
 }
 
-pub(crate) fn heartbeat_suffix() -> Option<String> {
+pub(crate) fn live_suffix() -> Option<String> {
     RssSample::read().map(|s| format!(" · rss {}", s.current_peak_mib()))
 }
 

--- a/wado-cli/src/rss.rs
+++ b/wado-cli/src/rss.rs
@@ -1,0 +1,92 @@
+struct RssSample {
+    current: u64,
+    peak: u64,
+}
+
+impl RssSample {
+    fn read() -> Option<Self> {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        Self::parse(&status)
+    }
+
+    fn parse(status: &str) -> Option<Self> {
+        let current = parse_kib_field(status, "VmRSS:")?;
+        let peak = parse_kib_field(status, "VmHWM:").unwrap_or(current);
+        Some(Self { current, peak })
+    }
+
+    fn current_peak_mib(&self) -> String {
+        format!("{}/{} MiB", to_mib(self.current), to_mib(self.peak))
+    }
+}
+
+fn parse_kib_field(status: &str, key: &str) -> Option<u64> {
+    let kib: u64 = status
+        .lines()
+        .find_map(|line| line.strip_prefix(key))?
+        .split_whitespace()
+        .next()?
+        .parse()
+        .ok()?;
+    Some(kib * 1024)
+}
+
+fn to_mib(bytes: u64) -> u64 {
+    (bytes + 512 * 1024) / (1024 * 1024)
+}
+
+pub(crate) fn heartbeat_suffix() -> Option<String> {
+    RssSample::read().map(|s| format!(" · rss {}", s.current_peak_mib()))
+}
+
+pub(crate) fn summary_line() -> Option<String> {
+    RssSample::read().map(|s| format!("rss:     peak {} MiB", to_mib(s.peak)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_STATUS: &str = "\
+Name:\twado
+VmPeak:\t 2097152 kB
+VmSize:\t 1048576 kB
+VmHWM:\t   716800 kB
+VmRSS:\t   524288 kB
+Threads:\t8
+";
+
+    #[test]
+    fn parses_current_and_peak_rss() {
+        let sample = RssSample::parse(SAMPLE_STATUS).expect("both fields present");
+        assert_eq!(sample.current, 524288 * 1024);
+        assert_eq!(sample.peak, 716800 * 1024);
+        assert_eq!(sample.current_peak_mib(), "512/700 MiB");
+    }
+
+    #[test]
+    fn falls_back_to_current_when_peak_field_absent() {
+        let sample = RssSample::parse("VmRSS:\t 100 kB\n").expect("current present");
+        assert_eq!(sample.current, 100 * 1024);
+        assert_eq!(sample.peak, 100 * 1024);
+    }
+
+    #[test]
+    fn returns_none_without_a_current_field() {
+        assert!(RssSample::parse("VmHWM:\t 100 kB\n").is_none());
+        assert!(RssSample::parse("").is_none());
+    }
+
+    #[test]
+    fn field_key_match_is_exact_including_colon() {
+        let status = "VmRSSFoo:\t 999 kB\nVmRSS:\t 42 kB\nVmHWM:\t 84 kB\n";
+        let sample = RssSample::parse(status).expect("exact field present");
+        assert_eq!(sample.current, 42 * 1024);
+    }
+
+    #[test]
+    fn rounds_mib_to_nearest_rather_than_truncating_down() {
+        let just_under_512_mib = 512 * 1024 * 1024 - 100 * 1024;
+        assert_eq!(to_mib(just_under_512_mib), 512);
+    }
+}

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -1845,8 +1845,14 @@ pub(crate) fn format_three_axis_lines(
         lines.push(todo_line);
     }
     if let Some(d) = duration {
-        lines.push(format!("(wall: {d})"));
+        lines.extend(resource_summary_lines(d));
     }
+    lines
+}
+
+pub(crate) fn resource_summary_lines(wall: &str) -> Vec<String> {
+    let mut lines = vec![format!("wall:    {wall}")];
+    lines.extend(crate::rss::summary_line());
     lines
 }
 

--- a/wado-cli/src/test_report.rs
+++ b/wado-cli/src/test_report.rs
@@ -263,7 +263,7 @@ fn print_heartbeat(state: &HeartbeatState) {
     println!(
         "[{}] {done}/{total} files{pct} · {counts}{eta}{}",
         test::format_duration(elapsed),
-        crate::rss::heartbeat_suffix().unwrap_or_default()
+        crate::rss::live_suffix().unwrap_or_default()
     );
 }
 
@@ -643,18 +643,19 @@ impl TestReporter for TapReporter {
 
     fn on_compile(&self, path: &str, event: CompileEvent, duration: Duration) {
         let dur = test::format_duration(duration);
+        let rss = crate::rss::live_suffix().unwrap_or_default();
         match event {
-            CompileEvent::Ok => self.comment(&format!("Compiled {path} ({dur})")),
+            CompileEvent::Ok => self.comment(&format!("Compiled {path} ({dur}){rss}")),
             CompileEvent::TodoModule => {
                 self.comment(&format!(
-                    "Compiled {path} (TODO module, compile error expected, {dur})"
+                    "Compiled {path} (TODO module, compile error expected, {dur}){rss}"
                 ));
                 self.doc().register_standalone(format!(
                     "ok - {path} # TODO module compile error expected"
                 ));
             }
             CompileEvent::Failed { detail } => {
-                self.comment(&format!("FAILED to compile {path} ({dur})"));
+                self.comment(&format!("FAILED to compile {path} ({dur}){rss}"));
                 let mut block = vec![format!("not ok - {path} (compile failed)")];
                 if let Some(msg) = detail {
                     block.extend(yaml_block("", &[("message", &msg)]));

--- a/wado-cli/src/test_report.rs
+++ b/wado-cli/src/test_report.rs
@@ -189,7 +189,9 @@ impl TestReporter for VerboseReporter {
             println!("=== aggregate ===");
             test::print_three_axis(grand, Some(&total_dur));
         } else {
-            println!("(wall: {total_dur})");
+            for line in test::resource_summary_lines(&total_dur) {
+                println!("{line}");
+            }
         }
     }
 }
@@ -259,8 +261,9 @@ fn print_heartbeat(state: &HeartbeatState) {
     }
 
     println!(
-        "[{}] {done}/{total} files{pct} · {counts}{eta}",
-        test::format_duration(elapsed)
+        "[{}] {done}/{total} files{pct} · {counts}{eta}{}",
+        test::format_duration(elapsed),
+        crate::rss::heartbeat_suffix().unwrap_or_default()
     );
 }
 

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -441,6 +441,9 @@ struct Builder<'a> {
     body: &'a Body,
     pool: ValuePool,
     value_of: IndexMap<ExprId, ValueId>,
+    block_writes: IndexMap<BlockId, std::rc::Rc<crate::hashmap::IndexSet<u32>>>,
+    fresh_invalidations: crate::hashmap::IndexSet<u32>,
+    mut_escaped_sorted: Vec<u32>,
     /// `local_index → current Value` at the current program point. Cloned at
     /// branch entries so each arm walks from the pre-branch snapshot.
     current_value: IndexMap<u32, ValueId>,
@@ -501,12 +504,19 @@ impl<'a> Builder<'a> {
             body,
             pool,
             value_of: IndexMap::default(),
+            block_writes: IndexMap::default(),
+            fresh_invalidations: crate::hashmap::IndexSet::default(),
             current_value: IndexMap::default(),
             heap_state: HeapState::new(),
             field_store: IndexMap::default(),
             aliased: aliased.clone(),
             untrackable: untrackable.clone(),
             mut_escaped: mut_escaped.clone(),
+            mut_escaped_sorted: {
+                let mut v: Vec<u32> = mut_escaped.iter().copied().collect();
+                v.sort_unstable();
+                v
+            },
             ref_targets: IndexMap::default(),
             type_table,
             loop_entry_values: IndexMap::default(),
@@ -721,30 +731,17 @@ impl<'a> Builder<'a> {
     /// `mut_escaped` receiver's field version stable across it.
     fn bump_call_effects(&mut self, call: ExprId) {
         let pure = self.pure_calls.contains(&call);
-        let mut targets: Vec<u32> = if pure {
-            self.mut_escaped
-                .iter()
-                .filter(|l| self.untrackable.contains(*l))
-                .copied()
-                .collect()
-        } else {
-            self.mut_escaped.iter().copied().collect()
-        };
-        // Mint the opaques by ascending local index, not `mut_escaped`'s
-        // insertion order: opaque `ValueId`s are handed out in mint order, so
+        // Iterate ascending local index, not `mut_escaped`'s insertion order:
+        // opaque `ValueId`s and heap versions are handed out in visit order, so
         // this keeps the value graph a deterministic function of the program
         // regardless of how the alias sets were built (#1440).
-        targets.sort_unstable();
-        for l in targets {
+        for i in 0..self.mut_escaped_sorted.len() {
+            let l = self.mut_escaped_sorted[i];
+            if pure && !self.untrackable.contains(&l) {
+                continue;
+            }
             self.heap_state.bump_local(l);
-            // A `&mut`-escaped local's *scalar* value can also be overwritten by
-            // the callee (`set_bool(&mut c, false)`), not only its heap fields, so
-            // drop its tracked `current_value` to a fresh opaque. Without this the
-            // graph keeps the pre-call constant (`c = true`) for reads after the
-            // call — a stale value the WIR codegen ignores (it reads the slot) but
-            // that over-merges with the call result a fresh build splits.
-            let opaque = self.pool.fresh_opaque_with_source(OpaqueSource::Local(l));
-            self.current_value.insert(l, opaque);
+            self.invalidate_local_with_source(l, Some(OpaqueSource::Local(l)));
         }
     }
 
@@ -753,7 +750,7 @@ impl<'a> Builder<'a> {
             // A parameter's value re-emits as `local.get idx` — record the
             // source so the extractor can materialise a promoted value over it.
             let opaque = self.pool.fresh_opaque_with_source(OpaqueSource::Local(idx));
-            self.current_value.insert(idx, opaque);
+            self.set_local_value(idx, opaque);
         }
     }
 
@@ -773,7 +770,7 @@ impl<'a> Builder<'a> {
                     self.pool
                         .fresh_opaque_with_source(OpaqueSource::Local(local_index))
                 });
-                self.current_value.insert(local_index, v);
+                self.set_local_value(local_index, v);
                 // `let x = S { f: lit, … }` binds `x` to a fresh opaque; seed
                 // each pure field so a later `x.f` read forwards the literal.
                 // A promoted constant binding has no struct fields / ref target.
@@ -893,6 +890,7 @@ impl<'a> Builder<'a> {
                     // mutates goes Opaque and any field it writes is
                     // invalidated (both below). Else `false && { x = 2; true }`
                     // would commit `x = 2` and forward the never-stored value.
+                    self.fresh_invalidations.clear();
                     let saved_cur = self.current_value.clone();
                     let rhs = self.walk_operand(right);
                     let changed: crate::hashmap::IndexSet<u32> = self
@@ -904,7 +902,7 @@ impl<'a> Builder<'a> {
                         .collect();
                     for &k in &changed {
                         let opaque = self.pool.fresh_opaque();
-                        self.current_value.insert(k, opaque);
+                        self.set_local_value(k, opaque);
                     }
                     // A reference the conditionally-run rhs reassigned (or whose
                     // pointee it reassigned) no longer has a known target.
@@ -991,7 +989,7 @@ impl<'a> Builder<'a> {
                     .unwrap_or_else(|| self.pool.fresh_opaque());
                 match target_kind {
                     ExprKind::Local { index, .. } => {
-                        self.current_value.insert(index, v);
+                        self.set_local_value(index, v);
                         // `local = S { f: lit, … }` rebinds `local` to a fresh
                         // object; seed each pure field like the `Let` case so a
                         // later `local.f` read forwards the literal.
@@ -1376,12 +1374,13 @@ impl<'a> Builder<'a> {
 
     fn read_local(&mut self, idx: u32) -> ValueId {
         if let Some(&v) = self.current_value.get(&idx) {
+            self.fresh_invalidations.swap_remove(&idx);
             v
         } else {
             // Unbound locals shouldn't occur on well-typed NIR; cache a
             // fresh Opaque so subsequent reads agree.
             let v = self.pool.fresh_opaque_with_source(OpaqueSource::Local(idx));
-            self.current_value.insert(idx, v);
+            self.set_local_value(idx, v);
             v
         }
     }
@@ -1392,7 +1391,7 @@ impl<'a> Builder<'a> {
                 let v = self
                     .pool
                     .fresh_opaque_with_source(OpaqueSource::Local(local_index));
-                self.current_value.insert(local_index, v);
+                self.set_local_value(local_index, v);
             }
             PatKind::Tuple(children, _) => {
                 for c in children {
@@ -1426,7 +1425,8 @@ impl<'a> Builder<'a> {
 
     /// Capture all flow-sensitive state (`current_value`, `heap_state`,
     /// `ref_targets`) at the current program point as one [`FlowSnapshot`].
-    fn flow_snapshot(&self) -> FlowSnapshot {
+    fn flow_snapshot(&mut self) -> FlowSnapshot {
+        self.fresh_invalidations.clear();
         FlowSnapshot {
             current_value: self.current_value.clone(),
             heap: self.heap_state.snapshot(),
@@ -1437,9 +1437,29 @@ impl<'a> Builder<'a> {
     /// Reset all flow-sensitive state to a previously captured snapshot. Used
     /// between branch arms so each arm walks from the common pre-branch state.
     fn flow_restore(&mut self, snap: &FlowSnapshot) {
+        self.fresh_invalidations.clear();
         self.current_value.clone_from(&snap.current_value);
         self.heap_state.restore(snap.heap.clone());
         self.ref_targets.clone_from(&snap.ref_targets);
+    }
+
+    fn set_local_value(&mut self, idx: u32, v: ValueId) {
+        self.fresh_invalidations.swap_remove(&idx);
+        self.current_value.insert(idx, v);
+    }
+
+    fn invalidate_local_with_source(&mut self, idx: u32, source: Option<OpaqueSource>) {
+        if self.current_value.contains_key(&idx) && self.fresh_invalidations.insert(idx) {
+            let opaque = match source {
+                Some(s) => self.pool.fresh_opaque_with_source(s),
+                None => self.pool.fresh_opaque(),
+            };
+            self.current_value.insert(idx, opaque);
+        }
+    }
+
+    fn invalidate_local(&mut self, idx: u32) {
+        self.invalidate_local_with_source(idx, None);
     }
 
     /// Join an if-style two-arm endpoint over all three flow components at
@@ -1516,7 +1536,7 @@ impl<'a> Builder<'a> {
             } else {
                 self.pool.fresh_opaque()
             };
-            self.current_value.insert(idx, merged);
+            self.set_local_value(idx, merged);
         }
     }
 
@@ -1547,7 +1567,7 @@ impl<'a> Builder<'a> {
             } else {
                 consensus.unwrap_or(saved_v)
             };
-            self.current_value.insert(idx, merged);
+            self.set_local_value(idx, merged);
         }
     }
 
@@ -1733,15 +1753,17 @@ impl<'a> Builder<'a> {
                 any_guard = true;
                 // A promoted constant guard (`Operand::Value`) writes nothing.
                 if let Some(ge) = g.as_expr() {
-                    collect_writes_in_expr(self.body, ge, &mut guard_writes);
+                    collect_writes_in_expr(
+                        self.body,
+                        ge,
+                        &mut guard_writes,
+                        &mut self.block_writes,
+                    );
                 }
             }
         }
-        for idx in &guard_writes {
-            if self.current_value.contains_key(idx) {
-                let opaque = self.pool.fresh_opaque();
-                self.current_value.insert(*idx, opaque);
-            }
+        for &idx in &guard_writes {
+            self.invalidate_local(idx);
         }
         self.drop_ref_targets_for(&guard_writes);
         if any_guard {
@@ -1782,12 +1804,12 @@ impl<'a> Builder<'a> {
     /// non-builtin call — keeps its pre-loop version, so a `table.used = 256`
     /// before a builtin-only loop still forwards inside and after it.
     fn walk_loop(&mut self, body_block: crate::nir_arena::BlockId) {
-        let mut writes: crate::hashmap::IndexSet<u32> = crate::hashmap::IndexSet::default();
-        collect_writes_in_block(self.body, body_block, &mut writes);
+        let writes = writes_of_block(self.body, body_block, &mut self.block_writes);
         let heap_effects =
             collect_loop_heap_effects(self.body, &self.pure_builtin_callees, body_block);
         // Snapshot before the reassigned-local opaques below overwrite the
         // written locals' pre-loop values.
+        self.fresh_invalidations.clear();
         self.loop_entry_values
             .insert(body_block, self.current_value.clone());
         // Born-as-operands: give each written local a `LoopPhi { entry, body_iter }`
@@ -1798,19 +1820,19 @@ impl<'a> Builder<'a> {
         // `body_iter` is patched to the post-body value below. A local whose entry
         // value has no recorded type falls back to a fresh opaque.
         let mut phis: Vec<(u32, ValueId)> = Vec::new();
-        for idx in &writes {
-            let Some(&entry) = self.current_value.get(idx) else {
+        for &idx in writes.iter() {
+            let Some(&entry) = self.current_value.get(&idx) else {
                 continue;
             };
             let phi = match self.pool.type_of(entry) {
                 Some(ty) => {
                     let phi = self.pool.alloc_loop_phi(entry, ty);
-                    phis.push((*idx, phi));
+                    phis.push((idx, phi));
                     phi
                 }
                 None => self.pool.fresh_opaque(),
             };
-            self.current_value.insert(*idx, phi);
+            self.set_local_value(idx, phi);
         }
         self.drop_ref_targets_for(&writes);
         self.apply_loop_heap_effects(&heap_effects);
@@ -1827,11 +1849,8 @@ impl<'a> Builder<'a> {
                 self.pool.set_loop_phi_body_iter(*phi, body_val);
             }
         }
-        for idx in &writes {
-            if self.current_value.contains_key(idx) {
-                let opaque = self.pool.fresh_opaque();
-                self.current_value.insert(*idx, opaque);
-            }
+        for &idx in writes.iter() {
+            self.invalidate_local(idx);
         }
         self.drop_ref_targets_for(&writes);
         self.apply_loop_heap_effects(&heap_effects);
@@ -1872,16 +1891,30 @@ impl<'a> Builder<'a> {
     /// never sees. Locals not written in the subtree keep their pre-block
     /// value.
     fn dirty_all_writes_in_block(&mut self, block: crate::nir_arena::BlockId) {
-        let mut writes: crate::hashmap::IndexSet<u32> = crate::hashmap::IndexSet::default();
-        collect_writes_in_block(self.body, block, &mut writes);
-        for idx in &writes {
-            if self.current_value.contains_key(idx) {
-                let opaque = self.pool.fresh_opaque();
-                self.current_value.insert(*idx, opaque);
-            }
+        let writes = writes_of_block(self.body, block, &mut self.block_writes);
+        for &idx in writes.iter() {
+            self.invalidate_local(idx);
         }
         self.drop_ref_targets_for(&writes);
     }
+}
+
+fn writes_of_block(
+    body: &Body,
+    block: crate::nir_arena::BlockId,
+    cache: &mut IndexMap<BlockId, std::rc::Rc<crate::hashmap::IndexSet<u32>>>,
+) -> std::rc::Rc<crate::hashmap::IndexSet<u32>> {
+    if let Some(ws) = cache.get(&block) {
+        return std::rc::Rc::clone(ws);
+    }
+    let mut out = crate::hashmap::IndexSet::default();
+    let stmts = body.blocks[block].stmts.clone();
+    for s in stmts {
+        collect_writes_in_stmt(body, s, &mut out, cache);
+    }
+    let rc = std::rc::Rc::new(out);
+    cache.insert(block, std::rc::Rc::clone(&rc));
+    rc
 }
 
 /// Whether `block`'s subtree contains a `break` targeting `label`. Used by
@@ -2075,49 +2108,63 @@ fn collect_writes_in_block(
     body: &Body,
     block: crate::nir_arena::BlockId,
     out: &mut crate::hashmap::IndexSet<u32>,
+    cache: &mut IndexMap<BlockId, std::rc::Rc<crate::hashmap::IndexSet<u32>>>,
 ) {
-    let stmts = body.blocks[block].stmts.clone();
-    for s in stmts {
-        collect_writes_in_stmt(body, s, out);
-    }
+    let ws = writes_of_block(body, block, cache);
+    out.extend(ws.iter().copied());
 }
 
-fn collect_writes_in_stmt(body: &Body, stmt: StmtId, out: &mut crate::hashmap::IndexSet<u32>) {
+fn collect_writes_in_stmt(
+    body: &Body,
+    stmt: StmtId,
+    out: &mut crate::hashmap::IndexSet<u32>,
+    cache: &mut IndexMap<BlockId, std::rc::Rc<crate::hashmap::IndexSet<u32>>>,
+) {
     match &body.stmts[stmt].kind {
         StmtKind::Let {
             local_index, value, ..
         } => {
             out.insert(*local_index);
             if let Some(ve) = value.as_expr() {
-                collect_writes_in_expr(body, ve, out);
+                collect_writes_in_expr(body, ve, out, cache);
             }
         }
         StmtKind::LetDestructure { pattern, value, .. } => {
-            collect_writes_in_pattern(body, *pattern, out);
-            collect_writes_in_operand(body, *value, out);
+            collect_writes_in_pattern(body, *pattern, out, cache);
+            collect_writes_in_operand(body, *value, out, cache);
         }
         _ => {
             let mut kids = Vec::new();
             body.for_each_child(NodeRef::Stmt(stmt), |c| kids.push(c));
             for c in kids {
                 match c {
-                    NodeRef::Expr(e) => collect_writes_in_expr(body, e, out),
-                    NodeRef::Stmt(s) => collect_writes_in_stmt(body, s, out),
-                    NodeRef::Block(b) => collect_writes_in_block(body, b, out),
-                    NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out),
+                    NodeRef::Expr(e) => collect_writes_in_expr(body, e, out, cache),
+                    NodeRef::Stmt(s) => collect_writes_in_stmt(body, s, out, cache),
+                    NodeRef::Block(b) => collect_writes_in_block(body, b, out, cache),
+                    NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out, cache),
                 }
             }
         }
     }
 }
 
-fn collect_writes_in_operand(body: &Body, op: Operand, out: &mut crate::hashmap::IndexSet<u32>) {
+fn collect_writes_in_operand(
+    body: &Body,
+    op: Operand,
+    out: &mut crate::hashmap::IndexSet<u32>,
+    cache: &mut IndexMap<BlockId, std::rc::Rc<crate::hashmap::IndexSet<u32>>>,
+) {
     if let Some(e) = op.as_expr() {
-        collect_writes_in_expr(body, e, out);
+        collect_writes_in_expr(body, e, out, cache);
     }
 }
 
-fn collect_writes_in_expr(body: &Body, expr: ExprId, out: &mut crate::hashmap::IndexSet<u32>) {
+fn collect_writes_in_expr(
+    body: &Body,
+    expr: ExprId,
+    out: &mut crate::hashmap::IndexSet<u32>,
+    cache: &mut IndexMap<BlockId, std::rc::Rc<crate::hashmap::IndexSet<u32>>>,
+) {
     if let ExprKind::Assign { target, .. } = &body.exprs[expr].kind
         && let ExprKind::Local { index, .. } = &body.exprs[*target].kind
     {
@@ -2127,15 +2174,20 @@ fn collect_writes_in_expr(body: &Body, expr: ExprId, out: &mut crate::hashmap::I
     body.for_each_child(NodeRef::Expr(expr), |c| kids.push(c));
     for c in kids {
         match c {
-            NodeRef::Expr(e) => collect_writes_in_expr(body, e, out),
-            NodeRef::Stmt(s) => collect_writes_in_stmt(body, s, out),
-            NodeRef::Block(b) => collect_writes_in_block(body, b, out),
-            NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out),
+            NodeRef::Expr(e) => collect_writes_in_expr(body, e, out, cache),
+            NodeRef::Stmt(s) => collect_writes_in_stmt(body, s, out, cache),
+            NodeRef::Block(b) => collect_writes_in_block(body, b, out, cache),
+            NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out, cache),
         }
     }
 }
 
-fn collect_writes_in_pattern(body: &Body, pat: PatId, out: &mut crate::hashmap::IndexSet<u32>) {
+fn collect_writes_in_pattern(
+    body: &Body,
+    pat: PatId,
+    out: &mut crate::hashmap::IndexSet<u32>,
+    cache: &mut IndexMap<BlockId, std::rc::Rc<crate::hashmap::IndexSet<u32>>>,
+) {
     if let PatKind::Binding { local_index, .. } = &body.pats[pat].kind {
         out.insert(*local_index);
     } else {
@@ -2143,8 +2195,8 @@ fn collect_writes_in_pattern(body: &Body, pat: PatId, out: &mut crate::hashmap::
         body.for_each_child(NodeRef::Pat(pat), |c| kids.push(c));
         for c in kids {
             match c {
-                NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out),
-                NodeRef::Expr(e) => collect_writes_in_expr(body, e, out),
+                NodeRef::Pat(p) => collect_writes_in_pattern(body, p, out, cache),
+                NodeRef::Expr(e) => collect_writes_in_expr(body, e, out, cache),
                 _ => {}
             }
         }

--- a/wado-compiler/tests/generated/fixtures/http_fields_immutable_errors.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_fields_immutable_errors.wir.wado
@@ -1129,7 +1129,6 @@ fn "http_fields_immutable_errors.wado/__cm_binding__Fields_set"(self, name, valu
     let __value_base: i32;
     let __value_i: i32;
     let __value_addr: i32;
-    let __value_elem: ref "core:prelude//List<u8>";
     let __list_len: i32;
     let __list_base: i32;
     let __list_i: i32;
@@ -1147,7 +1146,7 @@ fn "http_fields_immutable_errors.wado/__cm_binding__Fields_set"(self, name, valu
     let len_44: i32;
     let arr: ref Array<u8>;
     let _licm_repr_47: ref "Array<core:prelude/list.wado/List<u8>>";
-    let _licm_repr_49: ref Array<u8>;
+    let __sroa___value_elem_repr: ref Array<u8>;
     __name_packed = "core:rt/cm_lower_string"(name);
     __value_len = value.used;
     __value_base = "mem/realloc"(0, 0, 4, __value_len * 8);
@@ -1158,16 +1157,22 @@ fn "http_fields_immutable_errors.wado/__cm_binding__Fields_set"(self, name, valu
             break_if b79 __value_i >= __value_len;
             __value_addr = __value_base + (__value_i * 8);
             v_23 = builtin::array_get<ref "core:prelude//List<u8>">(_licm_repr_47, __value_i);
-            __value_elem = struct.new "core:prelude//List<u8>" { repr: ref.as_non_null(let __array_clone_src_2: ref Array<u8>; __array_clone_src_2 = v_23.repr; let __array_clone_len_2: i32; __array_clone_len_2 = builtin::array_len(__array_clone_src_2); let __array_clone_dst_2: ref Array<u8>; __array_clone_dst_2 = builtin::array_new<u8>(__array_clone_len_2); builtin::array_copy<u8>(__array_clone_dst_2, 0, __array_clone_src_2, 0, __array_clone_len_2); __array_clone_dst_2), used: v_23.used };
-            __list_len = __value_elem.used;
+            let __array_clone_src_2: ref Array<u8>;
+            __array_clone_src_2 = v_23.repr;
+            let __array_clone_len_2: i32;
+            __array_clone_len_2 = builtin::array_len(__array_clone_src_2);
+            let __array_clone_dst_2: ref Array<u8>;
+            __array_clone_dst_2 = builtin::array_new<u8>(__array_clone_len_2);
+            builtin::array_copy<u8>(__array_clone_dst_2, 0, __array_clone_src_2, 0, __array_clone_len_2);
+            __sroa___value_elem_repr = __array_clone_dst_2;
+            __list_len = v_23.used;
             __list_base = "mem/realloc"(0, 0, 1, __list_len * 1);
             __list_i = 0;
-            _licm_repr_49 = __value_elem.repr;
             b81: block {
                 l82: loop {
                     break_if b81 __list_i >= __list_len;
                     __list_addr = __list_base + (__list_i * 1);
-                    __list_elem = builtin::array_get<u8>(_licm_repr_49, __list_i);
+                    __list_elem = builtin::array_get<u8>(__sroa___value_elem_repr, __list_i);
                     builtin::store_u8(__list_addr, __list_elem);
                     __list_i = __list_i + 1;
                     continue l82;

--- a/wado-compiler/tests/generated/fixtures/http_fields_set.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/http_fields_set.wir.wado
@@ -981,7 +981,6 @@ fn "http_fields_set.wado/__cm_binding__Fields_set"(self, name, value) with Field
     let __value_base: i32;
     let __value_i: i32;
     let __value_addr: i32;
-    let __value_elem: ref "core:prelude//List<u8>";
     let __list_len: i32;
     let __list_base: i32;
     let __list_i: i32;
@@ -999,7 +998,7 @@ fn "http_fields_set.wado/__cm_binding__Fields_set"(self, name, value) with Field
     let len_44: i32;
     let arr: ref Array<u8>;
     let _licm_repr_47: ref "Array<core:prelude/list.wado/List<u8>>";
-    let _licm_repr_49: ref Array<u8>;
+    let __sroa___value_elem_repr: ref Array<u8>;
     __name_packed = "core:rt/cm_lower_string"(name);
     __value_len = value.used;
     __value_base = "mem/realloc"(0, 0, 4, __value_len * 8);
@@ -1010,16 +1009,22 @@ fn "http_fields_set.wado/__cm_binding__Fields_set"(self, name, value) with Field
             break_if b71 __value_i >= __value_len;
             __value_addr = __value_base + (__value_i * 8);
             v_23 = builtin::array_get<ref "core:prelude//List<u8>">(_licm_repr_47, __value_i);
-            __value_elem = struct.new "core:prelude//List<u8>" { repr: ref.as_non_null(let __array_clone_src_2: ref Array<u8>; __array_clone_src_2 = v_23.repr; let __array_clone_len_2: i32; __array_clone_len_2 = builtin::array_len(__array_clone_src_2); let __array_clone_dst_2: ref Array<u8>; __array_clone_dst_2 = builtin::array_new<u8>(__array_clone_len_2); builtin::array_copy<u8>(__array_clone_dst_2, 0, __array_clone_src_2, 0, __array_clone_len_2); __array_clone_dst_2), used: v_23.used };
-            __list_len = __value_elem.used;
+            let __array_clone_src_2: ref Array<u8>;
+            __array_clone_src_2 = v_23.repr;
+            let __array_clone_len_2: i32;
+            __array_clone_len_2 = builtin::array_len(__array_clone_src_2);
+            let __array_clone_dst_2: ref Array<u8>;
+            __array_clone_dst_2 = builtin::array_new<u8>(__array_clone_len_2);
+            builtin::array_copy<u8>(__array_clone_dst_2, 0, __array_clone_src_2, 0, __array_clone_len_2);
+            __sroa___value_elem_repr = __array_clone_dst_2;
+            __list_len = v_23.used;
             __list_base = "mem/realloc"(0, 0, 1, __list_len * 1);
             __list_i = 0;
-            _licm_repr_49 = __value_elem.repr;
             b73: block {
                 l74: loop {
                     break_if b73 __list_i >= __list_len;
                     __list_addr = __list_base + (__list_i * 1);
-                    __list_elem = builtin::array_get<u8>(_licm_repr_49, __list_i);
+                    __list_elem = builtin::array_get<u8>(__sroa___value_elem_repr, __list_i);
                     builtin::store_u8(__list_addr, __list_elem);
                     __list_i = __list_i + 1;
                     continue l74;


### PR DESCRIPTION
Resolves the intermittent `Test (Gale O2/O3)` CI failures — a false-red "1 compile failed" that never reproduced locally at `-O2`.

## Root cause & fix — `fix(compiler)`

At `-O3`, inline-expanded Gale generator functions (one reaches ~166k NIR exprs, thousands of `mut_escaped` locals, hundreds of nested splice blocks) drove the value-graph builder's scratch re-walk to allocate ~34.6M invalidation `Opaque`s for a **single** function — ~27s and +4.2 GiB transient per compile. Under `wado test`'s 4-way compile parallelism this OOM-killed the 16 GiB runner.

Three compounding superlinear terms in the builder are removed, all semantics-preserving:

- `fresh_invalidations` — a local already holding a still-unobserved invalidation `Opaque` is not re-invalidated (a second indistinguishable `Opaque` changes nothing observable). The dedup lives in one choke point; the set clears whenever `current_value` identities escape and drops entries on read/rebind.
- `writes_of_block` — per-block subtree write sets are memoized, so the nested labeled-block (inline splice) invalidation scans are linear instead of quadratic.
- `mut_escaped_sorted` — the deterministic mint order (#1440) comes from one precomputed sort rather than a per-call-site sort.

Effect: the pathological fixture (`codegen_label_collision_test.wado` at `-O3`) drops from 85s / 5.6 GiB peak to ~24s / ~1.7 GiB. The full `wado test -O3 package-gale` suite goes from an OOM-kill (~15.9 GiB, 46/1358 files) to completing at ~5.7 GiB peak, 0 failed. On the CI runner the `Test (Gale O3)` peak RSS drops from ~14.5 GiB (against the 16 GiB limit) to ~6 GiB.

## Diagnostics — `feat(cli)`

`wado test` now reports process RSS, which is what turned the opaque "1 compile failed" into a measurable memory signal:

- a `· rss <current>/<peak> MiB` suffix on the heartbeat digest;
- the same suffix on each TAP per-file `Compiled` / `FAILED to compile` line, so a mid-run OOM-kill's memory trajectory survives in the CI log even though the final summary never prints;
- an aligned `rss:` line in the final resource summary (heartbeat/verbose/tap).

Sampled from `/proc/self/status` on Linux; omitted elsewhere.

## CI — `ci`

Adds `workflow_dispatch` to the CI workflow so the full matrix (including the Gale jobs) can be run on a branch without opening a PR.

Closes #1648.

---
_Generated by [Claude Code](https://claude.ai/code/session_012yuo4PpVAHQwFoqdJ3vn5e)_