### PR TITLE
refactor(wit): compute the component-type section during the main compile

### DIFF
--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -233,6 +233,11 @@ pub struct CompileFlags {
     /// embedding WIT, to read the faithful import plan
     /// (`imported_cm_interfaces`) without a second compile.
     pub retain_wir: bool,
+    /// When `Some`, the main compile retains the WIT-relevant subset
+    /// (`CompileResult::wit_emit_snapshot`) so the `component-type` section is
+    /// encoded from that single analysis instead of a second frontend run
+    /// (issue #1654). Set by `wado compile` when embedding is requested.
+    pub embed_wit_contract: Option<wado_compiler::wit_emit::WitContract>,
 }
 
 impl CompileOptions {
@@ -253,6 +258,7 @@ impl CompileOptions {
             param_overrides: self.param_overrides.clone(),
             param_policy: self.param_policy,
             retain_wir: false,
+            embed_wit_contract: None,
         }
     }
 }
@@ -591,6 +597,7 @@ pub async fn try_compile_with_kiln_cache(
         param_overrides: flags.param_overrides.clone(),
         param_policy: flags.param_policy,
         retain_wir: flags.retain_wir,
+        embed_wit_contract: flags.embed_wit_contract.clone(),
         ..Default::default()
     };
 
@@ -1154,70 +1161,26 @@ fn skip_embed(explicit: bool, wasm: Vec<u8>, msg: &str) -> Result<Vec<u8>, CliEx
     Ok(wasm)
 }
 
