### PR TITLE
chore(wado-vscode): pin the VS Code version used by the E2E tests

### DIFF
--- a/wado-vscode/.vscode-test.mjs
+++ b/wado-vscode/.vscode-test.mjs
@@ -6,6 +6,8 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const fixtureWorkspace = path.join(here, 'src', 'test', 'fixtures', 'workspace');
 
 export default defineConfig({
+  // Pinned so a VS Code release cannot break CI on its own.
+  version: '1.131.0',
   files: 'out/test/suite/**/*.test.js',
   workspaceFolder: fixtureWorkspace,
   mocha: {

--- a/wado-vscode/package-lock.json
+++ b/wado-vscode/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "latest",
         "@types/vscode": "latest",
         "@vscode/test-cli": "latest",
-        "@vscode/test-electron": "latest",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "latest",
         "mocha": "latest",
         "typescript": "latest",
@@ -1108,9 +1108,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.0.0.tgz",
-      "integrity": "sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/wado-vscode/package.json
+++ b/wado-vscode/package.json
@@ -121,7 +121,7 @@
     "@types/node": "latest",
     "@types/vscode": "latest",
     "@vscode/test-cli": "latest",
-    "@vscode/test-electron": "latest",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "latest",
     "mocha": "latest",
     "typescript": "latest",


### PR DESCRIPTION
## Summary

`wado-vscode/.vscode-test.mjs` pins the editor build the E2E suite runs against (`1.131.0`, current stable) instead of resolving the `stable` channel, so the three-OS matrix and local runs share one deterministic VS Code and an editor release cannot break the job on its own.

`@vscode/test-electron` is held at `^3.1.0`, which resolves the macOS executable from the bundle's `Info.plist` (`CFBundleExecutable` → `Contents/MacOS/Code`), with a fallback to the sole regular file in `Contents/MacOS/`. VS Code stopped shipping the historical `Contents/MacOS/Electron` name that earlier releases of the launcher spawn, so this is what lets the pin track current stable. Linux and Windows launcher names are unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSHgA5egWABWNTLJEL2wxL