### PR TITLE
docs: state where a PR description and a WEP get their content from

### DIFF
--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -3,6 +3,17 @@ name: pull-request
 description: The rules for opening a PR you must read before creating or editing any pull request.
 ---
 
+## Before writing
+
+Read `git diff origin/main...HEAD` (three dots). The description comes from that
+diff, not from the session that produced it.
+
+Revise the branch while you are there: clean up comments and docs according to
+the project rules.
+
+Check mergeability with `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main`.
+If conflicting, resolve it with the `git-upstream-sync` skill.
+
 ## PR Title
 
 Use the Conventional Commits style for pull request titles:
@@ -20,19 +31,21 @@ It may include a scope, e.g. `feat(optimizer)`.
 
 ## PR Description
 
-Describe the outcome of the whole branch (`origin/main...HEAD` -- use three dots).
+Describe the outcome of the whole branch — what holds once it is merged.
 
-Do not include trial-and-error history in the branch; the commit history is the SSoT.
+Do not include trial-and-error history in the branch; the commit history is the
+SSoT. That is any sentence which only parses against the pre-branch state:
+"previously X, now Y", "an earlier approach", "X was replaced by Y", a count
+given as a delta ("2 -> 0"). Read each sentence back and ask whether it works
+for someone who sees only the merged tree. If it needs the old state, cut it.
 
-Add closing keywords for any issues that are resolved by this PR.
+- No: "Codegen looked the global up by name; it now compares the read's type."
+- Yes: "Codegen compares the read site's `result_ty` against the slot's type."
+
+If the branch obviously closes a known issue, add a closing keyword
+(`Closes #N`). Do not go looking for one to attach.
 
 No need to include a test section. CI runs the full test suite.
-
-## Before opening
-
-Revise the branch with `git diff origin/main...HEAD` and clean up comments and docs according to the project rules.
-
-Check mergeability with `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main`. If conflicting, resolve it with the `git-upstream-sync` skill.
 
 ## After opening & Periodic status checks
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,6 +22,11 @@ Filename: `docs/wep-YYYY-MM-DD-{feature-name}.md`
 
 It may include TODOs on WIP.
 
+A WEP is a living standard: it states the design as it stands now. When a design
+changes, rewrite the affected sections. Do not append an update log, keep
+superseded alternatives, or leave a checklist of what already landed — the git
+history is the SSoT for how the design got here.
+
 ### Index of WEPs
 
 - [Target WASI P3 Only](./wep-2026-01-11-wasi-p3-only.md)


### PR DESCRIPTION
A PR description and a WEP both describe a final state, so both are written from
the change itself rather than from the session that produced it. Each rule now
says so at the point where it is acted on.

## `.claude/skills/pull-request/SKILL.md`

The steps that run before drafting open the skill — read
`git diff origin/main...HEAD`, revise the branch, check mergeability — so the
diff is in hand before a description exists. The description is sourced from
that diff.

"Trial-and-error history" carries surface forms and a test, so a draft can be
checked against it: a sentence that only parses against the pre-branch state
("previously X, now Y", "an earlier approach", a count given as a delta) does
not belong. A No/Yes pair shows the rewrite.

A closing keyword is a reminder for a link that is already obvious, not a prompt
to go searching for an issue to attach.

## `docs/AGENTS.md`

The WEP section carries the living-standard rule: a WEP states the design as it
stands, and a design change is a rewrite of the affected sections — not an
appended update log, a retained superseded alternative, or a checklist of what
already landed. The git history is the SSoT for how a design got where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01664KUjLENq1zc1xk2s4Qpu

---
_Generated by [Claude Code](https://claude.ai/code/session_01664KUjLENq1zc1xk2s4Qpu)_