### PR TITLE
chore(dev): align session setup with CARGO_INCREMENTAL=0

### DIFF
--- a/.claude/hooks/cargo-cache-restore.mts
+++ b/.claude/hooks/cargo-cache-restore.mts
@@ -18,11 +18,11 @@
 //   WADO_CACHE_SCCACHE_OBJECT, SCCACHE_DIR.
 
 import { createSign } from "node:crypto";
-import { createWriteStream, readFileSync, mkdirSync } from "node:fs";
-import { execFileSync, spawn } from "node:child_process";
+import { readFileSync, mkdirSync } from "node:fs";
+import { spawn } from "node:child_process";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { tmpdir, homedir } from "node:os";
+import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -75,7 +75,19 @@ async function accessToken({ client_email, private_key, token_uri }: ServiceAcco
   return (await res.json()).access_token;
 }
 
-async function restore(token: string, object: string, destDir: string, tarName: string): Promise<boolean> {
+// Unpack straight from the network into destDir. Staging the tarball on disk
+// first would cost a peak of ~500 MB (sccache) of the session's fixed disk
+// allowance, which is the resource under pressure here.
+async function untar(body: ReadableStream<Uint8Array>, destDir: string): Promise<void> {
+  const tar = spawn("tar", ["-xzf", "-", "-C", destDir], { stdio: ["pipe", "ignore", "inherit"] });
+  const exited = new Promise<void>((resolve, reject) => {
+    tar.on("error", reject);
+    tar.on("close", (code) => (code === 0 ? resolve() : reject(new Error(`tar exited with code ${code}`))));
+  });
+  await Promise.all([pipeline(Readable.fromWeb(body), tar.stdin!), exited]);
+}
+
+async function restore(token: string, object: string, destDir: string): Promise<boolean> {
   const url =
     `https://storage.googleapis.com/storage/v1/b/${BUCKET}` +
     `/o/${encodeURIComponent(object)}?alt=media`;
@@ -90,9 +102,7 @@ async function restore(token: string, object: string, destDir: string, tarName: 
   if (!res.ok) throw new Error(`download failed: HTTP ${res.status} ${await res.text()}`);
 
   mkdirSync(destDir, { recursive: true });
-  const tarPath = join(tmpdir(), tarName);
-  await pipeline(Readable.fromWeb(res.body!), createWriteStream(tarPath));
-  execFileSync("tar", ["-xzf", tarPath, "-C", destDir]);
+  await untar(res.body!, destDir);
   log(`restored gs://${BUCKET}/${object} into ${destDir}`);
   return true;
 }
@@ -124,8 +134,8 @@ async function main(): Promise<void> {
   // Independent and best-effort: a missing sccache object must not stop the
   // registry restore, and vice versa.
   const [registry, sccache] = await Promise.allSettled([
-    restore(token, REGISTRY_OBJECT, CARGO_HOME, "cargo-registry-cache.tar.gz"),
-    restore(token, SCCACHE_OBJECT, SCCACHE_DIR, "cargo-sccache-cache.tar.gz"),
+    restore(token, REGISTRY_OBJECT, CARGO_HOME),
+    restore(token, SCCACHE_OBJECT, SCCACHE_DIR),
   ]);
   for (const r of [registry, sccache]) {
     if (r.status === "rejected") log(`skipped: ${(r.reason as Error).message}`);

--- a/.github/workflows/cargo-cache.yml
+++ b/.github/workflows/cargo-cache.yml
@@ -7,8 +7,8 @@
 # The registry cache saves the download; the sccache cache saves the compile of
 # the ~440 dependencies (an ~8 min cold build becomes an ~80s sccache-backed
 # rebuild in the container). See .claude/hooks/cargo-cache-restore.mts (consumer)
-# and the `warm-cache` task in mise.toml (which uses it, then hands off to
-# incremental for the dev loop).
+# and the `warm-cache` task in mise.toml (which turns it into a warm target/ the
+# dev loop then builds on directly).
 #
 # PATH PARITY IS LOAD-BEARING. sccache's Rust cache key is sensitive to the
 # absolute build paths (build-script OUT_DIR and dependency paths bake into it),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ mise run report-wasm-size  # measures the size of the generated Wasm files and r
 - A compiler bug is always P0 — no exceptions. The instant you suspect one, stop all other work, and as the top priority write a minimal reproducible e2e fixture and fix it. A workaround that lets the current task proceed is never a reason to skip or defer any of these.
 - A pre-existing issue — whether you find it or a reviewer points it out — must be fixed, with TDD when practical.
 - Use plain `cargo build` / `cargo run` / `cargo test` (the `dev` profile) for iteration. `Cargo.toml` raises `opt-level` on `wado-compiler`, `wado-dev-tools`, and deps so dev-build runtime is close to release for the parts that matter. `--release` is only for distributing binaries, not for the inner dev loop.
+- Cloud sessions run with `CARGO_INCREMENTAL=0`: `target/debug/incremental` does not fit the session's fixed disk allowance. Every rebuild is a full recompile of the touched crates, so scope the inner loop with `cargo check` and `-p <crate>` instead of relying on incremental relinks. Never set `CARGO_INCREMENTAL=1` in a task or script.
 - Use the `rust` skill when writing Rust.
 - Use the `wado` skill when writing Wado code or designing Wado language features.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ split-debuginfo = "unpacked"
 
 # All third-party deps at opt-level 2, with debug-assertions/overflow-checks off.
 # The `"*"` glob skips workspace members (they keep their own opt-level). Deps are
-# cached, so this only costs a one-time clean/CI build; incremental dev builds are
+# cached, so this only costs a one-time clean/CI build; dev rebuilds are
 # unaffected while every run gets faster — both compile (mimalloc, indexmap,
 # hashbrown) and test/run (wasmtime/wasmparser, previously opt-level 0).
 # `debug-assertions = false` is also load-bearing: dprint-core trips a

--- a/mise.toml
+++ b/mise.toml
@@ -32,14 +32,14 @@ mise run warm-cache
 """
 
 [tasks.warm-cache]
-description = "Reconstruct target/ from the restored sccache cache, then warm the incremental dev loop"
+description = "Reconstruct target/ from the restored sccache cache"
 run = """
 #!/usr/bin/env bash
 # Turns the restored sccache cache (see .claude/hooks/cargo-cache-restore.mts)
 # into a warm target/: an ~8 min cold dependency build becomes an ~80s
-# sccache-backed rebuild. sccache is used ONLY here — it disables incremental,
-# which cripples the edit/rebuild inner loop (measured ~12x slower on
-# wado-compiler edits), so we hand off to incremental immediately after.
+# sccache-backed rebuild. sccache is used ONLY here, because its cache key
+# depends on the CARGO_* set normalized below — a plain `cargo build` in this
+# container has a different set and would only add misses.
 # No-ops cleanly when sccache or the cache is absent (e.g. local dev).
 set -e -o pipefail
 export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cargo/sccache}"
@@ -51,19 +51,17 @@ if [ ! -d "$SCCACHE_DIR" ] || [ -z "$(ls -A "$SCCACHE_DIR" 2>/dev/null)" ]; then
   echo "no restored sccache cache at $SCCACHE_DIR; skipping warm-cache"
   exit 0
 fi
-# 1) Reconstruct dependency artifacts from the content-addressed cache.
-#    sccache hashes every CARGO_* env var into the Rust cache key, so expose
-#    exactly the CARGO_* set the cargo-cache.yml runner used — this container
-#    otherwise leaks CARGO_HTTP_CAINFO and drops the runner's three.
+# Reconstruct dependency artifacts from the content-addressed cache. sccache
+# hashes every CARGO_* env var into the Rust cache key, so expose exactly the
+# CARGO_* set the cargo-cache.yml runner used — this container otherwise leaks
+# CARGO_HTTP_CAINFO and drops the runner's three.
 unset $(compgen -e | grep '^CARGO_' || true)
 env CARGO_HOME="$HOME/.cargo" CARGO_TARGET_DIR="$PWD/target" CARGO_INCREMENTAL=0 \
   RUSTC_WRAPPER=sccache cargo build --workspace --locked
 sccache --show-stats || true
-# 2) Hand off to incremental so the first real edit is a fast relink rather
-#    than a full non-incremental recompile (sccache and incremental are
-#    mutually exclusive). Only the workspace crates rebuild here; the cached
-#    dependencies are reused.
-CARGO_INCREMENTAL=1 cargo build --workspace --locked
+# The dev loop also runs with CARGO_INCREMENTAL=0 (see AGENTS.md), so these
+# artifacts are exactly what a later plain `cargo build` wants: no hand-off
+# build is needed, and target/debug/incremental never materializes.
 """
 
 [tasks.on-task-done]

--- a/wado-compiler/tests/generated/fixtures/bug_equal_arms_delete_trap.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/bug_equal_arms_delete_trap.wir.wado
@@ -62,17 +62,17 @@ type "functype//core:rt/cm_stream_write_drain" = fn(i32, i32, i32, i32);  // Typ
 
 type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(23)
 
-type "functype//core:prelude/string.wado/String::realloc_to" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(24)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::realloc_to" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(24)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(25)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(25)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(26)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(26)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(27)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(27)
 
 type "functype//core:prelude/primitive.wado/i32::fmt_decimal$spec0" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(28)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write$spec0" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(29)
+type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(29)
 
 type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(30)
 
@@ -277,14 +277,14 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
 fn "core:prelude/fpfmt.wado/__initialize_module"() {
 }
 
-fn "core:prelude/string.wado/String::realloc_to"(self, new_capacity) {
+fn "core:prelude/string.wado/core:prelude/string.wado/String::realloc_to"(self, new_capacity) {
     let new_repr: ref Array<u8>;
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
-fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
+fn "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let a_4: i32;
     let a_6: i32;
@@ -292,30 +292,30 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    "core:prelude/string.wado/String::realloc_to"(self, a_4 = capacity * 2; a_6 = select i32(a_4 > min_capacity, a_4, min_capacity); select i32(a_6 > 8, a_6, 8));
+    "core:prelude/string.wado/core:prelude/string.wado/String::realloc_to"(self, a_4 = capacity * 2; a_6 = select i32(a_4 > min_capacity, a_4, min_capacity); select i32(a_6 > 8, a_6, 8));
 }
 
-fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+fn "core:prelude/string.wado/core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
     let new_used: i32;
     let start: i32;
     new_used = self.used + n;
     if @unlikely(new_used > builtin::array_len(self.repr)) {
         cold_path;
-        "core:prelude/string.wado/String::grow"(self, new_used);
+        "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used);
     }
     start = self.used;
     self.used = new_used;
     return start;
 }
 
-fn "core:prelude/string.wado/String::push_str"(self, other) {
+fn "core:prelude/string.wado/core:prelude/string.wado/String::push_str"(self, other) {
     let other_len: i32;
     let start: i32;
     other_len = other.used;
     if other_len == 0 {
         return;
     }
-    start = "core:prelude/string.wado/String::internal_reserve_uninit"(self, other_len);
+    start = "core:prelude/string.wado/core:prelude/string.wado/String::internal_reserve_uninit"(self, other_len);
     builtin::array_copy<u8>(self.repr, start, other.repr, 0, other_len);
 }
 
@@ -327,11 +327,11 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$spec0"(self, f) {
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
     digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
-    offset = "core:prelude/format.wado/Formatter::prepare_int_write$spec0"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_1, digit_count);
+    offset = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_1, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
 
-fn "core:prelude/format.wado/Formatter::prepare_int_write$spec0"(self, is_negative, prefix, digit_count) {
+fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0"(self, is_negative, prefix, digit_count) {
     let sign: ref "core:prelude/string.wado//String";
     let sign_len: i32;
     let prefix_len: i32;
@@ -343,12 +343,12 @@ fn "core:prelude/format.wado/Formatter::prepare_int_write$spec0"(self, is_negati
     sign_len = sign.used;
     prefix_len = prefix.used;
     if sign_len > 0 {
-        "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        "core:prelude/string.wado/core:prelude/string.wado/String::push_str"(self.buf, sign);
     }
     if prefix_len > 0 {
-        "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        "core:prelude/string.wado/core:prelude/string.wado/String::push_str"(self.buf, prefix);
     }
-    return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    return "core:prelude/string.wado/core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
 }
 
 export fn "bug_equal_arms_delete_trap.wado/__cm_export__run" as "run"

--- a/wado-compiler/tests/generated/fixtures/bug_float_to_int_cast_fold.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/bug_float_to_int_cast_fold.wir.wado
@@ -62,17 +62,17 @@ type "functype//core:rt/cm_stream_write_drain" = fn(i32, i32, i32, i32);  // Typ
 
 type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(23)
 
-type "functype//core:prelude/string.wado/String::realloc_to" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(24)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::realloc_to" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(24)
 
-type "functype//core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(25)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(25)
 
-type "functype//core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(26)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::internal_reserve_uninit" = fn(ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(26)
 
-type "functype//core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(27)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(27)
 
 type "functype//core:prelude/primitive.wado/i32::fmt_decimal$spec0" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(28)
 
-type "functype//core:prelude/format.wado/Formatter::prepare_int_write$spec0" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(29)
+type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(29)
 
 type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(30)
 
@@ -282,14 +282,14 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
 fn "core:prelude/fpfmt.wado/__initialize_module"() {
 }
 
-fn "core:prelude/string.wado/String::realloc_to"(self, new_capacity) {
+fn "core:prelude/string.wado/core:prelude/string.wado/String::realloc_to"(self, new_capacity) {
     let new_repr: ref Array<u8>;
     new_repr = builtin::array_new<u8>(new_capacity);
     builtin::array_copy<u8>(new_repr, 0, self.repr, 0, self.used);
     self.repr = new_repr;
 }
 
-fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
+fn "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, min_capacity) {
     let capacity: i32;
     let a_4: i32;
     let a_6: i32;
@@ -297,30 +297,30 @@ fn "core:prelude/string.wado/String::grow"(self, min_capacity) {
     if min_capacity <= capacity {
         return;
     }
-    "core:prelude/string.wado/String::realloc_to"(self, a_4 = capacity * 2; a_6 = select i32(a_4 > min_capacity, a_4, min_capacity); select i32(a_6 > 8, a_6, 8));
+    "core:prelude/string.wado/core:prelude/string.wado/String::realloc_to"(self, a_4 = capacity * 2; a_6 = select i32(a_4 > min_capacity, a_4, min_capacity); select i32(a_6 > 8, a_6, 8));
 }
 
-fn "core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
+fn "core:prelude/string.wado/core:prelude/string.wado/String::internal_reserve_uninit"(self, n) {
     let new_used: i32;
     let start: i32;
     new_used = self.used + n;
     if @unlikely(new_used > builtin::array_len(self.repr)) {
         cold_path;
-        "core:prelude/string.wado/String::grow"(self, new_used);
+        "core:prelude/string.wado/core:prelude/string.wado/String::grow"(self, new_used);
     }
     start = self.used;
     self.used = new_used;
     return start;
 }
 
-fn "core:prelude/string.wado/String::push_str"(self, other) {
+fn "core:prelude/string.wado/core:prelude/string.wado/String::push_str"(self, other) {
     let other_len: i32;
     let start: i32;
     other_len = other.used;
     if other_len == 0 {
         return;
     }
-    start = "core:prelude/string.wado/String::internal_reserve_uninit"(self, other_len);
+    start = "core:prelude/string.wado/core:prelude/string.wado/String::internal_reserve_uninit"(self, other_len);
     builtin::array_copy<u8>(self.repr, start, other.repr, 0, other_len);
 }
 
@@ -332,11 +332,11 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$spec0"(self, f) {
     let self_6: ref "core:prelude/string.wado//String";
     is_negative = self < 0;
     digit_count = "core:prelude/primitive.wado/count_digits_i64"(local.tee abs_val(select i64(is_negative, 0_i64 - builtin::i64_extend_i32_s(self), builtin::i64_extend_i32_s(self))));
-    offset = "core:prelude/format.wado/Formatter::prepare_int_write$spec0"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_1, digit_count);
+    offset = "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0"(f, is_negative, global:core:prelude/primitive.wado::__const_obj_1, digit_count);
     "core:prelude/primitive.wado/write_decimal_digits"(self_6 = f.buf; self_6.repr, offset, abs_val, digit_count);
 }
 
-fn "core:prelude/format.wado/Formatter::prepare_int_write$spec0"(self, is_negative, prefix, digit_count) {
+fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0"(self, is_negative, prefix, digit_count) {
     let sign: ref "core:prelude/string.wado//String";
     let sign_len: i32;
     let prefix_len: i32;
@@ -348,12 +348,12 @@ fn "core:prelude/format.wado/Formatter::prepare_int_write$spec0"(self, is_negati
     sign_len = sign.used;
     prefix_len = prefix.used;
     if sign_len > 0 {
-        "core:prelude/string.wado/String::push_str"(self.buf, sign);
+        "core:prelude/string.wado/core:prelude/string.wado/String::push_str"(self.buf, sign);
     }
     if prefix_len > 0 {
-        "core:prelude/string.wado/String::push_str"(self.buf, prefix);
+        "core:prelude/string.wado/core:prelude/string.wado/String::push_str"(self.buf, prefix);
     }
-    return "core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
+    return "core:prelude/string.wado/core:prelude/string.wado/String::internal_reserve_uninit"(self.buf, digit_count);
 }
 
 export fn "bug_float_to_int_cast_fold.wado/__cm_export__run" as "run"


### PR DESCRIPTION
Cloud sessions build with `CARGO_INCREMENTAL=0`, because `target/debug/incremental` does not fit the session's fixed disk allowance. This aligns the two pieces of session setup that own disk — the `warm-cache` task and the cargo-cache restore hook — with that operating mode.

`warm-cache` is a single sccache-backed build of the workspace, with the `CARGO_*` set normalized to the one `cargo-cache.yml` compiles under so the restored sccache entries hit. Those artifacts are what the dev loop consumes directly: a plain `cargo build --workspace --locked` immediately after `warm-cache` finishes in 0.31 s, and `target/debug/incremental` stays empty.

The restore hook pipes each GCS object straight into `tar -xzf -`, so a restore never stages an archive on disk — peak usage is the extracted tree alone, and nothing occupies `/tmp` for the rest of the session. tar's stderr is inherited, so a truncated stream reports its reason, and a non-zero tar exit propagates as a restore failure. Restoring stays best-effort: a session whose cache is missing or unreadable continues with a cold build.

`AGENTS.md` records the rule this depends on: scope the inner loop with `cargo check` and `-p <crate>` rather than incremental relinks, and never set `CARGO_INCREMENTAL=1` in a task or script.