-/// The silent analysis host and kiln redirects the main compile produced, so a
-/// `with { generator }` consumer re-analyzes exactly as it compiled. The kiln
-/// pipeline is cache-aware, so this reuses the main compile's outputs.
-async fn reanalysis_env(
-    path: &Path,
-    source: &str,
-) -> Result<(FilesystemCompilerHost, wado_compiler::kiln::InvocationIndex), String> {
-    let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
-    let manifest_pair = load_nearest_manifest(path);
-    let host = attach_manifest_and_component_deps(
-        FilesystemCompilerHost::silent(base_path.clone()),
-        manifest_pair.as_ref(),
-        &base_path,
-        source,
-        false,
-    )
-    .await
-    .map_err(|e| format!("resolving dependencies: {e}"))?;
-    let outcome = maybe_run_pipeline(path, &host, false, manifest_pair)
-        .await
-        .map_err(|e| format!("running kiln generators: {e}"))?;
-    Ok((host, outcome.invocations))
-}
-
-/// Append the WIT `component-type` section to `wasm`, using `world_imports`
-/// (the faithful plan read from the main compile's retained WIR, so no second
-/// optimize pass). `explicit` is true for `--embed-wit`: it makes a failure
-/// fatal, where the default-on path only warns and yields the un-embedded
-/// (still valid, self-describing) component.
-async fn embed_wit_section(
-    opts: &CompileOptions,
+/// Append the WIT `component-type` section to `wasm`, encoded from the WIT
+/// subset the main compile retained (`CompileResult::wit_emit_snapshot`) and
+/// `world_imports` (the faithful plan read from the main compile's retained
+/// WIR). The section is derived from the single analysis codegen ran — no
+/// second frontend pass to drift from it (issue #1654). `explicit` is true for
+/// `--embed-wit`: it makes a failure fatal, where the default-on path only
+/// warns and yields the un-embedded (still valid, self-describing) component.
+fn embed_wit_section(
+    snapshot: Option<wado_compiler::wit_emit::WitEmitSnapshot>,
     wasm: Vec<u8>,
     world_imports: Vec<String>,
     explicit: bool,
 ) -> Result<Vec<u8>, CliExit> {
-    let input = &opts.input;
-    let path = Path::new(input);
-    let Ok(source) = fs::read_to_string(path) else {
-        // The file compiled moments ago; an unreadable source now is unexpected.
-        return Ok(wasm);
+    let Some(snapshot) = snapshot else {
+        // The main compile completed (`is_complete()`), so the subset is always
+        // retained when embedding was requested; a missing snapshot here is
+        // unexpected rather than a normal skip.
+        return skip_embed(explicit, wasm, "WIT analysis subset was not retained");
     };
-
-    let (host, invocations) = match reanalysis_env(path, &source).await {
-        Ok(env) => env,
-        Err(msg) => return skip_embed(explicit, wasm, &msg),
-    };
-    let mut sem = wado_compiler::semantics_for_world(
-        &source,
-        &host,
-        Some(input),
-        opts.target_world.as_deref(),
-        invocations,
-    )
-    .await;
-    if !sem.is_complete() {
-        return skip_embed(explicit, wasm, "WIT analysis did not complete");
-    }
-    sem.set_wit_contract(wado_compiler::wit_emit::wit_contract(
-        opts.target_world.as_deref(),
-        opts.lib_world.as_deref(),
-        Some(&crate::wit::default_interface_name(input)),
-    ));
-
-    match wit_bundle::embed_component_type(&wasm, &sem, &world_imports) {
+    match wit_bundle::embed_component_type_from(&wasm, snapshot.input(), &world_imports) {
         Ok(embedded) => Ok(embedded),
         Err(e) => skip_embed(explicit, wasm, &e.to_string()),
     }
@@ -1309,6 +1272,15 @@ pub async fn run_returning_bytes(opts: CompileOptions) -> Result<Vec<u8>, CliExi
 
     let mut flags = opts.flags();
     flags.retain_wir = embed.is_some();
+    // When embedding, have the main compile retain the WIT subset so the section
+    // is derived from that single analysis, not a second frontend run (#1654).
+    if embed.is_some() {
+        flags.embed_wit_contract = Some(wado_compiler::wit_emit::wit_contract(
+            opts.target_world.as_deref(),
+            opts.lib_world.as_deref(),
+            Some(&crate::wit::default_interface_name(&opts.input)),
+        ));
+    }
     let result = try_compile(&opts.input, &flags)
         .await
         .map_err(|_| CliExit::silent_failure(1))?;
@@ -1343,8 +1315,7 @@ pub async fn run_returning_bytes(opts: CompileOptions) -> Result<Vec<u8>, CliExi
                     .wir_package
                     .map(|p| p.imported_cm_interfaces)
                     .unwrap_or_default();
-                // Boxed to keep the enclosing driver future under clippy's `large_futures` bound.
-                Box::pin(embed_wit_section(&opts, wasm, world_imports, explicit)).await?
+                embed_wit_section(result.wit_emit_snapshot, wasm, world_imports, explicit)?
             } else {
                 wasm
             };

--- a/wado-cli/src/compile.rs
+++ b/wado-cli/src/compile.rs
@@ -233,10 +233,9 @@ pub struct CompileFlags {
     /// embedding WIT, to read the faithful import plan
     /// (`imported_cm_interfaces`) without a second compile.
     pub retain_wir: bool,
-    /// When `Some`, the main compile retains the WIT-relevant subset
-    /// (`CompileResult::wit_emit_snapshot`) so the `component-type` section is
-    /// encoded from that single analysis instead of a second frontend run
-    /// (issue #1654). Set by `wado compile` when embedding is requested.
+    /// When `Some`, the compile retains the WIT subset
+    /// (`CompileResult::wit_emit_snapshot`) for encoding the `component-type`
+    /// section (issue #1654). Set by `wado compile` when embedding.
     pub embed_wit_contract: Option<wado_compiler::wit_emit::WitContract>,
 }
 
@@ -1161,13 +1160,10 @@ fn skip_embed(explicit: bool, wasm: Vec<u8>, msg: &str) -> Result<Vec<u8>, CliEx
     Ok(wasm)
 }
 
-/// Append the WIT `component-type` section to `wasm`, encoded from the WIT
-/// subset the main compile retained (`CompileResult::wit_emit_snapshot`) and
-/// `world_imports` (the faithful plan read from the main compile's retained
-/// WIR). The section is derived from the single analysis codegen ran — no
-/// second frontend pass to drift from it (issue #1654). `explicit` is true for
-/// `--embed-wit`: it makes a failure fatal, where the default-on path only
-/// warns and yields the un-embedded (still valid, self-describing) component.
+/// Append the WIT `component-type` section to `wasm`, encoded from the retained
+/// WIT `snapshot` and `world_imports` (the faithful plan from the retained WIR).
+/// `explicit` is true for `--embed-wit`: it makes a failure fatal, where the
+/// default-on path only warns and yields the un-embedded component.
 fn embed_wit_section(
     snapshot: Option<wado_compiler::wit_emit::WitEmitSnapshot>,
     wasm: Vec<u8>,
@@ -1175,9 +1171,6 @@ fn embed_wit_section(
     explicit: bool,
 ) -> Result<Vec<u8>, CliExit> {
     let Some(snapshot) = snapshot else {
-        // The main compile completed (`is_complete()`), so the subset is always
-        // retained when embedding was requested; a missing snapshot here is
-        // unexpected rather than a normal skip.
         return skip_embed(explicit, wasm, "WIT analysis subset was not retained");
     };
     match wit_bundle::embed_component_type_from(&wasm, snapshot.input(), &world_imports) {
@@ -1272,8 +1265,8 @@ pub async fn run_returning_bytes(opts: CompileOptions) -> Result<Vec<u8>, CliExi
 
     let mut flags = opts.flags();
     flags.retain_wir = embed.is_some();
-    // When embedding, have the main compile retain the WIT subset so the section
-    // is derived from that single analysis, not a second frontend run (#1654).
+    // When embedding, retain the WIT subset so the section is encoded from this
+    // compile, not a second frontend run (#1654).
     if embed.is_some() {
         flags.embed_wit_contract = Some(wado_compiler::wit_emit::wit_contract(
             opts.target_world.as_deref(),

--- a/wado-cli/src/run.rs
+++ b/wado-cli/src/run.rs
@@ -387,6 +387,7 @@ pub async fn run(opts: RunOptions) -> Result<(), CliExit> {
         param_overrides: opts.param_overrides,
         param_policy: opts.param_policy,
         retain_wir: false,
+        embed_wit_contract: None,
     };
     let cranelift_opt = opts.opt_level.to_wasmtime();
     // `run` is a driver on the build tier (like `cargo run`): in a project it

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -1197,6 +1197,7 @@ pub async fn run(opts: ServeOptions) -> Result<(), CliExit> {
         param_overrides: opts.param_overrides.clone(),
         param_policy: opts.param_policy,
         retain_wir: false,
+        embed_wit_contract: None,
     };
     let cranelift_opt = opts.opt_level.to_wasmtime();
     // `serve` is a driver on the build tier: in a project it builds the

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -108,6 +108,7 @@ impl TestOptions {
             param_overrides: self.param_overrides.clone(),
             param_policy: self.param_policy,
             retain_wir: false,
+            embed_wit_contract: None,
         }
     }
 }

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -1,7 +1,8 @@
 //! `wado wit` — emit the WIT text for a Wado program's component contract.
 //!
-//! Runs the frontend (`wado_compiler::semantics`) and stops; WIT is a
-//! pre-codegen fact, so there is no optimization level. See WEP
+//! Renders WIT from the subset one compile retains
+//! (`CompileResult::wit_emit_snapshot`) plus its import plan, so the text
+//! matches what `wado compile` embeds (issue #1654). See WEP
 //! `wep-2026-05-02-wit-interoperability.md`.
 
 use std::fs;
@@ -165,10 +166,8 @@ pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
     Ok(())
 }
 
-/// Compile `input` against a fixed WASI world (or the default) once, and return
-/// the WIT-relevant subset plus the faithful import set — both from that single
-/// analysis, so `wado wit` derives its text exactly like `wado compile` embeds
-/// its section, with no second frontend run (issue #1654).
+/// Compile `input` against a fixed WASI world (or the default), returning its
+/// WIT subset and import plan.
 async fn world_snapshot_and_imports(
     input: Option<String>,
     world: Option<String>,
@@ -199,9 +198,8 @@ async fn world_snapshot_and_imports(
     compile_wit_snapshot(&source, &host, &input, options).await
 }
 
-/// A single analysis host seeded with the dependency index the main compile
-/// uses. `wado wit` runs one compile on it and reads both the WIT subset and
-/// the import plan from that result — no silent twin, no second host.
+/// The analysis host seeded with the same dependency index the main compile
+/// uses.
 async fn analysis_host(
     base_path: &Path,
     project: Option<&manifest::ProjectManifest>,
@@ -229,9 +227,8 @@ async fn run_generators(
         .map_err(|e| CliExit::error(format!("wado wit: running kiln generators: {e}")))
 }
 
-/// Compile the `[package].lib` entry once for the library world — emitted as the
-/// anonymous `root`, exporting the default interface `namespace:name/name` (see
-/// `manifest::LIB_WORLD_NAME`) — returning its WIT subset and import plan.
+/// Compile the `[package].lib` entry for the synthesized library world (the
+/// anonymous `root`), returning its WIT subset and import plan.
 async fn lib_snapshot_and_imports(
     input: Option<String>,
     usage: &str,
@@ -266,10 +263,7 @@ async fn lib_snapshot_and_imports(
     compile_wit_snapshot(&source, &host, &entry_str, options).await
 }
 
-/// Run the single compile and pull out the retained WIT subset + import plan.
-/// A failed compile (or a subset the compile did not retain, unreachable when
-/// `embed_wit_contract` is set and the compile succeeded) is a hard error —
-/// diagnostics are already on the host.
+/// Run the compile and pull out the retained WIT subset + import plan.
 async fn compile_wit_snapshot(
     source: &str,
     host: &FilesystemCompilerHost,
@@ -278,11 +272,10 @@ async fn compile_wit_snapshot(
 ) -> Result<(WitEmitSnapshot, Vec<String>), CliExit> {
     let result = wado_compiler::compile_with_options(source, host, Some(input), options)
         .await
-        // Compile diagnostics are already on the loud host; exit quietly.
+        // Diagnostics are already on the loud host; exit quietly.
         .map_err(|_| CliExit::silent_failure(1))?;
-    // A successful compile with `embed_wit_contract` set always retains the
-    // subset, so this is unreachable; surface it loudly rather than as a silent
-    // exit-1 should a future change ever break that invariant.
+    // Unreachable while `embed_wit_contract` is set; surface it loudly rather
+    // than a silent exit-1 if that invariant ever breaks.
     let snapshot = result.wit_emit_snapshot.ok_or_else(|| {
         CliExit::error(
             "wado wit: compiler did not retain the WIT subset (internal error)".to_string(),

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -277,10 +277,14 @@ async fn compile_wit_snapshot(
 ) -> Result<(WitEmitSnapshot, Vec<String>), CliExit> {
     let result = wado_compiler::compile_with_options(source, host, Some(input), options)
         .await
+        // Compile diagnostics are already on the loud host; exit quietly.
         .map_err(|_| CliExit::silent_failure(1))?;
-    let snapshot = result
-        .wit_emit_snapshot
-        .ok_or_else(|| CliExit::silent_failure(1))?;
+    // A successful compile with `embed_wit_contract` set always retains the
+    // subset, so this is unreachable; surface it loudly rather than as a silent
+    // exit-1 should a future change ever break that invariant.
+    let snapshot = result.wit_emit_snapshot.ok_or_else(|| {
+        CliExit::error("wado wit: compiler did not retain the WIT subset (internal error)".to_string())
+    })?;
     Ok((snapshot, wir_imports(result.wir_package)))
 }
 

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -8,8 +8,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use lexopt::Arg::Value;
-use wado_compiler::semantics::Semantics;
-use wado_compiler::wit_emit::{self, WitEmitOptions, WitScope};
+use wado_compiler::CompilerOptions;
+use wado_compiler::wit_emit::{self, WitEmitOptions, WitEmitSnapshot, WitScope};
 
 use crate::args::{self, CliExit, OptSpec};
 use crate::compile::{attach_manifest_and_component_deps, load_nearest_manifest};
@@ -144,13 +144,13 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<WitOptions, CliExit> {
 pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
     let usage = format_usage();
     let scope = opts.scope;
-    let (sem, world_imports) = if opts.lib {
-        lib_semantics_and_opts(opts.input, &usage).await?
+    let (snapshot, world_imports) = if opts.lib {
+        lib_snapshot_and_imports(opts.input, &usage).await?
     } else {
-        world_semantics_and_opts(opts.input, opts.world, &usage).await?
+        world_snapshot_and_imports(opts.input, opts.world, &usage).await?
     };
 
-    let text = wit_emit::emit_wit_text(&sem, &WitEmitOptions { scope }, &world_imports)
+    let text = wit_emit::emit_wit_text_from(snapshot.input(), &WitEmitOptions { scope }, &world_imports)
         .map_err(|e| CliExit::error(format!("wado wit: {e}")))?;
 
     match opts.output {
@@ -164,13 +164,15 @@ pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
     Ok(())
 }
 
-/// Analyze `input` against a fixed WASI world (or the default) and build the
-/// emit options for it.
-async fn world_semantics_and_opts(
+/// Compile `input` against a fixed WASI world (or the default) once, and return
+/// the WIT-relevant subset plus the faithful import set — both from that single
+/// analysis, so `wado wit` derives its text exactly like `wado compile` embeds
+/// its section, with no second frontend run (issue #1654).
+async fn world_snapshot_and_imports(
     input: Option<String>,
     world: Option<String>,
     usage: &str,
-) -> Result<(Semantics, Vec<String>), CliExit> {
+) -> Result<(WitEmitSnapshot, Vec<String>), CliExit> {
     let input = manifest::resolve_input(input, EntryPointKind::Command, usage)?;
     let path = Path::new(&input);
     let source = fs::read_to_string(path)
@@ -178,42 +180,33 @@ async fn world_semantics_and_opts(
     let base_path = path.parent().map(Path::to_path_buf).unwrap_or_default();
 
     let manifest_pair = load_nearest_manifest(path);
-    let (host, quiet_host) = analysis_hosts(&base_path, manifest_pair.as_ref(), &source).await?;
-    let invocations = run_generators(path, &quiet_host, manifest_pair).await?;
+    let host = analysis_host(&base_path, manifest_pair.as_ref(), &source).await?;
+    let invocations = run_generators(path, &host, manifest_pair).await?;
 
-    let mut sem = wado_compiler::semantics_for_world(
-        &source,
-        &host,
-        Some(&input),
-        world.as_deref(),
-        invocations.clone(),
-    )
-    .await;
-    if !sem.is_complete() {
-        return Err(CliExit::silent_failure(1));
-    }
-
-    let world = world.unwrap_or_else(|| DEFAULT_WORLD.to_string());
-    sem.set_wit_contract(wado_compiler::wit_emit::wit_contract(
-        Some(&world),
-        None,
-        Some(&default_interface_name(&input)),
-    ));
-
-    let world_imports =
-        resolve_world_imports(&quiet_host, &source, &input, &world, invocations).await;
-    Ok((sem, world_imports))
+    let world_fq = world.clone().unwrap_or_else(|| DEFAULT_WORLD.to_string());
+    let contract =
+        wit_emit::wit_contract(Some(&world_fq), None, Some(&default_interface_name(&input)));
+    let options = CompilerOptions {
+        opt_level: wado_compiler::OptLevel::O2,
+        target_world: world,
+        invocations,
+        retain_wir: true,
+        unused_diagnostics: false,
+        embed_wit_contract: Some(contract),
+        ..Default::default()
+    };
+    compile_wit_snapshot(&source, &host, &input, options).await
 }
 
-/// The diagnostic-emitting analysis host and its silent twin, both seeded with
-/// the dependency index the main compile uses. The silent twin runs the kiln
-/// pipeline and the import probe, whose output `wado wit` does not surface.
-async fn analysis_hosts(
+/// A single analysis host seeded with the dependency index the main compile
+/// uses. `wado wit` runs one compile on it and reads both the WIT subset and
+/// the import plan from that result — no silent twin, no second host.
+async fn analysis_host(
     base_path: &Path,
     project: Option<&manifest::ProjectManifest>,
     source: &str,
-) -> Result<(FilesystemCompilerHost, FilesystemCompilerHost), CliExit> {
-    let host = attach_manifest_and_component_deps(
+) -> Result<FilesystemCompilerHost, CliExit> {
+    attach_manifest_and_component_deps(
         FilesystemCompilerHost::new(base_path.to_path_buf()),
         project,
         base_path,
@@ -221,17 +214,7 @@ async fn analysis_hosts(
         false,
     )
     .await
-    .map_err(CliExit::error)?;
-    let quiet_host = attach_manifest_and_component_deps(
-        FilesystemCompilerHost::silent(base_path.to_path_buf()),
-        project,
-        base_path,
-        source,
-        false,
-    )
-    .await
-    .map_err(CliExit::error)?;
-    Ok((host, quiet_host))
+    .map_err(CliExit::error)
 }
 
 async fn run_generators(
@@ -245,13 +228,13 @@ async fn run_generators(
         .map_err(|e| CliExit::error(format!("wado wit: running kiln generators: {e}")))
 }
 
-/// Analyze the `[package].lib` entry and build the emit options for the library
-/// world — emitted as the anonymous `root`, exporting the default interface
-/// `namespace:name/name` (see `manifest::LIB_WORLD_NAME`).
-async fn lib_semantics_and_opts(
+/// Compile the `[package].lib` entry once for the library world — emitted as the
+/// anonymous `root`, exporting the default interface `namespace:name/name` (see
+/// `manifest::LIB_WORLD_NAME`) — returning its WIT subset and import plan.
+async fn lib_snapshot_and_imports(
     input: Option<String>,
     usage: &str,
-) -> Result<(Semantics, Vec<String>), CliExit> {
+) -> Result<(WitEmitSnapshot, Vec<String>), CliExit> {
     let (project, target) = manifest::resolve_lib_project(input, usage)?;
 
     let entry_str = target.entry.to_string_lossy().into_owned();
@@ -263,35 +246,42 @@ async fn lib_semantics_and_opts(
         .map(Path::to_path_buf)
         .unwrap_or_default();
 
-    let (host, quiet_host) = analysis_hosts(&base_path, Some(&project), &source).await?;
-    let invocations = run_generators(&target.entry, &quiet_host, Some(project)).await?;
+    let host = analysis_host(&base_path, Some(&project), &source).await?;
+    let invocations = run_generators(&target.entry, &host, Some(project)).await?;
 
-    let mut sem = wado_compiler::semantics_for_world(
-        &source,
-        &host,
-        Some(&entry_str),
-        None,
-        invocations.clone(),
-    )
-    .await;
-    if !sem.is_complete() {
-        return Err(CliExit::silent_failure(1));
-    }
-    sem.set_wit_contract(wado_compiler::wit_emit::wit_contract(
-        None,
-        Some(&target.interface_fq),
-        None,
-    ));
-
-    let world_imports = resolve_lib_world_imports(
-        &quiet_host,
-        &source,
-        &entry_str,
-        &target.interface_fq,
+    let contract = wit_emit::wit_contract(None, Some(&target.interface_fq), None);
+    // Same `--lib` world + allocator as `wado compile --lib`, so the import set
+    // and subset match what that build embeds.
+    let options = CompilerOptions {
+        opt_level: wado_compiler::OptLevel::O2,
+        lib_world: Some(target.interface_fq.clone()),
+        allocator: Some("freelist".to_string()),
         invocations,
-    )
-    .await;
-    Ok((sem, world_imports))
+        retain_wir: true,
+        unused_diagnostics: false,
+        embed_wit_contract: Some(contract),
+        ..Default::default()
+    };
+    compile_wit_snapshot(&source, &host, &entry_str, options).await
+}
+
+/// Run the single compile and pull out the retained WIT subset + import plan.
+/// A failed compile (or a subset the compile did not retain, unreachable when
+/// `embed_wit_contract` is set and the compile succeeded) is a hard error —
+/// diagnostics are already on the host.
+async fn compile_wit_snapshot(
+    source: &str,
+    host: &FilesystemCompilerHost,
+    input: &str,
+    options: CompilerOptions,
+) -> Result<(WitEmitSnapshot, Vec<String>), CliExit> {
+    let result = wado_compiler::compile_with_options(source, host, Some(input), options)
+        .await
+        .map_err(|_| CliExit::silent_failure(1))?;
+    let snapshot = result
+        .wit_emit_snapshot
+        .ok_or_else(|| CliExit::silent_failure(1))?;
+    Ok((snapshot, wir_imports(result.wir_package)))
 }
 
 /// The faithful import set from a compiled WIR plan, empty when absent.
@@ -299,67 +289,6 @@ fn wir_imports(wir_package: Option<wado_compiler::wir::WirPackage>) -> Vec<Strin
     wir_package
         .map(|pkg| pkg.imported_cm_interfaces)
         .unwrap_or_default()
-}
-
-/// The imports the WIT should list, computed post-DCE. `Err` after a passing
-/// `semantics` is anomalous (a later-pass failure), so it warns rather than
-/// silently emitting import-less WIT.
-fn imports_or_warn<T, E>(result: Result<T, E>, wir: impl FnOnce(T) -> Vec<String>) -> Vec<String> {
-    let Ok(r) = result else {
-        eprintln!("warning: could not resolve world imports; WIT may omit import lines");
-        return Vec::new();
-    };
-    wir(r)
-}
-
-/// Analyze `source` against `world` (on the passed silent host, so diagnostics
-/// are not re-emitted) and read the faithful import set from the WIR plan.
-async fn resolve_world_imports(
-    host: &FilesystemCompilerHost,
-    source: &str,
-    input: &str,
-    world: &str,
-    invocations: wado_compiler::kiln::InvocationIndex,
-) -> Vec<String> {
-    let result = wado_compiler::dump_with_host_and_world(
-        source,
-        host,
-        Some(input),
-        wado_compiler::OptLevel::O2,
-        Some(world),
-        None,
-        None,
-        None,
-        &[],
-        &wado_compiler::hashmap::IndexMap::default(),
-        wado_compiler::param_resolution::ParamPolicy::default(),
-        invocations,
-    )
-    .await;
-    imports_or_warn(result, |r| wir_imports(r.wir_package))
-}
-
-/// Like [`resolve_world_imports`] but for the synthesized library world. Uses
-/// the same `compile_with_options` path (and allocator) as `wado compile --lib`
-/// so the import set matches what that build embeds. `lib_world` is the
-/// default-interface FQ the codegen keys on (`namespace:name/name`).
-async fn resolve_lib_world_imports(
-    host: &FilesystemCompilerHost,
-    source: &str,
-    input: &str,
-    lib_world: &str,
-    invocations: wado_compiler::kiln::InvocationIndex,
-) -> Vec<String> {
-    let options = wado_compiler::CompilerOptions {
-        opt_level: wado_compiler::OptLevel::O2,
-        lib_world: Some(lib_world.to_string()),
-        allocator: Some("freelist".to_string()),
-        retain_wir: true,
-        invocations,
-        ..Default::default()
-    };
-    let result = wado_compiler::compile_with_options(source, host, Some(input), options).await;
-    imports_or_warn(result, |r| wir_imports(r.wir_package))
 }
 
 /// The default interface name: the manifest `[package].name` when the input

--- a/wado-cli/src/wit.rs
+++ b/wado-cli/src/wit.rs
@@ -150,8 +150,9 @@ pub async fn run(opts: WitOptions) -> Result<(), CliExit> {
         world_snapshot_and_imports(opts.input, opts.world, &usage).await?
     };
 
-    let text = wit_emit::emit_wit_text_from(snapshot.input(), &WitEmitOptions { scope }, &world_imports)
-        .map_err(|e| CliExit::error(format!("wado wit: {e}")))?;
+    let text =
+        wit_emit::emit_wit_text_from(snapshot.input(), &WitEmitOptions { scope }, &world_imports)
+            .map_err(|e| CliExit::error(format!("wado wit: {e}")))?;
 
     match opts.output {
         Some(file) => {
@@ -283,7 +284,9 @@ async fn compile_wit_snapshot(
     // subset, so this is unreachable; surface it loudly rather than as a silent
     // exit-1 should a future change ever break that invariant.
     let snapshot = result.wit_emit_snapshot.ok_or_else(|| {
-        CliExit::error("wado wit: compiler did not retain the WIT subset (internal error)".to_string())
+        CliExit::error(
+            "wado wit: compiler did not retain the WIT subset (internal error)".to_string(),
+        )
     })?;
     Ok((snapshot, wir_imports(result.wir_package)))
 }

--- a/wado-cli/tests/kiln_embed_wit.rs
+++ b/wado-cli/tests/kiln_embed_wit.rs
@@ -1,9 +1,11 @@
 //! WIT emission for a Kiln `with { generator }` consumer (issue #1646).
 //!
-//! The WIT paths re-analyze the entry off the codegen pipeline, so they must
-//! rebuild the same generator redirects and manifest dependency index the main
-//! compile used; without them the re-analysis cannot load the generated module
-//! and the component ships without its `component-type` section.
+//! The WIT section and `wado wit` text are derived from the WIT subset the main
+//! compile retains (`CompileResult::wit_emit_snapshot`, issue #1654), so they
+//! reuse the generator redirects and dependency index that compile already ran.
+//! There is no second analysis to drift: a consumer whose only path to its
+//! import is a generator redirect still ships its `component-type` section,
+//! because the section comes from the exact compile that resolved that redirect.
 
 use std::fs;
 

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -133,6 +133,11 @@ pub struct CompileResult {
     pub wir_package: Option<wir::WirPackage>,
     /// Whether the entry module has `#![TODO]`
     pub is_todo_module: bool,
+    /// WIT-relevant frontend subset, retained when
+    /// [`CompilerOptions::embed_wit_contract`] is set. The CLI derives the
+    /// `component-type` section / `wado wit` text from this single analysis
+    /// (issue #1654). `None` otherwise.
+    pub wit_emit_snapshot: Option<wit_emit::WitEmitSnapshot>,
     /// Structural description of the generator's `pub struct Options`,
     /// populated only when `target_world == "core:kiln/generator"` and
     /// the Options struct extracts cleanly. Consumed by the CLI's kiln
@@ -250,6 +255,15 @@ pub struct CompilerOptions {
     /// Severity policy for the three param-resolution diagnostic classes
     /// (`--param-unknown` / `--param-invalid` / `--param-missing`).
     pub param_policy: param_resolution::ParamPolicy,
+    /// When `Some`, the main compile takes a [`wit_emit::WitEmitSnapshot`] of
+    /// the WIT-relevant frontend subset (using this contract) before `Semantics`
+    /// is destructured into codegen, and returns it on
+    /// [`CompileResult::wit_emit_snapshot`]. The CLI then encodes the
+    /// `component-type` section (`wado compile`) or renders WIT text
+    /// (`wado wit`) from that single analysis instead of re-analyzing the
+    /// frontend a second time (issue #1654). `None` skips the clone entirely, so
+    /// a build that does not embed WIT pays nothing.
+    pub embed_wit_contract: Option<wit_emit::WitContract>,
 }
 
 impl Default for CompilerOptions {
@@ -270,6 +284,7 @@ impl Default for CompilerOptions {
             lib_world: None,
             param_overrides: crate::hashmap::IndexMap::default(),
             param_policy: param_resolution::ParamPolicy::default(),
+            embed_wit_contract: None,
         }
     }
 }
@@ -727,13 +742,16 @@ pub async fn compile_with_options<H: CompilerHost>(
     // Wrap all subsequent Bail errors with is_todo_module
     let result = compile_after_load(load_result, options, &logger, filename);
     match result {
-        Ok((wasm, module, wir_package, kiln_options_descriptor)) => Ok(CompileResult {
-            wasm,
-            module,
-            wir_package,
-            is_todo_module,
-            kiln_options_descriptor,
-        }),
+        Ok((wasm, module, wir_package, wit_emit_snapshot, kiln_options_descriptor)) => {
+            Ok(CompileResult {
+                wasm,
+                module,
+                wir_package,
+                is_todo_module,
+                wit_emit_snapshot,
+                kiln_options_descriptor,
+            })
+        }
         Err(Bail) => Err(CompileFailure { is_todo_module }),
     }
 }
@@ -749,6 +767,7 @@ fn compile_after_load<H: CompilerHost>(
         Vec<u8>,
         ast::Module,
         Option<wir::WirPackage>,
+        Option<wit_emit::WitEmitSnapshot>,
         Option<kiln::OptionsDescriptor>,
     ),
     Bail,
@@ -802,6 +821,25 @@ fn compile_after_load<H: CompilerHost>(
     if !sem.is_complete() {
         return Err(Bail);
     }
+
+    // Take the WIT-relevant subset now, before `sem` is destructured into
+    // codegen below, so the `component-type` section / `wado wit` text derive
+    // from this single analysis instead of a second frontend run (issue #1654).
+    // Only when embedding is requested — a normal compile pays nothing. The
+    // `is_complete()` check above guarantees the registries are built; this is
+    // the pre-`--lib`-registration subset, matching what the deleted
+    // second-analysis path (`semantics_for_world`) produced.
+    let wit_emit_snapshot = options.embed_wit_contract.as_ref().map(|contract| {
+        wit_emit::WitEmitSnapshot::new(
+            snapshot_tir_modules(&sem.tir_modules),
+            sem.types.clone(),
+            sem.cm_interface_registry_arc()
+                .expect("cm_interface_registry present when is_complete"),
+            sem.world_registry_arc()
+                .expect("world_registry present when is_complete"),
+            contract.clone(),
+        )
+    });
 
     // Source-level unused diagnostics. Reads the liveness computed during
     // `semantics_with_logger`; gated on the option (CLI `--no-unused`).
@@ -1352,6 +1390,7 @@ fn compile_after_load<H: CompilerHost>(
         } else {
             None
         },
+        wit_emit_snapshot,
         kiln_options_descriptor,
     ))
 }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -134,9 +134,8 @@ pub struct CompileResult {
     /// Whether the entry module has `#![TODO]`
     pub is_todo_module: bool,
     /// WIT-relevant frontend subset, retained when
-    /// [`CompilerOptions::embed_wit_contract`] is set. The CLI derives the
-    /// `component-type` section / `wado wit` text from this single analysis
-    /// (issue #1654). `None` otherwise.
+    /// [`CompilerOptions::embed_wit_contract`] is set (issue #1654); `None`
+    /// otherwise.
     pub wit_emit_snapshot: Option<wit_emit::WitEmitSnapshot>,
     /// Structural description of the generator's `pub struct Options`,
     /// populated only when `target_world == "core:kiln/generator"` and
@@ -255,14 +254,10 @@ pub struct CompilerOptions {
     /// Severity policy for the three param-resolution diagnostic classes
     /// (`--param-unknown` / `--param-invalid` / `--param-missing`).
     pub param_policy: param_resolution::ParamPolicy,
-    /// When `Some`, the main compile takes a [`wit_emit::WitEmitSnapshot`] of
-    /// the WIT-relevant frontend subset (using this contract) before `Semantics`
-    /// is destructured into codegen, and returns it on
-    /// [`CompileResult::wit_emit_snapshot`]. The CLI then encodes the
-    /// `component-type` section (`wado compile`) or renders WIT text
-    /// (`wado wit`) from that single analysis instead of re-analyzing the
-    /// frontend a second time (issue #1654). `None` skips the clone entirely, so
-    /// a build that does not embed WIT pays nothing.
+    /// When `Some`, retain a [`wit_emit::WitEmitSnapshot`] (using this contract)
+    /// on [`CompileResult::wit_emit_snapshot`], so the CLI derives the
+    /// `component-type` section / `wado wit` text from this compile rather than
+    /// re-analyzing the frontend (issue #1654). `None` skips the clone.
     pub embed_wit_contract: Option<wit_emit::WitContract>,
 }
 
@@ -822,13 +817,10 @@ fn compile_after_load<H: CompilerHost>(
         return Err(Bail);
     }
 
-    // Take the WIT-relevant subset now, before `sem` is destructured into
-    // codegen below, so the `component-type` section / `wado wit` text derive
-    // from this single analysis instead of a second frontend run (issue #1654).
-    // Only when embedding is requested — a normal compile pays nothing. The
-    // `is_complete()` check above guarantees the registries are built; this is
-    // the pre-`--lib`-registration subset, matching what the deleted
-    // second-analysis path (`semantics_for_world`) produced.
+    // Clone the WIT subset before `sem` is destructured into codegen (issue
+    // #1654), so it survives the move. Captured pre-`--lib`-registration to
+    // match the removed second-analysis path; `is_complete()` guarantees the
+    // registries are built.
     let wit_emit_snapshot = options.embed_wit_contract.as_ref().map(|contract| {
         wit_emit::WitEmitSnapshot::new(
             snapshot_tir_modules(&sem.tir_modules),

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -199,6 +199,39 @@ impl Semantics {
         self.wit_contract = Some(c);
     }
 
+    /// A borrowed [`crate::wit_emit::WitEmitInput`] view over the WIT-relevant
+    /// subset, so the WIT emitter reads from this analysis directly.
+    #[must_use]
+    pub fn wit_emit_input(&self) -> crate::wit_emit::WitEmitInput<'_> {
+        crate::wit_emit::WitEmitInput {
+            is_complete: self.is_complete,
+            tir_modules: &self.tir_modules,
+            types: &self.types,
+            cm_interface_registry: self.cm_interface_registry(),
+            world_registry: self.world_registry(),
+            wit_contract: self.wit_contract.as_ref(),
+        }
+    }
+
+    /// A cloned handle to the CM interface registry `Arc`, or `None` when
+    /// analysis bailed before building it. Used by the main compile to take a
+    /// [`crate::wit_emit::WitEmitSnapshot`] before `Semantics` is destructured.
+    #[must_use]
+    pub fn cm_interface_registry_arc(&self) -> Option<std::sync::Arc<CmInterfaceRegistry>> {
+        self.state
+            .as_ref()
+            .map(|s| std::sync::Arc::clone(&s.tysys.cm_interface_registry))
+    }
+
+    /// A cloned handle to the world registry `Arc`, paired with
+    /// [`Self::cm_interface_registry_arc`] for the WIT snapshot.
+    #[must_use]
+    pub fn world_registry_arc(&self) -> Option<std::sync::Arc<WorldRegistry>> {
+        self.state
+            .as_ref()
+            .map(|s| std::sync::Arc::clone(&s.world_registry))
+    }
+
     /// Component Model world registry produced during annotate.
     ///
     /// Carries every `world` declaration the frontend has seen — stdlib

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -200,7 +200,7 @@ impl Semantics {
     }
 
     /// A borrowed [`crate::wit_emit::WitEmitInput`] view over the WIT-relevant
-    /// subset, so the WIT emitter reads from this analysis directly.
+    /// subset.
     #[must_use]
     pub fn wit_emit_input(&self) -> crate::wit_emit::WitEmitInput<'_> {
         crate::wit_emit::WitEmitInput {
@@ -213,9 +213,8 @@ impl Semantics {
         }
     }
 
-    /// A cloned handle to the CM interface registry `Arc`, or `None` when
-    /// analysis bailed before building it. Used by the main compile to take a
-    /// [`crate::wit_emit::WitEmitSnapshot`] before `Semantics` is destructured.
+    /// A cloned handle to the CM interface registry `Arc` (`None` before it is
+    /// built), for taking a [`crate::wit_emit::WitEmitSnapshot`].
     #[must_use]
     pub fn cm_interface_registry_arc(&self) -> Option<std::sync::Arc<CmInterfaceRegistry>> {
         self.state
@@ -224,7 +223,7 @@ impl Semantics {
     }
 
     /// A cloned handle to the world registry `Arc`, paired with
-    /// [`Self::cm_interface_registry_arc`] for the WIT snapshot.
+    /// [`Self::cm_interface_registry_arc`].
     #[must_use]
     pub fn world_registry_arc(&self) -> Option<std::sync::Arc<WorldRegistry>> {
         self.state

--- a/wado-compiler/src/wit_bundle.rs
+++ b/wado-compiler/src/wit_bundle.rs
@@ -21,7 +21,7 @@ use wasm_encoder::{Encode, Section};
 use wit_component::StringEncoding;
 
 use crate::semantics::Semantics;
-use crate::wit_emit::{self, WitEmitError, WitEmitOptions, WitScope};
+use crate::wit_emit::{self, WitEmitError, WitEmitInput, WitEmitOptions, WitScope};
 
 /// Append a `component-type` custom section to `component_bytes`, derived from
 /// the WIT text [`wit_emit::emit_wit_text`] renders for `sem` under `opts`.
@@ -41,16 +41,33 @@ pub fn embed_component_type(
     world_imports: &[String],
 ) -> Result<Vec<u8>, WitEmitError> {
     let payload = encode_component_type(sem, world_imports)?;
+    Ok(append_component_type_section(component_bytes, &payload))
+}
 
+/// Like [`embed_component_type`], but from a detached [`WitEmitInput`] view
+/// (issue #1654).
+pub fn embed_component_type_from(
+    component_bytes: &[u8],
+    input: WitEmitInput<'_>,
+    world_imports: &[String],
+) -> Result<Vec<u8>, WitEmitError> {
+    let payload = encode_component_type_from(input, world_imports)?;
+    Ok(append_component_type_section(component_bytes, &payload))
+}
+
+/// Append an already-encoded `component-type` payload to a component as a custom
+/// section, leaving the component's own type structure untouched.
+#[must_use]
+pub fn append_component_type_section(component_bytes: &[u8], payload: &[u8]) -> Vec<u8> {
     let section = wasm_encoder::CustomSection {
         name: "component-type".into(),
-        data: Cow::Borrowed(&payload),
+        data: Cow::Borrowed(payload),
     };
     let mut out = Vec::with_capacity(component_bytes.len() + payload.len() + 16);
     out.extend_from_slice(component_bytes);
     out.push(section.id());
     section.encode(&mut out);
-    Ok(out)
+    out
 }
 
 /// Render the WIT for `sem`/`opts` and encode it as a `component-type` section
@@ -61,12 +78,22 @@ pub fn encode_component_type(
     sem: &Semantics,
     world_imports: &[String],
 ) -> Result<Vec<u8>, WitEmitError> {
+    encode_component_type_from(sem.wit_emit_input(), world_imports)
+}
+
+/// Like [`encode_component_type`], but from a detached [`WitEmitInput`] view, so
+/// the `wado compile` embed path encodes the section from the main compile's
+/// retained subset without a second frontend analysis (issue #1654).
+pub fn encode_component_type_from(
+    input: WitEmitInput<'_>,
+    world_imports: &[String],
+) -> Result<Vec<u8>, WitEmitError> {
     // Force full scope: the section must be a self-contained WIT package so
     // `metadata::encode` can type the world without an external registry.
     let opts = WitEmitOptions {
         scope: WitScope::Full,
     };
-    let text = wit_emit::emit_wit_text(sem, &opts, world_imports)?;
+    let text = wit_emit::emit_wit_text_from(input, &opts, world_imports)?;
 
     let mut resolve = wit_parser::Resolve::new();
     let pkg = resolve
@@ -75,7 +102,7 @@ pub fn encode_component_type(
             description: format!("re-parsing emitted WIT failed: {e}"),
         })?;
 
-    let world_name = wit_emit::world_name(sem);
+    let world_name = wit_emit::world_name_from(input);
     let world = resolve
         .select_world(&[pkg], Some(world_name.as_str()))
         .map_err(|e| WitEmitError::Embed {

--- a/wado-compiler/src/wit_bundle.rs
+++ b/wado-compiler/src/wit_bundle.rs
@@ -81,9 +81,7 @@ pub fn encode_component_type(
     encode_component_type_from(sem.wit_emit_input(), world_imports)
 }
 
-/// Like [`encode_component_type`], but from a detached [`WitEmitInput`] view, so
-/// the `wado compile` embed path encodes the section from the main compile's
-/// retained subset without a second frontend analysis (issue #1654).
+/// Like [`encode_component_type`], but from a detached [`WitEmitInput`] view (issue #1654).
 pub fn encode_component_type_from(
     input: WitEmitInput<'_>,
     world_imports: &[String],

--- a/wado-compiler/src/wit_emit.rs
+++ b/wado-compiler/src/wit_emit.rs
@@ -5,11 +5,11 @@
 //! output — declared interfaces, exported items, the active world, and the
 //! type table — and renders a WIT document with [`wit_encoder`].
 //!
-//! `wado wit` prints the text. A planned Phase 2 (`wado compile` embedding, not
-//! yet implemented) will reuse the same text to derive the embedded
-//! `component-type` custom section. WIT is fully determined by name and type
-//! resolution, so emission reads [`Semantics`] and never touches monomorphize /
-//! lower / codegen.
+//! `wado wit` prints the text; `wado compile` embeds it as a `component-type`
+//! custom section (see [`crate::wit_bundle`]). WIT is fully determined by name
+//! and type resolution, so emission reads a [`WitEmitInput`] view — over a live
+//! [`Semantics`] or a detached [`WitEmitSnapshot`] — and never touches
+//! monomorphize / lower / codegen.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -99,13 +99,10 @@ pub fn wit_contract(
     }
 }
 
-/// The frontend subset the WIT emitter reads, as borrows.
-///
-/// Both a live [`Semantics`] (via [`Semantics::wit_emit_input`]) and a detached
-/// [`WitEmitSnapshot`] taken by the main compile feed the emitter through this
-/// view, so the `component-type` section and `wado wit` text are derived from
-/// the *same* analysis the codegen ran — no second frontend pass, no replay to
-/// drift (issue #1654).
+/// The frontend subset the WIT emitter reads, as borrows. A live [`Semantics`]
+/// and a detached [`WitEmitSnapshot`] both feed the emitter through this view,
+/// so `wado compile` and `wado wit` derive WIT from the same analysis codegen
+/// ran (issue #1654).
 #[derive(Clone, Copy)]
 pub struct WitEmitInput<'a> {
     /// Whether the analysis ran to completion; emission refuses partial state.
@@ -123,14 +120,10 @@ pub struct WitEmitInput<'a> {
     pub wit_contract: Option<&'a WitContract>,
 }
 
-/// A detached, owned copy of the WIT-relevant frontend subset, cloned by the
-/// main compile before `Semantics` is destructured into codegen (issue #1654).
-///
-/// Carried on [`crate::CompileResult`] so the CLI can encode the
-/// `component-type` section (`wado compile`) or render WIT text (`wado wit`)
-/// from the single analysis the codegen used, instead of re-running the
-/// frontend. Only cloned when embedding is requested, so a normal compile pays
-/// nothing.
+/// A detached, owned copy of the WIT-relevant frontend subset, cloned before
+/// `Semantics` is destructured into codegen and carried on
+/// [`crate::CompileResult`], so the CLI encodes the `component-type` section or
+/// renders `wado wit` text without re-running the frontend (issue #1654).
 pub struct WitEmitSnapshot {
     tir_modules: IndexMap<ModuleSource, TirModule>,
     types: TypeTable,
@@ -227,9 +220,7 @@ pub fn emit_wit_text(
     emit_wit_text_from(sem.wit_emit_input(), opts, world_imports)
 }
 
-/// Like [`emit_wit_text`], but from a detached [`WitEmitInput`] view, so the
-/// `wado compile` embed path and `wado wit` render from the main compile's
-/// retained subset without a second frontend analysis (issue #1654).
+/// Like [`emit_wit_text`], but from a detached [`WitEmitInput`] view (issue #1654).
 pub fn emit_wit_text_from(
     input: WitEmitInput<'_>,
     opts: &WitEmitOptions,

--- a/wado-compiler/src/wit_emit.rs
+++ b/wado-compiler/src/wit_emit.rs
@@ -18,9 +18,15 @@ use wit_encoder::{
     TypeDef, VariantCase, World, WorldItem,
 };
 
+use std::sync::Arc;
+
+use crate::component_model::CmInterfaceRegistry;
+use crate::hashmap::IndexMap;
+use crate::module_source::ModuleSource;
 use crate::name::to_kebab;
 use crate::semantics::Semantics;
-use crate::tir::{PrimitiveType, ResolvedType, TypeId, TypeTable};
+use crate::tir::{PrimitiveType, ResolvedType, TirModule, TypeId, TypeTable};
+use crate::world_registry::WorldRegistry;
 
 /// How much of the referenced interface graph to inline into the WIT document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -93,6 +99,86 @@ pub fn wit_contract(
     }
 }
 
+/// The frontend subset the WIT emitter reads, as borrows.
+///
+/// Both a live [`Semantics`] (via [`Semantics::wit_emit_input`]) and a detached
+/// [`WitEmitSnapshot`] taken by the main compile feed the emitter through this
+/// view, so the `component-type` section and `wado wit` text are derived from
+/// the *same* analysis the codegen ran — no second frontend pass, no replay to
+/// drift (issue #1654).
+#[derive(Clone, Copy)]
+pub struct WitEmitInput<'a> {
+    /// Whether the analysis ran to completion; emission refuses partial state.
+    pub is_complete: bool,
+    /// TIR modules whose user exports and type decls seed the WIT surface.
+    pub tir_modules: &'a IndexMap<ModuleSource, TirModule>,
+    /// Resolve-time type snapshot the emitter maps to WIT types.
+    pub types: &'a TypeTable,
+    /// CM interface registry for `source_interface` resolution and `full`-scope
+    /// inlining. `None` when analysis bailed before building it.
+    pub cm_interface_registry: Option<&'a CmInterfaceRegistry>,
+    /// World registry, to partition world-conformance exports from user exports.
+    pub world_registry: Option<&'a WorldRegistry>,
+    /// Emitted world name + default interface. `None` until the CLI sets it.
+    pub wit_contract: Option<&'a WitContract>,
+}
+
+/// A detached, owned copy of the WIT-relevant frontend subset, cloned by the
+/// main compile before `Semantics` is destructured into codegen (issue #1654).
+///
+/// Carried on [`crate::CompileResult`] so the CLI can encode the
+/// `component-type` section (`wado compile`) or render WIT text (`wado wit`)
+/// from the single analysis the codegen used, instead of re-running the
+/// frontend. Only cloned when embedding is requested, so a normal compile pays
+/// nothing.
+pub struct WitEmitSnapshot {
+    tir_modules: IndexMap<ModuleSource, TirModule>,
+    types: TypeTable,
+    cm_interface_registry: Arc<CmInterfaceRegistry>,
+    world_registry: Arc<WorldRegistry>,
+    wit_contract: WitContract,
+}
+
+impl WitEmitSnapshot {
+    #[must_use]
+    pub fn new(
+        tir_modules: IndexMap<ModuleSource, TirModule>,
+        types: TypeTable,
+        cm_interface_registry: Arc<CmInterfaceRegistry>,
+        world_registry: Arc<WorldRegistry>,
+        wit_contract: WitContract,
+    ) -> Self {
+        Self {
+            tir_modules,
+            types,
+            cm_interface_registry,
+            world_registry,
+            wit_contract,
+        }
+    }
+
+    /// A borrowed [`WitEmitInput`] view over this snapshot.
+    #[must_use]
+    pub fn input(&self) -> WitEmitInput<'_> {
+        WitEmitInput {
+            is_complete: true,
+            tir_modules: &self.tir_modules,
+            types: &self.types,
+            cm_interface_registry: Some(&self.cm_interface_registry),
+            world_registry: Some(&self.world_registry),
+            wit_contract: Some(&self.wit_contract),
+        }
+    }
+}
+
+impl std::fmt::Debug for WitEmitSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WitEmitSnapshot")
+            .field("wit_contract", &self.wit_contract)
+            .finish_non_exhaustive()
+    }
+}
+
 /// A failure that prevents emitting valid WIT.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WitEmitError {
@@ -138,11 +224,22 @@ pub fn emit_wit_text(
     opts: &WitEmitOptions,
     world_imports: &[String],
 ) -> Result<String, WitEmitError> {
-    if !sem.is_complete() {
+    emit_wit_text_from(sem.wit_emit_input(), opts, world_imports)
+}
+
+/// Like [`emit_wit_text`], but from a detached [`WitEmitInput`] view, so the
+/// `wado compile` embed path and `wado wit` render from the main compile's
+/// retained subset without a second frontend analysis (issue #1654).
+pub fn emit_wit_text_from(
+    input: WitEmitInput<'_>,
+    opts: &WitEmitOptions,
+    world_imports: &[String],
+) -> Result<String, WitEmitError> {
+    if !input.is_complete {
         return Err(WitEmitError::IncompleteSemantics);
     }
 
-    let mut emitter = Emitter::new(sem);
+    let mut emitter = Emitter::new(input);
     let package = emitter.build_package(world_imports)?;
     let mut out = package.to_string();
 
@@ -161,7 +258,10 @@ pub fn emit_wit_text(
 
 /// Drives one emission pass over the frontend's TIR modules.
 struct Emitter<'a> {
-    sem: &'a Semantics,
+    tir_modules: &'a IndexMap<ModuleSource, TirModule>,
+    cm_interface_registry: Option<&'a CmInterfaceRegistry>,
+    world_registry: Option<&'a WorldRegistry>,
+    wit_contract: Option<&'a WitContract>,
     types: &'a TypeTable,
     /// User-authored type declarations keyed by source name, gathered across
     /// every loaded user module so referenced types can be looked up by name.
@@ -197,9 +297,9 @@ struct TypeDecls<'a> {
 }
 
 impl<'a> Emitter<'a> {
-    fn new(sem: &'a Semantics) -> Self {
+    fn new(input: WitEmitInput<'a>) -> Self {
         let mut decls = TypeDecls::default();
-        for module in sem.tir_modules.values() {
+        for module in input.tir_modules.values() {
             for s in &module.structs {
                 decls.structs.insert(s.name.clone(), s);
             }
@@ -217,8 +317,11 @@ impl<'a> Emitter<'a> {
             }
         }
         Self {
-            sem,
-            types: &sem.types,
+            tir_modules: input.tir_modules,
+            cm_interface_registry: input.cm_interface_registry,
+            world_registry: input.world_registry,
+            wit_contract: input.wit_contract,
+            types: input.types,
             decls,
             referenced_interfaces: BTreeSet::new(),
             pending: BTreeMap::new(),
@@ -228,14 +331,12 @@ impl<'a> Emitter<'a> {
 
     fn build_package(&mut self, world_imports: &[String]) -> Result<Package, WitEmitError> {
         let contract = self
-            .sem
-            .wit_contract()
+            .wit_contract
             .ok_or(WitEmitError::IncompleteSemantics)?
             .clone();
         let exports = self.collect_exported_functions();
         let world_info = self
-            .sem
-            .world_registry()
+            .world_registry
             .and_then(|registry| registry.get(&contract.world_fq));
 
         // World imports: the faithful set the compiled component imports,
@@ -327,7 +428,7 @@ impl<'a> Emitter<'a> {
     /// order.
     fn collect_exported_functions(&self) -> Vec<ExportedFn> {
         let mut out = Vec::new();
-        for module in self.sem.tir_modules.values() {
+        for module in self.tir_modules.values() {
             // Only user-authored modules contribute to the WIT contract; the
             // bundled allocator / runtime modules also carry `export fn`
             // (canonical-ABI realloc), but those are not part of the contract.
@@ -367,7 +468,7 @@ impl<'a> Emitter<'a> {
     /// component imports, following each interface's function and type
     /// signatures to the interfaces they reference.
     fn transitive_import_closure(&self, roots: BTreeSet<String>) -> BTreeSet<String> {
-        let Some(registry) = self.sem.cm_interface_registry() else {
+        let Some(registry) = self.cm_interface_registry else {
             return roots;
         };
         let infos: Vec<crate::component_model::CmInterfaceInfo> = registry.interfaces().collect();
@@ -409,7 +510,7 @@ impl<'a> Emitter<'a> {
     /// Build one nested `package` per referenced CM package, each holding the
     /// full reconstructed definitions of the referenced interfaces in it.
     fn build_nested_packages(&self) -> Result<Vec<wit_encoder::NestedPackage>, WitEmitError> {
-        let Some(registry) = self.sem.cm_interface_registry() else {
+        let Some(registry) = self.cm_interface_registry else {
             return Ok(Vec::new());
         };
         let infos: Vec<crate::component_model::CmInterfaceInfo> = registry.interfaces().collect();
@@ -632,8 +733,7 @@ impl<'a> Emitter<'a> {
         uses: &mut Vec<(String, String)>,
     ) -> String {
         let cm_name = self
-            .sem
-            .cm_interface_registry()
+            .cm_interface_registry
             .zip(named.source_interface.as_deref())
             .and_then(|(reg, src)| {
                 reg.get_struct_cm_name_by_source(src, &named.name)
@@ -1143,8 +1243,14 @@ fn collect_named_type_sources(ty: &crate::ast::Type, out: &mut Vec<String>) {
 /// to the empty local name when unset (callers always set it before emitting).
 #[must_use]
 pub fn world_name(sem: &Semantics) -> String {
-    let world_fq = sem
-        .wit_contract()
+    world_name_from(sem.wit_emit_input())
+}
+
+/// Like [`world_name`], but from a detached [`WitEmitInput`] view.
+#[must_use]
+pub fn world_name_from(input: WitEmitInput<'_>) -> String {
+    let world_fq = input
+        .wit_contract
         .map(|c| c.world_fq.as_str())
         .unwrap_or("");
     to_kebab(&world_local_name(world_fq))


### PR DESCRIPTION
## Summary

WIT `component-type` embedding used to re-run the whole frontend a **second time**, separately from the main compile, to re-derive a `Semantics` for emission (`embed_wit_section` in `wado compile`, and both helpers in `wado wit`). That "analyze twice" design was the shared root of a recurring bug class: whenever the second analysis was not a faithful replay of the first, embedding silently broke (#1478 — un-threaded target world; #1646 — un-threaded Kiln generator redirects).

This branch derives the section from the **single `Semantics` the main compile already produces**, so a mismatch between "the compile" and "the WIT" is structurally impossible.

Closes #1654.

## What changed

- **`WitEmitInput` / `WitEmitSnapshot` (`wit_emit.rs`)** — the WIT emitter now reads a borrowed `WitEmitInput` view (over a live `Semantics` or a detached, owned `WitEmitSnapshot`) instead of `&Semantics` directly. The public `emit_wit_text` / `encode_component_type` / `world_name` keep their `&Semantics` signatures as thin wrappers, so existing callers and tests are untouched.
- **Single source of truth (`lib.rs`)** — `CompilerOptions::embed_wit_contract` opts a compile into retaining a `WitEmitSnapshot` (deep-cloned `tir_modules` + `types` + CM/world registry `Arc`s), captured before `Semantics` is destructured into codegen and returned on `CompileResult::wit_emit_snapshot`. Gated, so a non-embedding build clones nothing.
- **`wado compile` (`compile.rs`)** — `embed_wit_section` now just encodes the retained snapshot and appends the section; the second-analysis host/kiln re-run is deleted.
- **`wado wit` (`wit.rs`)** — collapses its own duplicated "load manifest → attach deps → run pipeline → analyze twice" into a single compile, reading the snapshot and the faithful WIR import plan from one result. The silent-twin host and the separate import compile are gone.

Net effect: world / invocations / deps drift between the compile and the embedded WIT is no longer possible, retiring the #1478/#1646 bug class rather than patching instances of it.

## Notes

- **`wado wit` now requires a compilable program.** Previously it emitted the interface (with empty import lines + a warning) even when a post-frontend phase failed; it now derives its text from a single successful compile. This is intended — `wado wit` does not need to operate on programs that fail to compile.
- No new tests: the refactor changes no observable output for compilable programs, so the existing suites (`wit`, `wit_bundle`, `wit_import_plan`, `kiln_embed_wit`, `cli`) stand as the regression net and remain green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XySuo9wbcGiHJBUABABfnQ)_