### PR TITLE
fix(cli): tolerate concurrent removal in kiln output reconcile

### DIFF
--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -603,10 +603,23 @@ fn walk_and_delete(
     kept: &indexmap::IndexSet<&str>,
     deleted: &mut Vec<String>,
 ) -> std::io::Result<()> {
-    for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
         let path = entry.path();
-        let ft = entry.file_type()?;
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
         if ft.is_dir() {
             walk_and_delete(manifest_root, &path, kept, deleted)?;
             continue;
@@ -628,8 +641,11 @@ fn walk_and_delete(
         if kept.contains(rel_str.as_str()) {
             continue;
         }
-        std::fs::remove_file(&path)?;
-        deleted.push(rel_str);
+        match std::fs::remove_file(&path) {
+            Ok(()) => deleted.push(rel_str),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Root-causes and fixes the non-deterministic `Test (Gale Ox)` compile failure tracked in #1666 — long misread as a flaky OOM.

`wado test` compiles the whole tree in parallel, and several files can share one `build/kiln/<synthetic_id>` output directory. Each compile runs `reconcile_outputs` to garbage-collect orphaned `#[generated]` files, so multiple workers walk and delete within the same directory at once. When one worker deletes an orphan another is about to delete — or a directory entry vanishes mid-walk — the loser's `remove_file` / `read_dir` / `file_type` fails with `NotFound`, aborting that file's compile with:

```
kiln: I/O error at build/kiln/kiln-…: No such file or directory (os error 2)
```

Non-deterministic, CI-only (high parallelism), never on a roomy local machine — the exact profile that read as memory pressure in #1666, even though RSS peaked well under the runner's ceiling and the process survived to print the full summary.

## Fix

Orphan GC is best-effort and idempotent: a concurrently-removed orphan is the desired end state, not a failure. `walk_and_delete` now treats `NotFound` as success at each filesystem step (`read_dir`, directory-entry iteration, `file_type`, `remove_file`). Generated output writes are already race-safe via `write_atomic` (temp + rename), so no other path needed hardening.

No test is added: a filesystem data race has no deterministic reproduction, and the existing `reconcile_outputs` unit tests continue to pass.

Closes #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PospSTEfJ8tKVFWLAfNnuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PospSTEfJ8tKVFWLAfNnuB)_