### PR TITLE
fix(cli): embed WIT component-type for kiln generator consumers

### DIFF
--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1144,6 +1144,16 @@ fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
     Ok(wat)
 }
 
+/// Report a WIT-embedding failure per `explicit`: fatal for `--embed-wit`,
+/// a warning (yielding the un-embedded, still valid component) otherwise.
+fn skip_embed(explicit: bool, wasm: Vec<u8>, msg: &str) -> Result<Vec<u8>, CliExit> {
+    if explicit {
+        return Err(CliExit::error(format!("--embed-wit: {msg}")));
+    }
+    eprintln!("warning: skipped embedding WIT component-type section: {msg}");
+    Ok(wasm)
+}
+
 /// Append the WIT `component-type` section to `wasm`, using `world_imports`
 /// (the faithful plan read from the main compile's retained WIR, so no second
 /// optimize pass). `explicit` is true for `--embed-wit`: it makes a failure
@@ -1151,7 +1161,6 @@ fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
 /// (still valid, self-describing) component.
 async fn embed_wit_section(
     opts: &CompileOptions,
-    project: Option<&manifest::ProjectManifest>,
     wasm: Vec<u8>,
     world_imports: Vec<String>,
     explicit: bool,
@@ -1164,28 +1173,43 @@ async fn embed_wit_section(
     };
 
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
-    // Attach the manifest `[dependencies]` so a multi-package project's
-    // re-analysis resolves the same imports the main compile did; a quiet host
-    // avoids re-emitting diagnostics.
-    let host = attach_manifest_deps(
+    // Mirror the main compile's analysis environment — the nearest manifest's
+    // dependency index (with prebuilt registry components, warm from the main
+    // compile) and the kiln pipeline's generator redirects — so a
+    // `with { generator }` consumer re-analyzes exactly as it compiled
+    // (issue #1646). A quiet host avoids re-emitting diagnostics; the pipeline
+    // is cache-aware, so this reuses the main compile's outputs.
+    let manifest_pair = load_nearest_manifest(path);
+    let host = match attach_manifest_and_component_deps(
         FilesystemCompilerHost::silent(base_path.clone()),
-        project,
+        manifest_pair.as_ref(),
         &base_path,
-    );
+        &source,
+        false,
+    )
+    .await
+    {
+        Ok(host) => host,
+        Err(e) => {
+            return skip_embed(explicit, wasm, &format!("resolving dependencies: {e}"));
+        }
+    };
+    let invocations = match maybe_run_pipeline(path, &host, false, manifest_pair).await {
+        Ok(outcome) => outcome.invocations,
+        Err(e) => {
+            return skip_embed(explicit, wasm, &format!("running kiln generators: {e}"));
+        }
+    };
     let mut sem = wado_compiler::semantics_for_world(
         &source,
         &host,
         Some(input),
         opts.target_world.as_deref(),
+        invocations,
     )
     .await;
     if !sem.is_complete() {
-        let msg = "WIT analysis did not complete";
-        if explicit {
-            return Err(CliExit::error(format!("--embed-wit: {msg}")));
-        }
-        eprintln!("warning: skipped embedding WIT component-type section: {msg}");
-        return Ok(wasm);
+        return skip_embed(explicit, wasm, "WIT analysis did not complete");
     }
     sem.set_wit_contract(wado_compiler::wit_emit::wit_contract(
         opts.target_world.as_deref(),
@@ -1195,11 +1219,7 @@ async fn embed_wit_section(
 
     match wit_bundle::embed_component_type(&wasm, &sem, &world_imports) {
         Ok(embedded) => Ok(embedded),
-        Err(e) if explicit => Err(CliExit::error(format!("--embed-wit: {e}"))),
-        Err(e) => {
-            eprintln!("warning: skipped embedding WIT component-type section: {e}");
-            Ok(wasm)
-        }
+        Err(e) => skip_embed(explicit, wasm, &e.to_string()),
     }
 }
 
@@ -1323,7 +1343,10 @@ pub async fn run_returning_bytes(opts: CompileOptions) -> Result<Vec<u8>, CliExi
                     .wir_package
                     .map(|p| p.imported_cm_interfaces)
                     .unwrap_or_default();
-                embed_wit_section(&opts, project.as_ref(), wasm, world_imports, explicit).await?
+                // Box the embedding future: it re-runs the frontend and Kiln
+                // pipeline, so inlining its state would push the enclosing
+                // build-driver future past clippy's `large_futures` threshold.
+                Box::pin(embed_wit_section(&opts, wasm, world_imports, explicit)).await?
             } else {
                 wasm
             };

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -1144,14 +1144,38 @@ fn wasm_to_wat(wasm: &[u8]) -> Result<String, CliExit> {
     Ok(wat)
 }
 
-/// Report a WIT-embedding failure per `explicit`: fatal for `--embed-wit`,
-/// a warning (yielding the un-embedded, still valid component) otherwise.
+/// Fatal under `--embed-wit`, otherwise a warning that yields the un-embedded
+/// (still valid, self-describing) component.
 fn skip_embed(explicit: bool, wasm: Vec<u8>, msg: &str) -> Result<Vec<u8>, CliExit> {
     if explicit {
         return Err(CliExit::error(format!("--embed-wit: {msg}")));
     }
     eprintln!("warning: skipped embedding WIT component-type section: {msg}");
     Ok(wasm)
+}
+
+/// The silent analysis host and kiln redirects the main compile produced, so a
+/// `with { generator }` consumer re-analyzes exactly as it compiled. The kiln
+/// pipeline is cache-aware, so this reuses the main compile's outputs.
+async fn reanalysis_env(
+    path: &Path,
+    source: &str,
+) -> Result<(FilesystemCompilerHost, wado_compiler::kiln::InvocationIndex), String> {
+    let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
+    let manifest_pair = load_nearest_manifest(path);
+    let host = attach_manifest_and_component_deps(
+        FilesystemCompilerHost::silent(base_path.clone()),
+        manifest_pair.as_ref(),
+        &base_path,
+        source,
+        false,
+    )
+    .await
+    .map_err(|e| format!("resolving dependencies: {e}"))?;
+    let outcome = maybe_run_pipeline(path, &host, false, manifest_pair)
+        .await
+        .map_err(|e| format!("running kiln generators: {e}"))?;
+    Ok((host, outcome.invocations))
 }
 
 /// Append the WIT `component-type` section to `wasm`, using `world_imports`
@@ -1172,33 +1196,9 @@ async fn embed_wit_section(
         return Ok(wasm);
     };
 
-    let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
-    // Mirror the main compile's analysis environment — the nearest manifest's
-    // dependency index (with prebuilt registry components, warm from the main
-    // compile) and the kiln pipeline's generator redirects — so a
-    // `with { generator }` consumer re-analyzes exactly as it compiled
-    // (issue #1646). A quiet host avoids re-emitting diagnostics; the pipeline
-    // is cache-aware, so this reuses the main compile's outputs.
-    let manifest_pair = load_nearest_manifest(path);
-    let host = match attach_manifest_and_component_deps(
-        FilesystemCompilerHost::silent(base_path.clone()),
-        manifest_pair.as_ref(),
-        &base_path,
-        &source,
-        false,
-    )
-    .await
-    {
-        Ok(host) => host,
-        Err(e) => {
-            return skip_embed(explicit, wasm, &format!("resolving dependencies: {e}"));
-        }
-    };
-    let invocations = match maybe_run_pipeline(path, &host, false, manifest_pair).await {
-        Ok(outcome) => outcome.invocations,
-        Err(e) => {
-            return skip_embed(explicit, wasm, &format!("running kiln generators: {e}"));
-        }
+    let (host, invocations) = match reanalysis_env(path, &source).await {
+        Ok(env) => env,
+        Err(msg) => return skip_embed(explicit, wasm, &msg),
     };
     let mut sem = wado_compiler::semantics_for_world(
         &source,
@@ -1343,9 +1343,7 @@ pub async fn run_returning_bytes(opts: CompileOptions) -> Result<Vec<u8>, CliExi
                     .wir_package
                     .map(|p| p.imported_cm_interfaces)
                     .unwrap_or_default();
-                // Box the embedding future: it re-runs the frontend and Kiln
-                // pipeline, so inlining its state would push the enclosing
-                // build-driver future past clippy's `large_futures` threshold.
+                // Boxed to keep the enclosing driver future under clippy's `large_futures` bound.
                 Box::pin(embed_wit_section(&opts, wasm, world_imports, explicit)).await?
             } else {
                 wasm

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -75,17 +75,11 @@ pub(crate) fn resolve_manifest(
     }
 }
 
-/// `member_dir` normalized so [`governing_workspace`] can locate the workspace.
-///
-/// That function walks up with `pop()` and matches members with `strip_prefix`,
-/// so an empty, relative, or `..`-bearing dir cannot find the workspace root —
-/// a bare relative entry (`src/main.wado`) discovers an empty root, and a path
-/// build-dependency joins `../pkg`. Those shapes are canonicalized to the same
-/// absolute, `..`-free dir an absolute entry path already produces; an already
-/// absolute, `..`-free dir is returned untouched, so the common path pays no
-/// syscall and its symlinks are not resolved. Normalization lives here, in the
-/// CLI, because `governing_workspace` is in wasm32-only `wado-lsp` and cannot
-/// touch the filesystem.
+/// `member_dir` as an absolute, `..`-free path so [`governing_workspace`] (which
+/// walks up with `pop()` and matches members with `strip_prefix`) can locate the
+/// workspace. An empty, relative, or `..`-bearing dir is canonicalized; an
+/// already absolute, `..`-free dir is borrowed untouched. Canonicalization stays
+/// CLI-side because `governing_workspace` lives in wasm32-only `wado-lsp`.
 fn workspace_anchor(member_dir: &Path) -> Cow<'_, Path> {
     let has_parent_dir = member_dir.components().any(|c| c == Component::ParentDir);
     if member_dir.is_absolute() && !has_parent_dir {

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -1,5 +1,6 @@
+use std::borrow::Cow;
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::{fs, io};
 
 use wado_lsp::workspace::governing_workspace;
@@ -67,30 +68,42 @@ pub(crate) fn resolve_manifest(
     member_dir: &Path,
     member_content: &str,
 ) -> Result<Manifest, DiscoveryError> {
-    // Locate the governing workspace from an absolute, `..`-free member dir.
-    // `governing_workspace` walks up with `pop()` and matches members with
-    // `strip_prefix`, so an empty, relative, or `..`-bearing dir (a bare
-    // relative entry like `src/main.wado` discovers an empty root, and a path
-    // build-dependency joins `../pkg`) fails to find the workspace — inheritance
-    // then wrongly degrades to a standalone parse that rejects an inherited-only
-    // member. Canonicalizing normalizes all three shapes to the same absolute
-    // dir an absolute entry path would produce.
-    let anchor = if member_dir.as_os_str().is_empty() {
-        Path::new(".")
-    } else {
-        member_dir
-    };
-    let canonical = fs::canonicalize(anchor).unwrap_or_else(|_| anchor.to_path_buf());
-    match find_workspace_root(&canonical, member_content) {
+    match find_workspace_root(member_dir, member_content) {
         Some(root_content) => wado_manifest::resolve_member(member_content, &root_content)
             .map_err(DiscoveryError::Parse),
         None => member_content.parse().map_err(DiscoveryError::Parse),
     }
 }
 
+/// `member_dir` normalized so [`governing_workspace`] can locate the workspace.
+///
+/// That function walks up with `pop()` and matches members with `strip_prefix`,
+/// so an empty, relative, or `..`-bearing dir cannot find the workspace root —
+/// a bare relative entry (`src/main.wado`) discovers an empty root, and a path
+/// build-dependency joins `../pkg`. Those shapes are canonicalized to the same
+/// absolute, `..`-free dir an absolute entry path already produces; an already
+/// absolute, `..`-free dir is returned untouched, so the common path pays no
+/// syscall and its symlinks are not resolved. Normalization lives here, in the
+/// CLI, because `governing_workspace` is in wasm32-only `wado-lsp` and cannot
+/// touch the filesystem.
+fn workspace_anchor(member_dir: &Path) -> Cow<'_, Path> {
+    let has_parent_dir = member_dir.components().any(|c| c == Component::ParentDir);
+    if member_dir.is_absolute() && !has_parent_dir {
+        return Cow::Borrowed(member_dir);
+    }
+    let anchor = if member_dir.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        member_dir
+    };
+    fs::canonicalize(anchor)
+        .map(Cow::Owned)
+        .unwrap_or(Cow::Borrowed(member_dir))
+}
+
 /// The workspace-root `wado.toml` contents governing `member_dir`, if any.
 fn find_workspace_root(member_dir: &Path, member_content: &str) -> Option<String> {
-    governing_workspace(member_dir, member_content).map(|(_, content)| content)
+    governing_workspace(&workspace_anchor(member_dir), member_content).map(|(_, content)| content)
 }
 
 /// The workspace root directory governing the package at `member_dir`, if it is
@@ -100,7 +113,7 @@ pub(crate) fn governing_workspace_root_dir(
 ) -> Result<Option<PathBuf>, DiscoveryError> {
     let content =
         fs::read_to_string(member_dir.join(MANIFEST_FILENAME)).map_err(DiscoveryError::Io)?;
-    Ok(governing_workspace(member_dir, &content).map(|(dir, _)| dir))
+    Ok(governing_workspace(&workspace_anchor(member_dir), &content).map(|(dir, _)| dir))
 }
 
 /// The directory a `license-file` path resolves against: the package's own root
@@ -113,7 +126,7 @@ pub(crate) fn license_file_base_dir(package_root: &Path) -> PathBuf {
     if own_manifest_declares_license_slot(&content) {
         return package_root.to_path_buf();
     }
-    governing_workspace(package_root, &content)
+    governing_workspace(&workspace_anchor(package_root), &content)
         .map(|(dir, _)| dir)
         .unwrap_or_else(|| package_root.to_path_buf())
 }

--- a/wado-cli/src/manifest.rs
+++ b/wado-cli/src/manifest.rs
@@ -67,7 +67,21 @@ pub(crate) fn resolve_manifest(
     member_dir: &Path,
     member_content: &str,
 ) -> Result<Manifest, DiscoveryError> {
-    match find_workspace_root(member_dir, member_content) {
+    // Locate the governing workspace from an absolute, `..`-free member dir.
+    // `governing_workspace` walks up with `pop()` and matches members with
+    // `strip_prefix`, so an empty, relative, or `..`-bearing dir (a bare
+    // relative entry like `src/main.wado` discovers an empty root, and a path
+    // build-dependency joins `../pkg`) fails to find the workspace — inheritance
+    // then wrongly degrades to a standalone parse that rejects an inherited-only
+    // member. Canonicalizing normalizes all three shapes to the same absolute
+    // dir an absolute entry path would produce.
+    let anchor = if member_dir.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        member_dir
+    };
+    let canonical = fs::canonicalize(anchor).unwrap_or_else(|_| anchor.to_path_buf());
+    match find_workspace_root(&canonical, member_content) {
         Some(root_content) => wado_manifest::resolve_member(member_content, &root_content)
             .map_err(DiscoveryError::Parse),
         None => member_content.parse().map_err(DiscoveryError::Parse),

--- a/wado-cli/src/rss.rs
+++ b/wado-cli/src/rss.rs
@@ -59,8 +59,8 @@ Threads:\t8
     #[test]
     fn parses_current_and_peak_rss() {
         let sample = RssSample::parse(SAMPLE_STATUS).expect("both fields present");
-        assert_eq!(sample.current, 524288 * 1024);
-        assert_eq!(sample.peak, 716800 * 1024);
+        assert_eq!(sample.current, 524_288 * 1024);
+        assert_eq!(sample.peak, 716_800 * 1024);
         assert_eq!(sample.current_peak_mib(), "512/700 MiB");
     }
 

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -199,7 +199,10 @@ async fn world_semantics_and_opts(
     )
     .await
     .map_err(CliExit::error)?;
-    let invocations = run_generators(path, &host, manifest_pair).await?;
+    // Run the generators on the silent host: their warnings were not asked for
+    // by `wado wit`, and a build failure still surfaces via `run_generators`'
+    // error. The analysis below keeps the loud host so it reports diagnostics.
+    let invocations = run_generators(path, &import_host, manifest_pair).await?;
 
     let mut sem = wado_compiler::semantics_for_world(
         &source,
@@ -274,7 +277,9 @@ async fn lib_semantics_and_opts(
     )
     .await
     .map_err(CliExit::error)?;
-    let invocations = run_generators(&target.entry, &host, Some(project)).await?;
+    // Generators run on the silent host (see the world path); the loud host
+    // below still reports analysis diagnostics.
+    let invocations = run_generators(&target.entry, &import_host, Some(project)).await?;
 
     let mut sem = wado_compiler::semantics_for_world(
         &source,

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -12,7 +12,7 @@ use wado_compiler::semantics::Semantics;
 use wado_compiler::wit_emit::{self, WitEmitOptions, WitScope};
 
 use crate::args::{self, CliExit, OptSpec};
-use crate::compile::attach_manifest_deps;
+use crate::compile::{attach_manifest_and_component_deps, load_nearest_manifest};
 use crate::compiler_host::FilesystemCompilerHost;
 use crate::manifest::{self, EntryPointKind};
 
@@ -176,10 +176,39 @@ async fn world_semantics_and_opts(
     let source = fs::read_to_string(path)
         .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
-    let host = FilesystemCompilerHost::new(base_path.clone());
 
-    let mut sem =
-        wado_compiler::semantics_for_world(&source, &host, Some(&input), world.as_deref()).await;
+    // Mirror the compile host: manifest dependencies (offline, analysis tier)
+    // and the kiln pipeline's generator redirects, so a `with { generator }`
+    // consumer analyzes here as it compiles (issue #1646).
+    let manifest_pair = load_nearest_manifest(path);
+    let host = attach_manifest_and_component_deps(
+        FilesystemCompilerHost::new(base_path.clone()),
+        manifest_pair.as_ref(),
+        &base_path,
+        &source,
+        false,
+    )
+    .await
+    .map_err(CliExit::error)?;
+    let import_host = attach_manifest_and_component_deps(
+        FilesystemCompilerHost::silent(base_path.clone()),
+        manifest_pair.as_ref(),
+        &base_path,
+        &source,
+        false,
+    )
+    .await
+    .map_err(CliExit::error)?;
+    let invocations = run_generators(path, &host, manifest_pair).await?;
+
+    let mut sem = wado_compiler::semantics_for_world(
+        &source,
+        &host,
+        Some(&input),
+        world.as_deref(),
+        invocations.clone(),
+    )
+    .await;
     if !sem.is_complete() {
         return Err(CliExit::silent_failure(1));
     }
@@ -191,9 +220,22 @@ async fn world_semantics_and_opts(
         Some(&default_interface_name(&input)),
     ));
 
-    let import_host = FilesystemCompilerHost::silent(base_path);
-    let world_imports = resolve_world_imports(&import_host, &source, &input, &world).await;
+    let world_imports =
+        resolve_world_imports(&import_host, &source, &input, &world, invocations).await;
     Ok((sem, world_imports))
+}
+
+/// Run the entry's kiln generators (cache-aware, so a prior build's outputs are
+/// reused) and return the redirect index the analysis needs.
+async fn run_generators(
+    entry_file: &Path,
+    host: &FilesystemCompilerHost,
+    manifest_pair: Option<manifest::ProjectManifest>,
+) -> Result<wado_compiler::kiln::InvocationIndex, CliExit> {
+    crate::compile::maybe_run_pipeline(entry_file, host, false, manifest_pair)
+        .await
+        .map(|outcome| outcome.invocations)
+        .map_err(|e| CliExit::error(format!("wado wit: running kiln generators: {e}")))
 }
 
 /// Analyze the `[package].lib` entry and build the emit options for the library
@@ -214,12 +256,34 @@ async fn lib_semantics_and_opts(
         .map(Path::to_path_buf)
         .unwrap_or_default();
 
-    let host = attach_manifest_deps(
+    let host = attach_manifest_and_component_deps(
         FilesystemCompilerHost::new(base_path.clone()),
         Some(&project),
         &base_path,
-    );
-    let mut sem = wado_compiler::semantics_for_world(&source, &host, Some(&entry_str), None).await;
+        &source,
+        false,
+    )
+    .await
+    .map_err(CliExit::error)?;
+    let import_host = attach_manifest_and_component_deps(
+        FilesystemCompilerHost::silent(base_path.clone()),
+        Some(&project),
+        &base_path,
+        &source,
+        false,
+    )
+    .await
+    .map_err(CliExit::error)?;
+    let invocations = run_generators(&target.entry, &host, Some(project)).await?;
+
+    let mut sem = wado_compiler::semantics_for_world(
+        &source,
+        &host,
+        Some(&entry_str),
+        None,
+        invocations.clone(),
+    )
+    .await;
     if !sem.is_complete() {
         return Err(CliExit::silent_failure(1));
     }
@@ -229,13 +293,14 @@ async fn lib_semantics_and_opts(
         None,
     ));
 
-    let import_host = attach_manifest_deps(
-        FilesystemCompilerHost::silent(base_path.clone()),
-        Some(&project),
-        &base_path,
-    );
-    let world_imports =
-        resolve_lib_world_imports(&import_host, &source, &entry_str, &target.interface_fq).await;
+    let world_imports = resolve_lib_world_imports(
+        &import_host,
+        &source,
+        &entry_str,
+        &target.interface_fq,
+        invocations,
+    )
+    .await;
     Ok((sem, world_imports))
 }
 
@@ -264,6 +329,7 @@ async fn resolve_world_imports(
     source: &str,
     input: &str,
     world: &str,
+    invocations: wado_compiler::kiln::InvocationIndex,
 ) -> Vec<String> {
     let result = wado_compiler::dump_with_host_and_world(
         source,
@@ -277,7 +343,7 @@ async fn resolve_world_imports(
         &[],
         &wado_compiler::hashmap::IndexMap::default(),
         wado_compiler::param_resolution::ParamPolicy::default(),
-        wado_compiler::kiln::InvocationIndex::default(),
+        invocations,
     )
     .await;
     imports_or_warn(result, |r| wir_imports(r.wir_package))
@@ -292,12 +358,14 @@ async fn resolve_lib_world_imports(
     source: &str,
     input: &str,
     lib_world: &str,
+    invocations: wado_compiler::kiln::InvocationIndex,
 ) -> Vec<String> {
     let options = wado_compiler::CompilerOptions {
         opt_level: wado_compiler::OptLevel::O2,
         lib_world: Some(lib_world.to_string()),
         allocator: Some("freelist".to_string()),
         retain_wir: true,
+        invocations,
         ..Default::default()
     };
     let result = wado_compiler::compile_with_options(source, host, Some(input), options).await;

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -177,32 +177,9 @@ async fn world_semantics_and_opts(
         .map_err(|e| CliExit::error(format!("reading '{}': {e}", path.display())))?;
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
 
-    // Mirror the compile host: manifest dependencies (offline, analysis tier)
-    // and the kiln pipeline's generator redirects, so a `with { generator }`
-    // consumer analyzes here as it compiles (issue #1646).
     let manifest_pair = load_nearest_manifest(path);
-    let host = attach_manifest_and_component_deps(
-        FilesystemCompilerHost::new(base_path.clone()),
-        manifest_pair.as_ref(),
-        &base_path,
-        &source,
-        false,
-    )
-    .await
-    .map_err(CliExit::error)?;
-    let import_host = attach_manifest_and_component_deps(
-        FilesystemCompilerHost::silent(base_path.clone()),
-        manifest_pair.as_ref(),
-        &base_path,
-        &source,
-        false,
-    )
-    .await
-    .map_err(CliExit::error)?;
-    // Run the generators on the silent host: their warnings were not asked for
-    // by `wado wit`, and a build failure still surfaces via `run_generators`'
-    // error. The analysis below keeps the loud host so it reports diagnostics.
-    let invocations = run_generators(path, &import_host, manifest_pair).await?;
+    let (host, quiet_host) = analysis_hosts(&base_path, manifest_pair.as_ref(), &source).await?;
+    let invocations = run_generators(path, &quiet_host, manifest_pair).await?;
 
     let mut sem = wado_compiler::semantics_for_world(
         &source,
@@ -224,12 +201,39 @@ async fn world_semantics_and_opts(
     ));
 
     let world_imports =
-        resolve_world_imports(&import_host, &source, &input, &world, invocations).await;
+        resolve_world_imports(&quiet_host, &source, &input, &world, invocations).await;
     Ok((sem, world_imports))
 }
 
-/// Run the entry's kiln generators (cache-aware, so a prior build's outputs are
-/// reused) and return the redirect index the analysis needs.
+/// The diagnostic-emitting analysis host and its silent twin, both seeded with
+/// the dependency index the main compile uses. The silent twin runs the kiln
+/// pipeline and the import probe, whose output `wado wit` does not surface.
+async fn analysis_hosts(
+    base_path: &Path,
+    project: Option<&manifest::ProjectManifest>,
+    source: &str,
+) -> Result<(FilesystemCompilerHost, FilesystemCompilerHost), CliExit> {
+    let host = attach_manifest_and_component_deps(
+        FilesystemCompilerHost::new(base_path.to_path_buf()),
+        project,
+        base_path,
+        source,
+        false,
+    )
+    .await
+    .map_err(CliExit::error)?;
+    let quiet_host = attach_manifest_and_component_deps(
+        FilesystemCompilerHost::silent(base_path.to_path_buf()),
+        project,
+        base_path,
+        source,
+        false,
+    )
+    .await
+    .map_err(CliExit::error)?;
+    Ok((host, quiet_host))
+}
+
 async fn run_generators(
     entry_file: &Path,
     host: &FilesystemCompilerHost,
@@ -259,27 +263,8 @@ async fn lib_semantics_and_opts(
         .map(Path::to_path_buf)
         .unwrap_or_default();
 
-    let host = attach_manifest_and_component_deps(
-        FilesystemCompilerHost::new(base_path.clone()),
-        Some(&project),
-        &base_path,
-        &source,
-        false,
-    )
-    .await
-    .map_err(CliExit::error)?;
-    let import_host = attach_manifest_and_component_deps(
-        FilesystemCompilerHost::silent(base_path.clone()),
-        Some(&project),
-        &base_path,
-        &source,
-        false,
-    )
-    .await
-    .map_err(CliExit::error)?;
-    // Generators run on the silent host (see the world path); the loud host
-    // below still reports analysis diagnostics.
-    let invocations = run_generators(&target.entry, &import_host, Some(project)).await?;
+    let (host, quiet_host) = analysis_hosts(&base_path, Some(&project), &source).await?;
+    let invocations = run_generators(&target.entry, &quiet_host, Some(project)).await?;
 
     let mut sem = wado_compiler::semantics_for_world(
         &source,
@@ -299,7 +284,7 @@ async fn lib_semantics_and_opts(
     ));
 
     let world_imports = resolve_lib_world_imports(
-        &import_host,
+        &quiet_host,
         &source,
         &entry_str,
         &target.interface_fq,

--- a/wado-cli/tests/kiln_build_dep.rs
+++ b/wado-cli/tests/kiln_build_dep.rs
@@ -101,3 +101,104 @@ export fn run() with Stdout {
         .assert()
         .success();
 }
+
+/// A path `[build-dependencies]` generator whose package is a **workspace
+/// member** (so its `[package]` fields inherit from `[workspace.package]`),
+/// invoked with a **bare relative entry path** (`src/main.wado`) from the
+/// consumer directory.
+///
+/// This is the shape of the real `gale-highlight-wado` package. A bare relative
+/// entry makes manifest discovery return an empty/relative project root; the
+/// generator package's `wado.toml` is then resolved through a relative
+/// `../gen` path that cannot locate the workspace root, so member inheritance
+/// fails, the generator is not rewritten to a `LocalPath`, and the pipeline
+/// reports it as an unsupported (registry-only) spec — "generator execution is
+/// not available in this host". The manifest root must be absolute so the
+/// dependency package resolves like it does under an absolute entry path.
+#[test]
+fn generator_build_dependency_in_workspace_member_bare_relative_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    // Workspace root: members inherit version + namespace.
+    fs::write(
+        root.join("wado.toml"),
+        r#"[workspace]
+members = ["gen", "app"]
+
+[workspace.package]
+version = "0.1.0"
+namespace = "acme"
+"#,
+    )
+    .unwrap();
+
+    // Generator package (workspace member: no explicit version/namespace).
+    let gen_pkg = root.join("gen");
+    fs::create_dir_all(gen_pkg.join("src")).unwrap();
+    fs::write(
+        gen_pkg.join("wado.toml"),
+        r#"[package]
+name = "gen"
+
+[world]
+"core:kiln/generator" = "src/generator.wado"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        gen_pkg.join("src/generator.wado"),
+        r#"use { Request, Response, OutputFile, Error } from "core:kiln";
+
+export fn generate(req: Request) -> Result<Response, Error> {
+    let _ = req.primary.content;
+    return Result::Ok(Response {
+        files: [OutputFile {
+            path: "greeting.wado",
+            content: "pub fn greeting() -> String { return \"hi from generator\"; }",
+            is_entry: true,
+        }],
+    });
+}
+"#,
+    )
+    .unwrap();
+
+    // Consumer package (workspace member) referencing the generator by nickname.
+    let app = root.join("app");
+    fs::create_dir_all(app.join("src")).unwrap();
+    fs::write(
+        app.join("wado.toml"),
+        r#"[package]
+name = "app"
+
+[world]
+"wasi:cli/command" = "src/main.wado"
+
+[build-dependencies]
+"lib:gen" = { path = "../gen", package = "acme:gen", version = "^0.1.0" }
+"#,
+    )
+    .unwrap();
+    fs::write(app.join("src/schema.idl"), "anything\n").unwrap();
+    fs::write(
+        app.join("src/main.wado"),
+        r#"use { println, Stdout } from "core:cli";
+use { greeting } from "./schema.idl" with {
+    generator: { module: "lib:gen" },
+};
+
+export fn run() with Stdout {
+    println(greeting());
+}
+"#,
+    )
+    .unwrap();
+
+    // Bare relative entry path from the consumer directory.
+    wado_in(&app)
+        .args(["run", "src/main.wado"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hi from generator"));
+}

--- a/wado-cli/tests/kiln_embed_wit.rs
+++ b/wado-cli/tests/kiln_embed_wit.rs
@@ -1,0 +1,94 @@
+//! WIT emission for a Kiln `with { generator }` consumer (issue #1646).
+//!
+//! The WIT paths re-analyze the entry off the codegen pipeline, so they must
+//! rebuild the same generator redirects and manifest dependency index the main
+//! compile used; without them the re-analysis cannot load the generated module
+//! and the component ships without its `component-type` section.
+
+use std::fs;
+
+mod common;
+use common::{custom_sections, wado_in};
+use predicates::prelude::*;
+
+/// A generator that emits a fixed valid-Wado parser, ignoring its input. The
+/// schema it consumes (`grammar.g4`) is deliberately *not* valid Wado, so the
+/// only way the consumer's `use { hello } from "./grammar.g4"` resolves is
+/// through the generator redirect. A WIT re-analysis that drops the redirect
+/// falls back to loading the raw grammar as Wado, which fails — the exact
+/// #1646 failure.
+const FIXED_OUTPUT_GENERATOR: &str = r#"use { Request, Response, OutputFile, Error } from "core:kiln";
+
+export fn generate(req: Request) -> Result<Response, Error> {
+    let _ = req.primary.content;
+    return Result::Ok(Response {
+        files: [OutputFile {
+            path: "out.wado",
+            content: "pub fn hello() -> i32 { return 42; }\n",
+            is_entry: true,
+        }],
+    });
+}
+"#;
+
+/// Not valid Wado (an ANTLR-style grammar stands in for the real `Wado.g4`):
+/// loading it as source must fail, so only the generator redirect resolves it.
+const NON_WADO_SCHEMA: &str = "grammar Wado;\nprogram : statement* EOF ;\n";
+
+fn write_project(root: &std::path::Path) {
+    fs::write(
+        root.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"gen-consumer\"\nversion = \"0.1.0\"\n\n\
+         [world]\n\"wasi:cli/command\" = \"src/main.wado\"\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/gen.wado"), FIXED_OUTPUT_GENERATOR).unwrap();
+    fs::write(root.join("src/grammar.g4"), NON_WADO_SCHEMA).unwrap();
+    fs::write(
+        root.join("src/main.wado"),
+        r#"use { println, Stdout } from "core:cli";
+use { hello } from "./grammar.g4"
+    with { generator: { module: "./gen.wado" } };
+
+export fn run() with Stdout {
+    println(`${hello()}`);
+}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn embed_wit_succeeds_for_generator_consumer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_project(root);
+    let out = root.join("out.wasm");
+
+    wado_in(root)
+        .args(["compile", "--embed-wit", "-o"])
+        .arg(&out)
+        .arg("src/main.wado")
+        .assert()
+        .success();
+
+    let sections = custom_sections(&out);
+    assert!(
+        sections.iter().any(|(n, _)| n == "component-type"),
+        "generator consumer must embed the component-type section, got {sections:?}"
+    );
+}
+
+#[test]
+fn wit_command_emits_for_generator_consumer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_project(root);
+
+    wado_in(root)
+        .args(["wit", "src/main.wado"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("world"));
+}

--- a/wado-cli/tests/kiln_embed_wit.rs
+++ b/wado-cli/tests/kiln_embed_wit.rs
@@ -92,3 +92,61 @@ fn wit_command_emits_for_generator_consumer() {
         .success()
         .stdout(predicate::str::contains("world"));
 }
+
+/// Library-world variant of `write_project`: the `[package].lib` entry consumes
+/// the same generator. Exercises the `--lib` embedding path, which #1646 also
+/// broke (`build/lib.wasm`) and which flows through different code than the
+/// command world.
+fn write_lib_project(root: &std::path::Path) {
+    fs::write(
+        root.join("wado.toml"),
+        "[package]\nnamespace = \"acme\"\nname = \"gen-lib\"\nversion = \"0.1.0\"\n\
+         lib = \"src/lib.wado\"\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+    fs::write(root.join("src/gen.wado"), FIXED_OUTPUT_GENERATOR).unwrap();
+    fs::write(root.join("src/grammar.g4"), NON_WADO_SCHEMA).unwrap();
+    fs::write(
+        root.join("src/lib.wado"),
+        r#"use { hello as hello_impl } from "./grammar.g4"
+    with { generator: { module: "./gen.wado" } };
+
+export fn hello() -> i32 { return hello_impl(); }
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn build_lib_embeds_component_type_for_generator_consumer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_lib_project(root);
+    let out = root.join("out.wasm");
+
+    wado_in(root)
+        .args(["build", "--lib", "-o"])
+        .arg(&out)
+        .assert()
+        .success();
+
+    let sections = custom_sections(&out);
+    assert!(
+        sections.iter().any(|(n, _)| n == "component-type"),
+        "generator-consumer library build must embed the component-type section, got {sections:?}"
+    );
+}
+
+#[test]
+fn wit_lib_emits_for_generator_consumer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_lib_project(root);
+
+    wado_in(root)
+        .args(["wit", "--lib"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("world"));
+}

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -973,21 +973,36 @@ pub async fn semantics<H: CompilerHost>(
     host: &H,
     filename: Option<&str>,
 ) -> Semantics {
-    semantics_for_world(source, host, filename, None).await
+    semantics_for_world(
+        source,
+        host,
+        filename,
+        None,
+        crate::kiln::InvocationIndex::new(),
+    )
+    .await
 }
 
-/// [`semantics`] with the target world threaded through, so the Kiln
-/// `Request<T>` adapter rewrite (`compile_with_options` phase 1b) is applied
-/// before analysis when `target_world == "core:kiln/generator"`. WIT emission
-/// re-derives `Semantics` off the codegen path and must see the same rewritten
+/// [`semantics`] with the target world and kiln redirects threaded through.
+///
+/// The target world drives the Kiln `Request<T>` adapter rewrite
+/// (`compile_with_options` phase 1b), applied before analysis when
+/// `target_world == "core:kiln/generator"`. WIT emission re-derives
+/// `Semantics` off the codegen path and must see the same rewritten
 /// `generate(req: raw-request)` signature the component exports; without the
 /// rewrite it sees the un-representable generic `Request<Options>` and skips
 /// the component-type section (issue #1478).
+///
+/// `invocations` redirects `use … with { generator }` clauses to their
+/// generated modules, exactly as `CompilerOptions::invocations` does for the
+/// main compile. A caller re-analyzing a kiln consumer must pass the same
+/// index, or the load fails and the analysis reports incomplete (issue #1646).
 pub async fn semantics_for_world<H: CompilerHost>(
     source: &str,
     host: &H,
     filename: Option<&str>,
     target_world: Option<&str>,
+    invocations: crate::kiln::InvocationIndex,
 ) -> Semantics {
     let parsed = crate::parse(source);
     // Surface every recovered lex/parse error, then analyze the partial AST
@@ -1002,15 +1017,7 @@ pub async fn semantics_for_world<H: CompilerHost>(
     for e in &parsed.errors {
         host.emit_diagnostic(parse_error_diagnostic(e, filename));
     }
-    match crate::load(
-        parsed,
-        filename,
-        host,
-        crate::kiln::InvocationIndex::new(),
-        LogLevel::default(),
-    )
-    .await
-    {
+    match crate::load(parsed, filename, host, invocations, LogLevel::default()).await {
         // General entry: build TIR so consumers that read `tir_modules`
         // (kiln options extraction) work. The LSP engine uses its own
         // annotate-only path (`semantics_of(.., build_tir = false)`).

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -983,20 +983,14 @@ pub async fn semantics<H: CompilerHost>(
     .await
 }
 
-/// [`semantics`] with the target world and kiln redirects threaded through.
+/// [`semantics`] with the target world and kiln redirects threaded through, so a
+/// re-analysis off the codegen path matches the main compile.
 ///
-/// The target world drives the Kiln `Request<T>` adapter rewrite
-/// (`compile_with_options` phase 1b), applied before analysis when
-/// `target_world == "core:kiln/generator"`. WIT emission re-derives
-/// `Semantics` off the codegen path and must see the same rewritten
-/// `generate(req: raw-request)` signature the component exports; without the
-/// rewrite it sees the un-representable generic `Request<Options>` and skips
-/// the component-type section (issue #1478).
-///
-/// `invocations` redirects `use … with { generator }` clauses to their
-/// generated modules, exactly as `CompilerOptions::invocations` does for the
-/// main compile. A caller re-analyzing a kiln consumer must pass the same
-/// index, or the load fails and the analysis reports incomplete (issue #1646).
+/// `target_world` drives the Kiln `Request<T>` adapter rewrite for the
+/// `core:kiln/generator` world; `invocations` redirects `use … with { generator }`
+/// clauses to their generated modules. A caller re-analyzing a kiln consumer must
+/// pass the same values the compile used, or the load fails and analysis reports
+/// incomplete.
 pub async fn semantics_for_world<H: CompilerHost>(
     source: &str,
     host: &H,

--- a/wado-compiler/tests/wit.rs
+++ b/wado-compiler/tests/wit.rs
@@ -112,6 +112,7 @@ export fn generate(req: Request<Options>) -> Result<Response, Error> {
         &host,
         Some("entry.wado"),
         Some("core:kiln/generator"),
+        wado_compiler::kiln::InvocationIndex::new(),
     ));
     assert!(sem.is_complete(), "generator semantics did not complete");
     sem.set_wit_contract(wit_emit::wit_contract(


### PR DESCRIPTION
Fixes the WIT `component-type` section being silently dropped for packages that consume a Kiln `with { generator }` dependency (e.g. `gale-highlight-wado`), plus a related manifest-resolution bug the investigation surfaced.

## WIT embedding for generator consumers

`wado compile` / `build` / `publish` re-derive `Semantics` off the codegen path to emit the `component-type` section. That second analysis loaded modules with no Kiln generator redirects and only `[dependencies]`, so a `with { generator }` consumer could not resolve its generated import — `Semantics::is_complete()` came back false and the section was skipped (`WIT analysis did not complete`; a hard error under `--embed-wit`).

The re-analysis now rebuilds the same environment the main compile used — nearest manifest, component/registry deps, and the Kiln pipeline's generator redirects (cache-aware, reusing the main compile's outputs) — and threads the resulting `InvocationIndex` through `semantics_for_world`, for `wado compile --embed-wit` / default embedding and for `wado wit` (world and `--lib`).

## Workspace-member manifest resolution

While reproducing the above, `wado compile src/main.wado` run from a workspace-member package with a bare relative entry path failed to resolve a path `[build-dependencies]` generator (`generator execution is not available in this host`). Manifest discovery returned an empty/relative project root, so `governing_workspace` — which walks up with `pop()` and matches members with `strip_prefix` — could not find the workspace, and `[workspace.package]` inheritance degraded to a standalone parse. A shared `workspace_anchor` normalizes the empty / relative / `..` shapes to an absolute path at all three `governing_workspace` call sites, including the `wado publish` gate and the license-file base.

## Also

- `wado wit` runs the Kiln pipeline on a silent host so generator warnings do not leak into inspection output.
- Regression tests: generator-consumer WIT embedding (command world and `--lib`), and workspace-member path-build-dependency resolution.

Closes #1646

Follow-up: #1654 removes the double frontend analysis that WIT embedding relies on, which would retire this bug class structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011WCNm1ms5ovgWDmeci9Ump)_