### PR TITLE
docs: specify provider metadata as source-bundled package artifacts

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -151,3 +151,4 @@ history is the SSoT for how the design got here.
 - [Byte Literals (`b'x'` and `b"..."`)](./wep-2026-07-19-byte-literal.md)
 - [`let ... else` Statements](./wep-2026-07-22-let-else.md)
 - [Async Canonical Options for `stream.read` / `stream.write`](./wep-2026-07-25-async-stream-canonical.md)
+- [Provider Metadata — Source-Bundled Package Artifacts](./wep-2026-07-26-provider-metadata.md)

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -789,13 +789,13 @@ use { Router } from "lib:router" with { git = "https://github.com/user/router.gi
 
 Which items a dependency exposes follows from whether its source is available, not from how it was fetched:
 
-| Dependency type                      | Path for a Wado consumer | Visible items       |
-| ------------------------------------ | ------------------------ | ------------------- |
-| Registry                             | Source (from the artifact's section) | `pub` + `export` |
-| Registry, published `--no-source`    | CM boundary              | `export` items only |
-| Git                                  | Source                   | `pub` + `export`    |
-| Path to directory (with `wado.toml`) | Source                   | `pub` + `export`    |
-| Path to single `.wado` file          | Source                   | `pub` + `export` (implicit `lib`) |
+| Dependency type                      | Path for a Wado consumer             | Visible items                     |
+| ------------------------------------ | ------------------------------------ | --------------------------------- |
+| Registry                             | Source (from the artifact's section) | `pub` + `export`                  |
+| Registry, published `--no-source`    | CM boundary                          | `export` items only               |
+| Git                                  | Source                               | `pub` + `export`                  |
+| Path to directory (with `wado.toml`) | Source                               | `pub` + `export`                  |
+| Path to single `.wado` file          | Source                               | `pub` + `export` (implicit `lib`) |
 
 A non-Wado CM consumer sees `export` items only in every row.
 

--- a/docs/wep-2026-02-14-package-manifest.md
+++ b/docs/wep-2026-02-14-package-manifest.md
@@ -211,7 +211,7 @@ use { parse, render } from "lib:markdown"; // OK: pub / export
 // use { tokenize } from "lib:markdown";    // ERROR: private
 ```
 
-When published as a `.wasm` component (e.g., to an OCI registry), only `export` items appear in the component's CM interface; `pub`-only items reach Wado consumers via the provider-metadata path below.
+When published as a `.wasm` component (e.g., to an OCI registry), only `export` items appear in the component's CM interface; `pub`-only items reach Wado consumers via the provider-metadata path below (see [Provider Metadata](./wep-2026-07-26-provider-metadata.md)).
 
 Crossing the package boundary requires `pub` (or `export`): a consumer may import only the `pub` / `export` items of a dependency's `lib`, never its `internal` or private items. This is a settled rule; enforcing it for wado-to-wado source dependencies is not yet implemented.
 
@@ -252,7 +252,9 @@ Registry resolution and publishing use OCI (the OCI Distribution Spec): a compon
 
 The earlier warg protocol is dropped. Its registry (`bytecodealliance/registry`) is archived and the ecosystem (`wasm-pkg-tools`) defaults to OCI. A warg-only registry such as wa.dev is reachable only through the external `wkg` tool, not natively; Wado neither implements nor wraps warg. Publishing is likewise done with `wkg`, not a Wado subcommand.
 
-Consuming (pulling), unlike publishing, does not go through `wkg`: a published package is a standalone Wasm Component Model artifact (one `application/wasm` layer), and resolving a dependency is a hot path that must not require an external binary. So the CLI pulls with a native OCI client (the `oci-client` crate), authenticating exactly as publish does (`WKG_OCI_USERNAME` / `WKG_OCI_PASSWORD`, else anonymous). `integrity` is the OCI manifest digest. Because the artifact is a prebuilt component, a registry dependency carries no transitive Wado dependencies and is consumed across the Component Model boundary (see [Wado-to-Wado Optimization](#wado-to-wado-optimization) — the source-sharing path applies to `path` deps, not registry components).
+Consuming (pulling), unlike publishing, does not go through `wkg`: a published package is a standalone Wasm Component Model artifact (one `application/wasm` layer), and resolving a dependency is a hot path that must not require an external binary. So the CLI pulls with a native OCI client (the `oci-client` crate), authenticating exactly as publish does (`WKG_OCI_USERNAME` / `WKG_OCI_PASSWORD`, else anonymous). `integrity` is the OCI manifest digest — one layer, one digest, which is also why the package's source rides in a custom section of that same `.wasm` rather than a second layer.
+
+The artifact carries both a prebuilt component and the package's Wado source, so a registry dependency does have transitive Wado dependencies, and a Wado consumer resolves it on the source-sharing path — see [Provider Metadata](./wep-2026-07-26-provider-metadata.md) for the artifact layout and the all-or-nothing selection rule, and [Wado-to-Wado Optimization](#wado-to-wado-optimization) for the two consumption paths. A `--no-source` artifact is a prebuilt component only, consumed across the Component Model boundary with `export` items alone.
 
 ### `[dependencies]` and `[dev-dependencies]`
 
@@ -778,18 +780,24 @@ use { Router } from "lib:router" with { git = "https://github.com/user/router.gi
 
 ### Path Dependencies to Single Files
 
-`path` dependencies can point to a single `.wado` file (not just directories). The referenced file is implicitly treated as `lib = <that file>` — only `export` items are visible at the CM boundary:
+`path` dependencies can point to a single `.wado` file (not just directories). The referenced file is implicitly treated as `lib = <that file>`:
 
 ```toml
 "lib:shared" = { path = "../shared.wado" }    # treated as lib = "shared.wado"
 "lib:utils"  = { path = "../utils" }          # reads ../utils/wado.toml for entry points
 ```
 
-| Dependency type                      | Boundary    | Visible items                        |
-| ------------------------------------ | ----------- | ------------------------------------ |
-| Registry / Git (with `wado.toml`)    | CM boundary | `export` items only                  |
-| Path to directory (with `wado.toml`) | CM boundary | `export` items only                  |
-| Path to single `.wado` file          | CM boundary | `export` items only (implicit `lib`) |
+Which items a dependency exposes follows from whether its source is available, not from how it was fetched:
+
+| Dependency type                      | Path for a Wado consumer | Visible items       |
+| ------------------------------------ | ------------------------ | ------------------- |
+| Registry                             | Source (from the artifact's section) | `pub` + `export` |
+| Registry, published `--no-source`    | CM boundary              | `export` items only |
+| Git                                  | Source                   | `pub` + `export`    |
+| Path to directory (with `wado.toml`) | Source                   | `pub` + `export`    |
+| Path to single `.wado` file          | Source                   | `pub` + `export` (implicit `lib`) |
+
+A non-Wado CM consumer sees `export` items only in every row.
 
 ### CLI Integration
 

--- a/docs/wep-2026-07-26-provider-metadata.md
+++ b/docs/wep-2026-07-26-provider-metadata.md
@@ -1,0 +1,96 @@
+# WEP: Provider Metadata — Source-Bundled Package Artifacts
+
+## Context
+
+Two established rules collide at the package boundary:
+
+- The CM ABI cannot represent closures, generics, traits, or effect polymorphism, so a published component exposes `export` items only ([Visibility](./wep-2026-06-25-visibility-internal-pub-export.md)).
+- `pub` is the Wado-native library API, reachable only on the GC-sharing path ([Package Manifest](./wep-2026-02-14-package-manifest.md) §Wado-to-Wado Optimization).
+
+A generic, higher-order, or trait-based library therefore has no registry distribution path — the API that makes it worth publishing disappears at publish time, leaving git source dependencies as the only channel. Several documents already route around this by citing a "Wado provider metadata" path, but no WEP specifies what that metadata is.
+
+Monomorphization settles the format question. A consumer instantiating a generic needs the body, not just the signature — Rust ships MIR in rlibs, Go ships bodies in export data. Wado must ship bodies too; only the serialization is open. This also means no format buys secrecy: shipping IR instead of source obfuscates, it does not close.
+
+## Decision
+
+A published package is a source package with a prebuilt CM binary attached, delivered as one `.wasm`.
+
+### The artifact
+
+The package's Wado source travels in a custom section named `wado:package`:
+
+| Content            | Purpose                                            |
+| ------------------ | -------------------------------------------------- |
+| Format version     | Consumer compatibility gate                        |
+| Compiler version   | Producing compiler, for the degradation rule below |
+| `wado.toml`        | The package's own dependencies and entry points    |
+| The package's `.wado` sources | Bodies for `pub` items, and everything they reach |
+
+The section content is deterministic: sorted file order, no timestamps, fixed compression level. Same input, same bytes, same digest — otherwise `integrity` and reproducible builds break.
+
+Sources are included whole rather than pruned to the `pub`-reachable set. A `pub` generic body calls `internal` helpers, so most of a package is reachable anyway; pruning can follow if size proves to matter.
+
+A custom section is not instantiated, so this costs distribution bytes only, never runtime size.
+
+### Why a section, not a second OCI layer
+
+OCI is the primary registry, and the single-`application/wasm`-layer convention is what generic OCI and wasm tooling already handles — custom sections propagate unchanged through the toolchain ([WIT Bundling](./wep-2026-03-21-wit-bundling.md)). A section also keeps the artifact self-describing outside any registry (`path` dependencies, `https://` imports, release assets), so one rule covers every channel, and `integrity` stays a single manifest digest with no per-layer verification scope to define.
+
+### Consumer selection is all or nothing
+
+| Consumer | `wado:package` present and supported | Path                                     |
+| -------- | ------------------------------------- | ---------------------------------------- |
+| Wado     | Yes                                   | Source; the compiled component is unused |
+| Wado     | No                                    | CM canonical ABI, `export` items only    |
+| Other CM | —                                     | CM canonical ABI, `export` items only    |
+
+A package is consumed one way or the other, never both. Mixing would compile the same declaration twice into two distinct nominal types — the split identity [Module Loader](./wep-2026-01-24-module-loader.md) §"Canonical module identity" avoids for local paths — and would put two compiler generations inside one package, so a fix present in one half is absent in the other.
+
+### The compiled component is the compatibility floor
+
+Because selection can fall back, the attached binary is not a duplicate of the source: it is what a consumer uses when the section's format or compiler version is out of range. Degradation is narrower than the source path, so it must not be silent when it matters:
+
+- Only `export` items are used — proceed on the CM path.
+- A `pub`-only item is used — error, naming the cause and the missing item.
+
+### Stripping
+
+- `wado publish` attaches the section; `wado compile` does not.
+- Final link drops the sections of statically composed dependencies ([Wasm CM Component Import](./wep-2026-06-26-wasm-cm-component-import.md)), at every optimization level. An application must not ship its dependencies' sources.
+- This is independent of `-Os` symbol stripping.
+
+### Transitive dependencies
+
+A source package carries its own `wado.toml`, so a registry dependency now has transitive Wado dependencies — revising [Package Manifest](./wep-2026-02-14-package-manifest.md) §Registry backend, which states the opposite for prebuilt components. Resolution and locking reuse the git-dependency path unchanged.
+
+Single-file mode has no lock file, so a source package whose manifest carries a version range is an error there, with the same remedy as any other unlockable range: pin exactly, or add a `wado.toml`.
+
+### `--no-source`
+
+`wado publish --no-source` emits a CM-only artifact. `pub`-only items are then unreachable to every consumer — the stated cost of withholding source, not a silent difference.
+
+## Consequences
+
+- The registry becomes a complete channel: a generic or trait-based library is publishable with its real API, and git source dependencies stop being the only way to ship one.
+- `pub` / `export` lose their distribution meaning. Visibility says who may name an item, `export` says which ABI carries it, and the artifact says how it ships — three independent axes.
+- Dependencies gain hover, go-to-definition, and `wado doc` for free, since their source is present.
+- Every consumer downloads both representations. Compression absorbs most of it, and the binary earns its bytes as the fallback path.
+- One artifact now presents two interfaces depending on who reads it. This mirrors Rust's rlib / `cdylib` split, but it makes the conformance requirement below load-bearing: a divergence would surface only for one class of consumer.
+
+## Implementation
+
+- [ ] Conformance test first: one fixture consumed through both paths, asserting identical observable behavior for `export` items. [Package Manifest](./wep-2026-02-14-package-manifest.md) §Wado-to-Wado Optimization claims this ("the optimization only affects performance"); until it is tested it is an assumption, and the rest of this WEP rests on it.
+- [ ] `wado:package` section format, with the determinism requirements.
+- [ ] Publish path: attach on `wado publish`, `--no-source` opt-out.
+- [ ] Consumer selection and the degradation diagnostics.
+- [ ] Strip composed dependencies' sections at final link.
+- [ ] Transitive resolution for registry source packages; revise Package Manifest §Registry backend.
+- [ ] LSP reads the section for dependency navigation.
+
+## References
+
+- [Visibility — `internal` / `pub` / `export`](./wep-2026-06-25-visibility-internal-pub-export.md)
+- [Package Manifest (`wado.toml`)](./wep-2026-02-14-package-manifest.md)
+- [WIT Bundling in Component Binaries](./wep-2026-03-21-wit-bundling.md)
+- [Wasm CM Component Import (`use`-based)](./wep-2026-06-26-wasm-cm-component-import.md)
+- [Module Loader Design](./wep-2026-01-24-module-loader.md)

--- a/docs/wep-2026-07-26-provider-metadata.md
+++ b/docs/wep-2026-07-26-provider-metadata.md
@@ -19,12 +19,12 @@ A published package is a source package with a prebuilt CM binary attached, deli
 
 The package's Wado source travels in a custom section named `wado:package`:
 
-| Content            | Purpose                                            |
-| ------------------ | -------------------------------------------------- |
-| Format version     | Consumer compatibility gate                        |
-| Compiler version   | Producing compiler, for the degradation rule below |
-| `wado.toml`        | The package's own dependencies and entry points    |
-| The package's `.wado` sources | Bodies for `pub` items, and everything they reach |
+| Content                       | Purpose                                            |
+| ----------------------------- | -------------------------------------------------- |
+| Format version                | Consumer compatibility gate                        |
+| Compiler version              | Producing compiler, for the degradation rule below |
+| `wado.toml`                   | The package's own dependencies and entry points    |
+| The package's `.wado` sources | Bodies for `pub` items, and everything they reach  |
 
 The section content is deterministic: sorted file order, no timestamps, fixed compression level. Same input, same bytes, same digest — otherwise `integrity` and reproducible builds break.
 
@@ -39,10 +39,10 @@ OCI is the primary registry, and the single-`application/wasm`-layer convention 
 ### Consumer selection is all or nothing
 
 | Consumer | `wado:package` present and supported | Path                                     |
-| -------- | ------------------------------------- | ---------------------------------------- |
-| Wado     | Yes                                   | Source; the compiled component is unused |
-| Wado     | No                                    | CM canonical ABI, `export` items only    |
-| Other CM | —                                     | CM canonical ABI, `export` items only    |
+| -------- | ------------------------------------ | ---------------------------------------- |
+| Wado     | Yes                                  | Source; the compiled component is unused |
+| Wado     | No                                   | CM canonical ABI, `export` items only    |
+| Other CM | —                                    | CM canonical ABI, `export` items only    |
 
 A package is consumed one way or the other, never both. Mixing would compile the same declaration twice into two distinct nominal types — the split identity [Module Loader](./wep-2026-01-24-module-loader.md) §"Canonical module identity" avoids for local paths — and would put two compiler generations inside one package, so a fix present in one half is absent in the other.
 


### PR DESCRIPTION
Specifies the "Wado provider metadata" path that several WEPs reference but none define.

A published package is a source package with a prebuilt CM binary attached, delivered as one `.wasm`: the package's `wado.toml` and Wado sources ride in a `wado:package` custom section alongside the component. This gives `pub`-only items — generics, closures, trait-based APIs, everything the CM ABI cannot represent — a registry distribution path, so publishing a library does not cost it the API that makes it worth publishing.

Monomorphization is what forces the shape: a consumer instantiating a generic needs the body, not just the signature, the same reason Rust ships MIR in rlibs and Go ships bodies in export data. Only the serialization was open, and no serialization buys secrecy, so source is the choice that also gives dependencies hover and go-to-definition for free.

## What the WEP settles

- The artifact: section contents, and the determinism requirements (sorted file order, no timestamps, fixed compression level) that keep `integrity` and reproducible builds intact.
- A section rather than a second OCI layer: the artifact stays self-describing outside a registry, `integrity` stays one digest, and generic OCI and wasm tooling propagates custom sections unchanged.
- Consumer selection is all or nothing. Compiling a package from source and linking its prebuilt binary in the same build would split one declaration into two nominal types and put two compiler generations inside one package, so a package resolves one way or the other.
- The prebuilt component is the compatibility floor. When the section's format or compiler version is out of range, a build using only `export` items proceeds on the CM path; one that reaches a `pub`-only item fails with a diagnostic naming the cause.
- Section stripping at final link, at every optimization level, so an application does not ship its dependencies' sources.
- `wado publish --no-source` for a CM-only artifact, with the cost stated: `pub`-only items are unreachable to every consumer.

Implementation is a checklist, headed by a conformance test asserting that `export` items behave identically through both paths. The Package Manifest WEP claims this holds; the rest of the design rests on it, so it is the first item rather than a later one.

## Package Manifest revisions

A registry dependency carries transitive Wado dependencies, resolved and locked on the same path as a git dependency. The visible-items table follows source availability rather than fetch method: registry, git, and path dependencies all expose `pub` + `export` to a Wado consumer, while a non-Wado CM consumer and a `--no-source` artifact expose `export` items only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JchKXfMF5c92YQyh8yPa5c)_