### PR TITLE
fix(cm): reclaim linear memory at the synchronously-lifted export boundary

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -153,3 +153,4 @@ history is the SSoT for how the design got here.
 - [Async Canonical Options for `stream.read` / `stream.write`](./wep-2026-07-25-async-stream-canonical.md)
 - [Provider Metadata — Source-Bundled Package Artifacts](./wep-2026-07-26-provider-metadata.md)
 - [Super Traits](./wep-2026-07-27-super-traits.md)
+- [`post-return` for Synchronously-Lifted Exports](./wep-2026-07-28-cm-post-return.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3550,13 +3550,6 @@ export fn run() { ... }
 A `pub`-only item reaches Wado consumers only (source dependency or
 provider-tagged `.wasm`); a non-Wado CM consumer sees `export` items only.
 
-At the CM boundary a library's exported functions and the types their signatures
-reference share one namespace, and names in it are kebab-cased and compared
-case-insensitively. Wado keeps types and functions in separate namespaces, so a
-pair that reads as unambiguous can still collide there — `variant Shape` beside
-`export fn shape`, or `HTTPServer` beside `HttpServer`, each landing on one CM
-name. Both are compile errors; rename one side.
-
 The ladder applies to top-level items. Members of an `impl` block (methods,
 associated constants) accept the same file-private / `internal` / `pub` ladder;
 `export` on a member is a compile error (a method has no Component Model

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3550,6 +3550,13 @@ export fn run() { ... }
 A `pub`-only item reaches Wado consumers only (source dependency or
 provider-tagged `.wasm`); a non-Wado CM consumer sees `export` items only.
 
+At the CM boundary a library's exported functions and the types their signatures
+reference share one namespace, and names in it are kebab-cased and compared
+case-insensitively. Wado keeps types and functions in separate namespaces, so a
+pair that reads as unambiguous can still collide there — `variant Shape` beside
+`export fn shape`, or `HTTPServer` beside `HttpServer`, each landing on one CM
+name. Both are compile errors; rename one side.
+
 The ladder applies to top-level items. Members of an `impl` block (methods,
 associated constants) accept the same file-private / `internal` / `pub` ladder;
 `export` on a member is a compile error (a method has no Component Model

--- a/docs/wep-2026-07-28-cm-post-return.md
+++ b/docs/wep-2026-07-28-cm-post-return.md
@@ -1,0 +1,207 @@
+# WEP: `post-return` for Synchronously-Lifted Exports
+
+Gives a sync-lifted `--lib` export a way to reclaim the linear memory it hands
+the host, by emitting the `post-return` canonical option and synthesizing the
+free function it names. Fixes wado-lang/wado#1683.
+
+## Context
+
+A non-`async` `--lib` export is lifted synchronously (`WorldExportPlan::sync_lift`).
+When its result flattens to more than one core value — `string`, `list`, a record,
+a tuple, an option, a result — the Canonical ABI returns it indirectly: the guest
+`realloc`s a buffer, lowers the value into it, and returns the pointer.
+
+```wat
+(func $lib.wado/__cm_export__chunk (param i32) (result i32)
+  ...
+  (local.set 2 (call $realloc (i32.const 0) (i32.const 0) (i32.const 4) (i32.const 8)))
+  ...)
+(func $chunk (canon lift (core func $chunk-core) (memory $memory) (realloc $realloc)))
+```
+
+Two allocations per call — the 8-byte `(ptr, len)` buffer and the UTF-8 payload
+behind it — and no `post-return` on the `canon lift`, which is the ABI's only
+channel for telling the guest the host is done reading:
+
+> the optional `post-return` function … is called, passing the same core wasm
+> results as parameters so that the `post-return` function can free any
+> associated allocations.
+>
+> — `CanonicalABI.md`, `canon_lift`
+
+Nothing frees them. The library world defaults to the `freelist` allocator
+precisely so a long-running host reclaims memory, and the return buffer is the
+one allocation it cannot reclaim: `tests/lib_sync_lift_post_return.rs` traps on
+call 8 of 48, having grown linear memory by exactly one payload per call.
+
+`post-return` is illegal alongside `async`, so async-lifted exports (the WASI
+worlds, `export async fn`) are outside this design by construction. Their
+equivalent leak is D2 under [Adjacent leaks](#adjacent-leaks).
+
+## Decision
+
+### `CmShape` — one classifier for lower and free
+
+The hard part is not calling `realloc`; it is knowing what to free. `post-return`
+receives only the outer pointer, so the free must walk the CM-laid-out value in
+linear memory and reach every nested buffer: a `list<string>` owns its element
+array _and_ one payload per element.
+
+The lowering side already knows this shape. `synthesize_lower_wasi_type_to_memory`
+dispatches a Wado type to record / variant / tuple / option / list / primitive and
+computes each part's offset through `cm_abi::layout_*_with_registry_scoped`. A free
+walker that re-derived the same dispatch independently would rot the moment a type
+is added on one side only.
+
+So the dispatch decision is extracted into a single classifier, `cm_shape(ty, …)`,
+and both walkers match on it exhaustively:
+
+```rust
+enum CmShape {
+    /// Fixed-width: ints, floats, bool, char, enum, flags, resource handle.
+    /// Owns nothing.
+    Scalar,
+    /// `(ptr, len)` at addr; owns `len` bytes at align 1.
+    Str,
+    /// `(ptr, len)` at addr; owns `len * elem.size` bytes at `elem.align`,
+    /// plus whatever each element owns.
+    List { elem: Box<CmField> },
+    /// Record or tuple: fields at fixed offsets.
+    Record { fields: Vec<CmField> },
+    /// Variant, option or result: a discriminant plus one payload per case
+    /// at a shared offset.
+    Variant { disc: DiscWidth, payload_offset: u32, cases: Vec<Option<CmField>> },
+}
+
+struct CmField { ty: Type, offset: u32, size: u32, align: u32 }
+```
+
+`CmField` carries the layout facts straight from `cm_abi`, so there is one source
+of truth for offsets. A new CM type kind means a new `CmShape` case, which fails
+to compile in both matches — the workspace already forbids wildcard arms, so this
+is enforced, not conventional.
+
+The per-arm lowering bodies are unchanged; only the classification head moves.
+The refactor is output-preserving and the golden corpus proves it.
+
+### The free walk
+
+`synthesize_free_cm_value(shape, addr)` folds over `CmShape`:
+
+| Shape     | Emitted                                                                                   |
+| --------- | ----------------------------------------------------------------------------------------- |
+| `Scalar`  | nothing                                                                                   |
+| `Str`     | `realloc(load(addr), load(addr+4), 1, 0)`                                                 |
+| `List`    | per-element walk when the element owns memory, then `realloc(base, count*size, align, 0)` |
+| `Record`  | walk each field that owns memory, at its offset                                           |
+| `Variant` | load the discriminant, walk the active case's payload when it owns memory                 |
+
+Two properties carry the correctness.
+
+Handles are never touched. An `own<r>` in a lifted result was transferred to the
+host during lift; `resource.drop` here would be a double-drop. Handles classify as
+`Scalar`, which emits nothing — that is why `Scalar` must mean "owns nothing", not
+"four bytes".
+
+A branch that owns no memory emits no code. `owns_memory` is a recursive predicate
+over `CmShape`; a `[u32, u32]` return produces only the outer free.
+
+The list guard `count > 0` mirrors the one `synthesize_lift_list` already carries,
+and keeps the `debug` allocator's poison length exact.
+
+### Wiring
+
+1. Synthesis (`synthesis/cm_binding.rs`, `SyncReturn` path). When the world return
+   type owns memory, synthesize `__cm_post_return__{export}`: `(param i32) -> ()`,
+   body = the free walk over the return type at the pointer, then
+   `realloc(ptr, cm_size(ty), cm_align(ty), 0)` for the outptr buffer itself.
+   Marked `is_cm_export` so DCE keeps it. Recorded in
+   `Package::post_return_binding_names`, alongside `export_binding_names`.
+
+2. Plan (`wir_build/component_plan.rs`). `WorldExportPlan` gains
+   `post_return_core_name: Option<String>`, only ever `Some` when `sync_lift`.
+
+3. WIR (`wir_build/functions.rs::register_exports`). Export the post-return
+   function from the core module under that name.
+
+4. Codegen (`codegen/component.rs`). Alias the core function and push
+   `CanonicalOption::PostReturn(idx)` into `lift_opts`.
+
+Owning memory implies more than one flat result, which implies the indirect
+return — so the post-return parameter is always the single `i32` outptr. The
+converse would be a Canonical ABI contradiction rather than user input, so
+synthesis asserts it instead of branching on it.
+
+### Verification
+
+The two allocators make the failure modes loud, in opposite directions:
+
+- `freelist` traps on double-free (`fl_used(header) == 0 → unreachable`). A free
+  walk that visits a buffer twice cannot pass.
+- `debug` poisons freed memory with `0xFF` and never reuses it. A free that runs
+  too early, or with an oversized length, corrupts data the test then reads back.
+
+Tests:
+
+- [ ] `tests/lib_sync_lift_post_return.rs` — drop both `#[ignore]`s. 48 calls
+      returning 1 MiB each under a 12 MiB cap; flat memory is the assertion.
+- [ ] `tests/cm_catalog.rs` — the type catalog (40+ exports: strings, nested
+      lists, tuples, options, results, records, variants, newtypes) already runs
+      under `debug`. Add a `freelist` pass calling each export twice, so the
+      double-free guard covers every shape the free walk can take.
+- [ ] A WAT assertion that `(post-return …)` is present for a `String`-returning
+      lib export and absent for a scalar-returning one.
+- [ ] Golden fixture regeneration for the CM catalog components.
+
+## Consequences
+
+An export whose result owns no memory gets no `post-return` at all: its component
+is byte-identical to today's, and no wasm size is spent where there is nothing to
+free. An export that does own memory pays one extra core function and one call per
+invocation.
+
+Under `bump` the emitted frees are no-ops — the allocator never reclaims — so a
+`--lib --allocator bump` build pays the call cost for no benefit. That is the
+allocator's documented trade-off, not a reason to make the option conditional on
+it: `canon lift` is fixed at compile time and the allocator choice is already
+visible there, but branching the ABI on it would make the component's contract
+depend on an allocation strategy.
+
+The lift path keeps its own, different free discipline: each lift site frees what
+it just read, and `synthesize_free_element` covers only the leaves the recursion
+does not self-free. Re-pointing those call sites at the standalone walker would
+free the same buffers twice. They are left alone here; unifying them is a follow-up
+whose safety rests on the same `freelist` double-free guard.
+
+### Adjacent leaks
+
+Two leaks of the same family surfaced while reading the boundary. Both are
+verified from generated WAT, and neither is fixed by `post-return`.
+
+D1 — a top-level `String` parameter is never freed. The host lowers it into guest
+memory with the guest's `realloc`; the adapter copies it into a GC string and drops
+the pointer:
+
+```wat
+(func $lib.wado/__cm_export__take (param i32 i32) (result i32)
+  (call $lib.wado/take (call $core:rt/memory_to_gc_string (local.get 0) (local.get 1))))
+```
+
+Nested strings are already freed — `synthesize_lift_list` and
+`synthesize_lift_option_inner` free what they read — so this is the top-level arm
+of `synthesize_lift_from_flat_params` alone, and it affects async-lifted exports
+equally. One-arm fix with its own reproduction fixture, landed with this WEP.
+
+D2 — a memory-backed `task.return` result is never freed. `canon_task_return`
+lifts eagerly (`lift_flat_values` before it returns), so the guest may free
+immediately after the call. Nothing does: `push_result_task_return_epilogue`
+lowers a `String` through `cm_lower_string` and abandons the payload.
+`post-return` is illegal with `async`, and the value lives in flat slots rather
+than in memory, so the fix is a different fold over the same `CmShape`. Separate
+issue, separate reproduction.
+
+## References
+
+- `vendor/component-model/design/mvp/CanonicalABI.md` — `canon_lift`, `canon_task_return`
+- `vendor/component-model/design/mvp/Explainer.md:1362-1368` — `post-return` rules
+- [Async Canonical Options for `stream.read` / `stream.write`](./wep-2026-07-25-async-stream-canonical.md) — the neighbouring canonical-option audit

--- a/docs/wep-2026-07-28-cm-post-return.md
+++ b/docs/wep-2026-07-28-cm-post-return.md
@@ -31,16 +31,24 @@ equivalent leak is D2 below.
 
 ## Decision
 
-Emit `post-return` on a synchronous lift whose result owns linear memory, and
+Emit `post-return` on a synchronous lift that returns its result indirectly, and
 synthesize the function it names.
+
+### When it is emitted
+
+The gate is the indirect return, not memory ownership. Anything wider than one
+core value comes back through a guest-allocated area, and that area leaks without
+`post-return` even when nothing hangs off it — a record of two `u32` owns no
+memory and still loses eight bytes per call. A result that fits in a core value
+allocates nothing and needs no option.
 
 ### What gets freed
 
 `post-return` receives only the outer pointer, so reclamation is a recursive,
 type-driven walk of the value in linear memory: a `list<string>` owns its element
 array _and_ one payload per element. The walk covers strings, lists, records,
-tuples, variants, options and results, and ends by releasing the out-pointer
-buffer itself.
+tuples, variants, options and results, and ends by releasing the return area
+itself.
 
 Two rules shape it.
 
@@ -48,9 +56,8 @@ Handles are never touched. Lifting _transfers_ an `own<r>` to the host, so
 dropping one here would be a double-drop. Handles count as owning nothing — the
 distinction is "owns no memory", not "is not four bytes wide".
 
-A part that owns no memory produces no code, so a scalar-only result contributes
-nothing beyond the outer free, and an export that owns nothing at all gets no
-`post-return` option.
+A part that owns no memory produces no code, so a result of scalars reduces to
+the single free of its return area.
 
 ### Staying in step with lowering
 
@@ -76,16 +83,21 @@ they pin both halves of correctness:
   or covers too much corrupts data the test reads back.
 
 The regression tests are a memory-capped reproduction of the leak, an assertion
-that the canonical option appears only where something is owned, and the CM type
-catalog round-tripped twice under `freelist` — the widest shape corpus available,
-covering strings, nested lists, tuples, options, results, records, variants,
-flags, enums and newtypes.
+that the canonical option tracks the indirect return rather than memory
+ownership, and the CM type catalog round-tripped twice under `freelist` — the
+widest shape corpus available, covering strings, nested lists, tuples, options,
+results, records, variants, flags, enums and newtypes.
+
+Where a leak can be pinned by inspecting the emitted component, that is preferred
+to exhausting a memory cap: the inspection is exact and cheap, while an
+exhaustion test has to guess allocator block arithmetic to stay meaningful and
+costs real time on a loaded machine.
 
 ## Consequences
 
-An export whose result owns no memory is unaffected: its component is unchanged,
-and no code size is spent where there is nothing to free. An export that does own
-memory pays one extra core function and one call per invocation.
+An export whose result fits in a core value is unaffected: its component is
+unchanged, and no code size is spent where nothing was allocated. An export
+returning indirectly pays one extra core function and one call per invocation.
 
 Under `bump` the emitted frees are no-ops, since that allocator never reclaims, so
 a `--lib --allocator bump` build pays the call cost for no benefit. Making the

--- a/docs/wep-2026-07-28-cm-post-return.md
+++ b/docs/wep-2026-07-28-cm-post-return.md
@@ -1,27 +1,17 @@
 # WEP: `post-return` for Synchronously-Lifted Exports
 
 Gives a sync-lifted `--lib` export a way to reclaim the linear memory it hands
-the host, by emitting the `post-return` canonical option and synthesizing the
-free function it names. Fixes wado-lang/wado#1683.
+the host. Fixes wado-lang/wado#1683.
 
 ## Context
 
-A non-`async` `--lib` export is lifted synchronously (`WorldExportPlan::sync_lift`).
-When its result flattens to more than one core value — `string`, `list`, a record,
-a tuple, an option, a result — the Canonical ABI returns it indirectly: the guest
-`realloc`s a buffer, lowers the value into it, and returns the pointer.
+A non-`async` `--lib` export is lifted synchronously. When its result is
+memory-backed — `string`, `list`, or a composite holding one — the Canonical ABI
+returns it indirectly: the guest allocates a buffer, lowers the value into it,
+and hands the host a pointer.
 
-```wat
-(func $lib.wado/__cm_export__chunk (param i32) (result i32)
-  ...
-  (local.set 2 (call $realloc (i32.const 0) (i32.const 0) (i32.const 4) (i32.const 8)))
-  ...)
-(func $chunk (canon lift (core func $chunk-core) (memory $memory) (realloc $realloc)))
-```
-
-Two allocations per call — the 8-byte `(ptr, len)` buffer and the UTF-8 payload
-behind it — and no `post-return` on the `canon lift`, which is the ABI's only
-channel for telling the guest the host is done reading:
+The ABI's only channel for telling the guest the host has finished reading is the
+`post-return` option of `canon lift`:
 
 > the optional `post-return` function … is called, passing the same core wasm
 > results as parameters so that the `post-return` function can free any
@@ -29,176 +19,101 @@ channel for telling the guest the host is done reading:
 >
 > — `CanonicalABI.md`, `canon_lift`
 
-Nothing frees them. The library world defaults to the `freelist` allocator
-precisely so a long-running host reclaims memory, and the return buffer is the
-one allocation it cannot reclaim: `tests/lib_sync_lift_post_return.rs` traps on
-call 8 of 48, having grown linear memory by exactly one payload per call.
+Wado never emitted it, so nothing freed the payload. The library world defaults
+to the `freelist` allocator precisely so that a long-running host reclaims
+memory, and the return buffer was the one allocation it could not reclaim: an
+export returning 1 MiB exhausts a 12 MiB memory cap after eight calls, growing by
+exactly one payload per call.
 
-`post-return` is illegal alongside `async`, so async-lifted exports (the WASI
-worlds, `export async fn`) are outside this design by construction. Their
-equivalent leak is D2 under [Adjacent leaks](#adjacent-leaks).
+`post-return` is illegal alongside `async`, so async-lifted exports — the WASI
+worlds and `export async fn` — are outside this design by construction. Their
+equivalent leak is D2 below.
 
 ## Decision
 
-### `CmShape` — one classifier for lower and free
+Emit `post-return` on a synchronous lift whose result owns linear memory, and
+synthesize the function it names.
 
-The hard part is not calling `realloc`; it is knowing what to free. `post-return`
-receives only the outer pointer, so the free must walk the CM-laid-out value in
-linear memory and reach every nested buffer: a `list<string>` owns its element
-array _and_ one payload per element.
+### What gets freed
 
-The lowering side already knows this shape. `synthesize_lower_wasi_type_to_memory`
-dispatches a Wado type to record / variant / tuple / option / list / primitive and
-computes each part's offset through `cm_abi::layout_*_with_registry_scoped`. A free
-walker that re-derived the same dispatch independently would rot the moment a type
-is added on one side only.
+`post-return` receives only the outer pointer, so reclamation is a recursive,
+type-driven walk of the value in linear memory: a `list<string>` owns its element
+array _and_ one payload per element. The walk covers strings, lists, records,
+tuples, variants, options and results, and ends by releasing the out-pointer
+buffer itself.
 
-So the dispatch decision is extracted into a single classifier, `cm_shape(ty, …)`,
-and both walkers match on it exhaustively:
+Two rules shape it.
 
-```rust
-enum CmShape {
-    /// Fixed-width: ints, floats, bool, char, enum, flags, resource handle.
-    /// Owns nothing.
-    Scalar,
-    /// `(ptr, len)` at addr; owns `len` bytes at align 1.
-    Str,
-    /// `(ptr, len)` at addr; owns `len * elem.size` bytes at `elem.align`,
-    /// plus whatever each element owns.
-    List { elem: Box<CmField> },
-    /// Record or tuple: fields at fixed offsets.
-    Record { fields: Vec<CmField> },
-    /// Variant, option or result: a discriminant plus one payload per case
-    /// at a shared offset.
-    Variant { disc: DiscWidth, payload_offset: u32, cases: Vec<Option<CmField>> },
-}
+Handles are never touched. Lifting _transfers_ an `own<r>` to the host, so
+dropping one here would be a double-drop. Handles count as owning nothing — the
+distinction is "owns no memory", not "is not four bytes wide".
 
-struct CmField { ty: Type, offset: u32, size: u32, align: u32 }
-```
+A part that owns no memory produces no code, so a scalar-only result contributes
+nothing beyond the outer free, and an export that owns nothing at all gets no
+`post-return` option.
 
-`CmField` carries the layout facts straight from `cm_abi`, so there is one source
-of truth for offsets. A new CM type kind means a new `CmShape` case, which fails
-to compile in both matches — the workspace already forbids wildcard arms, so this
-is enforced, not conventional.
+### Staying in step with lowering
 
-The per-arm lowering bodies are unchanged; only the classification head moves.
-The refactor is output-preserving and the golden corpus proves it.
+The freeing side and the lowering side must agree on where every buffer sits.
+They share one source of layout truth — the Canonical ABI layout helpers and the
+type registry — rather than each deriving offsets independently.
 
-### The free walk
-
-`synthesize_free_cm_value(shape, addr)` folds over `CmShape`:
-
-| Shape     | Emitted                                                                                   |
-| --------- | ----------------------------------------------------------------------------------------- |
-| `Scalar`  | nothing                                                                                   |
-| `Str`     | `realloc(load(addr), load(addr+4), 1, 0)`                                                 |
-| `List`    | per-element walk when the element owns memory, then `realloc(base, count*size, align, 0)` |
-| `Record`  | walk each field that owns memory, at its offset                                           |
-| `Variant` | load the discriminant, walk the active case's payload when it owns memory                 |
-
-Two properties carry the correctness.
-
-Handles are never touched. An `own<r>` in a lifted result was transferred to the
-host during lift; `resource.drop` here would be a double-drop. Handles classify as
-`Scalar`, which emits nothing — that is why `Scalar` must mean "owns nothing", not
-"four bytes".
-
-A branch that owns no memory emits no code. `owns_memory` is a recursive predicate
-over `CmShape`; a `[u32, u32]` return produces only the outer free.
-
-The list guard `count > 0` mirrors the one `synthesize_lift_list` already carries,
-and keeps the `debug` allocator's poison length exact.
-
-### Wiring
-
-1. Synthesis (`synthesis/cm_binding.rs`, `SyncReturn` path). When the world return
-   type owns memory, synthesize `__cm_post_return__{export}`: `(param i32) -> ()`,
-   body = the free walk over the return type at the pointer, then
-   `realloc(ptr, cm_size(ty), cm_align(ty), 0)` for the outptr buffer itself.
-   Marked `is_cm_export` so DCE keeps it. Recorded in
-   `Package::post_return_binding_names`, alongside `export_binding_names`.
-
-2. Plan (`wir_build/component_plan.rs`). `WorldExportPlan` gains
-   `post_return_core_name: Option<String>`, only ever `Some` when `sync_lift`.
-
-3. WIR (`wir_build/functions.rs::register_exports`). Export the post-return
-   function from the core module under that name.
-
-4. Codegen (`codegen/component.rs`). Alias the core function and push
-   `CanonicalOption::PostReturn(idx)` into `lift_opts`.
-
-Owning memory implies more than one flat result, which implies the indirect
-return — so the post-return parameter is always the single `i32` outptr. The
-converse would be a Canonical ABI contradiction rather than user input, so
-synthesis asserts it instead of branching on it.
+They are separate walks even so, because lowering needs naming and type identity
+that reclamation does not, and folding those in would only make the ownership
+model worse at its one job. Divergence is instead made loud: a type that reaches
+the CM boundary with no ownership rule fails on its first round-trip rather than
+leaking silently. Silence was the old behavior, and it is what let this bug
+survive.
 
 ### Verification
 
-The two allocators make the failure modes loud, in opposite directions:
+The two reclaiming allocators fail loudly in opposite directions, so between them
+they pin both halves of correctness:
 
-- `freelist` traps on double-free (`fl_used(header) == 0 → unreachable`). A free
-  walk that visits a buffer twice cannot pass.
-- `debug` poisons freed memory with `0xFF` and never reuses it. A free that runs
-  too early, or with an oversized length, corrupts data the test then reads back.
+- `freelist` traps on a double-free, so a walk that visits a buffer twice cannot
+  pass.
+- `debug` poisons freed memory and never reuses it, so a free that runs too early
+  or covers too much corrupts data the test reads back.
 
-Tests:
-
-- [ ] `tests/lib_sync_lift_post_return.rs` — drop both `#[ignore]`s. 48 calls
-      returning 1 MiB each under a 12 MiB cap; flat memory is the assertion.
-- [ ] `tests/cm_catalog.rs` — the type catalog (40+ exports: strings, nested
-      lists, tuples, options, results, records, variants, newtypes) already runs
-      under `debug`. Add a `freelist` pass calling each export twice, so the
-      double-free guard covers every shape the free walk can take.
-- [ ] A WAT assertion that `(post-return …)` is present for a `String`-returning
-      lib export and absent for a scalar-returning one.
-- [ ] Golden fixture regeneration for the CM catalog components.
+The regression tests are a memory-capped reproduction of the leak, an assertion
+that the canonical option appears only where something is owned, and the CM type
+catalog round-tripped twice under `freelist` — the widest shape corpus available,
+covering strings, nested lists, tuples, options, results, records, variants,
+flags, enums and newtypes.
 
 ## Consequences
 
-An export whose result owns no memory gets no `post-return` at all: its component
-is byte-identical to today's, and no wasm size is spent where there is nothing to
-free. An export that does own memory pays one extra core function and one call per
-invocation.
+An export whose result owns no memory is unaffected: its component is unchanged,
+and no code size is spent where there is nothing to free. An export that does own
+memory pays one extra core function and one call per invocation.
 
-Under `bump` the emitted frees are no-ops — the allocator never reclaims — so a
-`--lib --allocator bump` build pays the call cost for no benefit. That is the
-allocator's documented trade-off, not a reason to make the option conditional on
-it: `canon lift` is fixed at compile time and the allocator choice is already
-visible there, but branching the ABI on it would make the component's contract
-depend on an allocation strategy.
+Under `bump` the emitted frees are no-ops, since that allocator never reclaims, so
+a `--lib --allocator bump` build pays the call cost for no benefit. Making the
+option conditional on the allocator was rejected: `canon lift` states the
+component's contract with its host, and that contract should not depend on an
+allocation strategy.
 
-The lift path keeps its own, different free discipline: each lift site frees what
-it just read, and `synthesize_free_element` covers only the leaves the recursion
-does not self-free. Re-pointing those call sites at the standalone walker would
-free the same buffers twice. They are left alone here; unifying them is a follow-up
-whose safety rests on the same `freelist` double-free guard.
+The lift path keeps its own, different discipline — each lift site frees what it
+just read. Reclamation here is standalone, freeing a value nothing has consumed,
+so the two cannot simply be merged without double-freeing. Unifying them is a
+follow-up, and the `freelist` double-free trap is what would make it safe.
 
 ### Adjacent leaks
 
-Two leaks of the same family surfaced while reading the boundary. Both are
-verified from generated WAT, and neither is fixed by `post-return`.
+Two leaks of the same family surfaced while auditing the boundary. Neither is
+fixed by `post-return`.
 
-D1 — a top-level `String` parameter is never freed. The host lowers it into guest
-memory with the guest's `realloc`; the adapter copies it into a GC string and drops
-the pointer:
+D1 — a top-level `string` parameter was never freed. The caller lowers it into
+guest memory using the guest's own allocator, so the buffer belongs to the guest
+once it has been copied onto the GC heap. Nested strings were already released by
+the lift sites that read them; only the top-level case had no such site. Fixed
+with this WEP, with its own reproduction.
 
-```wat
-(func $lib.wado/__cm_export__take (param i32 i32) (result i32)
-  (call $lib.wado/take (call $core:rt/memory_to_gc_string (local.get 0) (local.get 1))))
-```
-
-Nested strings are already freed — `synthesize_lift_list` and
-`synthesize_lift_option_inner` free what they read — so this is the top-level arm
-of `synthesize_lift_from_flat_params` alone, and it affects async-lifted exports
-equally. One-arm fix with its own reproduction fixture, landed with this WEP.
-
-D2 — a memory-backed `task.return` result is never freed. `canon_task_return`
-lifts eagerly (`lift_flat_values` before it returns), so the guest may free
-immediately after the call. Nothing does: `push_result_task_return_epilogue`
-lowers a `String` through `cm_lower_string` and abandons the payload.
-`post-return` is illegal with `async`, and the value lives in flat slots rather
-than in memory, so the fix is a different fold over the same `CmShape`. Separate
-issue, separate reproduction.
+D2 — a memory-backed `task.return` result is never freed. `task.return` lifts
+eagerly, so the guest may release the payload as soon as the call returns, but
+nothing does. `post-return` is illegal with `async`, and the value lives in flat
+slots rather than in memory, so it needs a different fold over the same ownership
+model. Filed as wado-lang/wado#1708.
 
 ## References
 

--- a/docs/wep-2026-07-28-cm-post-return.md
+++ b/docs/wep-2026-07-28-cm-post-return.md
@@ -50,14 +50,12 @@ array _and_ one payload per element. The walk covers strings, lists, records,
 tuples, variants, options and results, and ends by releasing the return area
 itself.
 
-Two rules shape it.
-
 Handles are never touched. Lifting _transfers_ an `own<r>` to the host, so
-dropping one here would be a double-drop. Handles count as owning nothing — the
+dropping one would be a double-drop. Handles count as owning nothing — the
 distinction is "owns no memory", not "is not four bytes wide".
 
-A part that owns no memory produces no code, so a result of scalars reduces to
-the single free of its return area.
+A part owning no memory produces no code, so a result of scalars reduces to the
+single free of its return area.
 
 ### Staying in step with lowering
 
@@ -77,16 +75,10 @@ survive.
 The two reclaiming allocators fail loudly in opposite directions, so between them
 they pin both halves of correctness:
 
-- `freelist` traps on a double-free, so a walk that visits a buffer twice cannot
-  pass.
+- `freelist` traps on a double-free, so a walk visiting a buffer twice cannot
+  pass. Running the CM type catalog under it covers every shape the walk takes.
 - `debug` poisons freed memory and never reuses it, so a free that runs too early
   or covers too much corrupts data the test reads back.
-
-The regression tests are a memory-capped reproduction of the leak, an assertion
-that the canonical option tracks the indirect return rather than memory
-ownership, and the CM type catalog round-tripped twice under `freelist` — the
-widest shape corpus available, covering strings, nested lists, tuples, options,
-results, records, variants, flags, enums and newtypes.
 
 Where a leak can be pinned by inspecting the emitted component, that is preferred
 to exhausting a memory cap: the inspection is exact and cheap, while an
@@ -119,7 +111,7 @@ D1 — a top-level `string` parameter was never freed. The caller lowers it into
 guest memory using the guest's own allocator, so the buffer belongs to the guest
 once it has been copied onto the GC heap. Nested strings were already released by
 the lift sites that read them; only the top-level case had no such site. Fixed
-with this WEP, with its own reproduction.
+with this WEP.
 
 D2 — a memory-backed `task.return` result is never freed. `task.return` lifts
 eagerly, so the guest may release the payload as soon as the call returns, but

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2114,6 +2114,21 @@ fn emit_world_exports(
         }
         lift_opts.push(CanonicalOption::Memory(ctx.memory_idx()));
         lift_opts.push(CanonicalOption::Realloc(ctx.core_func_idx("realloc")));
+        // A sync lift returning a memory-backed value hands the host a guest
+        // allocation; `post-return` is where the guest gets it back. Only
+        // present when the result owns memory, so exports with nothing to
+        // reclaim keep the option off entirely.
+        if let Some(post_return) = &export.post_return_core_name {
+            let alias = format!("{post_return}-core");
+            ctx.register_core_func(&alias);
+            builder.core_alias_export(
+                Some(&alias),
+                ctx.core_instance_idx("main"),
+                post_return,
+                ExportKind::Func,
+            );
+            lift_opts.push(CanonicalOption::PostReturn(ctx.core_func_idx(&alias)));
+        }
         builder.lift_func(
             Some(cm_name),
             ctx.core_func_idx(&core_name),

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -2114,10 +2114,6 @@ fn emit_world_exports(
         }
         lift_opts.push(CanonicalOption::Memory(ctx.memory_idx()));
         lift_opts.push(CanonicalOption::Realloc(ctx.core_func_idx("realloc")));
-        // A sync lift returning a memory-backed value hands the host a guest
-        // allocation; `post-return` is where the guest gets it back. Only
-        // present when the result owns memory, so exports with nothing to
-        // reclaim keep the option off entirely.
         if let Some(post_return) = &export.post_return_core_name {
             let alias = format!("{post_return}-core");
             ctx.register_core_func(&alias);

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -3196,9 +3196,8 @@ pub trait CmTypeSink {
 }
 
 /// [`CmTypeSink`] that records the names a type walk would export, emitting
-/// nothing. Lets a caller ask which names a signature puts into an interface's
-/// namespace, through the very walk that would put them there — so the answer
-/// cannot drift from what codegen goes on to emit.
+/// nothing — so a caller can ask which names a signature puts into an
+/// interface's namespace through the same walk codegen uses to put them there.
 #[derive(Default)]
 pub struct CmNameSink {
     names: Vec<String>,
@@ -3206,7 +3205,6 @@ pub struct CmNameSink {
 }
 
 impl CmNameSink {
-    /// The CM names claimed so far, in walk order.
     pub fn names(&self) -> &[String] {
         &self.names
     }

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -3195,6 +3195,40 @@ pub trait CmTypeSink {
     fn name(&mut self, cm_name: &str, idx: u32) -> u32;
 }
 
+/// [`CmTypeSink`] that records the names a type walk would export, emitting
+/// nothing. Lets a caller ask which names a signature puts into an interface's
+/// namespace, through the very walk that would put them there — so the answer
+/// cannot drift from what codegen goes on to emit.
+#[derive(Default)]
+pub struct CmNameSink {
+    names: Vec<String>,
+    next_idx: u32,
+}
+
+impl CmNameSink {
+    /// The CM names claimed so far, in walk order.
+    pub fn names(&self) -> &[String] {
+        &self.names
+    }
+
+    fn alloc(&mut self) -> u32 {
+        let idx = self.next_idx;
+        self.next_idx += 1;
+        idx
+    }
+}
+
+impl CmTypeSink for CmNameSink {
+    fn define(&mut self, _defined: CmDefined<'_>) -> u32 {
+        self.alloc()
+    }
+
+    fn name(&mut self, cm_name: &str, _idx: u32) -> u32 {
+        self.names.push(cm_name.to_string());
+        self.alloc()
+    }
+}
+
 /// [`CmTypeSink`] that emits into an interface [`InstanceType`], sharing the
 /// caller's type-index counter so the engine and any direct emissions stay in
 /// lockstep. Reproduces the historical `CmInstanceTypeGen` behavior exactly.

--- a/wado-compiler/src/link.rs
+++ b/wado-compiler/src/link.rs
@@ -45,6 +45,7 @@ pub fn link(package: Package) -> FlatPackage {
         entry_tests,
         &package.test_name_filters,
         &package.export_binding_names,
+        &package.post_return_binding_names,
         &package.world_registry,
         &package.cm_interface_registry,
         package.lib_world_info.as_ref(),

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -203,10 +203,8 @@ pub fn is_variant_payload_field(field_name: &str) -> bool {
 
 /// Kebab-case a world export's function name for the Component Model boundary.
 ///
-/// Wado function identifiers are `[a-z0-9_]`, so replacing underscores already
-/// yields a valid CM extern name; already-kebab WASI names (`run`, `handle`) are
-/// unchanged. Kept apart from [`to_kebab`], which additionally splits word
-/// boundaries in `PascalCase` type names.
+/// Wado function identifiers are `[a-z0-9_]`, so replacing underscores suffices.
+/// Distinct from [`to_kebab`], which also splits `PascalCase` word boundaries.
 pub fn kebab_export_name(name: &str) -> String {
     name.replace('_', "-")
 }

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -201,6 +201,16 @@ pub fn is_variant_payload_field(field_name: &str) -> bool {
     field_name.starts_with("payload_")
 }
 
+/// Kebab-case a world export's function name for the Component Model boundary.
+///
+/// Wado function identifiers are `[a-z0-9_]`, so replacing underscores already
+/// yields a valid CM extern name; already-kebab WASI names (`run`, `handle`) are
+/// unchanged. Kept apart from [`to_kebab`], which additionally splits word
+/// boundaries in `PascalCase` type names.
+pub fn kebab_export_name(name: &str) -> String {
+    name.replace('_', "-")
+}
+
 /// Convert a Wado identifier (`snake_case` / `PascalCase` / `camelCase`) to
 /// Component Model kebab-case (`my-api`, `http-server`, `error-code`).
 ///

--- a/wado-compiler/src/package.rs
+++ b/wado-compiler/src/package.rs
@@ -73,6 +73,11 @@ pub struct Package {
     /// Populated by `synthesis::cm_binding` when export adapters are synthesized.
     /// For example: `"run"` → `"__cm_export__run"`.
     pub export_binding_names: IndexMap<String, String>,
+    /// Maps world export name → `post-return` function name, for the
+    /// sync-lifted exports whose result owns linear memory. Populated
+    /// alongside `export_binding_names`; absent for every other export, which
+    /// gets no `post-return` canonical option at all.
+    pub post_return_binding_names: IndexMap<String, String>,
     /// Flattened CM ABI parameter types for the `task-return` canonical intrinsic.
     /// Populated by `synthesis::cm_binding` when an export returns a Result type.
     /// Used by `optimize_dce` to override the builtin registry's single-`i32` signature.
@@ -170,6 +175,7 @@ impl Package {
             test_name_filters: Vec::new(),
             // CM export adapter mapping
             export_binding_names: IndexMap::default(),
+            post_return_binding_names: IndexMap::default(),
             task_return_flat_params: None,
             // Wasm assets loaded from `use _ from "<path>" with { type: ... }`
             wasm_assets: IndexMap::default(),

--- a/wado-compiler/src/package.rs
+++ b/wado-compiler/src/package.rs
@@ -73,10 +73,10 @@ pub struct Package {
     /// Populated by `synthesis::cm_binding` when export adapters are synthesized.
     /// For example: `"run"` → `"__cm_export__run"`.
     pub export_binding_names: IndexMap<String, String>,
-    /// Maps world export name → `post-return` function name, for the
-    /// sync-lifted exports whose result owns linear memory. Populated
-    /// alongside `export_binding_names`; absent for every other export, which
-    /// gets no `post-return` canonical option at all.
+    /// Maps world export name → `post-return` function name, for the sync-lifted
+    /// exports that return indirectly. Populated alongside
+    /// `export_binding_names`; absent for every other export, which gets no
+    /// `post-return` canonical option.
     pub post_return_binding_names: IndexMap<String, String>,
     /// Flattened CM ABI parameter types for the `task-return` canonical intrinsic.
     /// Populated by `synthesis::cm_binding` when an export returns a Result type.

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -616,10 +616,8 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
                 adapter,
             ));
 
-            // A synchronous lift returns its value through guest-allocated
-            // memory; `post-return` is the ABI's only channel for handing that
-            // memory back. Async lifts return through `task.return`, where the
-            // option is not even permitted.
+            // `post-return` is illegal alongside `async`, so only a synchronous
+            // lift can reclaim its return area this way.
             if matches!(strategy, ExportReturnStrategy::SyncReturn)
                 && let Some(post_return) = synthesize_post_return(&export.name, &env)
             {
@@ -632,11 +630,10 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
         }
     }
 
-    // After the per-export loop: the name check walks every export signature
-    // through the CM type engine, which recurses without a depth guard, so it
-    // must not see a signature `validate_boundary_representable` would have
-    // rejected. A recursive type reaches the engine only if this runs first,
-    // and overflows the stack instead of producing that diagnostic.
+    // Must follow the loop above: the name check walks signatures through the CM
+    // type engine, which recurses without a depth guard, so a recursive type has
+    // to be rejected by `validate_boundary_representable` first or it overflows
+    // the stack instead of getting that diagnostic.
     if is_lib_world {
         validate_lib_interface_names(&world_info, &project.cm_interface_registry)?;
     }
@@ -660,68 +657,32 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
     Ok(())
 }
 
-/// Reject two library exports that would claim the same name in the synthesized
-/// interface.
+/// Reject a library whose exports would claim one interface name twice.
 ///
 /// A Component Model interface has one namespace covering its types *and* its
 /// functions — "An interface has a single namespace which means that none of the
-/// defined names can collide" — and names in it must be unique
-/// case-insensitively (`WIT.md`). Wado gives types and functions separate
-/// namespaces, so `variant Shape` alongside `export fn shape` reads as
-/// unambiguous right up until both kebab-case to `shape` at the boundary. Left
-/// to codegen, that surfaces as a Wasm validation failure reported as a compiler
-/// bug, when it is the source that has to change.
-///
-/// The exported type names come from the same walk codegen uses to emit them, so
-/// the set checked here is the set that lands in the instance.
+/// defined names can collide" — with case-insensitive uniqueness (`WIT.md`).
+/// Wado keeps the two apart, so `variant Shape` beside `export fn shape` reads
+/// as unambiguous until both kebab-case to `shape`. Left to codegen it surfaces
+/// as a Wasm validation failure reported as a compiler bug, when it is the
+/// source that has to change.
 fn validate_lib_interface_names(
     world_info: &WorldInfo,
     cm_interface_registry: &crate::component_model::CmInterfaceRegistry,
 ) -> Result<(), String> {
-    let mut type_gen = match world_info.exports.first().and_then(|e| e.from_interface_fq.as_deref())
-    {
-        Some(fq) => crate::component_model::CmTypeGen::with_interface_hint(fq),
-        None => crate::component_model::CmTypeGen::new(),
-    };
-    let mut sink = crate::component_model::CmNameSink::default();
-    let no_resources = IndexMap::default();
-    let mut walk = |ty: &crate::ast::Type| {
-        let resolved = cm_interface_registry.resolve_type_preserving_local_newtypes(ty);
-        type_gen.ast_type_to_cm(&mut sink, &resolved, cm_interface_registry, &no_resources);
-    };
-    for export in &world_info.exports {
-        for (_, ty) in &export.params {
-            walk(ty);
-        }
-        if let Some(ty) = &export.return_type {
-            walk(ty);
-        }
-    }
-
-    // The Wado types behind each exported CM name, so a collision can name both
-    // sides. A user type's CM name is `to_kebab` of its Wado name, applied by
-    // the registry when it records the type.
-    let mut wado_names: IndexMap<String, IndexSet<String>> = IndexMap::default();
-    for export in &world_info.exports {
-        for (_, ty) in &export.params {
-            collect_named_types(ty, &mut wado_names);
-        }
-        if let Some(ty) = &export.return_type {
-            collect_named_types(ty, &mut wado_names);
-        }
-    }
+    let exported = exported_cm_type_names(world_info, cm_interface_registry);
+    let wado_names = wado_names_by_cm_name(world_info);
     let describe = |cm_name: &str| match wado_names.get(cm_name).and_then(IndexSet::first) {
         Some(wado) => format!("type `{wado}` (exported as `{cm_name}`)"),
         None => format!("type `{cm_name}`"),
     };
 
-    // One claim per name, first claimant wins the error message's "already".
     let mut claimed: IndexMap<String, String> = IndexMap::default();
-    for cm_name in sink.names() {
-        // Two Wado types kebab-casing onto one CM name never reach the sink
+    for cm_name in &exported {
+        // Two Wado types kebab-casing onto one CM name never reach `exported`
         // twice: `CmTypeGen` caches by CM name, so the second silently reuses
-        // the first one's type and the two records merge. Catch it from the
-        // signatures, where both names are still distinct.
+        // the first one's type and the two merge. Catch it from the signatures,
+        // where both names are still distinct.
         if let Some(wado) = wado_names.get(cm_name)
             && wado.len() > 1
         {
@@ -762,9 +723,50 @@ fn validate_lib_interface_names(
     Ok(())
 }
 
-/// Group the named types reachable from `ty` by the CM name they kebab-case to,
-/// so a collision can be reported with the Wado names behind it — and so two
-/// types landing on one name are visible at all.
+/// The CM type names the export signatures put into the interface, taken from
+/// the same walk codegen uses to emit them.
+fn exported_cm_type_names(
+    world_info: &WorldInfo,
+    cm_interface_registry: &crate::component_model::CmInterfaceRegistry,
+) -> Vec<String> {
+    let mut type_gen = match world_info
+        .exports
+        .first()
+        .and_then(|e| e.from_interface_fq.as_deref())
+    {
+        Some(fq) => crate::component_model::CmTypeGen::with_interface_hint(fq),
+        None => crate::component_model::CmTypeGen::new(),
+    };
+    let mut sink = crate::component_model::CmNameSink::default();
+    let no_resources = IndexMap::default();
+    for ty in export_signature_types(world_info) {
+        let resolved = cm_interface_registry.resolve_type_preserving_local_newtypes(ty);
+        type_gen.ast_type_to_cm(&mut sink, &resolved, cm_interface_registry, &no_resources);
+    }
+    sink.names().to_vec()
+}
+
+/// The Wado types behind each CM name the signatures mention. A user type's CM
+/// name is `to_kebab` of its Wado name, applied by the registry when it records
+/// the type, so this inverts that exactly.
+fn wado_names_by_cm_name(world_info: &WorldInfo) -> IndexMap<String, IndexSet<String>> {
+    let mut out = IndexMap::default();
+    for ty in export_signature_types(world_info) {
+        collect_named_types(ty, &mut out);
+    }
+    out
+}
+
+fn export_signature_types(world_info: &WorldInfo) -> impl Iterator<Item = &crate::ast::Type> {
+    world_info.exports.iter().flat_map(|export| {
+        export
+            .params
+            .iter()
+            .map(|(_, ty)| ty)
+            .chain(export.return_type.as_ref())
+    })
+}
+
 fn collect_named_types(ty: &crate::ast::Type, out: &mut IndexMap<String, IndexSet<String>>) {
     use crate::ast::Type;
     match ty {
@@ -791,10 +793,7 @@ fn collect_named_types(ty: &crate::ast::Type, out: &mut IndexMap<String, IndexSe
         Type::Reference(inner) | Type::MutReference(inner) => collect_named_types(inner, out),
         // Not representable at the CM boundary; a signature carrying one is
         // rejected by `validate_boundary_representable` before this runs.
-        Type::Function(_)
-        | Type::TypePackSpread(_, _)
-        | Type::Infer(_)
-        | Type::Error(_) => {}
+        Type::Function(_) | Type::TypePackSpread(_, _) | Type::Infer(_) | Type::Error(_) => {}
     }
 }
 

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -10,6 +10,7 @@
 //!
 //! See `docs/wep-2026-02-15-cm-binding-synthesis.md` for design details.
 
+mod cm_free;
 mod export_adapter;
 mod import_adapter;
 mod lift;
@@ -34,7 +35,10 @@ use crate::wir::CmPayloadType;
 use crate::world_registry::WorldExportInfo;
 
 pub use export_adapter::export_binding_func_name;
-use export_adapter::{ExportBindingEnv, ExportReturnStrategy, synthesize_export_binding};
+use export_adapter::{
+    ExportBindingEnv, ExportReturnStrategy, post_return_func_name, synthesize_export_binding,
+    synthesize_post_return,
+};
 pub use import_adapter::binding_func_name;
 use import_adapter::synthesize_adapter;
 pub use lift::synthesize_lift;
@@ -509,6 +513,7 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
 
     // Collect adapters in a read-only pass (synthesize_export_binding needs &tir_modules)
     let mut export_adapters: Vec<(String, String, Rc<RefCell<TirFunction>>)> = Vec::new();
+    let mut post_returns: Vec<(String, String, Rc<RefCell<TirFunction>>)> = Vec::new();
     {
         let entry_module = project
             .tir_modules
@@ -610,6 +615,20 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
                 export_binding_func_name(&export.name),
                 adapter,
             ));
+
+            // A synchronous lift returns its value through guest-allocated
+            // memory; `post-return` is the ABI's only channel for handing that
+            // memory back. Async lifts return through `task.return`, where the
+            // option is not even permitted.
+            if matches!(strategy, ExportReturnStrategy::SyncReturn)
+                && let Some(post_return) = synthesize_post_return(&export.name, &env)
+            {
+                post_returns.push((
+                    export.name.clone(),
+                    post_return_func_name(&export.name),
+                    post_return,
+                ));
+            }
         }
     }
 
@@ -622,6 +641,12 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
             .export_binding_names
             .insert(export_name, binding_name);
         entry_module.functions.push(adapter);
+    }
+    for (export_name, func_name, post_return) in post_returns {
+        project
+            .post_return_binding_names
+            .insert(export_name, func_name);
+        entry_module.functions.push(post_return);
     }
     Ok(())
 }

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -1856,8 +1856,20 @@ mod tests {
             fix.ctx(),
         );
         assert_eq!(consumed, 2);
-        // Should be a call to memory_to_gc_string
-        assert!(matches!(expr.kind, TirExprKind::Call { .. }));
+        // The lifted string is materialized into a local so the caller-lowered
+        // buffer can be released before the value is used.
+        assert!(matches!(expr.kind, TirExprKind::Local { .. }));
+
+        let emitted = format!("{stmts:?}");
+        assert!(
+            emitted.contains("memory_to_gc_string"),
+            "expected the copy onto the GC heap in:\n{emitted}"
+        );
+        assert!(
+            emitted.contains("realloc"),
+            "the buffer the caller lowered the string into must be released \
+             once it has been copied:\n{emitted}"
+        );
     }
 
     #[test]

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -32,7 +32,7 @@ use crate::package::Package;
 use crate::tir::{ResolvedType, TirExpr, TirExprKind, TirFunction, TirModule, TypeId, TypeTable};
 use crate::tir_visitor::TirRefVisitor;
 use crate::wir::CmPayloadType;
-use crate::world_registry::WorldExportInfo;
+use crate::world_registry::{WorldExportInfo, WorldInfo};
 
 pub use export_adapter::export_binding_func_name;
 use export_adapter::{
@@ -509,6 +509,9 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
     let is_kiln_generator = project
         .world_registry
         .is_generator_world(&project.target_world);
+    if is_lib_world {
+        validate_lib_interface_names(&world_info, &project.cm_interface_registry)?;
+    }
     let entry_type_table = entry_type_table(project);
 
     // Collect adapters in a read-only pass (synthesize_export_binding needs &tir_modules)
@@ -649,6 +652,144 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
         entry_module.functions.push(post_return);
     }
     Ok(())
+}
+
+/// Reject two library exports that would claim the same name in the synthesized
+/// interface.
+///
+/// A Component Model interface has one namespace covering its types *and* its
+/// functions — "An interface has a single namespace which means that none of the
+/// defined names can collide" — and names in it must be unique
+/// case-insensitively (`WIT.md`). Wado gives types and functions separate
+/// namespaces, so `variant Shape` alongside `export fn shape` reads as
+/// unambiguous right up until both kebab-case to `shape` at the boundary. Left
+/// to codegen, that surfaces as a Wasm validation failure reported as a compiler
+/// bug, when it is the source that has to change.
+///
+/// The exported type names come from the same walk codegen uses to emit them, so
+/// the set checked here is the set that lands in the instance.
+fn validate_lib_interface_names(
+    world_info: &WorldInfo,
+    cm_interface_registry: &crate::component_model::CmInterfaceRegistry,
+) -> Result<(), String> {
+    let mut type_gen = match world_info.exports.first().and_then(|e| e.from_interface_fq.as_deref())
+    {
+        Some(fq) => crate::component_model::CmTypeGen::with_interface_hint(fq),
+        None => crate::component_model::CmTypeGen::new(),
+    };
+    let mut sink = crate::component_model::CmNameSink::default();
+    let no_resources = IndexMap::default();
+    let mut walk = |ty: &crate::ast::Type| {
+        let resolved = cm_interface_registry.resolve_type_preserving_local_newtypes(ty);
+        type_gen.ast_type_to_cm(&mut sink, &resolved, cm_interface_registry, &no_resources);
+    };
+    for export in &world_info.exports {
+        for (_, ty) in &export.params {
+            walk(ty);
+        }
+        if let Some(ty) = &export.return_type {
+            walk(ty);
+        }
+    }
+
+    // The Wado types behind each exported CM name, so a collision can name both
+    // sides. A user type's CM name is `to_kebab` of its Wado name, applied by
+    // the registry when it records the type.
+    let mut wado_names: IndexMap<String, IndexSet<String>> = IndexMap::default();
+    for export in &world_info.exports {
+        for (_, ty) in &export.params {
+            collect_named_types(ty, &mut wado_names);
+        }
+        if let Some(ty) = &export.return_type {
+            collect_named_types(ty, &mut wado_names);
+        }
+    }
+    let describe = |cm_name: &str| match wado_names.get(cm_name).and_then(IndexSet::first) {
+        Some(wado) => format!("type `{wado}` (exported as `{cm_name}`)"),
+        None => format!("type `{cm_name}`"),
+    };
+
+    // One claim per name, first claimant wins the error message's "already".
+    let mut claimed: IndexMap<String, String> = IndexMap::default();
+    for cm_name in sink.names() {
+        // Two Wado types kebab-casing onto one CM name never reach the sink
+        // twice: `CmTypeGen` caches by CM name, so the second silently reuses
+        // the first one's type and the two records merge. Catch it from the
+        // signatures, where both names are still distinct.
+        if let Some(wado) = wado_names.get(cm_name)
+            && wado.len() > 1
+        {
+            let names: Vec<String> = wado.iter().map(|n| format!("`{n}`")).collect();
+            return Err(format!(
+                "types {} share the Component Model name `{cm_name}` in this \
+                 library's interface, which can name each type only once. \
+                 Rename all but one of them.",
+                names.join(" and "),
+            ));
+        }
+        let key = cm_name.to_ascii_lowercase();
+        if let Some(previous) = claimed.get(&key) {
+            return Err(format!(
+                "{} and {} both claim the name `{cm_name}` in this library's \
+                 Component Model interface, where types and functions share one \
+                 namespace. Rename one of them.",
+                describe(cm_name),
+                previous,
+            ));
+        }
+        claimed.insert(key, describe(cm_name));
+    }
+    for export in &world_info.exports {
+        let cm_name = crate::name::kebab_export_name(&export.name);
+        let key = cm_name.to_ascii_lowercase();
+        if let Some(previous) = claimed.get(&key) {
+            return Err(format!(
+                "export `{}` becomes `{cm_name}` in this library's Component \
+                 Model interface, where {} already claims that name — an \
+                 interface has a single namespace covering both types and \
+                 functions. Rename one of them.",
+                export.name, previous,
+            ));
+        }
+        claimed.insert(key, format!("function `{}`", export.name));
+    }
+    Ok(())
+}
+
+/// Group the named types reachable from `ty` by the CM name they kebab-case to,
+/// so a collision can be reported with the Wado names behind it — and so two
+/// types landing on one name are visible at all.
+fn collect_named_types(ty: &crate::ast::Type, out: &mut IndexMap<String, IndexSet<String>>) {
+    use crate::ast::Type;
+    match ty {
+        Type::Named(named) => {
+            out.entry(crate::name::to_kebab(&named.name))
+                .or_default()
+                .insert(named.name.clone());
+        }
+        Type::Generic(generic) => {
+            for arg in &generic.args {
+                collect_named_types(arg, out);
+            }
+        }
+        Type::Tuple(elems) => {
+            for elem in elems {
+                collect_named_types(elem, out);
+            }
+        }
+        Type::NamespacedGeneric(generic) => {
+            for arg in &generic.args {
+                collect_named_types(arg, out);
+            }
+        }
+        Type::Reference(inner) | Type::MutReference(inner) => collect_named_types(inner, out),
+        // Not representable at the CM boundary; a signature carrying one is
+        // rejected by `validate_boundary_representable` before this runs.
+        Type::Function(_)
+        | Type::TypePackSpread(_, _)
+        | Type::Infer(_)
+        | Type::Error(_) => {}
+    }
 }
 
 /// The user function backing a world export: the origin `pub fn` for an

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -509,9 +509,6 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
     let is_kiln_generator = project
         .world_registry
         .is_generator_world(&project.target_world);
-    if is_lib_world {
-        validate_lib_interface_names(&world_info, &project.cm_interface_registry)?;
-    }
     let entry_type_table = entry_type_table(project);
 
     // Collect adapters in a read-only pass (synthesize_export_binding needs &tir_modules)
@@ -633,6 +630,15 @@ fn synthesize_export_adapters(project: &mut Package) -> Result<(), String> {
                 ));
             }
         }
+    }
+
+    // After the per-export loop: the name check walks every export signature
+    // through the CM type engine, which recurses without a depth guard, so it
+    // must not see a signature `validate_boundary_representable` would have
+    // rejected. A recursive type reaches the engine only if this runs first,
+    // and overflows the stack instead of producing that diagnostic.
+    if is_lib_world {
+        validate_lib_interface_names(&world_info, &project.cm_interface_registry)?;
     }
 
     let entry_module = project

--- a/wado-compiler/src/synthesis/cm_binding/cm_free.rs
+++ b/wado-compiler/src/synthesis/cm_binding/cm_free.rs
@@ -27,10 +27,8 @@ use crate::synthesis::common::{
 
 use super::types::{CmStdlibNames, binary_add, is_unit_type};
 
-/// What [`cm_shape`] needs to classify a type: the registry that resolves named
-/// types, the package scoping those lookups, and the stdlib name snapshot.
-/// Deliberately lighter than `LowerContext` — freeing needs no `TypeTable`,
-/// because it reads the CM value out of memory rather than out of a GC object.
+/// Lighter than `LowerContext`: freeing reads the value out of memory rather
+/// than out of a GC object, so it needs no `TypeTable`.
 pub(super) struct CmShapeContext<'a> {
     pub cm_interface_registry: &'a CmInterfaceRegistry,
     pub cm_package: &'a str,
@@ -40,10 +38,10 @@ pub(super) struct CmShapeContext<'a> {
 /// A part of a CM value: a record field, a variant payload, or a list element.
 pub(super) struct CmField {
     pub shape: CmShape,
-    /// Byte offset from the parent value's address. Always 0 for a list
-    /// element, whose address is computed from the element buffer base.
+    /// Byte offset from the parent's address; 0 for a list element, whose
+    /// address comes from the element buffer base.
     pub offset: u32,
-    /// Canonical ABI size — the element stride for a list element.
+    /// Canonical ABI size — the stride for a list element.
     pub size: u32,
     pub align: u32,
 }
@@ -56,13 +54,12 @@ impl CmField {
 
 /// How a Wado type owns linear memory once lowered to the CM ABI.
 pub(super) enum CmShape {
-    /// Fixed-width and self-contained: integers, floats, `bool`, `char`, unit,
-    /// an `enum` or `flags` discriminant, and every handle — resource,
-    /// `stream`, `future`. Owns nothing.
+    /// Owns nothing: integers, floats, `bool`, `char`, unit, an `enum` or
+    /// `flags` discriminant, and every handle.
     ///
-    /// Handles are `Scalar` because lifting *transfers* them to the host;
-    /// dropping one here would be a double-drop. `Scalar` means "owns no
-    /// memory", never "is four bytes".
+    /// Handles belong here because lifting *transfers* them to the host, so
+    /// dropping one would be a double-drop. `Scalar` means "owns no memory",
+    /// never "is four bytes".
     Scalar,
     /// `string`: `(ptr, len)` at the value's address, `len` bytes at align 1.
     Str,
@@ -72,33 +69,23 @@ pub(super) enum CmShape {
     /// `record` or `tuple`: fields at fixed offsets, no discriminant.
     Record(Vec<CmField>),
     /// `variant`, `option` or `result`: a one-byte discriminant at offset 0
-    /// selecting one payload. Indexed by discriminant value; `None` is a case
-    /// without a payload.
+    /// selecting one payload, indexed by discriminant value.
     Variant(Vec<Option<CmField>>),
 }
 
 impl CmShape {
-    /// Whether freeing this value emits anything at all. Lets the walk skip
-    /// whole subtrees — a `[u32, u32]` record contributes no code.
     pub(super) fn owns_memory(&self) -> bool {
         match self {
             CmShape::Scalar => false,
             CmShape::Str | CmShape::List(_) => true,
             CmShape::Record(fields) => fields.iter().any(CmField::owns_memory),
-            CmShape::Variant(cases) => cases
-                .iter()
-                .flatten()
-                .any(CmField::owns_memory),
+            CmShape::Variant(cases) => cases.iter().flatten().any(CmField::owns_memory),
         }
     }
 }
 
-/// Classify `ty` by how it owns linear memory at the CM boundary.
-///
-/// Mirrors the dispatch of `lower::synthesize_lower_wasi_type_to_memory` — a
-/// named record, a named variant, a tuple, `Option`, `List`, `Result`, and
-/// everything else fixed-width — and takes every layout number from the same
-/// `cm_abi` helpers.
+/// Classify `ty` by how it owns linear memory at the CM boundary, mirroring the
+/// dispatch of `lower::synthesize_lower_wasi_type_to_memory`.
 pub(super) fn cm_shape(ty: &Type, ctx: &CmShapeContext<'_>) -> CmShape {
     let resolved = ctx.cm_interface_registry.resolve_type(ty);
     let names = ctx.names;
@@ -117,10 +104,7 @@ pub(super) fn cm_shape(ty: &Type, ctx: &CmShapeContext<'_>) -> CmShape {
                 Some(ctx.cm_package),
             )
             .offsets[1];
-            CmShape::Variant(vec![
-                None,
-                payload_case(&g.args[0], payload_offset, ctx),
-            ])
+            CmShape::Variant(vec![None, payload_case(&g.args[0], payload_offset, ctx)])
         }
         Type::Generic(g) if g.name == names.result && g.args.len() == 2 => {
             let payload_offset = cm_abi::layout_result_with_registry_scoped(
@@ -135,10 +119,7 @@ pub(super) fn cm_shape(ty: &Type, ctx: &CmShapeContext<'_>) -> CmShape {
                 payload_case(&g.args[1], payload_offset, ctx),
             ])
         }
-        // `Own`/`Borrow`/`Stream`/`Future` are i32 handles the host now owns.
-        Type::Generic(g)
-            if matches!(g.name.as_str(), "Stream" | "Future" | "Own" | "Borrow") =>
-        {
+        Type::Generic(g) if matches!(g.name.as_str(), "Stream" | "Future" | "Own" | "Borrow") => {
             CmShape::Scalar
         }
         Type::Reference(_) | Type::MutReference(_) => CmShape::Scalar,
@@ -149,8 +130,7 @@ pub(super) fn cm_shape(ty: &Type, ctx: &CmShapeContext<'_>) -> CmShape {
     }
 }
 
-/// A named type is a registry record, a registry variant, or a fixed-width
-/// leaf (primitive, `enum`, `flags`, resource handle).
+/// A registry record, a registry variant, or a fixed-width leaf.
 fn named_shape(named: &NamedType, ctx: &CmShapeContext<'_>) -> CmShape {
     let Some(source) = ctx
         .cm_interface_registry
@@ -192,7 +172,6 @@ fn named_shape(named: &NamedType, ctx: &CmShapeContext<'_>) -> CmShape {
     CmShape::Scalar
 }
 
-/// Lay `types` out as a record/tuple and describe each field.
 fn field_list(types: &[Type], ctx: &CmShapeContext<'_>) -> Vec<CmField> {
     let offsets = cm_abi::layout_fields_with_registry_scoped(
         types.iter(),
@@ -216,8 +195,7 @@ fn field_of(ty: &Type, offset: u32, ctx: &CmShapeContext<'_>) -> CmField {
     }
 }
 
-/// A variant case's payload, or `None` when the case carries nothing to free —
-/// either it has no payload at all, or its payload is unit.
+/// A case's payload, or `None` when it is unit and so carries nothing to free.
 fn payload_case(ty: &Type, offset: u32, ctx: &CmShapeContext<'_>) -> Option<CmField> {
     if is_unit_type(ty) {
         return None;
@@ -225,10 +203,8 @@ fn payload_case(ty: &Type, offset: u32, ctx: &CmShapeContext<'_>) -> Option<CmFi
     Some(field_of(ty, offset, ctx))
 }
 
-/// Free every linear-memory buffer the CM value at `addr` owns.
-///
-/// `addr` must be evaluable more than once; callers pass a local reference.
-/// Emits nothing when the value owns no memory.
+/// Free every linear-memory buffer the CM value at `addr` owns. `addr` is
+/// evaluated more than once, so callers pass a local reference.
 pub(super) fn synthesize_free_cm_value(
     shape: &CmShape,
     addr: &TirExpr,
@@ -237,7 +213,7 @@ pub(super) fn synthesize_free_cm_value(
 ) -> Vec<TirStmt> {
     match shape {
         CmShape::Scalar => vec![],
-        CmShape::Str => vec![free_ptr_len(addr, 1)],
+        CmShape::Str => vec![free_ptr_len(addr, 1, 1)],
         CmShape::List(elem) => free_list(elem, addr, next_local, locals),
         CmShape::Record(fields) => fields
             .iter()
@@ -250,15 +226,10 @@ pub(super) fn synthesize_free_cm_value(
     }
 }
 
-/// `realloc(load(addr), load(addr + 4) * stride, align, 0)` — the shared shape
-/// of `string` and `list`, whose `(ptr, len)` pair sits at the value's address.
-/// The `len > 0` guard mirrors the lowering side, which allocates nothing for
-/// an empty payload, and keeps the `debug` allocator's poison length exact.
-fn free_ptr_len(addr: &TirExpr, align: u32) -> TirStmt {
-    free_ptr_len_strided(addr, 1, align)
-}
-
-fn free_ptr_len_strided(addr: &TirExpr, stride: u32, align: u32) -> TirStmt {
+/// Release the buffer behind the `(ptr, len)` pair at `addr`, shared by `string`
+/// and `list`. The `len > 0` guard mirrors the lowering side, which allocates
+/// nothing for an empty payload, and keeps `debug`'s poison length exact.
+fn free_ptr_len(addr: &TirExpr, stride: u32, align: u32) -> TirStmt {
     let ptr = builtin_call("i32_load", vec![addr.clone()], TypeTable::I32);
     let len = builtin_call(
         "i32_load",
@@ -354,14 +325,11 @@ fn free_list(
         ));
         body.push(expr_stmt(assign(
             local_ref(i_local, "__free_i", TypeTable::I32),
-            binary_add(
-                local_ref(i_local, "__free_i", TypeTable::I32),
-                i32_const(1),
-            ),
+            binary_add(local_ref(i_local, "__free_i", TypeTable::I32), i32_const(1)),
         )));
         stmts.push(loop_stmt(block(body)));
     }
-    stmts.push(free_ptr_len_strided(addr, elem.size, elem.align));
+    stmts.push(free_ptr_len(addr, elem.size, elem.align));
     stmts
 }
 

--- a/wado-compiler/src/synthesis/cm_binding/cm_free.rs
+++ b/wado-compiler/src/synthesis/cm_binding/cm_free.rs
@@ -1,0 +1,420 @@
+//! Which parts of a CM value own linear memory, and how to give it back.
+//!
+//! The Canonical ABI hands a memory-backed value to the host as a pointer into
+//! guest memory, and the guest allocated every buffer behind it. [`CmShape`]
+//! records where those buffers are; [`synthesize_free_cm_value`] emits the
+//! `realloc(ptr, size, align, 0)` calls that release them, walking nested
+//! buffers the outer pointer alone cannot reach — a `list<string>` owns its
+//! element array *and* one payload per element.
+//!
+//! Every offset, size and alignment comes from the `cm_abi` helpers the
+//! lowering side uses, so the two cannot disagree about layout. [`cm_shape`]
+//! panics on a type shape it does not recognise: a type reaching the CM
+//! boundary without an ownership rule fails loudly on first use rather than
+//! leaking silently.
+
+use crate::ast::{NamedType, Type};
+use crate::cm_abi;
+use crate::component_model::{
+    CmInterfaceRegistry, cm_align_with_registry_scoped, cm_size_with_registry_scoped,
+};
+use crate::tir::{TirBinaryOp, TirExpr, TirLocal, TirStmt, TypeTable};
+
+use crate::synthesis::common::{
+    alloc_local, assign, binary, block, break_stmt, builtin_call, expr_stmt, i32_const, if_stmt,
+    let_mut_stmt, let_stmt, local_ref, loop_stmt,
+};
+
+use super::types::{CmStdlibNames, binary_add, is_unit_type};
+
+/// What [`cm_shape`] needs to classify a type: the registry that resolves named
+/// types, the package scoping those lookups, and the stdlib name snapshot.
+/// Deliberately lighter than `LowerContext` — freeing needs no `TypeTable`,
+/// because it reads the CM value out of memory rather than out of a GC object.
+pub(super) struct CmShapeContext<'a> {
+    pub cm_interface_registry: &'a CmInterfaceRegistry,
+    pub cm_package: &'a str,
+    pub names: &'a CmStdlibNames,
+}
+
+/// A part of a CM value: a record field, a variant payload, or a list element.
+pub(super) struct CmField {
+    pub shape: CmShape,
+    /// Byte offset from the parent value's address. Always 0 for a list
+    /// element, whose address is computed from the element buffer base.
+    pub offset: u32,
+    /// Canonical ABI size — the element stride for a list element.
+    pub size: u32,
+    pub align: u32,
+}
+
+impl CmField {
+    fn owns_memory(&self) -> bool {
+        self.shape.owns_memory()
+    }
+}
+
+/// How a Wado type owns linear memory once lowered to the CM ABI.
+pub(super) enum CmShape {
+    /// Fixed-width and self-contained: integers, floats, `bool`, `char`, unit,
+    /// an `enum` or `flags` discriminant, and every handle — resource,
+    /// `stream`, `future`. Owns nothing.
+    ///
+    /// Handles are `Scalar` because lifting *transfers* them to the host;
+    /// dropping one here would be a double-drop. `Scalar` means "owns no
+    /// memory", never "is four bytes".
+    Scalar,
+    /// `string`: `(ptr, len)` at the value's address, `len` bytes at align 1.
+    Str,
+    /// `list<T>`: `(ptr, len)` at the value's address, elements at
+    /// `ptr + i * elem.size`.
+    List(Box<CmField>),
+    /// `record` or `tuple`: fields at fixed offsets, no discriminant.
+    Record(Vec<CmField>),
+    /// `variant`, `option` or `result`: a one-byte discriminant at offset 0
+    /// selecting one payload. Indexed by discriminant value; `None` is a case
+    /// without a payload.
+    Variant(Vec<Option<CmField>>),
+}
+
+impl CmShape {
+    /// Whether freeing this value emits anything at all. Lets the walk skip
+    /// whole subtrees — a `[u32, u32]` record contributes no code.
+    pub(super) fn owns_memory(&self) -> bool {
+        match self {
+            CmShape::Scalar => false,
+            CmShape::Str | CmShape::List(_) => true,
+            CmShape::Record(fields) => fields.iter().any(CmField::owns_memory),
+            CmShape::Variant(cases) => cases
+                .iter()
+                .flatten()
+                .any(CmField::owns_memory),
+        }
+    }
+}
+
+/// Classify `ty` by how it owns linear memory at the CM boundary.
+///
+/// Mirrors the dispatch of `lower::synthesize_lower_wasi_type_to_memory` — a
+/// named record, a named variant, a tuple, `Option`, `List`, `Result`, and
+/// everything else fixed-width — and takes every layout number from the same
+/// `cm_abi` helpers.
+pub(super) fn cm_shape(ty: &Type, ctx: &CmShapeContext<'_>) -> CmShape {
+    let resolved = ctx.cm_interface_registry.resolve_type(ty);
+    let names = ctx.names;
+    match &resolved {
+        Type::Named(named) if named.name == names.string => CmShape::Str,
+        Type::Named(named) => named_shape(named, ctx),
+        Type::Tuple(elems) if elems.is_empty() => CmShape::Scalar,
+        Type::Tuple(elems) => CmShape::Record(field_list(elems, ctx)),
+        Type::Generic(g) if g.name == names.array && g.args.len() == 1 => {
+            CmShape::List(Box::new(field_of(&g.args[0], 0, ctx)))
+        }
+        Type::Generic(g) if g.name == names.option && g.args.len() == 1 => {
+            let payload_offset = cm_abi::layout_option_with_registry_scoped(
+                &g.args[0],
+                ctx.cm_interface_registry,
+                Some(ctx.cm_package),
+            )
+            .offsets[1];
+            CmShape::Variant(vec![
+                None,
+                payload_case(&g.args[0], payload_offset, ctx),
+            ])
+        }
+        Type::Generic(g) if g.name == names.result && g.args.len() == 2 => {
+            let payload_offset = cm_abi::layout_result_with_registry_scoped(
+                &g.args[0],
+                &g.args[1],
+                ctx.cm_interface_registry,
+                Some(ctx.cm_package),
+            )
+            .offsets[1];
+            CmShape::Variant(vec![
+                payload_case(&g.args[0], payload_offset, ctx),
+                payload_case(&g.args[1], payload_offset, ctx),
+            ])
+        }
+        // `Own`/`Borrow`/`Stream`/`Future` are i32 handles the host now owns.
+        Type::Generic(g)
+            if matches!(g.name.as_str(), "Stream" | "Future" | "Own" | "Borrow") =>
+        {
+            CmShape::Scalar
+        }
+        Type::Reference(_) | Type::MutReference(_) => CmShape::Scalar,
+        other => panic!(
+            "no CM memory-ownership rule for `{other:?}`; add one here alongside \
+             its rule in `lower::synthesize_lower_wasi_type_to_memory`"
+        ),
+    }
+}
+
+/// A named type is a registry record, a registry variant, or a fixed-width
+/// leaf (primitive, `enum`, `flags`, resource handle).
+fn named_shape(named: &NamedType, ctx: &CmShapeContext<'_>) -> CmShape {
+    let Some(source) = ctx
+        .cm_interface_registry
+        .resolve_cm_source_for(named, Some(ctx.cm_package))
+    else {
+        return CmShape::Scalar;
+    };
+    if let Some(fields) = ctx
+        .cm_interface_registry
+        .get_struct_fields_with_wado_names_by_source(source, &named.name)
+    {
+        let field_types: Vec<Type> = fields
+            .iter()
+            .map(|(_, _, ty)| ctx.cm_interface_registry.resolve_type(ty))
+            .collect();
+        return CmShape::Record(field_list(&field_types, ctx));
+    }
+    if let Some(cases) = ctx
+        .cm_interface_registry
+        .get_variant_cases_by_source(source, &named.name)
+    {
+        let payloads: Vec<Option<Type>> = cases.iter().map(|c| c.payload.clone()).collect();
+        let payload_offset = cm_abi::variant_payload_offset_with_registry_scoped(
+            payloads.iter().flatten(),
+            ctx.cm_interface_registry,
+            Some(ctx.cm_package),
+        );
+        return CmShape::Variant(
+            payloads
+                .iter()
+                .map(|payload| {
+                    payload
+                        .as_ref()
+                        .and_then(|ty| payload_case(ty, payload_offset, ctx))
+                })
+                .collect(),
+        );
+    }
+    CmShape::Scalar
+}
+
+/// Lay `types` out as a record/tuple and describe each field.
+fn field_list(types: &[Type], ctx: &CmShapeContext<'_>) -> Vec<CmField> {
+    let offsets = cm_abi::layout_fields_with_registry_scoped(
+        types.iter(),
+        ctx.cm_interface_registry,
+        Some(ctx.cm_package),
+    )
+    .offsets;
+    types
+        .iter()
+        .zip(offsets)
+        .map(|(ty, offset)| field_of(ty, offset, ctx))
+        .collect()
+}
+
+fn field_of(ty: &Type, offset: u32, ctx: &CmShapeContext<'_>) -> CmField {
+    CmField {
+        shape: cm_shape(ty, ctx),
+        offset,
+        size: cm_size_with_registry_scoped(ty, ctx.cm_interface_registry, Some(ctx.cm_package)),
+        align: cm_align_with_registry_scoped(ty, ctx.cm_interface_registry, Some(ctx.cm_package)),
+    }
+}
+
+/// A variant case's payload, or `None` when the case carries nothing to free —
+/// either it has no payload at all, or its payload is unit.
+fn payload_case(ty: &Type, offset: u32, ctx: &CmShapeContext<'_>) -> Option<CmField> {
+    if is_unit_type(ty) {
+        return None;
+    }
+    Some(field_of(ty, offset, ctx))
+}
+
+/// Free every linear-memory buffer the CM value at `addr` owns.
+///
+/// `addr` must be evaluable more than once; callers pass a local reference.
+/// Emits nothing when the value owns no memory.
+pub(super) fn synthesize_free_cm_value(
+    shape: &CmShape,
+    addr: &TirExpr,
+    next_local: &mut u32,
+    locals: &mut Vec<TirLocal>,
+) -> Vec<TirStmt> {
+    match shape {
+        CmShape::Scalar => vec![],
+        CmShape::Str => vec![free_ptr_len(addr, 1)],
+        CmShape::List(elem) => free_list(elem, addr, next_local, locals),
+        CmShape::Record(fields) => fields
+            .iter()
+            .filter(|f| f.owns_memory())
+            .flat_map(|f| {
+                synthesize_free_cm_value(&f.shape, &at_offset(addr, f.offset), next_local, locals)
+            })
+            .collect(),
+        CmShape::Variant(cases) => free_variant(cases, addr, next_local, locals),
+    }
+}
+
+/// `realloc(load(addr), load(addr + 4) * stride, align, 0)` — the shared shape
+/// of `string` and `list`, whose `(ptr, len)` pair sits at the value's address.
+/// The `len > 0` guard mirrors the lowering side, which allocates nothing for
+/// an empty payload, and keeps the `debug` allocator's poison length exact.
+fn free_ptr_len(addr: &TirExpr, align: u32) -> TirStmt {
+    free_ptr_len_strided(addr, 1, align)
+}
+
+fn free_ptr_len_strided(addr: &TirExpr, stride: u32, align: u32) -> TirStmt {
+    let ptr = builtin_call("i32_load", vec![addr.clone()], TypeTable::I32);
+    let len = builtin_call(
+        "i32_load",
+        vec![binary_add(addr.clone(), i32_const(4))],
+        TypeTable::I32,
+    );
+    let size = if stride == 1 {
+        len.clone()
+    } else {
+        binary(
+            TirBinaryOp::Mul,
+            len.clone(),
+            i32_const(stride as i32),
+            TypeTable::I32,
+        )
+    };
+    if_stmt(
+        binary(TirBinaryOp::Gt, len, i32_const(0), TypeTable::BOOL),
+        block(vec![expr_stmt(builtin_call(
+            "realloc",
+            vec![ptr, size, i32_const(align as i32), i32_const(0)],
+            TypeTable::I32,
+        ))]),
+        None,
+    )
+}
+
+/// Walk the elements that own memory, then release the element buffer itself.
+fn free_list(
+    elem: &CmField,
+    addr: &TirExpr,
+    next_local: &mut u32,
+    locals: &mut Vec<TirLocal>,
+) -> Vec<TirStmt> {
+    let mut stmts = Vec::new();
+    if elem.owns_memory() {
+        let base_local = alloc_local(next_local, locals, TypeTable::I32);
+        stmts.push(let_stmt(
+            "__free_base",
+            base_local,
+            TypeTable::I32,
+            builtin_call("i32_load", vec![addr.clone()], TypeTable::I32),
+        ));
+        let count_local = alloc_local(next_local, locals, TypeTable::I32);
+        stmts.push(let_stmt(
+            "__free_count",
+            count_local,
+            TypeTable::I32,
+            builtin_call(
+                "i32_load",
+                vec![binary_add(addr.clone(), i32_const(4))],
+                TypeTable::I32,
+            ),
+        ));
+        let i_local = alloc_local(next_local, locals, TypeTable::I32);
+        stmts.push(let_mut_stmt(
+            "__free_i",
+            i_local,
+            TypeTable::I32,
+            i32_const(0),
+        ));
+
+        let mut body = vec![if_stmt(
+            binary(
+                TirBinaryOp::GtEq,
+                local_ref(i_local, "__free_i", TypeTable::I32),
+                local_ref(count_local, "__free_count", TypeTable::I32),
+                TypeTable::BOOL,
+            ),
+            block(vec![break_stmt()]),
+            None,
+        )];
+        let elem_addr_local = alloc_local(next_local, locals, TypeTable::I32);
+        body.push(let_stmt(
+            "__free_elem_addr",
+            elem_addr_local,
+            TypeTable::I32,
+            binary_add(
+                local_ref(base_local, "__free_base", TypeTable::I32),
+                binary(
+                    TirBinaryOp::Mul,
+                    local_ref(i_local, "__free_i", TypeTable::I32),
+                    i32_const(elem.size as i32),
+                    TypeTable::I32,
+                ),
+            ),
+        ));
+        body.extend(synthesize_free_cm_value(
+            &elem.shape,
+            &local_ref(elem_addr_local, "__free_elem_addr", TypeTable::I32),
+            next_local,
+            locals,
+        ));
+        body.push(expr_stmt(assign(
+            local_ref(i_local, "__free_i", TypeTable::I32),
+            binary_add(
+                local_ref(i_local, "__free_i", TypeTable::I32),
+                i32_const(1),
+            ),
+        )));
+        stmts.push(loop_stmt(block(body)));
+    }
+    stmts.push(free_ptr_len_strided(addr, elem.size, elem.align));
+    stmts
+}
+
+/// Load the one-byte discriminant the lowering side stored at offset 0 and free
+/// the active case's payload. Cases owning no memory contribute no branch.
+fn free_variant(
+    cases: &[Option<CmField>],
+    addr: &TirExpr,
+    next_local: &mut u32,
+    locals: &mut Vec<TirLocal>,
+) -> Vec<TirStmt> {
+    let owning: Vec<(usize, &CmField)> = cases
+        .iter()
+        .enumerate()
+        .filter_map(|(i, case)| case.as_ref().map(|f| (i, f)))
+        .filter(|(_, f)| f.owns_memory())
+        .collect();
+    if owning.is_empty() {
+        return vec![];
+    }
+
+    let disc_local = alloc_local(next_local, locals, TypeTable::I32);
+    let mut stmts = vec![let_stmt(
+        "__free_disc",
+        disc_local,
+        TypeTable::I32,
+        builtin_call("i32_load8_u", vec![addr.clone()], TypeTable::I32),
+    )];
+    for (index, field) in owning {
+        let payload = synthesize_free_cm_value(
+            &field.shape,
+            &at_offset(addr, field.offset),
+            next_local,
+            locals,
+        );
+        stmts.push(if_stmt(
+            binary(
+                TirBinaryOp::Eq,
+                local_ref(disc_local, "__free_disc", TypeTable::I32),
+                i32_const(index as i32),
+                TypeTable::BOOL,
+            ),
+            block(payload),
+            None,
+        ));
+    }
+    stmts
+}
+
+fn at_offset(addr: &TirExpr, offset: u32) -> TirExpr {
+    if offset == 0 {
+        addr.clone()
+    } else {
+        binary_add(addr.clone(), i32_const(offset as i32))
+    }
+}

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -1769,18 +1769,31 @@ pub(super) fn post_return_func_name(export_name: &str) -> String {
 }
 
 /// Synthesize the `post-return` function for a sync-lifted export, or `None`
-/// when its result owns no linear memory and there is nothing to reclaim.
+/// when the export returns nothing for the guest to reclaim.
 ///
-/// The canonical ABI calls it with the lifted core function's results, which
-/// for a memory-owning result is the single out-pointer: owning memory implies
-/// more than one flat result, and more than one flat result is returned
-/// indirectly. It frees what the value points at, then the out-pointer buffer
-/// itself.
+/// The gate is the indirect return, not memory ownership: a result flattening to
+/// more than one core value is returned through a guest-allocated area, and that
+/// area needs freeing even when nothing hangs off it — a record of two `u32`
+/// owns no memory yet still leaks its eight bytes per call. Ownership only
+/// decides whether the walk that reaches nested buffers emits anything.
+///
+/// The canonical ABI calls the function with the lifted core function's results,
+/// which in the indirect case is that single out-pointer.
 pub(super) fn synthesize_post_return(
     export_name: &str,
     env: &ExportBindingEnv<'_>,
 ) -> Option<Rc<RefCell<TirFunction>>> {
     let ty = env.world_return?;
+    let flat_count = {
+        let tt = env.type_table.borrow();
+        compute_export_flat_return_types(ty, env.tir_modules, &tt).len()
+    };
+    // Matches `push_sync_return_epilogue`, which allocates the return area under
+    // exactly this condition.
+    if flat_count <= 1 {
+        return None;
+    }
+
     let names = super::types::CmStdlibNames::from_compiler_items(
         env.type_table.borrow().compiler_items(),
     );
@@ -1790,20 +1803,6 @@ pub(super) fn synthesize_post_return(
         names: &names,
     };
     let shape = cm_shape(ty, &shape_ctx);
-    if !shape.owns_memory() {
-        return None;
-    }
-
-    let flat_count = {
-        let tt = env.type_table.borrow();
-        compute_export_flat_return_types(ty, env.tir_modules, &tt).len()
-    };
-    assert!(
-        flat_count > 1,
-        "`{export_name}` returns a memory-owning value that flattens to \
-         {flat_count} core value(s); the Canonical ABI returns anything wider \
-         than one value indirectly, so post-return has no out-pointer to free"
-    );
 
     let ptr = param_local("__ret_ptr", TypeTable::I32, false);
     let mut locals = vec![ptr];

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -43,6 +43,7 @@ use crate::synthesis::common::{
     synth_span,
 };
 
+use super::cm_free::{CmShapeContext, cm_shape, synthesize_free_cm_value};
 use super::import_adapter::make_binding_function;
 use super::lift::synthesize_lift_list;
 use super::lower::synthesize_lower_wasi_type_to_memory;
@@ -744,11 +745,40 @@ pub(super) fn synthesize_lift_from_flat_params(
         super::types::CmStdlibNames::from_compiler_items(type_table_cell.borrow().compiler_items());
     match ty {
         Type::Named(named) if named.name == names.string => {
-            // String flat ABI: (ptr: i32, len: i32) pointing to linear memory
+            // String flat ABI: (ptr: i32, len: i32) pointing to linear memory.
+            //
+            // The caller lowered the string into *our* memory through *our*
+            // `realloc`, so the buffer is the guest's to release once
+            // `memory_to_gc_string` has copied it onto the GC heap. Nested
+            // strings are released by the lift site that reads them
+            // (`synthesize_lift_list`, `synthesize_lift_option_inner`); this
+            // is the top-level arm, which had no such site.
             let ptr = local_ref(flat_param_locals[0], "__p", TypeTable::I32);
             let len = local_ref(flat_param_locals[1], "__p", TypeTable::I32);
-            let lifted = internal_call("memory_to_gc_string", vec![ptr, len], target_type_id);
-            (lifted, 2)
+            let lifted_local = alloc_local(next_local, locals, target_type_id);
+            stmts.push(let_stmt(
+                "__lifted_string",
+                lifted_local,
+                target_type_id,
+                internal_call(
+                    "memory_to_gc_string",
+                    vec![ptr.clone(), len.clone()],
+                    target_type_id,
+                ),
+            ));
+            stmts.push(if_stmt(
+                binary(TirBinaryOp::Gt, len.clone(), i32_const(0), TypeTable::BOOL),
+                block(vec![expr_stmt(builtin_call(
+                    "realloc",
+                    vec![ptr, len, i32_const(1), i32_const(0)],
+                    TypeTable::I32,
+                ))]),
+                None,
+            ));
+            (
+                local_ref(lifted_local, "__lifted_string", target_type_id),
+                2,
+            )
         }
         Type::Named(_)
             if matches!(
@@ -1728,6 +1758,94 @@ fn push_sync_return_epilogue(
             }
         }
     }
+}
+
+/// The core function named by a sync lift's `post-return` canonical option.
+///
+/// Mirrors [`export_binding_func_name`]; the two names differ so the core
+/// module can export both.
+pub(super) fn post_return_func_name(export_name: &str) -> String {
+    format!("__cm_post_return__{export_name}")
+}
+
+/// Synthesize the `post-return` function for a sync-lifted export, or `None`
+/// when its result owns no linear memory and there is nothing to reclaim.
+///
+/// The canonical ABI calls it with the lifted core function's results, which
+/// for a memory-owning result is the single out-pointer: owning memory implies
+/// more than one flat result, and more than one flat result is returned
+/// indirectly. It frees what the value points at, then the out-pointer buffer
+/// itself.
+pub(super) fn synthesize_post_return(
+    export_name: &str,
+    env: &ExportBindingEnv<'_>,
+) -> Option<Rc<RefCell<TirFunction>>> {
+    let ty = env.world_return?;
+    let names = super::types::CmStdlibNames::from_compiler_items(
+        env.type_table.borrow().compiler_items(),
+    );
+    let shape_ctx = CmShapeContext {
+        cm_interface_registry: env.cm_interface_registry,
+        cm_package: env.cm_package,
+        names: &names,
+    };
+    let shape = cm_shape(ty, &shape_ctx);
+    if !shape.owns_memory() {
+        return None;
+    }
+
+    let flat_count = {
+        let tt = env.type_table.borrow();
+        compute_export_flat_return_types(ty, env.tir_modules, &tt).len()
+    };
+    assert!(
+        flat_count > 1,
+        "`{export_name}` returns a memory-owning value that flattens to \
+         {flat_count} core value(s); the Canonical ABI returns anything wider \
+         than one value indirectly, so post-return has no out-pointer to free"
+    );
+
+    let ptr = param_local("__ret_ptr", TypeTable::I32, false);
+    let mut locals = vec![ptr];
+    let mut next_local = 1;
+    let addr = local_ref(0, "__ret_ptr", TypeTable::I32);
+
+    let mut body = synthesize_free_cm_value(&shape, &addr, &mut next_local, &mut locals);
+    let size = crate::component_model::cm_size_with_registry_scoped(
+        ty,
+        env.cm_interface_registry,
+        Some(env.cm_package),
+    );
+    let align = crate::component_model::cm_align_with_registry_scoped(
+        ty,
+        env.cm_interface_registry,
+        Some(env.cm_package),
+    );
+    body.push(expr_stmt(builtin_call(
+        "realloc",
+        vec![
+            addr,
+            i32_const(size as i32),
+            i32_const(align as i32),
+            i32_const(0),
+        ],
+        TypeTable::I32,
+    )));
+
+    Some(finalize_export_binding(
+        post_return_func_name(export_name),
+        vec![TirParam {
+            name: "__ret_ptr".to_string(),
+            type_id: TypeTable::I32,
+            local_index: 0,
+            is_mut: false,
+            is_mut_ref: false,
+            span: synth_span(),
+        }],
+        TypeTable::UNIT,
+        body,
+        locals,
+    ))
 }
 
 /// `ResultTaskReturn` epilogue: store the `Result<T, E>` value, zero the flat

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -746,13 +746,10 @@ pub(super) fn synthesize_lift_from_flat_params(
     match ty {
         Type::Named(named) if named.name == names.string => {
             // String flat ABI: (ptr: i32, len: i32) pointing to linear memory.
-            //
-            // The caller lowered the string into *our* memory through *our*
-            // `realloc`, so the buffer is the guest's to release once
-            // `memory_to_gc_string` has copied it onto the GC heap. Nested
-            // strings are released by the lift site that reads them
-            // (`synthesize_lift_list`, `synthesize_lift_option_inner`); this
-            // is the top-level arm, which had no such site.
+            // The caller lowered it there through *our* `realloc`, so the buffer
+            // is the guest's to release once it has been copied onto the GC
+            // heap. Nested strings are released by the lift site that reads
+            // them; this arm is the only top-level one.
             let ptr = local_ref(flat_param_locals[0], "__p", TypeTable::I32);
             let len = local_ref(flat_param_locals[1], "__p", TypeTable::I32);
             let lifted_local = alloc_local(next_local, locals, target_type_id);
@@ -1761,24 +1758,22 @@ fn push_sync_return_epilogue(
 }
 
 /// The core function named by a sync lift's `post-return` canonical option.
-///
-/// Mirrors [`export_binding_func_name`]; the two names differ so the core
-/// module can export both.
+/// Distinct from [`export_binding_func_name`] so the core module exports both.
 pub(super) fn post_return_func_name(export_name: &str) -> String {
     format!("__cm_post_return__{export_name}")
 }
 
 /// Synthesize the `post-return` function for a sync-lifted export, or `None`
-/// when the export returns nothing for the guest to reclaim.
+/// when nothing was allocated for it to reclaim.
 ///
-/// The gate is the indirect return, not memory ownership: a result flattening to
-/// more than one core value is returned through a guest-allocated area, and that
-/// area needs freeing even when nothing hangs off it — a record of two `u32`
-/// owns no memory yet still leaks its eight bytes per call. Ownership only
-/// decides whether the walk that reaches nested buffers emits anything.
+/// The gate is the indirect return, not memory ownership: a result wider than
+/// one core value comes back through a guest-allocated area that leaks without
+/// this, even when nothing hangs off it — a record of two `u32` owns no memory
+/// and still loses its eight bytes per call. Ownership only decides whether the
+/// walk over nested buffers emits anything.
 ///
-/// The canonical ABI calls the function with the lifted core function's results,
-/// which in the indirect case is that single out-pointer.
+/// The canonical ABI calls it with the lifted core function's results, which in
+/// the indirect case is that single out-pointer.
 pub(super) fn synthesize_post_return(
     export_name: &str,
     env: &ExportBindingEnv<'_>,
@@ -1788,15 +1783,13 @@ pub(super) fn synthesize_post_return(
         let tt = env.type_table.borrow();
         compute_export_flat_return_types(ty, env.tir_modules, &tt).len()
     };
-    // Matches `push_sync_return_epilogue`, which allocates the return area under
-    // exactly this condition.
+    // The condition `push_sync_return_epilogue` allocates the area under.
     if flat_count <= 1 {
         return None;
     }
 
-    let names = super::types::CmStdlibNames::from_compiler_items(
-        env.type_table.borrow().compiler_items(),
-    );
+    let names =
+        super::types::CmStdlibNames::from_compiler_items(env.type_table.borrow().compiler_items());
     let shape_ctx = CmShapeContext {
         cm_interface_registry: env.cm_interface_registry,
         cm_package: env.cm_package,

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -71,11 +71,10 @@ pub struct WorldExportPlan {
     /// adapters are synthesized as value-returning functions. The WASI worlds
     /// (CLI, HTTP, kiln) and `async` `--lib` exports keep the async lift.
     pub sync_lift: bool,
-    /// Core function backing the lift's `post-return` canonical option, when
-    /// this export's result owns linear memory. `None` leaves the option off
-    /// entirely — there is nothing to reclaim, and the option is illegal
-    /// alongside `async` anyway, so this is only ever `Some` under
-    /// [`Self::sync_lift`].
+    /// Core function backing the lift's `post-return` canonical option, which
+    /// reclaims the area an indirectly-returned result came back through.
+    /// `None` leaves the option off; the option is illegal alongside `async`,
+    /// so this is only ever `Some` under [`Self::sync_lift`].
     pub post_return_core_name: Option<String>,
     /// This is a `--lib` world export: codegen builds its CM param/result types
     /// from the raw Wado types in [`Self::param_types`] / [`Self::result_type`]

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -6,6 +6,7 @@
 use crate::ast::Type;
 use crate::component_model::{CmInterfaceRegistry, is_unit_type};
 use crate::hashmap::IndexMap;
+use crate::name::kebab_export_name;
 use crate::tir::TirTest;
 use crate::world_registry::{WorldExportInfo, WorldInfo, WorldRegistry};
 
@@ -426,13 +427,6 @@ fn resolve_cm_export_type(
         };
     }
     panic!("unsupported world export type shape: {ty:?}");
-}
-
-/// Kebab-case a world export name for the Component Model boundary: underscores
-/// become hyphens. Wado identifiers are `[a-z0-9_]`, so this yields a valid CM
-/// extern name. Already-kebab WASI names (`run`, `handle`) are unchanged.
-fn kebab_export_name(name: &str) -> String {
-    name.replace('_', "-")
 }
 
 /// Convert a test function name (e.g., `__test_0_my_name`) to a valid kebab-case

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -70,6 +70,12 @@ pub struct WorldExportPlan {
     /// adapters are synthesized as value-returning functions. The WASI worlds
     /// (CLI, HTTP, kiln) and `async` `--lib` exports keep the async lift.
     pub sync_lift: bool,
+    /// Core function backing the lift's `post-return` canonical option, when
+    /// this export's result owns linear memory. `None` leaves the option off
+    /// entirely — there is nothing to reclaim, and the option is illegal
+    /// alongside `async` anyway, so this is only ever `Some` under
+    /// [`Self::sync_lift`].
+    pub post_return_core_name: Option<String>,
     /// This is a `--lib` world export: codegen builds its CM param/result types
     /// from the raw Wado types in [`Self::param_types`] / [`Self::result_type`]
     /// (via [`crate::component_model::CmTypeGen`]) rather than the WASI-only
@@ -168,6 +174,7 @@ pub fn build_component_plan(
     tests: &[TirTest],
     test_name_filters: &[String],
     export_binding_names: &IndexMap<String, String>,
+    post_return_binding_names: &IndexMap<String, String>,
     world_registry: &WorldRegistry,
     cm_interface_registry: &CmInterfaceRegistry,
     lib_world: Option<&WorldInfo>,
@@ -181,6 +188,7 @@ pub fn build_component_plan(
         build_world_export_plans(
             target_world,
             export_binding_names,
+            post_return_binding_names,
             world_registry,
             cm_interface_registry,
             lib_world,
@@ -228,6 +236,7 @@ pub fn build_component_plan(
 fn build_world_export_plans(
     target_world: &str,
     export_binding_names: &IndexMap<String, String>,
+    post_return_binding_names: &IndexMap<String, String>,
     world_registry: &WorldRegistry,
     cm_interface_registry: &CmInterfaceRegistry,
     lib_world: Option<&WorldInfo>,
@@ -257,6 +266,7 @@ fn build_world_export_plans(
                 .get(&export.name)
                 .cloned()
                 .unwrap_or_else(|| export.name.clone());
+            let post_return_core_name = post_return_binding_names.get(&export.name).cloned();
 
             // Library exports carry their raw Wado types; codegen builds the
             // CM value types (and the named types they reference) top-level via
@@ -311,6 +321,7 @@ fn build_world_export_plans(
                 // `async` exports (WASI CLI / HTTP, the kiln generator's
                 // `generate`, async lib exports) keep the `task.return` lift.
                 sync_lift: !export.is_async,
+                post_return_core_name,
                 is_lib: is_lib_world,
             }
         })

--- a/wado-compiler/src/wir_build/functions.rs
+++ b/wado-compiler/src/wir_build/functions.rs
@@ -590,6 +590,24 @@ fn register_exports(ctx: &mut WirContext<'_>) {
                 ctx.func_map.keys().collect::<Vec<_>>()
             );
         }
+
+        // The lift's `post-return` names a core function, so it needs its own
+        // core export for codegen to alias.
+        if let Some(post_return) = &export.post_return_core_name {
+            let fq = format!("{entry_source}/{post_return}");
+            let Some(func_id) = ctx.func_map.get(&fq) else {
+                panic!(
+                    "[WIR] post-return function '{post_return}' not found (fq: {fq}); available: {:?}",
+                    ctx.func_map.keys().collect::<Vec<_>>()
+                );
+            };
+            ctx.exports.push(crate::wir::WirExport {
+                name: post_return.clone(),
+                desc: crate::wir::WirExportDesc::Func {
+                    func_id: func_id.clone(),
+                },
+            });
+        }
     }
 
     // Also export test functions

--- a/wado-compiler/src/wir_build/functions.rs
+++ b/wado-compiler/src/wir_build/functions.rs
@@ -591,8 +591,6 @@ fn register_exports(ctx: &mut WirContext<'_>) {
             );
         }
 
-        // The lift's `post-return` names a core function, so it needs its own
-        // core export for codegen to alias.
         if let Some(post_return) = &export.post_return_core_name {
             let fq = format!("{entry_source}/{post_return}");
             let Some(func_id) = ctx.func_map.get(&fq) else {

--- a/wado-compiler/tests/cm_catalog.rs
+++ b/wado-compiler/tests/cm_catalog.rs
@@ -531,14 +531,19 @@ async fn embedded_stream_round_trip(
 }
 
 /// Compile the catalog fixture as a library world at `opt_level`.
+///
+/// The default allocator is `debug`, which poisons freed memory and so surfaces
+/// lift/lower use-after-free at the boundary.
 fn compile_catalog(opt_level: OptLevel) -> Vec<u8> {
+    compile_catalog_with_allocator(opt_level, "debug")
+}
+
+fn compile_catalog_with_allocator(opt_level: OptLevel, allocator: &str) -> Vec<u8> {
     let source = std::fs::read_to_string(FIXTURE).expect("read cm_catalog fixture");
     let options = CompilerOptions {
         opt_level,
         lib_world: Some(LIB_WORLD_FQ.to_string()),
-        // The debug allocator poisons freed memory, surfacing lift/lower
-        // use-after-free at the boundary.
-        allocator: Some("debug".to_string()),
+        allocator: Some(allocator.to_string()),
         ..Default::default()
     };
     common::compile_source_with_compiler_options(Path::new(FIXTURE), &source, options)
@@ -1415,4 +1420,90 @@ fn cm_catalog_round_trip_o0() {
 #[test]
 fn cm_catalog_round_trip_o2() {
     run_round_trips(OptLevel::O2);
+}
+
+/// Round-trip every value case twice under `freelist`, whose free path traps on
+/// a block that is already free.
+///
+/// This is the guard for the `post-return` free walk (wado-lang/wado#1683): the
+/// walk visits every buffer a returned value owns, and a shape it visits twice —
+/// a variant case counted under two discriminants, an element freed both in the
+/// loop and with the array — is a double-free. Calling twice also catches a walk
+/// that frees a buffer the host has not finished with, since `freelist` hands the
+/// block straight back on the next call.
+///
+/// The catalog is the widest shape corpus available: strings, nested lists,
+/// tuples, options, results, records, variants, flags, enums and newtypes.
+fn run_double_free_guard(opt_level: OptLevel) {
+    let wasm = compile_catalog_with_allocator(opt_level, "freelist");
+    let engine = common::engine();
+    let opt = common::opt_level_name(opt_level);
+
+    common::runtime().block_on(async {
+        let component = Component::new(engine, &wasm).expect("instantiate component type");
+        let linker = common::linker(engine).expect("build linker");
+        let state = common::WasiState::new_with_pipes(
+            wasmtime_wasi::p2::pipe::MemoryOutputPipe::new(65536),
+            wasmtime_wasi::p2::pipe::MemoryOutputPipe::new(65536),
+        );
+        let mut store = Store::new(engine, state);
+        store.set_epoch_deadline((common::DEFAULT_TIMEOUT_MS / 1000).max(1));
+        let instance = linker
+            .instantiate_async(&mut store, &component)
+            .await
+            .expect("instantiate library component");
+        let iface = instance
+            .get_export(&mut store, None, LIB_WORLD_FQ)
+            .map(|(_, idx)| idx);
+
+        let mut failures = Vec::new();
+        for Case { export, value } in cases() {
+            let func = iface
+                .as_ref()
+                .and_then(|i| instance.get_export(&mut store, Some(i), export))
+                .map(|(_, idx)| idx)
+                .and_then(|idx| instance.get_func(&mut store, idx));
+            let Some(func) = func else {
+                failures.push(format!("[{opt}] export `{export}` not found"));
+                continue;
+            };
+            for call in 0..2 {
+                let mut results = vec![Val::Bool(false); func.ty(&store).results().len()];
+                match func
+                    .call_async(&mut store, std::slice::from_ref(&value), &mut results)
+                    .await
+                {
+                    Ok(()) if results.first() == Some(&value) => {}
+                    Ok(()) => failures.push(format!(
+                        "[{opt}] `{export}` call {call}: round-trip mismatch\n  \
+                         in:  {value:?}\n  out: {:?}",
+                        results.first()
+                    )),
+                    Err(e) => failures.push(format!(
+                        "[{opt}] `{export}` call {call} trapped: {e:#}\n  \
+                         A `freelist` trap here is a double-free or a \
+                         premature free in the `post-return` walk."
+                    )),
+                }
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "{} of {} catalog exports failed under `freelist`:\n{}",
+            failures.len(),
+            cases().len(),
+            failures.join("\n")
+        );
+    });
+}
+
+#[test]
+fn cm_catalog_no_double_free_o0() {
+    run_double_free_guard(OptLevel::O0);
+}
+
+#[test]
+fn cm_catalog_no_double_free_o2() {
+    run_double_free_guard(OptLevel::O2);
 }

--- a/wado-compiler/tests/cm_catalog.rs
+++ b/wado-compiler/tests/cm_catalog.rs
@@ -1394,6 +1394,44 @@ fn cm_lib_rejects_empty_record_boundary_type() {
     );
 }
 
+/// A Component Model interface has one namespace shared by its types and its
+/// functions, and names in it must be unique case-insensitively (`WIT.md`). Wado
+/// source has separate namespaces, so a `PascalCase` type and a `snake_case`
+/// function look unambiguous right up until kebab-casing maps them onto the same
+/// CM name. That must be a diagnostic naming both, not an ICE from Wasm
+/// validation.
+#[test]
+fn cm_lib_rejects_export_name_colliding_with_type_name() {
+    let err = try_compile_lib(
+        "variant Shape {\n    Dot,\n    Line(u32),\n}\n\
+         export fn shape(v: u32) -> u32 {\n    return v;\n}\n\
+         export fn make(v: u32) -> Shape {\n    if v == 0 {\n        \
+         return Shape::Dot;\n    } else {\n        return Shape::Line(v);\n    }\n}\n",
+    )
+    .expect_err("a function and a type sharing a CM name should fail to compile");
+    assert!(
+        err.contains("`shape`") && err.contains("`Shape`"),
+        "expected a collision diagnostic naming both the function and the type, got: {err}"
+    );
+}
+
+/// Two type names that differ only in a way kebab-casing erases land on the same
+/// CM name with no function involved at all.
+#[test]
+fn cm_lib_rejects_two_types_sharing_a_cm_name() {
+    let err = try_compile_lib(
+        "struct HTTPServer {\n    port: u32,\n}\n\
+         struct HttpServer {\n    host: String,\n}\n\
+         export fn a(v: HTTPServer) -> u32 {\n    return v.port;\n}\n\
+         export fn b(v: HttpServer) -> String {\n    return v.host;\n}\n",
+    )
+    .expect_err("two types sharing a CM name should fail to compile");
+    assert!(
+        err.contains("http-server"),
+        "expected a diagnostic naming the shared CM name, got: {err}"
+    );
+}
+
 /// The fixture is the published package source reused verbatim, so it must stay
 /// byte-identical to `package-cm-catalog/src/lib.wado`; otherwise the test
 /// corpus and the shipped package could drift apart.

--- a/wado-compiler/tests/cm_catalog.rs
+++ b/wado-compiler/tests/cm_catalog.rs
@@ -1415,6 +1415,23 @@ fn cm_lib_rejects_export_name_colliding_with_type_name() {
     );
 }
 
+/// The interface name check walks every export signature through the CM type
+/// engine, which recurses without a depth guard. It has to run behind the
+/// boundary-representability check, or a recursive type overflows the stack
+/// instead of getting the diagnostic that already exists for it.
+#[test]
+fn cm_lib_rejects_recursive_type_before_the_name_check_walks_it() {
+    let err = try_compile_lib(
+        "pub struct Node {\n    next: Option<Node>,\n    value: u32,\n}\n\
+         export fn depth(n: Node) -> u32 {\n    return n.value;\n}\n",
+    )
+    .expect_err("a recursive boundary type should fail to compile");
+    assert!(
+        err.contains("recursive") && err.contains("Node"),
+        "expected the recursive-type boundary diagnostic, got: {err}"
+    );
+}
+
 /// Two type names that differ only in a way kebab-casing erases land on the same
 /// CM name with no function involved at all.
 #[test]

--- a/wado-compiler/tests/cm_catalog.rs
+++ b/wado-compiler/tests/cm_catalog.rs
@@ -530,10 +530,9 @@ async fn embedded_stream_round_trip(
     Ok(())
 }
 
-/// Compile the catalog fixture as a library world at `opt_level`.
-///
-/// The default allocator is `debug`, which poisons freed memory and so surfaces
-/// lift/lower use-after-free at the boundary.
+/// Compile the catalog fixture as a library world at `opt_level`, under the
+/// `debug` allocator: it poisons freed memory, surfacing use-after-free at the
+/// boundary.
 fn compile_catalog(opt_level: OptLevel) -> Vec<u8> {
     compile_catalog_with_allocator(opt_level, "debug")
 }
@@ -1395,9 +1394,8 @@ fn cm_lib_rejects_empty_record_boundary_type() {
 }
 
 /// A Component Model interface has one namespace shared by its types and its
-/// functions, and names in it must be unique case-insensitively (`WIT.md`). Wado
-/// source has separate namespaces, so a `PascalCase` type and a `snake_case`
-/// function look unambiguous right up until kebab-casing maps them onto the same
+/// functions (`WIT.md`). Wado keeps the two apart, so a `PascalCase` type and a
+/// `snake_case` function look unambiguous until kebab-casing maps them onto one
 /// CM name. That must be a diagnostic naming both, not an ICE from Wasm
 /// validation.
 #[test]
@@ -1480,15 +1478,10 @@ fn cm_catalog_round_trip_o2() {
 /// Round-trip every value case twice under `freelist`, whose free path traps on
 /// a block that is already free.
 ///
-/// This is the guard for the `post-return` free walk (wado-lang/wado#1683): the
-/// walk visits every buffer a returned value owns, and a shape it visits twice —
-/// a variant case counted under two discriminants, an element freed both in the
-/// loop and with the array — is a double-free. Calling twice also catches a walk
-/// that frees a buffer the host has not finished with, since `freelist` hands the
-/// block straight back on the next call.
-///
-/// The catalog is the widest shape corpus available: strings, nested lists,
-/// tuples, options, results, records, variants, flags, enums and newtypes.
+/// The guard for the `post-return` free walk (wado-lang/wado#1683): a buffer the
+/// walk visits twice is a double-free, and calling twice also catches a buffer
+/// freed while the host still needs it, since `freelist` hands the block straight
+/// back on the next call. The catalog is the widest shape corpus available.
 fn run_double_free_guard(opt_level: OptLevel) {
     let wasm = compile_catalog_with_allocator(opt_level, "freelist");
     let engine = common::engine();

--- a/wado-compiler/tests/lib_sync_lift_post_return.rs
+++ b/wado-compiler/tests/lib_sync_lift_post_return.rs
@@ -1,25 +1,17 @@
-//! Return-buffer reclamation for synchronously-lifted `--lib` exports.
+//! Buffer reclamation at the synchronously-lifted `--lib` boundary.
 //!
-//! A non-`async` `--lib` export is lifted with `sync_lift`. When it returns a
-//! memory-backed value — `string`, `list<T>`, a composite via outptr — the guest
-//! allocates the payload with `realloc` and hands the host a pointer. The
-//! Canonical ABI's only mechanism for telling the guest that the host has
-//! finished reading is the `post-return` option of `canon lift`
-//! (`CanonicalABI.md`).
+//! A non-`async` `--lib` export returning a value wider than one core value
+//! hands the host a pointer into guest memory. The Canonical ABI's only channel
+//! for telling the guest the host has finished reading is the `post-return`
+//! option of `canon lift` (`CanonicalABI.md`).
 //!
-//! The tests cap guest memory well below the total payload they move, so a
-//! per-call leak exhausts the cap while correct reclamation stays flat. They run
-//! under `freelist` — the library world's own default — which also traps on
-//! double-free, so an over-eager free walk fails here too.
+//! The runtime tests cap guest memory well below the total payload they move, so
+//! a per-call leak exhausts the cap while correct reclamation stays flat. They
+//! run under `freelist` — the library world's own default — which also traps on
+//! double-free, so an over-eager free fails here too.
 //!
-//! Covered:
-//!
-//! - the returned payload, reclaimed through `post-return`;
-//! - an incoming `string` parameter, whose buffer the caller allocated with the
-//!   guest's `realloc` and which the export binding releases once it has copied
-//!   it onto the GC heap;
-//! - the canonical option itself: present when the result owns memory, absent
-//!   when it does not.
+//! Covered: the returned payload, an incoming `string` parameter, and the
+//! canonical option itself, which tracks the indirect return.
 
 #![allow(unused_crate_dependencies)]
 
@@ -212,10 +204,9 @@ fn lib_sync_lift_param_buffer_is_reclaimed_o2() {
     run_param(OptLevel::O2);
 }
 
-/// One memory-owning result and one that owns nothing, so the assertion below
-/// pins every direction of the canonical option in a single component: a result
-/// that owns a buffer, one that owns nothing but is still returned indirectly,
-/// and one returned in a core result with no allocation at all.
+/// Every direction of the canonical option in one component: a result that owns
+/// a buffer, one that owns nothing but is still returned indirectly, and one
+/// returned in a core result with no allocation at all.
 const OPTION_SOURCE: &str = r#"
 struct Pair {
     a: u32,
@@ -274,4 +265,3 @@ fn post_return_tracks_the_indirect_return() {
          its lift must carry no `post-return`:\n{direct}"
     );
 }
-

--- a/wado-compiler/tests/lib_sync_lift_post_return.rs
+++ b/wado-compiler/tests/lib_sync_lift_post_return.rs
@@ -7,11 +7,19 @@
 //! finished reading is the `post-return` option of `canon lift`
 //! (`CanonicalABI.md`).
 //!
-//! Codegen never emits it, so nothing frees the payload — in the very allocator
-//! the library world picks in order to reclaim memory (`freelist`).
+//! The tests cap guest memory well below the total payload they move, so a
+//! per-call leak exhausts the cap while correct reclamation stays flat. They run
+//! under `freelist` — the library world's own default — which also traps on
+//! double-free, so an over-eager free walk fails here too.
 //!
-//! The test caps guest memory well below the total payload it returns, so a
-//! per-call leak exhausts the cap while correct reclamation stays flat.
+//! Covered:
+//!
+//! - the returned payload, reclaimed through `post-return`;
+//! - an incoming `string` parameter, whose buffer the caller allocated with the
+//!   guest's `realloc` and which the export binding releases once it has copied
+//!   it onto the GC heap;
+//! - the canonical option itself: present when the result owns memory, absent
+//!   when it does not.
 
 #![allow(unused_crate_dependencies)]
 
@@ -66,23 +74,43 @@ fn capped_engine() -> Engine {
     Engine::new(&config).expect("build capped engine")
 }
 
-fn compile_lib(opt_level: OptLevel) -> Vec<u8> {
+fn compile_lib(source: &str, opt_level: OptLevel) -> Vec<u8> {
     let options = CompilerOptions {
         opt_level,
         lib_world: Some(LIB_WORLD_FQ.to_string()),
         // The library world's own default. `bump` never frees anything, so it
-        // cannot distinguish a leak from correct behavior.
+        // cannot distinguish a leak from correct behavior, and `freelist` traps
+        // on double-free, so it also catches an over-eager free.
         allocator: Some("freelist".to_string()),
         ..Default::default()
     };
-    common::compile_source_with_compiler_options(Path::new("lib.wado"), SOURCE, options)
+    common::compile_source_with_compiler_options(Path::new("lib.wado"), source, options)
         .expect("library failed to compile")
         .wasm
 }
 
+/// Resolve `name` in the library world's instance export, falling back to a
+/// bare top-level export.
+fn lib_func(
+    store: &mut Store<common::WasiState>,
+    instance: &wasmtime::component::Instance,
+    name: &str,
+) -> wasmtime::component::Func {
+    let iface = instance
+        .get_export(&mut *store, None, LIB_WORLD_FQ)
+        .map(|(_, idx)| idx);
+    let (_, func_idx) = iface
+        .and_then(|i| instance.get_export(&mut *store, Some(&i), name))
+        .or_else(|| instance.get_export(&mut *store, None, name))
+        .unwrap_or_else(|| panic!("`{name}` export not found"));
+    instance
+        .get_func(&mut *store, func_idx)
+        .unwrap_or_else(|| panic!("`{name}` is not a func"))
+}
+
 fn run(opt_level: OptLevel) {
     let engine = capped_engine();
-    let wasm = compile_lib(opt_level);
+    let wasm = compile_lib(SOURCE, opt_level);
     let component = Component::new(&engine, &wasm).expect("component failed to load");
 
     common::runtime().block_on(async {
@@ -92,16 +120,7 @@ fn run(opt_level: OptLevel) {
             .instantiate_async(&mut store, &component)
             .await
             .expect("instantiate library component");
-        let iface = instance
-            .get_export(&mut store, None, LIB_WORLD_FQ)
-            .map(|(_, idx)| idx);
-        let (_, func_idx) = iface
-            .and_then(|i| instance.get_export(&mut store, Some(&i), "chunk"))
-            .or_else(|| instance.get_export(&mut store, None, "chunk"))
-            .expect("`chunk` export not found");
-        let func = instance
-            .get_func(&mut store, func_idx)
-            .expect("`chunk` is not a func");
+        let func = lib_func(&mut store, &instance, "chunk");
 
         for call in 0..CALLS {
             let mut results = vec![Val::Bool(false)];
@@ -112,8 +131,9 @@ fn run(opt_level: OptLevel) {
                         "[{opt_level:?}] call {call} of {CALLS} failed after \
                          {leaked} MiB of returned payload, with guest memory \
                          capped at {cap} MiB: {e:#}\n\
-                         Each synchronously-lifted return leaks its payload \
-                         buffer because `canon lift` carries no `post-return`.",
+                         The `post-return` free walk is not reclaiming the \
+                         returned payload buffer (out-of-bounds), or is \
+                         reclaiming it twice (freelist double-free trap).",
                         leaked = (call * PAYLOAD) >> 20,
                         cap = MEMORY_CAP >> 20,
                     )
@@ -126,17 +146,110 @@ fn run(opt_level: OptLevel) {
     });
 }
 
-// Ignored until wado-lang/wado#1683: with no `post-return`, both trap on call 8
-// of 48, one unreclaimed 1 MiB buffer per call. Remove the attributes with the fix.
-
 #[test]
-#[ignore = "known leak: sync-lifted `--lib` exports never free their return buffer"]
 fn lib_sync_lift_return_buffer_is_reclaimed_o0() {
     run(OptLevel::O0);
 }
 
 #[test]
-#[ignore = "known leak: sync-lifted `--lib` exports never free their return buffer"]
 fn lib_sync_lift_return_buffer_is_reclaimed_o2() {
     run(OptLevel::O2);
+}
+
+/// Takes a `string` and returns a scalar, so the only guest allocation in play
+/// is the parameter buffer the caller lowered into guest memory.
+const PARAM_SOURCE: &str = r#"
+export fn measure(s: String) -> u32 {
+    return s.len() as u32;
+}
+"#;
+
+fn run_param(opt_level: OptLevel) {
+    let engine = capped_engine();
+    let wasm = compile_lib(PARAM_SOURCE, opt_level);
+    let component = Component::new(&engine, &wasm).expect("component failed to load");
+    let arg = "x".repeat(PAYLOAD);
+
+    common::runtime().block_on(async {
+        let linker = common::linker(&engine).expect("build linker");
+        let mut store = Store::new(&engine, common::WasiState::new());
+        let instance = linker
+            .instantiate_async(&mut store, &component)
+            .await
+            .expect("instantiate library component");
+        let func = lib_func(&mut store, &instance, "measure");
+
+        for call in 0..CALLS {
+            let mut results = vec![Val::Bool(false)];
+            func.call_async(&mut store, &[Val::String(arg.clone())], &mut results)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "[{opt_level:?}] call {call} of {CALLS} failed after \
+                         {leaked} MiB of passed-in payload, with guest memory \
+                         capped at {cap} MiB: {e:#}\n\
+                         The export binding is not releasing the caller-lowered \
+                         `string` parameter buffer, or is releasing it twice.",
+                        leaked = (call * PAYLOAD) >> 20,
+                        cap = MEMORY_CAP >> 20,
+                    )
+                });
+            match results.into_iter().next() {
+                Some(Val::U32(n)) => assert_eq!(n as usize, PAYLOAD, "parameter length"),
+                other => panic!("[{opt_level:?}] expected a u32 result, got {other:?}"),
+            }
+        }
+    });
+}
+
+#[test]
+fn lib_sync_lift_param_buffer_is_reclaimed_o0() {
+    run_param(OptLevel::O0);
+}
+
+#[test]
+fn lib_sync_lift_param_buffer_is_reclaimed_o2() {
+    run_param(OptLevel::O2);
+}
+
+/// One memory-owning result and one that owns nothing, so the assertion below
+/// pins both directions of the canonical option in a single component.
+const OPTION_SOURCE: &str = r#"
+export fn owns_memory(n: u32) -> List<u32> {
+    return [n];
+}
+
+export fn owns_nothing(n: u32) -> u32 {
+    return n;
+}
+"#;
+
+/// `post-return` is emitted only where there is something to reclaim: a lift
+/// whose result owns no linear memory keeps the option off, so components that
+/// cannot leak stay byte-identical to what they were before it existed.
+#[test]
+fn post_return_is_emitted_only_for_memory_owning_results() {
+    let wasm = compile_lib(OPTION_SOURCE, OptLevel::O0);
+    let wat = wasmprinter::print_bytes(&wasm).expect("print component");
+
+    let lift_of = |name: &str| -> String {
+        wat.lines()
+            .find(|line| line.contains("canon lift") && line.contains(&format!("${name} ")))
+            .unwrap_or_else(|| panic!("no `canon lift` line for `{name}` in:\n{wat}"))
+            .to_string()
+    };
+
+    let owning = lift_of("owns-memory");
+    assert!(
+        owning.contains("post-return"),
+        "a `list<u32>` result owns its element buffer and has nothing else to \
+         free it, so its lift needs `post-return`:\n{owning}"
+    );
+
+    let scalar = lift_of("owns-nothing");
+    assert!(
+        !scalar.contains("post-return"),
+        "a `u32` result owns no memory, so its lift must carry no \
+         `post-return`:\n{scalar}"
+    );
 }

--- a/wado-compiler/tests/lib_sync_lift_post_return.rs
+++ b/wado-compiler/tests/lib_sync_lift_post_return.rs
@@ -213,22 +213,36 @@ fn lib_sync_lift_param_buffer_is_reclaimed_o2() {
 }
 
 /// One memory-owning result and one that owns nothing, so the assertion below
-/// pins both directions of the canonical option in a single component.
+/// pins every direction of the canonical option in a single component: a result
+/// that owns a buffer, one that owns nothing but is still returned indirectly,
+/// and one returned in a core result with no allocation at all.
 const OPTION_SOURCE: &str = r#"
+struct Pair {
+    a: u32,
+    b: u32,
+}
+
 export fn owns_memory(n: u32) -> List<u32> {
     return [n];
 }
 
-export fn owns_nothing(n: u32) -> u32 {
+export fn indirect_scalars(n: u32) -> Pair {
+    return Pair { a: n, b: n };
+}
+
+export fn direct(n: u32) -> u32 {
     return n;
 }
 "#;
 
-/// `post-return` is emitted only where there is something to reclaim: a lift
-/// whose result owns no linear memory keeps the option off, so components that
-/// cannot leak stay byte-identical to what they were before it existed.
+/// `post-return` tracks the indirect return, not memory ownership.
+///
+/// Anything wider than one core value comes back through a guest-allocated area,
+/// and that area leaks without the option even when nothing hangs off it. A
+/// result that fits in a core value allocates nothing, so its lift keeps the
+/// option off and its component stays as it was before `post-return` existed.
 #[test]
-fn post_return_is_emitted_only_for_memory_owning_results() {
+fn post_return_tracks_the_indirect_return() {
     let wasm = compile_lib(OPTION_SOURCE, OptLevel::O0);
     let wat = wasmprinter::print_bytes(&wasm).expect("print component");
 
@@ -246,10 +260,18 @@ fn post_return_is_emitted_only_for_memory_owning_results() {
          free it, so its lift needs `post-return`:\n{owning}"
     );
 
-    let scalar = lift_of("owns-nothing");
+    let indirect = lift_of("indirect-scalars");
     assert!(
-        !scalar.contains("post-return"),
-        "a `u32` result owns no memory, so its lift must carry no \
-         `post-return`:\n{scalar}"
+        indirect.contains("post-return"),
+        "a record of two `u32` owns no memory, but still comes back through a \
+         guest-allocated area that leaks without `post-return`:\n{indirect}"
+    );
+
+    let direct = lift_of("direct");
+    assert!(
+        !direct.contains("post-return"),
+        "a `u32` result is returned in a core result and allocates nothing, so \
+         its lift must carry no `post-return`:\n{direct}"
     );
 }
+


### PR DESCRIPTION
A synchronously-lifted `--lib` export returning a value wider than one core
value hands the host a pointer into guest memory. The Canonical ABI's only
channel for telling the guest the host has finished reading is the `post-return`
option of `canon lift`, and Wado emits it.

## `post-return`

The option is emitted on a sync lift that returns indirectly, and the function it
names is synthesized alongside the export adapter.

The gate is the indirect return rather than memory ownership: anything wider than
one core value comes back through a guest-allocated area that leaks without the
option even when nothing hangs off it — a record of two `u32` owns no memory and
still loses eight bytes per call. A result that fits in a core value allocates
nothing, gets no option, and leaves its component untouched.

Reclamation is a recursive, type-driven walk of the value in linear memory, since
`post-return` receives only the outer pointer and a list of strings owns its
element array *and* one payload per element. It covers strings, lists, records,
tuples, variants, options and results, and ends by releasing the return area.
Handles are never touched: lifting transfers an owned handle to the host, so
dropping one would be a double-drop.

The walk and the lowering side share one source of layout truth — the Canonical
ABI layout helpers and the type registry — so they cannot disagree about where a
buffer sits. A type reaching the boundary with no ownership rule fails on its
first round-trip instead of silently emitting nothing.

`post-return` is illegal alongside `async`, so async-lifted exports are out of
scope by construction. Their equivalent leak is wado-lang/wado#1708.

## Export parameters

A top-level `string` parameter is released once it has been copied onto the GC
heap. The caller lowers it into guest memory through the guest's own allocator,
so the buffer belongs to the guest; nested strings are already released by the
lift sites that read them.

## Library interface name collisions

A Component Model interface has one namespace covering its types and its
functions, with case-insensitive uniqueness. Wado keeps the two apart, so
`variant Shape` beside `export fn shape` reads as unambiguous until both
kebab-case to `shape`. Both ways a library can claim one name twice are now
compile errors naming each side:

```
error: export `shape` becomes `shape` in this library's Component Model
interface, where type `Shape` (exported as `shape`) already claims that name — an
interface has a single namespace covering both types and functions. Rename one of
them.
```

```
error: types `HTTPServer` and `HttpServer` share the Component Model name
`http-server` in this library's interface, which can name each type only once.
Rename all but one of them.
```

The type-versus-type case matters beyond the diagnostic: `CmTypeGen` caches
records by CM name, so two Wado types landing on one name merge into a single
type and the export signatures are built from the wrong shape. Rejecting at the
source keeps that unreachable.

The check runs behind `validate_boundary_representable`, because it walks
signatures through the CM type engine, which recurses without a depth guard.

## Verification

The two reclaiming allocators fail loudly in opposite directions: `freelist`
traps on a double-free, and `debug` poisons freed memory without reusing it. The
CM type catalog runs under both — round-tripped twice under `freelist`, so every
shape the free walk can take is covered by the double-free trap.

Closes #1683

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBXBUBPeTkrJpWtCkSKA8g