### PR TITLE
feat(marl): customizable code-block highlighting via a Highlight effect

### DIFF
--- a/package-marl/src/fmt_html.wado
+++ b/package-marl/src/fmt_html.wado
@@ -52,19 +52,23 @@ pub interface Highlight {
 
 /// The default `Highlight`: no language-specific markup, just HTML-escape —
 /// so `render` reproduces plain `<pre><code>` output.
-struct PlainHighlight {}
+struct PlainHighlight {
+}
 
 impl Highlight for PlainHighlight {
     fn highlight(&mut self, code: String, _lang: String) -> String {
         resume escape_text_ref(&code);
     }
+
     ..trap
 }
 
 /// Render Markdown to HTML with plain (escaped) code blocks.
 export fn render(source: String) -> RenderResult {
     let mut h = PlainHighlight {};
-    return with &mut h do { render_document(source) };
+    return with &mut h do {
+        render_document(source);
+    };
 }
 
 /// Render Markdown to HTML, delegating each code block to a `Highlight`

--- a/package-marl/src/fmt_html.wado
+++ b/package-marl/src/fmt_html.wado
@@ -42,7 +42,39 @@ pub struct HeadingInfo {
     pub text: String,
 }
 
+/// Renders a fenced code block's body to HTML. The result is inserted
+/// verbatim (not escaped), so a handler owns output safety: the default
+/// `render` escapes; a syntax highlighter emits `<span class="...">` markup.
+/// `lang` is the fence info string (empty for a plain block).
+pub interface Highlight {
+    fn highlight(code: String, lang: String) -> String;
+}
+
+/// The default `Highlight`: no language-specific markup, just HTML-escape —
+/// so `render` reproduces plain `<pre><code>` output.
+struct PlainHighlight {}
+
+impl Highlight for PlainHighlight {
+    fn highlight(&mut self, code: String, _lang: String) -> String {
+        resume escape_text_ref(&code);
+    }
+    ..trap
+}
+
+/// Render Markdown to HTML with plain (escaped) code blocks.
 export fn render(source: String) -> RenderResult {
+    let mut h = PlainHighlight {};
+    return with &mut h do { render_document(source) };
+}
+
+/// Render Markdown to HTML, delegating each code block to a `Highlight`
+/// handler — the extension point a consumer satisfies with a syntax
+/// highlighter (e.g. a `provider` supplying `wado-lang:gale-highlight-wado`).
+export fn render_highlighted(source: String) -> RenderResult with Highlight {
+    return render_document(source);
+}
+
+fn render_document(source: String) -> RenderResult with Highlight {
     let parsed = parse(&source);
     let mut r = Renderer {
         refs: parsed.refs,
@@ -67,7 +99,7 @@ impl Renderer {
 
     /// Blocks join with a single newline, and front matter / reference
     /// definitions contribute no output — they are metadata, not content.
-    fn render_blocks(&mut self, nodes: &List<Node>) -> String {
+    fn render_blocks(&mut self, nodes: &List<Node>) -> String with Highlight {
         let mut parts: List<String> = [];
         for let node of nodes {
             if node matches { Node::FrontMatter(_) | Node::LinkReferenceDef(_) } {
@@ -78,7 +110,7 @@ impl Renderer {
         return parts.join("\n");
     }
 
-    fn render_block(&mut self, node: &Node) -> String {
+    fn render_block(&mut self, node: &Node) -> String with Highlight {
         return match node {
             Node::Heading(h) => self.render_heading(h),
             Node::Paragraph(p) => `<p>${render_inline_seq(&p.children, &self.refs)}</p>`,
@@ -102,7 +134,7 @@ impl Renderer {
 
     // --- lists ---
 
-    fn render_list(&mut self, list: &MdList) -> String {
+    fn render_list(&mut self, list: &MdList) -> String with Highlight {
         let loose = list_is_loose(list);
         let mut parts: List<String> = [];
         for let item of list.items {
@@ -113,7 +145,7 @@ impl Renderer {
         return `${open}\n${inner}\n${close}`;
     }
 
-    fn render_item(&mut self, item: &MdItem, loose: bool) -> String {
+    fn render_item(&mut self, item: &MdItem, loose: bool) -> String with Highlight {
         let marker = match item.marker {
             Some(m) => if m.checked { "[x] " } else { "[ ] " },
             None => "",
@@ -130,7 +162,7 @@ impl Renderer {
     /// normally. A task-list marker (`[ ] ` / `[x] `) leads the first child's
     /// content, so it lands inside the `<p>` of a loose item without
     /// inspecting the output.
-    fn render_item_children(&mut self, children: &List<Node>, loose: bool, marker: String) -> String {
+    fn render_item_children(&mut self, children: &List<Node>, loose: bool, marker: String) -> String with Highlight {
         let mut parts: List<String> = [];
         let mut first = true;
         for let child of children {
@@ -141,7 +173,7 @@ impl Renderer {
         return parts.join("\n");
     }
 
-    fn render_item_child(&mut self, child: &Node, loose: bool, lead: &String) -> String {
+    fn render_item_child(&mut self, child: &Node, loose: bool, lead: &String) -> String with Highlight {
         match child {
             Node::Paragraph(p) => {
                 let inline = render_inline_seq(&p.children, &self.refs);
@@ -182,14 +214,14 @@ fn collect_heading_text(children: &List<Node>, out: &mut String) {
     }
 }
 
-fn render_code_block(cb: &CodeBlock) -> String {
+fn render_code_block(cb: &CodeBlock) -> String with Highlight {
     let mut out = String::new();
     out.push_str(&"<pre><code");
     if cb.tag.len() > 0 {
         out.push_str(&` class="language-${escape_attr_ref(&cb.tag)}"`);
     }
     out.push('>');
-    out.push_str(&escape_text_ref(&cb.code));
+    out.push_str(&Highlight::highlight(cb.code, cb.tag));
     out.push_str(&"</code></pre>");
     return out;
 }

--- a/package-marl/src/fmt_html_test.wado
+++ b/package-marl/src/fmt_html_test.wado
@@ -418,12 +418,14 @@ test "render reports no headings for a heading-free document" {
 
 use { render_highlighted, Highlight } from "./fmt_html.wado";
 
-struct MarkHl {}
+struct MarkHl {
+}
 
 impl Highlight for MarkHl {
     fn highlight(&mut self, code: String, lang: String) -> String {
         resume `<mark data-lang="${lang}">${code}</mark>`;
     }
+
     ..trap
 }
 
@@ -432,7 +434,7 @@ test "render_highlighted delegates each code block to the Highlight handler, une
     let out = with &mut h do {
         render_highlighted("```wado
 let x = 1;
-```")
+```");
     };
     assert out.html == "<pre><code class=\"language-wado\"><mark data-lang=\"wado\">let x = 1;
 </mark></code></pre>";

--- a/package-marl/src/fmt_html_test.wado
+++ b/package-marl/src/fmt_html_test.wado
@@ -413,3 +413,34 @@ test "render reports no headings for a heading-free document" {
     let result = render("just a paragraph");
     assert result.headings.is_empty();
 }
+
+// --- highlight extension point ---
+
+use { render_highlighted, Highlight } from "./fmt_html.wado";
+
+struct MarkHl {}
+
+impl Highlight for MarkHl {
+    fn highlight(&mut self, code: String, lang: String) -> String {
+        resume `<mark data-lang="${lang}">${code}</mark>`;
+    }
+    ..trap
+}
+
+test "render_highlighted delegates each code block to the Highlight handler, unescaped" {
+    let mut h = MarkHl {};
+    let out = with &mut h do {
+        render_highlighted("```wado
+let x = 1;
+```")
+    };
+    assert out.html == "<pre><code class=\"language-wado\"><mark data-lang=\"wado\">let x = 1;
+</mark></code></pre>";
+}
+
+test "render still escapes code blocks by default" {
+    assert render("```wado
+a < b
+```").html == "<pre><code class=\"language-wado\">a &lt; b
+</code></pre>";
+}

--- a/package-marl/src/lib.wado
+++ b/package-marl/src/lib.wado
@@ -5,6 +5,6 @@
 //! walks the tree to safe HTML, `format` prints it back to canonical
 //! Markdown. See `docs/wep-2026-07-05-marl.md`.
 
-pub use { render, RenderResult, HeadingInfo } from "./fmt_html.wado";
+pub use { render, render_highlighted, Highlight, RenderResult, HeadingInfo } from "./fmt_html.wado";
 pub use { escape_text, escape_attr } from "./html.wado";
 pub use { format } from "./format.wado";

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -1762,10 +1762,9 @@ impl CmInterfaceRegistry {
     /// the export interface; reported so the user renames the effect.
     pub fn register_lib_guest_effect_imports(
         &mut self,
-        module: &crate::ast::Module,
+        interfaces: &[&crate::ast::InterfaceDecl],
         lib_fq: &str,
     ) -> Result<(), String> {
-        use crate::ast::Item;
         let Some(base) = CmImport::parse(lib_fq) else {
             return Ok(());
         };
@@ -1775,16 +1774,11 @@ impl CmInterfaceRegistry {
                 .iter()
                 .any(|m| m.attrs.iter().any(|a| a.as_cm_import().is_some()))
         };
-        let collisions: Vec<&str> = module
-            .items
+        let collisions: Vec<&str> = interfaces
             .iter()
-            .filter_map(|item| match item {
-                Item::Interface(effect)
-                    if is_guest_effect(effect) && to_kebab(&effect.name) == base.interface =>
-                {
-                    Some(effect.name.as_str())
-                }
-                _ => None,
+            .filter_map(|effect| {
+                (is_guest_effect(effect) && to_kebab(&effect.name) == base.interface)
+                    .then_some(effect.name.as_str())
             })
             .collect();
         if !collisions.is_empty() {
@@ -1795,10 +1789,7 @@ impl CmInterfaceRegistry {
                 base.interface
             ));
         }
-        for item in &module.items {
-            let Item::Interface(effect) = item else {
-                continue;
-            };
+        for effect in interfaces {
             if !is_guest_effect(effect) {
                 continue;
             }

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -443,10 +443,9 @@ fn collect_lib_surface(
         }
         for item in &module.items {
             match item {
-                // Only public interfaces reach the library's API: an effect a
-                // consumer must satisfy appears in an exported signature, so it
-                // is public. A private, internally-handled effect is excluded,
-                // so it cannot trip the name-collision check spuriously.
+                // Only public interfaces reach the API: an effect a consumer
+                // satisfies is public (it appears in an exported signature). A
+                // private, internally-handled effect is excluded.
                 Item::Interface(decl) if decl.visibility.is_public() => {
                     submodule_interfaces.push(decl.clone());
                 }
@@ -1273,9 +1272,8 @@ fn compile_after_load<H: CompilerHost>(
         // Submodule-defined types reachable through the facade's exports.
         registry.register_lib_local_items(&lib_surface.submodule_type_decls, fq);
         // Guest effect interfaces left unhandled at the boundary become CM
-        // imports the consumer satisfies. Collected from the entry module and
-        // every submodule, since a library spreads its effects (like its types)
-        // across files behind the facade.
+        // imports the consumer satisfies — from the entry module and every
+        // submodule, since a library spreads its effects (like its types).
         let mut guest_interfaces: Vec<&ast::InterfaceDecl> = entry
             .items
             .iter()

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -424,6 +424,7 @@ const KILN_GENERATOR_IMPL_FQ: &str = "kiln:generator/generator@0.1.0";
 struct LibSurface {
     submodule_exports: Vec<world_registry::WorldExportInfo>,
     submodule_type_decls: Vec<(ModuleSource, ast::Item)>,
+    submodule_interfaces: Vec<ast::InterfaceDecl>,
 }
 
 fn collect_lib_surface(
@@ -435,12 +436,14 @@ fn collect_lib_surface(
 
     let mut submodule_exports = Vec::new();
     let mut submodule_type_decls = Vec::new();
+    let mut submodule_interfaces = Vec::new();
     for (source, module) in modules {
         if source == entry_source || !source.is_local() {
             continue;
         }
         for item in &module.items {
             match item {
+                Item::Interface(decl) => submodule_interfaces.push(decl.clone()),
                 Item::Function(func) if func.is_export => {
                     submodule_exports.push(WorldExportInfo {
                         name: func.name.clone(),
@@ -467,6 +470,7 @@ fn collect_lib_surface(
     LibSurface {
         submodule_exports,
         submodule_type_decls,
+        submodule_interfaces,
     }
 }
 
@@ -1073,6 +1077,7 @@ fn compile_after_load<H: CompilerHost>(
         LibSurface {
             submodule_exports: Vec::new(),
             submodule_type_decls: Vec::new(),
+            submodule_interfaces: Vec::new(),
         }
     };
 
@@ -1262,8 +1267,19 @@ fn compile_after_load<H: CompilerHost>(
         // Submodule-defined types reachable through the facade's exports.
         registry.register_lib_local_items(&lib_surface.submodule_type_decls, fq);
         // Guest effect interfaces left unhandled at the boundary become CM
-        // imports the consumer satisfies.
-        if let Err(msg) = registry.register_lib_guest_effect_imports(entry, fq) {
+        // imports the consumer satisfies. Collected from the entry module and
+        // every submodule, since a library spreads its effects (like its types)
+        // across files behind the facade.
+        let mut guest_interfaces: Vec<&ast::InterfaceDecl> = entry
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                ast::Item::Interface(decl) => Some(decl),
+                _ => None,
+            })
+            .collect();
+        guest_interfaces.extend(lib_surface.submodule_interfaces.iter());
+        if let Err(msg) = registry.register_lib_guest_effect_imports(&guest_interfaces, fq) {
             let _ = logger.error(compiler_host::Diagnostic {
                 severity: compiler_host::Severity::Error,
                 code: compiler_host::Code::DuplicateDefinition,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -443,7 +443,13 @@ fn collect_lib_surface(
         }
         for item in &module.items {
             match item {
-                Item::Interface(decl) => submodule_interfaces.push(decl.clone()),
+                // Only public interfaces reach the library's API: an effect a
+                // consumer must satisfy appears in an exported signature, so it
+                // is public. A private, internally-handled effect is excluded,
+                // so it cannot trip the name-collision check spuriously.
+                Item::Interface(decl) if decl.visibility.is_public() => {
+                    submodule_interfaces.push(decl.clone());
+                }
                 Item::Function(func) if func.is_export => {
                     submodule_exports.push(WorldExportInfo {
                         name: func.name.clone(),

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -467,20 +467,36 @@ fn synthesize_dispatch_wrappers(
     key: &InstantiationKey,
     meta: &EffectMeta,
     plan: &DispatchPlan,
-    open_effects: &IndexSet<String>,
+    open_effects: &IndexSet<(ModuleSource, String)>,
 ) {
     let (effect_module, base_name, type_args) = key;
     let effect_module = effect_module.clone();
     let base_name = base_name.clone();
     let is_resource = meta.is_resource;
     let interner = project.interner.clone();
+    // Route the no-handler fallback to the CM import only for an effect that is
+    // both open at the boundary AND registered as a CM import (a `--lib` guest
+    // effect or WASI). A non-lib build registers no guest imports, so its
+    // wrappers keep trapping rather than emitting an unresolvable import call.
+    let is_open = open_effects.contains(&(effect_module.clone(), base_name.clone()));
+    let open_and_registered: Vec<bool> = plan
+        .operations
+        .iter()
+        .map(|op| {
+            is_open
+                && project
+                    .cm_interface_registry
+                    .get_function(&format!("{base_name}::{}", op.name))
+                    .is_some()
+        })
+        .collect();
     let entry_module = project
         .tir_modules
         .get_mut(entry_source)
         .expect("entry module must exist");
     let type_table = entry_module.type_table.clone();
     let label = instantiation_label(&base_name, type_args, &type_table.borrow());
-    for op in &plan.operations {
+    for (op, &is_open_import) in plan.operations.iter().zip(&open_and_registered) {
         let wrapper = build_dispatch_wrapper_function(
             entry_source,
             &effect_module,
@@ -490,7 +506,7 @@ fn synthesize_dispatch_wrappers(
             op,
             plan,
             is_resource,
-            open_effects.contains(&base_name),
+            is_open_import,
             &type_table,
             &interner,
         );
@@ -2936,14 +2952,23 @@ pub fn synthesize_pre_cm_binding(mut project: Package) -> Result<Package, String
 
 /// Effect names declared in the `with` clause of any exported function — the
 /// effects left open at the library boundary.
-fn open_boundary_effects(project: &Package) -> IndexSet<String> {
-    let mut out: IndexSet<String> = IndexSet::default();
+fn open_boundary_effects(project: &Package) -> IndexSet<(ModuleSource, String)> {
+    let mut out: IndexSet<(ModuleSource, String)> = IndexSet::default();
     for module in project.tir_modules.values() {
         for func_rc in &module.functions {
             let func = func_rc.borrow();
             if func.is_export {
                 for e in &func.effects {
-                    out.insert(e.name().to_string());
+                    // Key by `(module_source, name)` to match the dispatch
+                    // `InstantiationKey`; a generic `Param` effect has no concrete
+                    // identity and never keys a monomorphized wrapper.
+                    if let EffectRef::Concrete {
+                        name,
+                        module_source,
+                    } = e
+                    {
+                        out.insert((module_source.clone(), name.clone()));
+                    }
                 }
             }
         }
@@ -2997,7 +3022,7 @@ fn synthesize_dispatch_infrastructure(
     project: &mut Package,
     effect_index: &IndexMap<EffectKey, EffectMeta>,
     active_instantiations: &IndexSet<InstantiationKey>,
-    open_effects: &IndexSet<String>,
+    open_effects: &IndexSet<(ModuleSource, String)>,
 ) -> IndexMap<InstantiationKey, DispatchPlan> {
     let entry_source = project.entry_module_source.clone();
     // Pre-substitute every active instantiation's operations against the

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -474,10 +474,9 @@ fn synthesize_dispatch_wrappers(
     let base_name = base_name.clone();
     let is_resource = meta.is_resource;
     let interner = project.interner.clone();
-    // Route the no-handler fallback to the CM import only for an effect that is
-    // both open at the boundary AND registered as a CM import (a `--lib` guest
-    // effect or WASI). A non-lib build registers no guest imports, so its
-    // wrappers keep trapping rather than emitting an unresolvable import call.
+    // Route to the CM import only when the effect is open AND actually
+    // registered as one: a non-lib build registers no guest imports, so its
+    // wrappers keep trapping rather than emit an unresolvable import call.
     let is_open = open_effects.contains(&(effect_module.clone(), base_name.clone()));
     let open_and_registered: Vec<bool> = plan
         .operations
@@ -824,11 +823,9 @@ fn build_dispatch_wrapper_function(
             span,
         ));
     } else if op.cm_name.is_some() || is_open_boundary_effect {
-        // A cm-tagged (WASI) op, or a guest effect an exported function leaves
-        // open at the library boundary: emit the user-effect Call form
-        // (`Effect::op(args)`) so cm_binding's effect-call collector and
-        // rewriter lower it to the CM import — the no-handler case of an open
-        // effect is "call the consumer's implementation", not a trap.
+        // A cm-tagged (WASI) op or an open guest effect: emit the effect Call
+        // form so cm_binding lowers it to the CM import. The no-handler case of
+        // an open effect is "call the consumer's implementation", not a trap.
         let effect_call = TirExpr::new(
             TirExprKind::Call {
                 func: FunctionRef {
@@ -2928,12 +2925,11 @@ pub fn synthesize_pre_cm_binding(mut project: Package) -> Result<Package, String
         return Ok(project);
     }
 
-    // Effects an exported function declares `with E` are *open* at the library
-    // boundary: a consumer must satisfy them, so the dispatch wrapper's
-    // no-handler fallback routes to the CM import rather than trapping. An
-    // effect handled by every export (declared by none) keeps trapping. This is
-    // the union of exports' required effects, and is what lets one export
-    // install a default handler while a sibling leaves the effect open.
+    // Effects an exported function declares `with E` are open at the boundary
+    // (the union of exports' required effects); one handled by every export is
+    // not. An open effect's dispatch wrapper routes its no-handler fallback to
+    // the CM import instead of trapping — so a default-installing export and a
+    // sibling that leaves the effect open can coexist.
     let open_effects = open_boundary_effects(&project);
 
     let plans = synthesize_dispatch_infrastructure(

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -467,6 +467,7 @@ fn synthesize_dispatch_wrappers(
     key: &InstantiationKey,
     meta: &EffectMeta,
     plan: &DispatchPlan,
+    open_effects: &IndexSet<String>,
 ) {
     let (effect_module, base_name, type_args) = key;
     let effect_module = effect_module.clone();
@@ -489,6 +490,7 @@ fn synthesize_dispatch_wrappers(
             op,
             plan,
             is_resource,
+            open_effects.contains(&base_name),
             &type_table,
             &interner,
         );
@@ -505,6 +507,7 @@ fn build_dispatch_wrapper_function(
     op: &TirEffectOp,
     plan: &DispatchPlan,
     is_resource: bool,
+    is_open_boundary_effect: bool,
     type_table: &std::rc::Rc<std::cell::RefCell<TypeTable>>,
     interner: &std::cell::RefCell<ModuleSourceInterner>,
 ) -> TirFunction {
@@ -804,11 +807,12 @@ fn build_dispatch_wrapper_function(
             },
             span,
         ));
-    } else if op.cm_name.is_some() {
-        // WASI / cm-tagged effect call: emit the user-effect Call form
-        // (`Effect::op(args)`) so cm_binding's effect-call collector
-        // and rewriter pick it up exactly as it would a hand-written
-        // effect call.
+    } else if op.cm_name.is_some() || is_open_boundary_effect {
+        // A cm-tagged (WASI) op, or a guest effect an exported function leaves
+        // open at the library boundary: emit the user-effect Call form
+        // (`Effect::op(args)`) so cm_binding's effect-call collector and
+        // rewriter lower it to the CM import — the no-handler case of an open
+        // effect is "call the consumer's implementation", not a trap.
         let effect_call = TirExpr::new(
             TirExprKind::Call {
                 func: FunctionRef {
@@ -2908,13 +2912,43 @@ pub fn synthesize_pre_cm_binding(mut project: Package) -> Result<Package, String
         return Ok(project);
     }
 
-    let plans = synthesize_dispatch_infrastructure(&mut project, &effect_index, &active_effects);
+    // Effects an exported function declares `with E` are *open* at the library
+    // boundary: a consumer must satisfy them, so the dispatch wrapper's
+    // no-handler fallback routes to the CM import rather than trapping. An
+    // effect handled by every export (declared by none) keeps trapping. This is
+    // the union of exports' required effects, and is what lets one export
+    // install a default handler while a sibling leaves the effect open.
+    let open_effects = open_boundary_effects(&project);
+
+    let plans = synthesize_dispatch_infrastructure(
+        &mut project,
+        &effect_index,
+        &active_effects,
+        &open_effects,
+    );
     rewrite_call_sites_to_wrappers(&mut project, &plans);
     // Hand the plans off to `synthesize_post_check` via the project so
     // the late half doesn't re-derive the same struct / global / wrapper
     // triple from existing declarations.
     project.dispatch_plans = plans;
     Ok(project)
+}
+
+/// Effect names declared in the `with` clause of any exported function — the
+/// effects left open at the library boundary.
+fn open_boundary_effects(project: &Package) -> IndexSet<String> {
+    let mut out: IndexSet<String> = IndexSet::default();
+    for module in project.tir_modules.values() {
+        for func_rc in &module.functions {
+            let func = func_rc.borrow();
+            if func.is_export {
+                for e in &func.effects {
+                    out.insert(e.name().to_string());
+                }
+            }
+        }
+    }
+    out
 }
 
 /// **Late phase** — desugar `WithHandler` expressions into the
@@ -2963,6 +2997,7 @@ fn synthesize_dispatch_infrastructure(
     project: &mut Package,
     effect_index: &IndexMap<EffectKey, EffectMeta>,
     active_instantiations: &IndexSet<InstantiationKey>,
+    open_effects: &IndexSet<String>,
 ) -> IndexMap<InstantiationKey, DispatchPlan> {
     let entry_source = project.entry_module_source.clone();
     // Pre-substitute every active instantiation's operations against the
@@ -3006,7 +3041,7 @@ fn synthesize_dispatch_infrastructure(
         let meta = substituted_metas
             .get(key)
             .expect("substituted meta must exist for every active instantiation");
-        synthesize_dispatch_wrappers(project, &entry_source, key, meta, plan);
+        synthesize_dispatch_wrappers(project, &entry_source, key, meta, plan, open_effects);
     }
     plans
 }

--- a/wado-compiler/tests/guest_effect_import.rs
+++ b/wado-compiler/tests/guest_effect_import.rs
@@ -136,3 +136,38 @@ test "shape compiles" {}
         "a fully-handled effect must not surface as a CM import"
     );
 }
+
+/// An effect handled in one export but left unhandled in another must still
+/// surface as a CM import: the lib's import surface is the union of its
+/// exports' required effects. This is the two-function pattern (a default
+/// `render` that installs a handler, plus a `render_highlighted` a consumer
+/// customizes) that `marl` relies on.
+#[test]
+fn effect_handled_in_one_export_and_open_in_another_is_imported() {
+    let source = r#"
+interface Highlight {
+    fn highlight(code: String, lang: String) -> String;
+}
+struct DefaultHl {}
+impl Highlight for DefaultHl {
+    fn highlight(&mut self, code: String, lang: String) -> String {
+        resume `${lang}:${code}`;
+    }
+    ..trap
+}
+export fn render(code: String, lang: String) -> String {
+    let mut h = DefaultHl {};
+    return with &mut h do { Highlight::highlight(code, lang) };
+}
+export fn render_highlighted(code: String, lang: String) -> String with Highlight {
+    return Highlight::highlight(code, lang);
+}
+test "shape compiles" {}
+"#;
+    let wasm = compile_lib_source(source);
+    assert!(
+        imported_interface(&wasm, GUEST_IFACE_FQ).is_some(),
+        "an effect left unhandled by an export must surface as a CM import even \
+         if another export handles it internally"
+    );
+}

--- a/wado-compiler/tests/guest_effect_import.rs
+++ b/wado-compiler/tests/guest_effect_import.rs
@@ -137,6 +137,39 @@ test "shape compiles" {}
     );
 }
 
+/// Outside a `--lib` build no guest-effect CM import is registered, so a guest
+/// effect left open at a (non-lib) export must not ICE in WIR build: the
+/// dispatch wrapper's no-handler fallback traps rather than emitting an
+/// unresolvable import call. Regression guard for the open-boundary routing.
+#[test]
+fn open_guest_effect_in_a_non_lib_build_does_not_ice() {
+    let source = r#"
+interface E { fn op(c: String) -> String; }
+struct H {}
+impl E for H {
+    fn op(&mut self, c: String) -> String { resume c; }
+    ..trap
+}
+export fn opened(c: String) -> String with E { return E::op(c); }
+export fn run() {
+    let mut h = H {};
+    let _ = with &mut h do { E::op("a") };
+}
+"#;
+    // Default (CLI) world, not `--lib`: must compile without panicking.
+    let options = CompilerOptions {
+        opt_level: OptLevel::O2,
+        ..Default::default()
+    };
+    let result =
+        common::compile_source_with_compiler_options(Path::new("nonlib.wado"), source, options);
+    assert!(
+        result.is_ok(),
+        "a non-lib open guest effect should compile, not ICE: {:?}",
+        result.err()
+    );
+}
+
 /// An effect handled in one export but left unhandled in another must still
 /// surface as a CM import: the lib's import surface is the union of its
 /// exports' required effects. This is the two-function pattern (a default


### PR DESCRIPTION
## Summary

Adds an extension point to marl for syntax-highlighting fenced code blocks, and fixes the compiler so the pattern it relies on works: a library that installs a **default** handler for a guest effect in one export while leaving that effect **open** in another.

## marl: the `Highlight` extension point

- `render` stays pure — it installs a default `Highlight` handler that HTML-escapes, so existing output is unchanged (all prior render tests pass verbatim).
- `render_highlighted(source) with Highlight` delegates each code block to a `Highlight` handler; the result is inserted **verbatim**, so the handler owns output safety (the default escapes; a highlighter emits `<span class="…">`).
- A consumer supplies the highlighter via provider composition:

  ```wado
  use { render_highlighted } from "wado-lang:marl" with { provider: "./highlight_provider.wado" };
  ```

  where `highlight_provider.wado` supplies `wado-lang:gale-highlight-wado`'s `highlight`.

Proven end to end: a consumer importing `Marl::render_highlighted` with such a provider produces the highlighted code block.

## compiler: open-boundary effect fix

A `--lib` that used a guest effect **both** handled (a default-installing export) **and** open (an export declared `with E`) emitted no CM import, so the open export could not be satisfied by a consumer/provider. Two root causes, both fixed:

- The effect-dispatch wrapper's no-handler fallback routed to the CM import only for `#[cm]`-tagged (WASI) ops; a guest effect trapped instead. Now an effect declared `with E` by any **exported** function is *open* at the boundary — the union of exports' required effects — and its fallback lowers to the CM import. A fully-handled effect still traps and imports nothing.
- `register_lib_guest_effect_imports` scanned only the entry module, missing a guest effect defined in a **submodule** and re-exported (marl's `Highlight` lives in `fmt_html.wado`). It now registers guest interfaces from every public submodule too, mirroring submodule *type* registration.

Hardening on the same change: open effects are keyed by `(module_source, name)`, not the bare name, so two same-named effects in different modules don't cross-trigger; only concrete effects qualify (a generic `Param` effect has no monomorphized identity); the open→import route is gated on the effect being **registered** as a CM import, so a non-lib open guest effect keeps trapping instead of producing a WIR-build ICE; and only public submodule interfaces enter the lib surface, so a private internally-handled effect can't trip the name-collision check.

## Not in scope

- The gale `.scm` capture-class extension (richer token classes) and the site wiring — follow-ups after release.
- Async / stream / future value surface for effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vVX2ftY5JPmvciZjoaUPw

---
_Generated by [Claude Code](https://claude.ai/code/session_012vVX2ftY5JPmvciZjoaUPw)_