### PR TITLE
fix(gale): correct the descriptor tree comparators, and extend Stage B′ to 98 pins

### DIFF
--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -102,11 +102,12 @@ The Stage B′ JVM-oracle infrastructure (design in [`antlr4-compatibility.md`](
 
 `[stage_b_oracle_skip]` has been re-triaged (2026-07-30) and is down to the seven descriptors whose oracle output is not a valid pin at all — TestRig encodes non-ASCII as `?` while Gale renders the real code points, so pinning would strictly worsen Gale. Those are permanent unless the oracle's output encoding is fixed upstream; nothing else is parked there.
 
+Stage B′ is the **fallback** for descriptors Stage B cannot compare, not a parallel pin: the oracle manifest is written only on the paths where the descriptor's own `[output]` is not a tree Stage B can use. So a category having no `stage_b_oracle/` directory is not by itself a gap — it can equally mean every comparable descriptor is already covered by Stage B directly. Read coverage per descriptor, not per directory.
+
 Remaining:
 
-- **Extend Stage B′ to the categories it does not cover** — `ParseTrees` (which has Stage A / B / C coverage but no oracle pin) and `Listeners` (no coverage at any stage: every descriptor sits in `[skip]`). Needs a JDK-equipped re-extract.
-- **Graduate the `[skip]` bucket, which a re-extract alone will not move.** Those thirteen descriptors carry StringTemplate directives that name host-side artefacts — `<ImportListener(...)>`, `<BasicListener(...)>`, `<ParserPropertyMember()>`, `<PositionAdjustingLexer()>` — and none are in the expansion table (`src/g4/action_templates.wado`), which only covers directives with a grammar-level meaning. Each needs either a table entry or the judgement that it is genuinely target-language-specific; the Listeners ones look like the latter.
-- **Stage B compares its expected trees through `normalize_tree`.** Stage B′ no longer does (it lost a real divergence that way — see the whitespace note in the extractor), and Stage B is exposed to the same class of masking. No committed Stage B expected tree currently contains whitespace inside token text, so this is latent rather than live; decide it when one does.
+- **The `[skip]` bucket is down to three, each held by a directive that changes what the parser produces**: `ParseTrees/AltNum` (`contextSuperClass` + `<TreeNodeWithAltNumField>` render alt numbers into node names), `ParserExec/ParserProperty` (`<ParserPropertyMember()>` declares the member a semantic predicate calls), `LexerExec/PositionAdjustingLexer` (`<PositionAdjustingLexer()>` overrides `nextToken()`). Expanding any of them away would leave a test that no longer tests what the descriptor is for, so each needs the host-side construct genuinely modelled — or the judgement that it is target-language-specific and stays skipped.
+- **Stage B compares its expected trees through `normalize_tree`.** Stage B′ no longer does — it lost a real divergence that way (a token whose own text ends in a space). Stage B is exposed to the same class of masking; no committed Stage B expected tree currently contains whitespace inside token text, so this is latent rather than live.
 
 ### Composite (slave-grammar) descriptors
 

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -8,72 +8,15 @@ Open work towards full ANTLR4 compatibility and the performance budget it implie
 
 This file lists what is **not yet done** at a behavioral level; find the code via search, not line pointers. Closed work belongs in commit history.
 
-## Diagnostics & introspection ([#1246](https://github.com/wado-lang/wado/issues/1246))
+## Order of attack
 
-Grammar-authoring DX follow-ups:
+1. **Soundness and compatibility divergence** — these mis-parse valid input, so they outrank every feature below.
+2. **Structured diagnostic-to-rule identity** before the diagnostics that depend on it.
+3. **A descriptor re-extract** whenever a JDK and the `vendor/antlr4` submodule are at hand — it is the only way to re-triage the skip buckets, and several entries are stale rather than blocked.
+4. **Stage C**, starting with the SuperClass action-op replay: the largest block, and the gate for drop-in ANTLR4 replacement.
+5. Everything else, in whatever order a live case surfaces it.
 
-- **Optional-scan-guard-fallback warning.** Lowering warns on an overlap tournament today; the obvious next warning fires when an `e?` resolves to a scan-guarded optional (live case: a rule in `example/Wado.g4`). Deferred because it needs the enclosing rule name available at the warn site; add the diagnostic kind, the warn, and a fixture together.
-- **Structured diagnostic-to-rule identity.** A diagnostic's owning rule is carried today as the free-form human label the warn was raised with, and tooling re-associates it by substring-matching the quoted rule name — so group-scoped warnings (no quoted rule name) never inline under their owning rule. Carry a structured owner (rule name / index), set it at the warn site, and compare by equality, keeping the label display-only. The same change lets the overlap-dispatch builder be told explicitly whether it is on the scan pass instead of recovering that from a label suffix.
-
-## LL prediction — remaining gaps
-
-### Iter-body K-prefix for `Repeat` inner rule references
-
-The K-prefix follow-mask path closes the multi-token tail-greedy gap at the outer alternative position, but a rule reference inside a `Repeat` body still falls back to the 1-token mask path. The fixed-point "next iteration | exit-to-caller" computation that would let it gate is straightforward but not yet plumbed. Few real grammars need it; revisit when a descriptor surfaces a regression.
-
-### Multi-alt rule-reference expansion in the caller-side mask analysis
-
-The K-prefix caller-side mask analysis halts at a multi-alternative rule reference because a per-depth union of the alternatives' prefixes would over-yield by matching cross-alternative sequences no real alternative admits. A per-alternative sequence representation could extend the walk safely — useful when a caller's continuation passes through a multi-alternative rule like `expr : literal | name`.
-
-## Stage B′ — JVM-oracle integration
-
-The Stage B′ pipeline covers `FullContextParsing`, `LeftRecursion`, `ParserErrors`, `ParserExec`, `SemPredEvalParser`, and `Sets`, with the remaining prediction divergences pinned as oracle-todo. The infrastructure (design in [`antlr4-compatibility.md`](./antlr4-compatibility.md)) is in place; Java is needed only at extract time, not in CI.
-
-Remaining:
-
-- **Extend coverage to the remaining parser categories** (`ParseTrees`, `Listeners`) and re-triage the oracle-skip / oracle-todo entries after each re-extract. Several oracle-skip entries were recorded because StringTemplate directives sat outside action bodies where the stripper cannot reach; extract-time action-template expansion (see `antlr4-compatibility.md`) now turns those into plain Java type slots, so re-triage them at the next JDK-equipped re-extract — some should graduate from skip.
-
-## Composite (slave-grammar) descriptors
-
-Every `CompositeLexers` / `CompositeParsers` descriptor short-circuits on the presence of imported slave grammars. Independent blockers:
-
-- **Importer multi-input plumbing.** A grammar import (`import S;`) must resolve against the sibling slave-grammar files. Kiln already supports multi-input; lift the short-circuit once resolution lands.
-- **Host-side output (Stage C).** Every composite descriptor's expected output is a host-side artefact — action prints, token dumps, or empty — so none survive the Stage B output normalizer. Re-evaluate once Stage C lands.
-
-## Stage C — action / predicate execution
-
-Design in [`action.md`](./action.md). Remaining:
-
-- Lexer actions under a `Repeat`. The action replay places each action at the cursor it was written at, covering mid-element and nested-group placement, but a `Repeat` matches an unknown number of times and the non-greedy / lookahead-aware emitters restructure the sequence around it. An alt carrying one keeps the flat emit: top-level actions run at the end of the match, anything nested inside warns.
-- The ATN-class lexer path.
-- The rest of the lexer `$`-attribute surface — `$type` and member methods reading match position / text. The char-position half is covered: java2wado resolves `getCharPositionInLine()` and `_tokenStartCharPositionInLine`, but only in a Java body; the identity translator still has no `$`-form for either.
-- `@lexer::members` for a `language = Java` grammar. A Java member method takes `&mut self`, but a lexer predicate runs inside `try_<rule>(lx: &Lexer, ...)` — the tournament must not mutate through a losing candidate. Java lexer bodies therefore see no members, and a reference is reported. Wiring them needs a split between members a predicate may read and members only an action may touch.
-- Two same-named rule labels bound to _different_ rules in different alternatives (`x=a | x=b`). Per-alternative resolution disambiguates token-vs-rule, which is all the binding records, so a `.field` read still resolves against the first-declared rule's value channel. `$<label>.text` is unaffected — it reads the call's own span.
-- The SuperClass effect interface for the real-world grammars below. Landed for **predicate-only** lexer bases, including `language = Java`: RustLexer tokenizes and parses end to end through a hand-written `impl RustLexerBase`. See `action.md` ("SuperClass — an effect interface"). Remaining before TypeScript / ANTLRv4 run: action ops (`{this.m();}` — the winner-replay path), the parser side (parser-rule superClass predicates like `{this.NextGT()}?`, currently discarded), and lifecycle hooks (`nextToken` for last-token tracking). Action-op bases stay carved out (byte-identical) until the replay path lands.
-- Make the ANTLR descriptor output corpus codegen-and-compare (parse-only today), unblocking the output acceptance.
-- Extend the Stage C output-compare beyond `Sets` and `SemPredEvalParser`, the categories it runs for today. The remaining ones are a mechanical extractor re-run plus triage of whatever lands in `[stage_c_todo]` / `[stage_c_skip]`.
-- Parser actions on the paths that still warn: a non-transparent group's alternatives (the transparent path inlines its actions with its elements), an LR suffix, and a multi-alt prequel. Each surfaces `UnsupportedAction`, so a grammar that needs one is never silently wrong.
-- The recognizer accessors ANTLR exposes to an action that Gale does not model: `getExpectedTokens()` and `getVocabulary()` (live case: the `ParserErrors/LL1ErrorInfo` descriptor prints the expected set), and `PredictionMode` / `dumpDFA`, which describe ANTLR's simulator rather than the grammar.
-- java2wado numeric promotion: an `i32` token member (`$X.int` / `.type` / `.line` / `.pos` / `.index`) mixed with a wider value-channel field (`returns [long v]` / `[float]` / `[double]`) mismatches Wado's strict widths, since Wado has no implicit widening. Loud compile error, not silent; no corpus grammar hits it. A proper fix threads Java's promotion rules through the translator.
-
-Gale still silently discards action / predicate contents for the real-world grammars whose constructs the parser subset does not yet cover (`ANTLRv4Lexer`, `RustLexer`, `RustParser`, `TypeScriptLexer`, `TypeScriptParser`): they load cleanly, but the generated recognizer behaves as if every predicate were `true` and every action a no-op. That is wrong for:
-
-- Rust's `>>` / `>>=` token splitting in generics (`{this.NextGT()}?`) and float-literal disambiguation (`{this.FloatLiteralPossible()}?`); without them Gale mis-parses nested generics. (Raw-string `#`-count matching is _not_ a Stage C case — it is a recursive fragment, an ATN-class lexer concern.)
-- TypeScript's regex-vs-division disambiguation and other context-sensitive lexer and parser rules.
-
-All of these call `this.<method>()` against a hand-written `superClass` base that lives outside the `.g4` — executing them needs the SuperClass mechanism, not just action translation.
-
-Stage C is a hard prerequisite for treating Gale as a drop-in ANTLR4 replacement, for any lexer-level optimization (a fast tokenizer is meaningless if it tokenizes incorrectly), and for `superClass` / `tokenVocab`. It also unblocks composite-descriptor output comparison and parser descriptors whose output is purely action-print stdout.
-
-## gale-highlight — theme vocabulary
-
-`gale-highlight` provides a grammar-agnostic `Theme` (capture-class → CSS color), `stylesheet`, and `default_theme`. The _color → class_ half is covered; the _rule → class_ half is not: the set of capture classes is grammar-defined (the `.scm` highlight query), so a theme author keys colors by hand-typed class names with nothing to validate against, and a class the grammar emits but the theme omits is silently unstyled.
-
-- **Expose a grammar's capture vocabulary from the generator.** Gale already parses the `.scm` at generation time; emit the capture names it uses as a generated artefact (e.g. a `pub const CAPTURES: List<String>`, or a class → default-color map) alongside the parser. A grammar package could then build or validate a `Theme` against the real class set, turning a mistyped or dropped class into a signal instead of silent unstyled output.
-
-## Performance
-
-Runtime performance — the benchmark state, the live profile, the directions that would move the needle, and measured dead-ends (e.g. data-driven scan) — lives in [`perf.md`](./perf.md).
+The two LL-prediction gaps are deliberately parked, not queued — see below.
 
 ## Code-health bugs
 
@@ -86,12 +29,12 @@ The highest-risk bugs: a static-prediction edge or a parse/scan asymmetry that c
 Entries state the symptom, how to reproduce it, and anything already measured — not a diagnosis or a proposed fix. A diagnosis written here reads as an instruction later, and two have been wrong: one would have broken compatibility if implemented as written, the other described a difference that did not exist.
 
 - [ ] Valid input is rejected — the emitted dispatch has no else-fallback: `a : X+ Y | X Z` fails on `X X Y`. The opaque-rule expansion path separately drops at-end alternatives its template keeps.
-- [ ] Two operator alternatives of an ATN-class LR rule that open on the same token (`expr NOT? IN …` and `expr NOT? BETWEEN …`, both on `NOT`) are decided by alternative order rather than by lookahead. No committed grammar has the shape: `lr_between.g4` and `lr_atn_mid_operand.g4` run their loops on the simulator, but their operators open on distinct tokens, and SQLite — which does have the shared `NOT` — is not ATN-class at its loop. Reproducing it needs a new fixture with both properties.
 - [ ] A lexer alternation that is _not_ in tail position takes the first matching arm, not the one that lets the whole rule match: `I : ('a' | 'ab') 'bc'` rejects `abc`. Tail-position alternations are maximal-munch and unaffected.
+- [ ] Overlapping-but-unequal first-char ranges in the lexer dispatch shadow later rules: a char in the intersection only tries the first range group, and the wildcard fallback is unreachable for it.
+- [ ] A wildcard alternative gets an empty-token branch in a direct dispatch at the lowered-IR level, and `w=.` escapes the wildcard machinery entirely (the check does not unwrap labels). The surface-IR paths apply the wildcard soundness invariant; these do not.
+- [ ] Two operator alternatives of an ATN-class LR rule that open on the same token (`expr NOT? IN …` and `expr NOT? BETWEEN …`, both on `NOT`) are decided by alternative order rather than by lookahead. No committed grammar has the shape: `lr_between.g4` and `lr_atn_mid_operand.g4` run their loops on the simulator, but their operators open on distinct tokens, and SQLite — which does have the shared `NOT` — is not ATN-class at its loop. Reproducing it needs a new fixture with both properties.
 - [ ] A label on a transparent group (`x=(ID)`) silently drops the binding.
 - [ ] `\P{...}` (negated Unicode property) is parsed as literal chars — only lowercase `\p` is detected — and an unknown `\p{...}` property expands to an empty set with no diagnostic.
-- [ ] A wildcard alternative gets an empty-token branch in a direct dispatch at the lowered-IR level, and `w=.` escapes the wildcard machinery entirely (the check does not unwrap labels). The surface-IR paths apply the wildcard soundness invariant; these do not.
-- [ ] Overlapping-but-unequal first-char ranges in the lexer dispatch shadow later rules: a char in the intersection only tries the first range group, and the wildcard fallback is unreachable for it.
 - [ ] A surrogate code point in a char range (legal in ANTLR4 for matching UTF-16 code units) collapses to a single replacement char — range endpoints are Unicode scalars.
 
 ### Pipeline and tooling correctness
@@ -100,7 +43,7 @@ Entries state the symptom, how to reproduce it, and anything already measured �
 
 ### Deleted-terminal rendering
 
-`to_string_tree` matches ANTLR4's `Trees.toStringTree` everywhere except a deleted terminal: Gale prints `<skip z>` where ANTLR4 prints the bare token (`<missing X>` already matches). The marker is a deliberate extension — it is what makes Gale's own error-recovery fixtures able to tell recovery from a clean parse — so `ParseTrees/ExtraToken` sits in `[stage_b_skip]` rather than being forced to pass. Decide once: either the corpus gets an ANTLR-identical rendering mode, or the marker becomes opt-in and the recovery fixtures read the `Skip` rows structurally.
+`to_string_tree` matches ANTLR4's `Trees.toStringTree` everywhere except a deleted terminal: Gale prints `<skip z>` where ANTLR4 prints the bare token (`<missing X>` already matches). The marker is a deliberate extension — it is what makes Gale's own error-recovery fixtures able to tell recovery from a clean parse — so `ParseTrees/ExtraToken` sits in `[stage_b_skip]` rather than being forced to pass. Decide once: either the corpus gets an ANTLR-identical rendering mode, or the marker becomes opt-in and the recovery fixtures read the `Skip` rows structurally. This is a decision, not an implementation task — nothing else moves until it is made.
 
 ### Diagnostics and minor
 
@@ -113,3 +56,80 @@ Entries state the symptom, how to reproduce it, and anything already measured �
 ### Unchecked-argument quality nits (non-crash)
 
 - [ ] Malformed lexer command _arguments_ are unchecked (the paren panics are fixed): `pushMode(42)` interns a mode literally named `42`, and `-> ;` yields the odd "unknown lexer command ;".
+
+## Diagnostics & introspection
+
+Grammar-authoring DX follow-ups, from the review in [#1246](https://github.com/wado-lang/wado/issues/1246) (closed — these are what it left behind). Take them in this order; the first is a prerequisite for the second.
+
+- **Structured diagnostic-to-rule identity.** A diagnostic's owning rule is carried today as the free-form human label the warn was raised with, and tooling re-associates it by substring-matching the quoted rule name — so group-scoped warnings (no quoted rule name) never inline under their owning rule. Carry a structured owner (rule name / index), set it at the warn site, and compare by equality, keeping the label display-only. The same change lets the overlap-dispatch builder be told explicitly whether it is on the scan pass instead of recovering that from a label suffix.
+- **Optional-scan-guard-fallback warning.** Lowering warns on an overlap tournament today; the obvious next warning fires when an `e?` resolves to a scan-guarded optional (live case: a rule in `example/Wado.g4`). Deferred because it needs the enclosing rule name available at the warn site; add the diagnostic kind, the warn, and a fixture together.
+
+## Stage C — action / predicate execution
+
+Design in [`action.md`](./action.md). The largest remaining block, and a hard prerequisite for treating Gale as a drop-in ANTLR4 replacement, for any lexer-level optimization (a fast tokenizer is meaningless if it tokenizes incorrectly), and for `superClass` / `tokenVocab`. It also unblocks composite-descriptor output comparison and parser descriptors whose output is purely action-print stdout.
+
+Gale still silently discards action / predicate contents for the real-world grammars whose constructs the parser subset does not yet cover (`ANTLRv4Lexer`, `RustLexer`, `RustParser`, `TypeScriptLexer`, `TypeScriptParser`): they load cleanly, but the generated recognizer behaves as if every predicate were `true` and every action a no-op. That is wrong for:
+
+- Rust's `>>` / `>>=` token splitting in generics (`{this.NextGT()}?`) and float-literal disambiguation (`{this.FloatLiteralPossible()}?`); without them Gale mis-parses nested generics. (Raw-string `#`-count matching is _not_ a Stage C case — it is a recursive fragment, an ATN-class lexer concern.)
+- TypeScript's regex-vs-division disambiguation and other context-sensitive lexer and parser rules.
+
+All of these call `this.<method>()` against a hand-written `superClass` base that lives outside the `.g4` — executing them needs the SuperClass mechanism, not just action translation. So that comes first:
+
+- **The SuperClass effect interface** for those grammars. Landed for **predicate-only** lexer bases, including `language = Java`: RustLexer tokenizes and parses end to end through a hand-written `impl RustLexerBase`. See `action.md` ("SuperClass — an effect interface"). Remaining before TypeScript / ANTLRv4 run: action ops (`{this.m();}` — the winner-replay path), the parser side (parser-rule superClass predicates like `{this.NextGT()}?`, currently discarded), and lifecycle hooks (`nextToken` for last-token tracking). Action-op bases stay carved out (byte-identical) until the replay path lands.
+
+Then the paths that still warn — each surfaces `UnsupportedAction`, so a grammar that needs one is never silently wrong:
+
+- Parser actions on a non-transparent group's alternatives (the transparent path inlines its actions with its elements), an LR suffix, and a multi-alt prequel.
+- Lexer actions under a `Repeat`. The action replay places each action at the cursor it was written at, covering mid-element and nested-group placement, but a `Repeat` matches an unknown number of times and the non-greedy / lookahead-aware emitters restructure the sequence around it. An alt carrying one keeps the flat emit: top-level actions run at the end of the match, anything nested inside warns.
+
+Then the surface gaps:
+
+- The rest of the lexer `$`-attribute surface — `$type` and member methods reading match position / text. The char-position half is covered: java2wado resolves `getCharPositionInLine()` and `_tokenStartCharPositionInLine`, but only in a Java body; the identity translator still has no `$`-form for either.
+- `@lexer::members` for a `language = Java` grammar. A Java member method takes `&mut self`, but a lexer predicate runs inside `try_<rule>(lx: &Lexer, ...)` — the tournament must not mutate through a losing candidate. Java lexer bodies therefore see no members, and a reference is reported. Wiring them needs a split between members a predicate may read and members only an action may touch.
+- The recognizer accessors ANTLR exposes to an action that Gale does not model: `getExpectedTokens()` and `getVocabulary()` (live case: the `ParserErrors/LL1ErrorInfo` descriptor, one of the `[stage_c_todo]` entries, prints the expected set), and `PredictionMode` / `dumpDFA`, which describe ANTLR's simulator rather than the grammar — decide whether those two are ever in scope.
+- Two same-named rule labels bound to _different_ rules in different alternatives (`x=a | x=b`). Per-alternative resolution disambiguates token-vs-rule, which is all the binding records, so a `.field` read still resolves against the first-declared rule's value channel. `$<label>.text` is unaffected — it reads the call's own span.
+- The ATN-class lexer path.
+- java2wado numeric promotion: an `i32` token member (`$X.int` / `.type` / `.line` / `.pos` / `.index`) mixed with a wider value-channel field (`returns [long v]` / `[float]` / `[double]`) mismatches Wado's strict widths, since Wado has no implicit widening. Loud compile error, not silent; no corpus grammar hits it — lowest priority here. A proper fix threads Java's promotion rules through the translator.
+
+And the corpus side, which is extractor work rather than codegen work (see "Descriptor corpus" below):
+
+- Make the ANTLR descriptor output corpus codegen-and-compare (parse-only today), unblocking the output acceptance.
+- Extend the Stage C output-compare beyond `Sets` and `SemPredEvalParser`, the categories it runs for today. The remaining ones are a mechanical extractor re-run plus triage of whatever lands in `[stage_c_todo]` / `[stage_c_skip]`.
+
+## Descriptor corpus — coverage and re-triage
+
+The Stage B′ JVM-oracle infrastructure (design in [`antlr4-compatibility.md`](./antlr4-compatibility.md)) is in place and its pinned trees all pass — `[stage_b_oracle_todo]` is empty, so no prediction divergence is currently pinned there. Java is needed only at extract time, not in CI; the extract also needs the `vendor/antlr4` submodule initialized.
+
+Remaining, all gated on a JDK-equipped re-extract:
+
+- **Extend Stage B′ to the categories it does not cover** — `ParseTrees` (which has Stage A / B / C coverage but no oracle pin) and `Listeners` (no coverage at any stage: every descriptor sits in `[skip]`).
+- **Re-triage the skip buckets after each re-extract.** Several `[skip]` / `[stage_b_oracle_skip]` entries were recorded because StringTemplate directives sat outside action bodies where the stripper cannot reach; extract-time action-template expansion (see `antlr4-compatibility.md`) now turns those into plain Java type slots, so some should graduate from skip. Entries parked on a downstream `wado-compiler` failure need the failure re-checked rather than assumed — the note is only as fresh as the last run.
+
+### Composite (slave-grammar) descriptors
+
+Every `CompositeLexers` / `CompositeParsers` descriptor short-circuits on the presence of imported slave grammars. Independent blockers:
+
+- **Importer multi-input plumbing.** A grammar import (`import S;`) must resolve against the sibling slave-grammar files. Kiln already supports multi-input; lift the short-circuit once resolution lands. Actionable on its own, ahead of Stage C.
+- **Host-side output (Stage C).** Every composite descriptor's expected output is a host-side artefact — action prints, token dumps, or empty — so none survive the Stage B output normalizer. Re-evaluate once Stage C lands.
+
+## gale-highlight — theme vocabulary
+
+`gale-highlight` provides a grammar-agnostic `Theme` (capture-class → CSS color), `stylesheet`, and `default_theme`. The _color → class_ half is covered; the _rule → class_ half is not: the set of capture classes is grammar-defined (the `.scm` highlight query), so a theme author keys colors by hand-typed class names with nothing to validate against, and a class the grammar emits but the theme omits is silently unstyled.
+
+- **Expose a grammar's capture vocabulary from the generator.** Gale already parses the `.scm` at generation time; emit the capture names it uses as a generated artefact (e.g. a `pub const CAPTURES: List<String>`, or a class → default-color map) alongside the parser. A grammar package could then build or validate a `Theme` against the real class set, turning a mistyped or dropped class into a signal instead of silent unstyled output.
+
+## LL prediction — parked gaps
+
+Not queued work: both are known edges of the static path, and the complete answer is the runtime ATN simulator (`AGENTS.md` records three over-broad static repairs that each silently broke a real grammar). Revisit only when a descriptor or a real grammar surfaces a regression, and pair any repair with a rejection-case fixture.
+
+### Iter-body K-prefix for `Repeat` inner rule references
+
+The K-prefix follow-mask path closes the multi-token tail-greedy gap at the outer alternative position, but a rule reference inside a `Repeat` body still falls back to the 1-token mask path. The fixed-point "next iteration | exit-to-caller" computation that would let it gate is straightforward but not yet plumbed.
+
+### Multi-alt rule-reference expansion in the caller-side mask analysis
+
+The K-prefix caller-side mask analysis halts at a multi-alternative rule reference because a per-depth union of the alternatives' prefixes would over-yield by matching cross-alternative sequences no real alternative admits. A per-alternative sequence representation could extend the walk safely — useful when a caller's continuation passes through a multi-alternative rule like `expr : literal | name`.
+
+## Performance
+
+Runtime performance — the benchmark state, the live profile, the directions that would move the needle, and measured dead-ends (e.g. data-driven scan) — lives in [`perf.md`](./perf.md).

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -100,10 +100,13 @@ And the corpus side, which is extractor work rather than codegen work (see "Desc
 
 The Stage B′ JVM-oracle infrastructure (design in [`antlr4-compatibility.md`](./antlr4-compatibility.md)) is in place and its pinned trees all pass — `[stage_b_oracle_todo]` is empty, so no prediction divergence is currently pinned there. Java is needed only at extract time, not in CI; the extract also needs the `vendor/antlr4` submodule initialized.
 
-Remaining, all gated on a JDK-equipped re-extract:
+`[stage_b_oracle_skip]` has been re-triaged (2026-07-30) and is down to the seven descriptors whose oracle output is not a valid pin at all — TestRig encodes non-ASCII as `?` while Gale renders the real code points, so pinning would strictly worsen Gale. Those are permanent unless the oracle's output encoding is fixed upstream; nothing else is parked there.
 
-- **Extend Stage B′ to the categories it does not cover** — `ParseTrees` (which has Stage A / B / C coverage but no oracle pin) and `Listeners` (no coverage at any stage: every descriptor sits in `[skip]`).
-- **Re-triage the skip buckets after each re-extract.** Several `[skip]` / `[stage_b_oracle_skip]` entries were recorded because StringTemplate directives sat outside action bodies where the stripper cannot reach; extract-time action-template expansion (see `antlr4-compatibility.md`) now turns those into plain Java type slots, so some should graduate from skip. Entries parked on a downstream `wado-compiler` failure need the failure re-checked rather than assumed — the note is only as fresh as the last run.
+Remaining:
+
+- **Extend Stage B′ to the categories it does not cover** — `ParseTrees` (which has Stage A / B / C coverage but no oracle pin) and `Listeners` (no coverage at any stage: every descriptor sits in `[skip]`). Needs a JDK-equipped re-extract.
+- **Graduate the `[skip]` bucket, which a re-extract alone will not move.** Those thirteen descriptors carry StringTemplate directives that name host-side artefacts — `<ImportListener(...)>`, `<BasicListener(...)>`, `<ParserPropertyMember()>`, `<PositionAdjustingLexer()>` — and none are in the expansion table (`src/g4/action_templates.wado`), which only covers directives with a grammar-level meaning. Each needs either a table entry or the judgement that it is genuinely target-language-specific; the Listeners ones look like the latter.
+- **Stage B compares its expected trees through `normalize_tree`.** Stage B′ no longer does (it lost a real divergence that way — see the whitespace note in the extractor), and Stage B is exposed to the same class of masking. No committed Stage B expected tree currently contains whitespace inside token text, so this is latent rather than live; decide it when one does.
 
 ### Composite (slave-grammar) descriptors
 

--- a/package-gale/TODO.md
+++ b/package-gale/TODO.md
@@ -12,7 +12,7 @@ This file lists what is **not yet done** at a behavioral level; find the code vi
 
 1. **Soundness and compatibility divergence** — these mis-parse valid input, so they outrank every feature below.
 2. **Structured diagnostic-to-rule identity** before the diagnostics that depend on it.
-3. **A descriptor re-extract** whenever a JDK and the `vendor/antlr4` submodule are at hand — it is the only way to re-triage the skip buckets, and several entries are stale rather than blocked.
+3. **A descriptor re-extract** whenever a JDK and the `vendor/antlr4` submodule are at hand. The skip buckets were re-triaged this way on 2026-07-30 and are now small; the standing value is that a re-extract is what proves an entry is still blocked rather than merely old.
 4. **Stage C**, starting with the SuperClass action-op replay: the largest block, and the gate for drop-in ANTLR4 replacement.
 5. Everything else, in whatever order a live case surfaces it.
 
@@ -93,8 +93,7 @@ Then the surface gaps:
 
 And the corpus side, which is extractor work rather than codegen work (see "Descriptor corpus" below):
 
-- Make the ANTLR descriptor output corpus codegen-and-compare (parse-only today), unblocking the output acceptance.
-- Extend the Stage C output-compare beyond `Sets` and `SemPredEvalParser`, the categories it runs for today. The remaining ones are a mechanical extractor re-run plus triage of whatever lands in `[stage_c_todo]` / `[stage_c_skip]`.
+- The output-compare itself has landed across the parser categories (`FullContextParsing`, `LeftRecursion`, `ParseTrees`, `ParserErrors`, `ParserExec`, `SemPredEvalParser`, `Sets`), and lexer action output is compared by Stage A claim (d) instead. What is left is not more categories but the gaps above: the five `[stage_c_todo]` entries, and the descriptors that auto-skip because their action bodies hit a path that still warns.
 
 ## Descriptor corpus — coverage and re-triage
 

--- a/package-gale/antlr4-compatibility.md
+++ b/package-gale/antlr4-compatibility.md
@@ -159,7 +159,10 @@ Test sources covering Stage B:
    `tests/antlr4-compat/stage_b/<Category>/<Name>_test.wado`, emitted
    by the descriptor extractor for every descriptor whose `[output]` is
    a clean parse tree (rejected by the Stage B output normalizer
-   otherwise — action-body prints, token dumps, ATN traces).
+   otherwise — action-body prints, token dumps, ATN traces). A tree
+   render both starts and ends at a paren, so an `[output]` that
+   continues past the closing paren is host-side print output the
+   descriptor emits alongside its tree, not a tree to compare.
    Two emit shapes:
    - **Full-tree** when the `[output]` root rule equals `[start]`.
      Compares `t::to_tree(&root).to_string_tree()` against the
@@ -188,10 +191,19 @@ reproducible.
 Stage B′ extends Stage B to descriptors whose own `[output]` is host-
 language chatter (`<writeln(...)>` action prints, `Token.toString`
 dumps, ATN traces) by sourcing the expected parse tree from the
-published ANTLR4 jar instead of from `[output]`. Stage B and Stage B′
-share the same parse-tree comparator and the same generated parser
-under `tests/generated/antlr4_compat_b/`; they differ only in where
-"the right answer" comes from.
+published ANTLR4 jar instead of from `[output]`. Because Stage B′
+ignores `[output]` entirely, a descriptor blocked only by host-side
+scaffolding in its `[output]` is still reachable — the scaffolding has
+to leave the grammar loadable, not be reproducible.
+
+Stage B and Stage B′ share the generated parser under
+`tests/generated/antlr4_compat_b/`, but not the comparator. Stage B
+compares through `normalize_tree`, which collapses whitespace runs so a
+hand-written expected tree can be indented. Stage B′ compares verbatim:
+the oracle's tree is already one line, so collapsing can only lose
+information — and it does whenever a token's own text carries
+whitespace (`BREAK: 'break '` renders `break  break`, the token's
+trailing space plus the child separator).
 
 The oracle is the published jar treated as a black box; the wrapper
 script `package-gale/scripts/antlr4-oracle.sh` runs it, captures the
@@ -204,9 +216,10 @@ hygiene rule in [`AGENTS.md`](./AGENTS.md)).
 Stage B′ runs at descriptor-extraction time, not at test time. Its
 inputs (grammar + input) are stable; its output (the oracle tree) is
 committed to the generated test file so CI does not need Java. The
-jar version used for a given extraction is recorded as a `// Generated
-against ANTLR4 4.x.y` comment in the emitted test file so any diff in
-the oracle's answer surfaces in commit history.
+jar version used for a given extraction is recorded as an `// Expected
+tree: antlr-4.x.y-complete.jar on the action-body-stripped grammar`
+comment in the emitted test file so any diff in the oracle's answer
+surfaces in commit history.
 
 For grammars that contain action bodies (`{ ... }` or `{ ... }?`),
 the extractor strips them before invoking the oracle. Extracted
@@ -652,10 +665,10 @@ tests/antlr4-compat/stage_b/<Category>/<Name>_test.wado
                   │              │                   — full-tree or sub-tree;
                   │              │                   one file per eligible descriptor)
 tests/antlr4-compat/stage_b_oracle/<Category>/<Name>_test.wado
-                  │              │                  (Stage B′: same comparator, but
-                  │              │                   expected tree comes from running
-                  │              │                   scripts/antlr4-oracle.sh on the
-                  │              │                   stripped grammar at extract time)
+                  │              │                  (Stage B′: expected tree comes from
+                  │              │                   running scripts/antlr4-oracle.sh on
+                  │              │                   the stripped grammar at extract time,
+                  │              │                   and is compared verbatim)
                   │              └── all consult tests/antlr4-compat/status.toml
                   │                  to decorate todo / skip entries
                   ▼
@@ -679,6 +692,17 @@ expansion table was pinned clean-room — helper names, descriptor
 `.stg` files (License hygiene in [`AGENTS.md`](./AGENTS.md)). An
 unknown helper is left verbatim and warned to stderr: either add it to
 the table or triage the descriptor into `[skip]`.
+
+Some helpers name host-side scaffolding — a generated listener class, an
+import — that no Gale artefact corresponds to. Those expand to nothing,
+which is sound precisely because the corpus compares parse trees and the
+scaffolding is not observable in one. The line to hold: a helper that
+changes what the parser produces must **not** expand away, or the
+descriptor is left testing something other than what it is for. So
+`TreeNodeWithAltNumField` (renders alt numbers into node names),
+`ParserPropertyMember` (declares the member a semantic predicate calls),
+and `PositionAdjustingLexer` (overrides `nextToken()`) stay `[skip]`
+rather than being stubbed out.
 
 `scripts/expand_action_templates_in_place.wado` applies the identical
 transform to the committed corpus without `vendor/antlr4` (used for the
@@ -729,21 +753,29 @@ triage state) live under `package-gale/tests/antlr4-compat/`:
 [stage_b_oracle_skip]
 "<Category>/<Name>" = "one-line reason this descriptor opts OUT of Stage B′ (oracle crash, action-stripper corruption, irrelevant comparison)"
 
-[stage_b_oracle_force]
-"<Category>/<Name>" = "one-line reason this descriptor uses the oracle EVEN THOUGH its own [output] is already a clean tree (rare; testsuite [output] is stale)"
+[stage_b_oracle_todo]
+"<Category>/<Name>" = "one-line reason Gale's tree differs from the oracle's, which is the right answer"
+
+[stage_c_todo]
+"<Category>/<Name>" = "one-line reason the action-print output does not match yet"
+
+[stage_c_skip]
+"<Category>/<Name>" = "one-line reason no amount of Stage C work can reproduce this [output]"
 ```
 
-| State                    | Effect                                                                                  | When to use                                                                                                                                                         |
-| ------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| (default)                | Test runs, must pass                                                                    | Descriptor is a clean ANTLR4 grammar Gale should accept                                                                                                             |
-| `[todo]`                 | Per-category claim-(a) test marked `#[TODO]` so failure is expected and recorded        | Descriptor exposes a real Gale gap (parser, lexer, or IR feature). Add a corresponding entry to `TODO.md`                                                           |
-| `[skip]`                 | Per-category claim-(a) test not emitted at all                                          | Descriptor relies on the upstream test runner's StringTemplate substitution / target-language template, so it is not a self-contained `.g4`                         |
-| `[stage_a_todo]`         | Per-descriptor claim-(b/c/d) variant test emitted with `#[TODO]` so failure is expected | Generated parser/lexer behaviour diverges (LL prediction gap, codegen bug, lexer behavior gap, channel-routing gap, or Stage-C-blocked action / semantic predicate) |
-| `[stage_a_skip]`         | Per-descriptor claim-(b/c/d) variant test not emitted                                   | Gale codegen produces invalid Wado for the descriptor's grammar, so the test cannot even compile. Runtime gaps go to `[stage_a_todo]`.                              |
-| `[stage_b_todo]`         | Stage B test emitted with `#[TODO]` so divergence is expected                           | Tree-shape comparison fails at runtime (Gale codegen, LR rewriting, or Stage-C-blocked action handling)                                                             |
-| `[stage_b_skip]`         | Stage B test not emitted                                                                | Gale codegen produces invalid Wado for the descriptor's grammar; a `#[TODO]` marker would have nothing to attach to                                                 |
-| `[stage_b_oracle_skip]`  | Stage B′ test not emitted; descriptor falls back to its previous auto-skip behaviour    | The oracle crashes on the grammar, the action-body stripper would corrupt it, or the descriptor's parse tree is irrelevant for some reason                          |
-| `[stage_b_oracle_force]` | Stage B′ test emitted even when the descriptor's own `[output]` is already a clean tree | The testsuite's recorded `[output]` is stale relative to the oracle and we trust the oracle's answer; rare                                                          |
+| State                   | Effect                                                                                  | When to use                                                                                                                                                         |
+| ----------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (default)               | Test runs, must pass                                                                    | Descriptor is a clean ANTLR4 grammar Gale should accept                                                                                                             |
+| `[todo]`                | Per-category claim-(a) test marked `#[TODO]` so failure is expected and recorded        | Descriptor exposes a real Gale gap (parser, lexer, or IR feature). Add a corresponding entry to `TODO.md`                                                           |
+| `[skip]`                | Per-category claim-(a) test not emitted at all                                          | Descriptor relies on the upstream test runner's StringTemplate substitution / target-language template, so it is not a self-contained `.g4`                         |
+| `[stage_a_todo]`        | Per-descriptor claim-(b/c/d) variant test emitted with `#[TODO]` so failure is expected | Generated parser/lexer behaviour diverges (LL prediction gap, codegen bug, lexer behavior gap, channel-routing gap, or Stage-C-blocked action / semantic predicate) |
+| `[stage_a_skip]`        | Per-descriptor claim-(b/c/d) variant test not emitted                                   | Gale codegen produces invalid Wado for the descriptor's grammar, so the test cannot even compile. Runtime gaps go to `[stage_a_todo]`.                              |
+| `[stage_b_todo]`        | Stage B test emitted with `#[TODO]` so divergence is expected                           | Tree-shape comparison fails at runtime (Gale codegen, LR rewriting, or Stage-C-blocked action handling)                                                             |
+| `[stage_b_skip]`        | Stage B test not emitted                                                                | Gale codegen produces invalid Wado for the descriptor's grammar; a `#[TODO]` marker would have nothing to attach to                                                 |
+| `[stage_b_oracle_skip]` | Stage B′ test not emitted; descriptor falls back to its previous auto-skip behaviour    | The oracle crashes on the grammar, the action-body stripper would corrupt it, or the oracle's tree is not a valid pin (e.g. TestRig mojibakes non-ASCII to `?`)     |
+| `[stage_b_oracle_todo]` | Stage B′ test emitted with `#[TODO]`                                                    | The oracle's tree is the right expected value but Gale's parser produces a different one; flipping to unmarked is the signal that the gap closed                    |
+| `[stage_c_todo]`        | Stage C output-compare emitted with `#[TODO]`                                           | Action bodies execute but the printed output does not match yet — a gap that can close                                                                              |
+| `[stage_c_skip]`        | Stage C output-compare not emitted                                                      | The `[output]` is not a property of the grammar (a host-option artefact, or a generated listener's walk), so no amount of Stage C work reaches it                   |
 
 The reason text is written verbatim into the generated test as a
 comment. Keep it free of backslashes and double quotes — the script's

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -2056,12 +2056,10 @@ fn strip_tail_eof_marker(s: &String) -> String {
     return out;
 }
 
-/// The oracle's tree is compared verbatim, not through `normalize_tree`.
-/// That helper collapses whitespace runs so a hand-written driver test can
-/// indent its expected tree; the oracle's is already one line, so collapsing
-/// can only lose information — and it does whenever a token's own text
-/// contains whitespace (`BREAK: 'break '` renders `break  break `, two
-/// spaces: the token's trailing space plus the child separator).
+/// Compares verbatim, unlike Stage B's `normalize_tree` — the oracle's tree
+/// is already one line, so collapsing whitespace can only lose information,
+/// and it does whenever a token's own text carries whitespace
+/// (`BREAK: 'break '` renders `break  break `).
 fn emit_stage_b_oracle_test_file(
     category: &String,
     name: &String,
@@ -2127,9 +2125,8 @@ fn normalize_output_for_stage_b(raw: &String) -> Option<String> {
     if !s.starts_with("(") {
         return null;
     }
-    // A tree render ends at its closing paren. Anything after it is
-    // host-side print output the descriptor emits alongside the tree, so
-    // the `[output]` as a whole is not a tree to compare.
+    // Anything past the closing paren is a host-side print emitted
+    // alongside the tree, so the `[output]` as a whole is not one.
     if !s.ends_with(")") {
         return null;
     }
@@ -2320,11 +2317,8 @@ test "normalize: action print like (a+b) without separator after name is rejecte
 }
 
 test "normalize: host-side prints after the tree are rejected" {
-    // A `to_string_tree` render ends at its closing paren. The Listeners
-    // descriptors print the tree and then let a listener print more lines
-    // (`(a 1 2)\n1\n2`); comparing that as one tree would silently pin the
-    // listener output as tree content — the whitespace-collapsing
-    // `normalize_tree` on the expected side hides the difference.
+    // The Listeners descriptors print the tree, then let a listener print
+    // more lines; accepting that pins listener output as tree content.
     assert normalize_output_for_stage_b(&"(a 1 2)\n1\n2") matches { None };
     assert normalize_output_for_stage_b(&"(a x)\n[a, s]") matches { None };
     // An indented tree still ends at its closing paren.

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -2056,6 +2056,12 @@ fn strip_tail_eof_marker(s: &String) -> String {
     return out;
 }
 
+/// The oracle's tree is compared verbatim, not through `normalize_tree`.
+/// That helper collapses whitespace runs so a hand-written driver test can
+/// indent its expected tree; the oracle's is already one line, so collapsing
+/// can only lose information — and it does whenever a token's own text
+/// contains whitespace (`BREAK: 'break '` renders `break  break `, two
+/// spaces: the token's trailing space plus the child separator).
 fn emit_stage_b_oracle_test_file(
     category: &String,
     name: &String,
@@ -2074,7 +2080,7 @@ fn emit_stage_b_oracle_test_file(
             triage_doc_line(&"stage_b_oracle"),
         ],
         output_subdir: "antlr4_compat_b_oracle",
-        import_names: ["normalize_tree"],
+        import_names: [],
         test_label: "stage_b_oracle",
         triage: *triage,
     };
@@ -2083,8 +2089,7 @@ fn emit_stage_b_oracle_test_file(
         w.line(&`let expected = "${escape_for_wado_str(expected_tree)}";`);
         w.line(&`let result = t::${parse_call_for_start(start)}(&input);`);
         w.line(&"let actual = t::to_string_tree(&result);");
-        w.line(&"let norm = normalize_tree(&expected);");
-        w.line(&"assert actual == norm, `actual:   ${actual}\\nexpected: ${norm}`;");
+        w.line(&"assert actual == expected, `actual:   ${actual}\\nexpected: ${expected}`;");
     });
 }
 

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -614,18 +614,26 @@ fn emit_test_file_for_category(category: &String, entries: &List<DescriptorEntry
     w.blank();
     w.line(&"use { parse } from \"../../src/g4/parser.wado\";");
     w.blank();
+    let mut needs_separator = false;
     for let e of entries {
         match &e.triage {
             Skip(_) => {
                 continue;
             },
             Todo(reason) => {
+                if needs_separator {
+                    w.blank();
+                }
                 w.line(&`// triage: ${escape_for_wado_str(reason)}`);
                 w.line(&"#[TODO]");
             },
             Pass => {
+                if needs_separator {
+                    w.blank();
+                }
             },
         }
+        needs_separator = true;
         w.begin(&`test "${*category}/${e.name}"`);
         w.line(&`let input = #include_str("./grammars/${e.g4_relpath}");`);
         for let slave of &e.slave_relpaths {
@@ -640,7 +648,6 @@ fn emit_test_file_for_category(category: &String, entries: &List<DescriptorEntry
         w.dedent();
         w.line(&"}");
         w.end();
-        w.blank();
     }
     return w.to_string();
 }

--- a/package-gale/scripts/extract_antlr4_descriptors.wado
+++ b/package-gale/scripts/extract_antlr4_descriptors.wado
@@ -2127,6 +2127,12 @@ fn normalize_output_for_stage_b(raw: &String) -> Option<String> {
     if !s.starts_with("(") {
         return null;
     }
+    // A tree render ends at its closing paren. Anything after it is
+    // host-side print output the descriptor emits alongside the tree, so
+    // the `[output]` as a whole is not a tree to compare.
+    if !s.ends_with(")") {
+        return null;
+    }
     let chars: List<char> = s.chars().collect();
     if chars.len() < 2 {
         return null;
@@ -2311,6 +2317,18 @@ test "normalize: action print like (a+b) without separator after name is rejecte
     assert normalize_output_for_stage_b(&"(s a)") matches { Some(_) };
     assert normalize_output_for_stage_b(&"(s\n  a)") matches { Some(_) };
     assert normalize_output_for_stage_b(&"(s\ta)") matches { Some(_) };
+}
+
+test "normalize: host-side prints after the tree are rejected" {
+    // A `to_string_tree` render ends at its closing paren. The Listeners
+    // descriptors print the tree and then let a listener print more lines
+    // (`(a 1 2)\n1\n2`); comparing that as one tree would silently pin the
+    // listener output as tree content — the whitespace-collapsing
+    // `normalize_tree` on the expected side hides the difference.
+    assert normalize_output_for_stage_b(&"(a 1 2)\n1\n2") matches { None };
+    assert normalize_output_for_stage_b(&"(a x)\n[a, s]") matches { None };
+    // An indented tree still ends at its closing paren.
+    assert normalize_output_for_stage_b(&"(s\n  (a x))") matches { Some(_) };
 }
 
 test "normalize: line-noise output starting with paren but no name is rejected" {

--- a/package-gale/src/g4/action_templates.wado
+++ b/package-gale/src/g4/action_templates.wado
@@ -328,8 +328,8 @@ fn expand_helper(name: &String, recv: &Option<String>, args: &List<String>) -> R
             require_args(args, 2, name)?;
             return Result::Ok(`${r}.${args[0]}.${args[1]}`);
         },
-        // Walks the tree with the generated listener — a host-side effect
-        // with no bearing on the parse tree, so the receiver is discarded.
+        // Host-side scaffolding (see the group below); the receiver it
+        // would walk is discarded with it.
         "WalkListener" => {
             let _ = require_receiver(recv, name)?;
             return Result::Ok("");
@@ -362,13 +362,11 @@ fn expand_helper(name: &String, recv: &Option<String>, args: &List<String>) -> R
         "GetExpectedTokenNames" => Result::Ok("getExpectedTokens().toString(getVocabulary())"),
         "Invoke_foo" => Result::Ok("this.foo();"),
         "RuleInvocationStack" => Result::Ok("getRuleInvocationStack()"),
-        // Host-side scaffolding: a listener import or class definition the
-        // testsuite injects per target. None of it is observable in the
-        // parse tree, which is all the corpus compares, so it expands away
-        // rather than being modelled. A directive that *does* change what
-        // the parser produces — `PositionAdjustingLexer` overriding
-        // `nextToken()`, `TreeNodeWithAltNumField` changing node rendering —
-        // must not be added here; those descriptors stay `[skip]`.
+        // Host-side scaffolding — a listener import or class the testsuite
+        // injects per target, invisible in the parse tree the corpus
+        // compares. A helper that changes what the parser *produces* must
+        // not join this group; see the action-template section of
+        // `antlr4-compatibility.md` for what that rules out and why.
         "ImportRuleInvocationStack" => Result::Ok(""),
         "ImportListener" | "BasicListener" | "LRListener" | "LRWithLabelsListener" | "RuleGetterListener"
         | "TokenGetterListener" => {

--- a/package-gale/src/g4/action_templates.wado
+++ b/package-gale/src/g4/action_templates.wado
@@ -111,6 +111,10 @@ pub fn expand_action_templates(src: &String) -> ExpandOutcome {
                 i = end;
                 continue;
             },
+            '<' && i + 1 < n && chars[i + 1] == '!' => {
+                i = scan_st_comment(&chars, i);
+                continue;
+            },
             '<' && is_template_start(&chars, i) => {
                 match eval_template(&chars, i) {
                     Ok(expanded) => {
@@ -131,6 +135,21 @@ pub fn expand_action_templates(src: &String) -> ExpandOutcome {
         i += 1;
     }
     return ExpandOutcome { text: out, warnings };
+}
+
+/// Scan a `<! ... !>` StringTemplate comment. `pos` must point at the `<`.
+/// Returns the index just past the closing `!>`, or `chars.len()` if
+/// unterminated.
+fn scan_st_comment(chars: &List<char>, pos: i32) -> i32 {
+    let n = chars.len();
+    let mut i = pos + 2;
+    while i + 1 < n {
+        if chars[i] == '!' && chars[i + 1] == '>' {
+            return i + 2;
+        }
+        i += 1;
+    }
+    return n;
 }
 
 struct Expanded {
@@ -287,6 +306,9 @@ fn expand_helper(name: &String, recv: &Option<String>, args: &List<String>) -> R
         "write" => {
             return Result::Ok(`System.out.print(${chain_or_arg(recv, args, name)?});`);
         },
+        "ToStringTree" => {
+            return Result::Ok(`${chain_or_arg(recv, args, name)?}.toStringTree(this)`);
+        },
         "Invoke_pred" => {
             return Result::Ok(`this.pred(${require_receiver(recv, name)?})`);
         },
@@ -305,6 +327,12 @@ fn expand_helper(name: &String, recv: &Option<String>, args: &List<String>) -> R
             let r = require_receiver(recv, name)?;
             require_args(args, 2, name)?;
             return Result::Ok(`${r}.${args[0]}.${args[1]}`);
+        },
+        // Walks the tree with the generated listener — a host-side effect
+        // with no bearing on the parse tree, so the receiver is discarded.
+        "WalkListener" => {
+            let _ = require_receiver(recv, name)?;
+            return Result::Ok("");
         },
         _ => {
         },
@@ -333,15 +361,25 @@ fn expand_helper(name: &String, recv: &Option<String>, args: &List<String>) -> R
         "BailErrorStrategy" => Result::Ok("setErrorHandler(new BailErrorStrategy());"),
         "GetExpectedTokenNames" => Result::Ok("getExpectedTokens().toString(getVocabulary())"),
         "Invoke_foo" => Result::Ok("this.foo();"),
+        "RuleInvocationStack" => Result::Ok("getRuleInvocationStack()"),
+        // Host-side scaffolding: a listener import or class definition the
+        // testsuite injects per target. None of it is observable in the
+        // parse tree, which is all the corpus compares, so it expands away
+        // rather than being modelled. A directive that *does* change what
+        // the parser produces — `PositionAdjustingLexer` overriding
+        // `nextToken()`, `TreeNodeWithAltNumField` changing node rendering —
+        // must not be added here; those descriptors stay `[skip]`.
+        "ImportRuleInvocationStack" => Result::Ok(""),
+        "ImportListener" | "BasicListener" | "LRListener" | "LRWithLabelsListener" | "RuleGetterListener"
+        | "TokenGetterListener" => {
+            require_args(args, 1, name)?;
+            Result::Ok("");
+        },
         "Declare_pred" => Result::Ok("boolean pred(boolean v) {\n\tSystem.out.println(\"eval=\" + v);\n\treturn v;\n}"),
         "Declare_foo" => Result::Ok("public void foo() {\n\tSystem.out.println(\"foo\");\n}"),
         // Compile-time check that the rule context exposes list getters.
         "DeclareContextListGettersFunction" => Result::Ok("void foo() {\n\tSContext s = null;\n\ts.a();\n\ts.b();\n}"),
         // One argument.
-        "ToStringTree" => {
-            require_args(args, 1, name)?;
-            Result::Ok(`${args[0]}.toStringTree(this)`);
-        },
         "PlusText" => {
             require_args(args, 1, name)?;
             Result::Ok(`"${args[0]}" + getText()`);
@@ -376,7 +414,7 @@ fn expand_helper(name: &String, recv: &Option<String>, args: &List<String>) -> R
             require_args(args, 2, name)?;
             Result::Ok(`((${args[0]})${args[1]})`);
         },
-        "ContextRuleFunction" | "ParserToken" => {
+        "ContextRuleFunction" | "ParserToken" | "ContextMember" => {
             require_args(args, 2, name)?;
             Result::Ok(`${args[0]}.${args[1]}`);
         },

--- a/package-gale/src/g4/action_templates.wado
+++ b/package-gale/src/g4/action_templates.wado
@@ -368,8 +368,7 @@ fn expand_helper(name: &String, recv: &Option<String>, args: &List<String>) -> R
         // not join this group; see the action-template section of
         // `antlr4-compatibility.md` for what that rules out and why.
         "ImportRuleInvocationStack" => Result::Ok(""),
-        "ImportListener" | "BasicListener" | "LRListener" | "LRWithLabelsListener" | "RuleGetterListener"
-        | "TokenGetterListener" => {
+        "ImportListener" | "BasicListener" | "LRListener" | "LRWithLabelsListener" | "RuleGetterListener" | "TokenGetterListener" => {
             require_args(args, 1, name)?;
             Result::Ok("");
         },

--- a/package-gale/src/g4/action_templates_test.wado
+++ b/package-gale/src/g4/action_templates_test.wado
@@ -163,3 +163,40 @@ test "expand: TokenStartColumnEquals lexer predicate" {
     let expected = "INDENT : [ \\t]+ { _tokenStartCharPositionInLine == 0 }? ;";
     assert expand(&g) == expected, `got '${expand(&g)}'`;
 }
+
+test "expand: StringTemplate comment is dropped" {
+    let g = "a: 'a' myset 'd' ; <! bit complicated because of the JavaScript target !>";
+    assert expand(&g) == "a: 'a' myset 'd' ; ", `got '${expand(&g)}'`;
+}
+
+test "expand: StringTemplate comment spanning lines is dropped" {
+    let g = "grammar T;\n<!\n  a note\n!>\ns : ID ;";
+    assert expand(&g) == "grammar T;\n\ns : ID ;", `got '${expand(&g)}'`;
+}
+
+test "expand: listener scaffolding expands to nothing" {
+    let g = "grammar T;\n\n<ImportListener(\"T\")>\n<BasicListener(\"T\")>\n\ns : r=a ;";
+    assert expand(&g) == "grammar T;\n\n\n\n\ns : r=a ;", `got '${expand(&g)}'`;
+}
+
+test "expand: every listener class helper expands to nothing" {
+    let g = "<LRListener(\"T\")><LRWithLabelsListener(\"T\")><RuleGetterListener(\"T\")><TokenGetterListener(\"T\")>";
+    assert expand(&g) == "", `got '${expand(&g)}'`;
+}
+
+test "expand: ContextMember chained into ToStringTree and writeln" {
+    let g = "s @after {<ContextMember(\"$ctx\", \"r\"):ToStringTree():writeln()>} : r=a ;";
+    let expected = "s @after {System.out.println($ctx.r.toStringTree(this));} : r=a ;";
+    assert expand(&g) == expected, `got '${expand(&g)}'`;
+}
+
+test "expand: WalkListener drops its receiver" {
+    let g = "s @after {<ContextMember(\"$ctx\", \"r\"):WalkListener()>} : r=a ;";
+    assert expand(&g) == "s @after {} : r=a ;", `got '${expand(&g)}'`;
+}
+
+test "expand: rule invocation stack helpers" {
+    let g = "grammar T;\n<ImportRuleInvocationStack()>\na : 'x' {<RuleInvocationStack():writeln()>} ;";
+    let expected = "grammar T;\n\na : 'x' {System.out.println(getRuleInvocationStack());} ;";
+    assert expand(&g) == expected, `got '${expand(&g)}'`;
+}

--- a/package-gale/tests/antlr4-compat/grammars/CompositeParsers/DelegatorInvokesFirstVersionOfDelegateRule.slave1.g4
+++ b/package-gale/tests/antlr4-compat/grammars/CompositeParsers/DelegatorInvokesFirstVersionOfDelegateRule.slave1.g4
@@ -1,2 +1,2 @@
 parser grammar T;
-a : B {System.out.println("T.a");};<! hidden by S.a !>
+a : B {System.out.println("T.a");};

--- a/package-gale/tests/antlr4-compat/grammars/Listeners/Basic.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Listeners/Basic.g4
@@ -1,0 +1,19 @@
+grammar T;
+
+
+
+
+s
+@after {
+System.out.println($ctx.r.toStringTree(this));
+
+}
+  : r=a ;
+a : INT INT
+  | ID
+  ;
+MULT: '*' ;
+ADD : '+' ;
+INT : [0-9]+ ;
+ID  : [a-z]+ ;
+WS : [ \t\n]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/Listeners/LR.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Listeners/LR.g4
@@ -1,0 +1,20 @@
+grammar T;
+
+
+
+
+s
+@after {
+System.out.println($ctx.r.toStringTree(this));
+
+}
+   : r=e ;
+e : e op='*' e
+   | e op='+' e
+   | INT
+   ;
+MULT: '*' ;
+ADD : '+' ;
+INT : [0-9]+ ;
+ID  : [a-z]+ ;
+WS : [ \t\n]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/Listeners/LRWithLabels.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Listeners/LRWithLabels.g4
@@ -1,0 +1,20 @@
+grammar T;
+
+
+
+
+s
+@after {
+System.out.println($ctx.r.toStringTree(this));
+
+}
+  : r=e ;
+e : e '(' eList ')' # Call
+  | INT    # Int
+  ;
+eList : e (',' e)* ;
+MULT: '*' ;
+ADD : '+' ;
+INT : [0-9]+ ;
+ID  : [a-z]+ ;
+WS : [ \t\n]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/Listeners/RuleGetters_1.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Listeners/RuleGetters_1.g4
@@ -1,0 +1,20 @@
+grammar T;
+
+
+
+
+s
+@after {
+System.out.println($ctx.r.toStringTree(this));
+
+}
+  : r=a ;
+a : b b        // forces list
+  | b      // a list still
+  ;
+b : ID | INT;
+MULT: '*' ;
+ADD : '+' ;
+INT : [0-9]+ ;
+ID  : [a-z]+ ;
+WS : [ \t\n]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/Listeners/RuleGetters_2.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Listeners/RuleGetters_2.g4
@@ -1,0 +1,20 @@
+grammar T;
+
+
+
+
+s
+@after {
+System.out.println($ctx.r.toStringTree(this));
+
+}
+  : r=a ;
+a : b b        // forces list
+  | b      // a list still
+  ;
+b : ID | INT;
+MULT: '*' ;
+ADD : '+' ;
+INT : [0-9]+ ;
+ID  : [a-z]+ ;
+WS : [ \t\n]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/Listeners/TokenGetters_1.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Listeners/TokenGetters_1.g4
@@ -1,0 +1,19 @@
+grammar T;
+
+
+
+
+s
+@after {
+System.out.println($ctx.r.toStringTree(this));
+
+}
+  : r=a ;
+a : INT INT
+  | ID
+  ;
+MULT: '*' ;
+ADD : '+' ;
+INT : [0-9]+ ;
+ID  : [a-z]+ ;
+WS : [ \t\n]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/Listeners/TokenGetters_2.g4
+++ b/package-gale/tests/antlr4-compat/grammars/Listeners/TokenGetters_2.g4
@@ -1,0 +1,19 @@
+grammar T;
+
+
+
+
+s
+@after {
+System.out.println($ctx.r.toStringTree(this));
+
+}
+  : r=a ;
+a : INT INT
+  | ID
+  ;
+MULT: '*' ;
+ADD : '+' ;
+INT : [0-9]+ ;
+ID  : [a-z]+ ;
+WS : [ \t\n]+ -> skip ;

--- a/package-gale/tests/antlr4-compat/grammars/ParseTrees/TokenAndRuleContextString.g4
+++ b/package-gale/tests/antlr4-compat/grammars/ParseTrees/TokenAndRuleContextString.g4
@@ -1,0 +1,14 @@
+grammar T;
+
+
+s
+@init {
+setBuildParseTree(true);
+}
+@after {
+System.out.println($r.ctx.toStringTree(this));
+}
+  : r=a ;
+a : 'x' {
+System.out.println(getRuleInvocationStack());
+} ;

--- a/package-gale/tests/antlr4-compat/grammars/ParserErrors/SingleSetInsertionConsumption.g4
+++ b/package-gale/tests/antlr4-compat/grammars/ParserErrors/SingleSetInsertionConsumption.g4
@@ -1,0 +1,3 @@
+grammar T;
+myset: ('b'|'c') ;
+a: 'a' myset 'd' {System.out.println("" + $myset.stop);} ; 

--- a/package-gale/tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionConsumption.g4
+++ b/package-gale/tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionConsumption.g4
@@ -1,0 +1,3 @@
+grammar T;
+myset: ('b'|'c') ;
+a: 'a' myset 'd' {System.out.println("" + $myset.stop);} ; 

--- a/package-gale/tests/antlr4-compat/listeners_test.wado
+++ b/package-gale/tests/antlr4-compat/listeners_test.wado
@@ -1,77 +1,61 @@
 #![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
 // Do not edit by hand — re-run the generator to regenerate.
 //
-// Source category: ParseTrees (ANTLR4 runtime-testsuite).
+// Source category: Listeners (ANTLR4 runtime-testsuite).
 // Triage data: package-gale/tests/antlr4-compat/status.toml
 
 use { parse } from "../../src/g4/parser.wado";
 
-test "ParseTrees/ExtraToken" {
-    let input = #include_str("./grammars/ParseTrees/ExtraToken.g4");
+test "Listeners/Basic" {
+    let input = #include_str("./grammars/Listeners/Basic.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
     }
 }
 
-test "ParseTrees/ExtraTokensAndAltLabels" {
-    let input = #include_str("./grammars/ParseTrees/ExtraTokensAndAltLabels.g4");
+test "Listeners/LR" {
+    let input = #include_str("./grammars/Listeners/LR.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
     }
 }
 
-test "ParseTrees/NoViableAlt" {
-    let input = #include_str("./grammars/ParseTrees/NoViableAlt.g4");
+test "Listeners/LRWithLabels" {
+    let input = #include_str("./grammars/Listeners/LRWithLabels.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
     }
 }
 
-test "ParseTrees/RuleRef" {
-    let input = #include_str("./grammars/ParseTrees/RuleRef.g4");
+test "Listeners/RuleGetters_1" {
+    let input = #include_str("./grammars/Listeners/RuleGetters_1.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
     }
 }
 
-test "ParseTrees/Sync" {
-    let input = #include_str("./grammars/ParseTrees/Sync.g4");
+test "Listeners/RuleGetters_2" {
+    let input = #include_str("./grammars/Listeners/RuleGetters_2.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
     }
 }
 
-test "ParseTrees/Token2" {
-    let input = #include_str("./grammars/ParseTrees/Token2.g4");
+test "Listeners/TokenGetters_1" {
+    let input = #include_str("./grammars/Listeners/TokenGetters_1.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
     }
 }
 
-test "ParseTrees/TokenAndRuleContextString" {
-    let input = #include_str("./grammars/ParseTrees/TokenAndRuleContextString.g4");
-    let result = parse(input);
-    if let Err(err) = &result {
-        panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
-    }
-}
-
-test "ParseTrees/TwoAltLoop" {
-    let input = #include_str("./grammars/ParseTrees/TwoAltLoop.g4");
-    let result = parse(input);
-    if let Err(err) = &result {
-        panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
-    }
-}
-
-test "ParseTrees/TwoAlts" {
-    let input = #include_str("./grammars/ParseTrees/TwoAlts.g4");
+test "Listeners/TokenGetters_2" {
+    let input = #include_str("./grammars/Listeners/TokenGetters_2.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);

--- a/package-gale/tests/antlr4-compat/parser_errors_test.wado
+++ b/package-gale/tests/antlr4-compat/parser_errors_test.wado
@@ -166,6 +166,14 @@ test "ParserErrors/SingleSetInsertion" {
     }
 }
 
+test "ParserErrors/SingleSetInsertionConsumption" {
+    let input = #include_str("./grammars/ParserErrors/SingleSetInsertionConsumption.g4");
+    let result = parse(input);
+    if let Err(err) = &result {
+        panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
+    }
+}
+
 test "ParserErrors/SingleTokenDeletion" {
     let input = #include_str("./grammars/ParserErrors/SingleTokenDeletion.g4");
     let result = parse(input);
@@ -200,6 +208,14 @@ test "ParserErrors/SingleTokenDeletionBeforeLoop2" {
 
 test "ParserErrors/SingleTokenDeletionBeforePredict" {
     let input = #include_str("./grammars/ParserErrors/SingleTokenDeletionBeforePredict.g4");
+    let result = parse(input);
+    if let Err(err) = &result {
+        panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);
+    }
+}
+
+test "ParserErrors/SingleTokenDeletionConsumption" {
+    let input = #include_str("./grammars/ParserErrors/SingleTokenDeletionConsumption.g4");
     let result = parse(input);
     if let Err(err) = &result {
         panic(`parse failed: ${err.message} at ${err.span.start}..${err.span.end}`);

--- a/package-gale/tests/antlr4-compat/stage_a/Listeners/Basic_parse_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/Listeners/Basic_parse_test.wado
@@ -1,0 +1,25 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/Basic (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (b): the generated parser must accept the descriptor's
+// [input] without returning an error. No parse-tree shape comparison.
+
+use t from "../../grammars/Listeners/Basic.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/Listeners/Basic",
+        },
+    };
+
+test "stage_a_parse: Listeners/Basic" {
+    let input = "1 2";
+    let result = t::parse_s(&input);
+    if !result.ok() {
+        let d = &result.diagnostics[0];
+        panic(`parse failed: ${d.message} at ${d.span.start}..${d.span.end}`);
+    }
+}

--- a/package-gale/tests/antlr4-compat/stage_a/Listeners/LRWithLabels_parse_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/Listeners/LRWithLabels_parse_test.wado
@@ -1,0 +1,25 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/LRWithLabels (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (b): the generated parser must accept the descriptor's
+// [input] without returning an error. No parse-tree shape comparison.
+
+use t from "../../grammars/Listeners/LRWithLabels.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/Listeners/LRWithLabels",
+        },
+    };
+
+test "stage_a_parse: Listeners/LRWithLabels" {
+    let input = "1(2,3)";
+    let result = t::parse_s(&input);
+    if !result.ok() {
+        let d = &result.diagnostics[0];
+        panic(`parse failed: ${d.message} at ${d.span.start}..${d.span.end}`);
+    }
+}

--- a/package-gale/tests/antlr4-compat/stage_a/Listeners/LR_parse_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/Listeners/LR_parse_test.wado
@@ -1,0 +1,25 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/LR (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (b): the generated parser must accept the descriptor's
+// [input] without returning an error. No parse-tree shape comparison.
+
+use t from "../../grammars/Listeners/LR.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/Listeners/LR",
+        },
+    };
+
+test "stage_a_parse: Listeners/LR" {
+    let input = "1+2*3";
+    let result = t::parse_s(&input);
+    if !result.ok() {
+        let d = &result.diagnostics[0];
+        panic(`parse failed: ${d.message} at ${d.span.start}..${d.span.end}`);
+    }
+}

--- a/package-gale/tests/antlr4-compat/stage_a/Listeners/RuleGetters_1_parse_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/Listeners/RuleGetters_1_parse_test.wado
@@ -1,0 +1,25 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/RuleGetters_1 (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (b): the generated parser must accept the descriptor's
+// [input] without returning an error. No parse-tree shape comparison.
+
+use t from "../../grammars/Listeners/RuleGetters_1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/Listeners/RuleGetters_1",
+        },
+    };
+
+test "stage_a_parse: Listeners/RuleGetters_1" {
+    let input = "1 2";
+    let result = t::parse_s(&input);
+    if !result.ok() {
+        let d = &result.diagnostics[0];
+        panic(`parse failed: ${d.message} at ${d.span.start}..${d.span.end}`);
+    }
+}

--- a/package-gale/tests/antlr4-compat/stage_a/Listeners/RuleGetters_2_parse_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/Listeners/RuleGetters_2_parse_test.wado
@@ -1,0 +1,25 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/RuleGetters_2 (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (b): the generated parser must accept the descriptor's
+// [input] without returning an error. No parse-tree shape comparison.
+
+use t from "../../grammars/Listeners/RuleGetters_2.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/Listeners/RuleGetters_2",
+        },
+    };
+
+test "stage_a_parse: Listeners/RuleGetters_2" {
+    let input = "abc";
+    let result = t::parse_s(&input);
+    if !result.ok() {
+        let d = &result.diagnostics[0];
+        panic(`parse failed: ${d.message} at ${d.span.start}..${d.span.end}`);
+    }
+}

--- a/package-gale/tests/antlr4-compat/stage_a/Listeners/TokenGetters_1_parse_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/Listeners/TokenGetters_1_parse_test.wado
@@ -1,0 +1,25 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/TokenGetters_1 (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (b): the generated parser must accept the descriptor's
+// [input] without returning an error. No parse-tree shape comparison.
+
+use t from "../../grammars/Listeners/TokenGetters_1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/Listeners/TokenGetters_1",
+        },
+    };
+
+test "stage_a_parse: Listeners/TokenGetters_1" {
+    let input = "1 2";
+    let result = t::parse_s(&input);
+    if !result.ok() {
+        let d = &result.diagnostics[0];
+        panic(`parse failed: ${d.message} at ${d.span.start}..${d.span.end}`);
+    }
+}

--- a/package-gale/tests/antlr4-compat/stage_a/Listeners/TokenGetters_2_parse_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/Listeners/TokenGetters_2_parse_test.wado
@@ -1,0 +1,25 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/TokenGetters_2 (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (b): the generated parser must accept the descriptor's
+// [input] without returning an error. No parse-tree shape comparison.
+
+use t from "../../grammars/Listeners/TokenGetters_2.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/Listeners/TokenGetters_2",
+        },
+    };
+
+test "stage_a_parse: Listeners/TokenGetters_2" {
+    let input = "abc";
+    let result = t::parse_s(&input);
+    if !result.ok() {
+        let d = &result.diagnostics[0];
+        panic(`parse failed: ${d.message} at ${d.span.start}..${d.span.end}`);
+    }
+}

--- a/package-gale/tests/antlr4-compat/stage_a/ParseTrees/TokenAndRuleContextString_parse_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/ParseTrees/TokenAndRuleContextString_parse_test.wado
@@ -1,0 +1,25 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParseTrees/TokenAndRuleContextString (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (b): the generated parser must accept the descriptor's
+// [input] without returning an error. No parse-tree shape comparison.
+
+use t from "../../grammars/ParseTrees/TokenAndRuleContextString.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString",
+        },
+    };
+
+test "stage_a_parse: ParseTrees/TokenAndRuleContextString" {
+    let input = "x";
+    let result = t::parse_s(&input);
+    if !result.ok() {
+        let d = &result.diagnostics[0];
+        panic(`parse failed: ${d.message} at ${d.span.start}..${d.span.end}`);
+    }
+}

--- a/package-gale/tests/antlr4-compat/stage_a/ParserErrors/SingleSetInsertionConsumption_err_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/ParserErrors/SingleSetInsertionConsumption_err_test.wado
@@ -1,0 +1,23 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParserErrors/SingleSetInsertionConsumption (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (c): the generated parser/lexer must report an error for [input].
+//   - Parser-type: t::parse(&input) must return Err.
+//   - Lexer-type:  t::tokenize(&input) must produce at least one TK_ERROR.
+
+use t from "../../grammars/ParserErrors/SingleSetInsertionConsumption.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/ParserErrors/SingleSetInsertionConsumption",
+        },
+    };
+
+test "stage_a_err: ParserErrors/SingleSetInsertionConsumption" {
+    let input = "ad";
+    let result = t::parse_a(&input);
+    assert !result.ok(), `expected parse to fail but it succeeded`;
+}

--- a/package-gale/tests/antlr4-compat/stage_a/ParserErrors/SingleTokenDeletionConsumption_err_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_a/ParserErrors/SingleTokenDeletionConsumption_err_test.wado
@@ -1,0 +1,23 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParserErrors/SingleTokenDeletionConsumption (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_a_*]).
+//
+// Stage A claim (c): the generated parser/lexer must report an error for [input].
+//   - Parser-type: t::parse(&input) must return Err.
+//   - Lexer-type:  t::tokenize(&input) must produce at least one TK_ERROR.
+
+use t from "../../grammars/ParserErrors/SingleTokenDeletionConsumption.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionConsumption",
+        },
+    };
+
+test "stage_a_err: ParserErrors/SingleTokenDeletionConsumption" {
+    let input = "aabd";
+    let result = t::parse_a(&input);
+    assert !result.ok(), `expected parse to fail but it succeeded`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1",
         },
     };
-use { normalize_tree } from "../../grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4";
 
 test "stage_b_oracle: FullContextParsing/FullContextIF_THEN_ELSEParse_1" {
     let input = "{ if x then return }";
     let expected = "(s { (stat if x then (stat return)) })";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/JavaExpressions_3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/JavaExpressions_3_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/JavaExpressions_3.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/JavaExpressions_3.g4";
 
 test "stage_b_oracle: LeftRecursion/JavaExpressions_3" {
     let input = "a > b";
     let expected = "(s (e (e a) > (e b)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/JavaExpressions_4_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/JavaExpressions_4_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/JavaExpressions_4.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/JavaExpressions_4.g4";
 
 test "stage_b_oracle: LeftRecursion/JavaExpressions_4" {
     let input = "a >> b";
     let expected = "(s (e (e a) >> (e b)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4";
 
 test "stage_b_oracle: LeftRecursion/MultipleAlternativesWithCommonLabel_1" {
     let input = "4";
     let expected = "(s (e 4))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4";
 
 test "stage_b_oracle: LeftRecursion/MultipleAlternativesWithCommonLabel_2" {
     let input = "1+2";
     let expected = "(s (e (e 1) + (e 2)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4";
 
 test "stage_b_oracle: LeftRecursion/MultipleAlternativesWithCommonLabel_3" {
     let input = "1+2*3";
     let expected = "(s (e (e 1) + (e (e 2) * (e 3))))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4";
 
 test "stage_b_oracle: LeftRecursion/MultipleAlternativesWithCommonLabel_4" {
     let input = "i++*3";
     let expected = "(s (e (e (e i) ++) * (e 3)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4";
 
 test "stage_b_oracle: LeftRecursion/MultipleAlternativesWithCommonLabel_5" {
     let input = "(99)+3";
     let expected = "(s (e (e ( (e 99) )) + (e 3)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/PrefixOpWithActionAndLabel_1 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1",
+        },
+    };
+
+test "stage_b_oracle: LeftRecursion/PrefixOpWithActionAndLabel_1" {
+    let input = "a";
+    let expected = "(s (e a))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/PrefixOpWithActionAndLabel_2 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2",
+        },
+    };
+
+test "stage_b_oracle: LeftRecursion/PrefixOpWithActionAndLabel_2" {
+    let input = "a+b";
+    let expected = "(s (e (e a) + (e b)))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/PrefixOpWithActionAndLabel_3 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3",
+        },
+    };
+
+test "stage_b_oracle: LeftRecursion/PrefixOpWithActionAndLabel_3" {
+    let input = "a=b+c";
+    let expected = "(s (e (e a = (e b)) + (e c)))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4";
 
 test "stage_b_oracle: LeftRecursion/ReturnValueAndActionsAndLabels_1" {
     let input = "4";
     let expected = "(s (e 4))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4";
 
 test "stage_b_oracle: LeftRecursion/ReturnValueAndActionsAndLabels_2" {
     let input = "1+2";
     let expected = "(s (e (e 1) + (e 2)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4";
 
 test "stage_b_oracle: LeftRecursion/ReturnValueAndActionsAndLabels_3" {
     let input = "1+2*3";
     let expected = "(s (e (e 1) + (e (e 2) * (e 3))))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4";
 
 test "stage_b_oracle: LeftRecursion/ReturnValueAndActionsAndLabels_4" {
     let input = "i++*3";
     let expected = "(s (e (e (e i) ++) * (e 3)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4";
 
 test "stage_b_oracle: LeftRecursion/ReturnValueAndActionsList1_2" {
     let input = "a,c>>x";
     let expected = "(s (expr (expr a) , (expr c) >> (expr x)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4";
 
 test "stage_b_oracle: LeftRecursion/ReturnValueAndActionsList1_4" {
     let input = "a*b,c,x*y>>r";
     let expected = "(s (expr (expr (expr a) * (expr b)) , (expr c) , (expr (expr x) * (expr y)) >> (expr r)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4";
 
 test "stage_b_oracle: LeftRecursion/ReturnValueAndActionsList2_2" {
     let input = "a,c>>x";
     let expected = "(s (expr (expr (expr a) , (expr c)) >> (expr x)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4",
         },
     };
-use { normalize_tree } from "../../grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4";
 
 test "stage_b_oracle: LeftRecursion/ReturnValueAndActionsList2_4" {
     let input = "a*b,c,x*y>>r";
     let expected = "(s (expr (expr (expr (expr (expr a) * (expr b)) , (expr c)) , (expr (expr x) * (expr y))) >> (expr r)))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActions_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActions_1_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/ReturnValueAndActions_1 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/LeftRecursion/ReturnValueAndActions_1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_1",
+        },
+    };
+
+test "stage_b_oracle: LeftRecursion/ReturnValueAndActions_1" {
+    let input = "4";
+    let expected = "(s (e 4))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActions_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActions_2_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/ReturnValueAndActions_2 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/LeftRecursion/ReturnValueAndActions_2.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_2",
+        },
+    };
+
+test "stage_b_oracle: LeftRecursion/ReturnValueAndActions_2" {
+    let input = "1+2";
+    let expected = "(s (e (e 1) + (e 2)))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActions_3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActions_3_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/ReturnValueAndActions_3 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/LeftRecursion/ReturnValueAndActions_3.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_3",
+        },
+    };
+
+test "stage_b_oracle: LeftRecursion/ReturnValueAndActions_3" {
+    let input = "1+2*3";
+    let expected = "(s (e (e 1) + (e (e 2) * (e 3))))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActions_4_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/LeftRecursion/ReturnValueAndActions_4_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: LeftRecursion/ReturnValueAndActions_4 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/LeftRecursion/ReturnValueAndActions_4.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_4",
+        },
+    };
+
+test "stage_b_oracle: LeftRecursion/ReturnValueAndActions_4" {
+    let input = "(1+2)*3";
+    let expected = "(s (e (e ( (e (e 1) + (e 2)) )) * (e 3)))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/Basic_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/Basic_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/Basic (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/Listeners/Basic.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/Listeners/Basic",
+        },
+    };
+
+test "stage_b_oracle: Listeners/Basic" {
+    let input = "1 2";
+    let expected = "(s (a 1 2))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/LRWithLabels_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/LRWithLabels_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/LRWithLabels (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/Listeners/LRWithLabels.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/Listeners/LRWithLabels",
+        },
+    };
+
+test "stage_b_oracle: Listeners/LRWithLabels" {
+    let input = "1(2,3)";
+    let expected = "(s (e (e 1) ( (eList (e 2) , (e 3)) )))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/LR_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/LR_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/LR (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/Listeners/LR.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/Listeners/LR",
+        },
+    };
+
+test "stage_b_oracle: Listeners/LR" {
+    let input = "1+2*3";
+    let expected = "(s (e (e 1) + (e (e 2) * (e 3))))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/RuleGetters_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/RuleGetters_1_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/RuleGetters_1 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/Listeners/RuleGetters_1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/Listeners/RuleGetters_1",
+        },
+    };
+
+test "stage_b_oracle: Listeners/RuleGetters_1" {
+    let input = "1 2";
+    let expected = "(s (a (b 1) (b 2)))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/RuleGetters_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/RuleGetters_2_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/RuleGetters_2 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/Listeners/RuleGetters_2.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/Listeners/RuleGetters_2",
+        },
+    };
+
+test "stage_b_oracle: Listeners/RuleGetters_2" {
+    let input = "abc";
+    let expected = "(s (a (b abc)))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/TokenGetters_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/TokenGetters_1_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/TokenGetters_1 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/Listeners/TokenGetters_1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/Listeners/TokenGetters_1",
+        },
+    };
+
+test "stage_b_oracle: Listeners/TokenGetters_1" {
+    let input = "1 2";
+    let expected = "(s (a 1 2))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/TokenGetters_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Listeners/TokenGetters_2_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: Listeners/TokenGetters_2 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/Listeners/TokenGetters_2.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/Listeners/TokenGetters_2",
+        },
+    };
+
+test "stage_b_oracle: Listeners/TokenGetters_2" {
+    let input = "abc";
+    let expected = "(s (a abc))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParseTrees/TokenAndRuleContextString_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParseTrees/TokenAndRuleContextString_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParseTrees/TokenAndRuleContextString (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/ParseTrees/TokenAndRuleContextString.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/ParseTrees/TokenAndRuleContextString",
+        },
+    };
+
+test "stage_b_oracle: ParseTrees/TokenAndRuleContextString" {
+    let input = "x";
+    let expected = "(s (a x))";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserErrors/ContextListGetters_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserErrors/ContextListGetters_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserErrors/ContextListGetters.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters",
         },
     };
-use { normalize_tree } from "../../grammars/ParserErrors/ContextListGetters.g4";
 
 test "stage_b_oracle: ParserErrors/ContextListGetters" {
     let input = "abab";
     let expected = "(s (a a) (b b) (a a) (b b))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserErrors/LL1ErrorInfo_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserErrors/LL1ErrorInfo_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserErrors/LL1ErrorInfo.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo",
         },
     };
-use { normalize_tree } from "../../grammars/ParserErrors/LL1ErrorInfo.g4";
 
 test "stage_b_oracle: ParserErrors/LL1ErrorInfo" {
     let input = "dog and software";
     let expected = "(start (animal dog) and acClass (service software))";
     let result = t::parse_start(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/APlus_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/APlus_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/APlus.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/APlus",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/APlus.g4";
 
 test "stage_b_oracle: ParserExec/APlus" {
     let input = "a b c";
     let expected = "(a a b c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AStar_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AStar_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/AStar_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/AStar_2",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/AStar_2.g4";
 
 test "stage_b_oracle: ParserExec/AStar_2" {
     let input = "a b c";
     let expected = "(a a b c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorAPlus_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorAPlus_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/AorAPlus.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/AorAPlus",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/AorAPlus.g4";
 
 test "stage_b_oracle: ParserExec/AorAPlus" {
     let input = "a b c";
     let expected = "(a a b c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorAStar_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorAStar_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/AorAStar_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/AorAStar_2.g4";
 
 test "stage_b_oracle: ParserExec/AorAStar_2" {
     let input = "a b c";
     let expected = "(a a b c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorBPlus_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorBPlus_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/AorBPlus.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/AorBPlus",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/AorBPlus.g4";
 
 test "stage_b_oracle: ParserExec/AorBPlus" {
     let input = "a 34 c";
     let expected = "(a a 34 c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorBStar_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorBStar_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/AorBStar_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/AorBStar_2.g4";
 
 test "stage_b_oracle: ParserExec/AorBStar_2" {
     let input = "a 34 c";
     let expected = "(a a 34 c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorB_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/AorB_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/AorB.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/AorB",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/AorB.g4";
 
 test "stage_b_oracle: ParserExec/AorB" {
     let input = "34";
     let expected = "(a 34)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Basic_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Basic_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/Basic.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/Basic",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/Basic.g4";
 
 test "stage_b_oracle: ParserExec/Basic" {
     let input = "abc 34";
     let expected = "(a abc 34)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/BuildParseTree_FALSE_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/BuildParseTree_FALSE_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/BuildParseTree_FALSE.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/BuildParseTree_FALSE.g4";
 
 test "stage_b_oracle: ParserExec/BuildParseTree_FALSE" {
     let input = "A B";
     let expected = "(r (a A) (b B))";
     let result = t::parse_r(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/IfIfElseGreedyBinding1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/IfIfElseGreedyBinding1_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/IfIfElseGreedyBinding1.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/IfIfElseGreedyBinding1.g4";
 
 test "stage_b_oracle: ParserExec/IfIfElseGreedyBinding1" {
     let input = "if y if y x else x";
     let expected = "(start (statement (ifStatement if y (statement (ifStatement if y (statement x) else (statement x))))))";
     let result = t::parse_start(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/IfIfElseGreedyBinding2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/IfIfElseGreedyBinding2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/IfIfElseGreedyBinding2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/IfIfElseGreedyBinding2.g4";
 
 test "stage_b_oracle: ParserExec/IfIfElseGreedyBinding2" {
     let input = "if y if y x else x";
     let expected = "(start (statement (ifStatement if y (statement (ifStatement if y (statement x) else (statement x))))))";
     let result = t::parse_start(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/IfIfElseNonGreedyBinding1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/IfIfElseNonGreedyBinding1_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/IfIfElseNonGreedyBinding1.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/IfIfElseNonGreedyBinding1.g4";
 
 test "stage_b_oracle: ParserExec/IfIfElseNonGreedyBinding1" {
     let input = "if y if y x else x";
     let expected = "(start (statement (ifStatement if y (statement (ifStatement if y (statement x))) else (statement x))))";
     let result = t::parse_start(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/IfIfElseNonGreedyBinding2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/IfIfElseNonGreedyBinding2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/IfIfElseNonGreedyBinding2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/IfIfElseNonGreedyBinding2.g4";
 
 test "stage_b_oracle: ParserExec/IfIfElseNonGreedyBinding2" {
     let input = "if y if y x else x";
     let expected = "(start (statement (ifStatement if y (statement (ifStatement if y (statement x))) else (statement x))))";
     let result = t::parse_start(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_1_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/Keyword_1.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/Keyword_1",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/Keyword_1.g4";
 
 test "stage_b_oracle: ParserExec/Keyword_1" {
     let input = "break;continue;return;";
     let expected = "(program (state break;) (state continue;) (state return;))";
     let result = t::parse_program(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/Keyword_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/Keyword_2",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/Keyword_2.g4";
 
 test "stage_b_oracle: ParserExec/Keyword_2" {
     let input = "break;continue;return;";
     let expected = "(program (sempred break;) (sempred continue;) (sempred return;))";
     let result = t::parse_program(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_3_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/Keyword_3.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/Keyword_3",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/Keyword_3.g4";
 
 test "stage_b_oracle: ParserExec/Keyword_3" {
     let input = "break;continue;return;";
     let expected = "(program (action break;) (action continue;) (action return;))";
     let result = t::parse_program(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_4_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_4_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/Keyword_4.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/Keyword_4",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/Keyword_4.g4";
 
 test "stage_b_oracle: ParserExec/Keyword_4" {
     let input = "break;continue;return;";
     let expected = "(program (ruleIndexMap break;) (ruleIndexMap continue;) (ruleIndexMap return;))";
     let result = t::parse_program(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_5_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_5_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/Keyword_5.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/Keyword_5",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/Keyword_5.g4";
 
 test "stage_b_oracle: ParserExec/Keyword_5" {
     let input = "break;continue;return;";
     let expected = "(program (addErrorListener break;) (addErrorListener continue;) (addErrorListener return;))";
     let result = t::parse_program(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_6_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Keyword_6_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/Keyword_6.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/Keyword_6",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/Keyword_6.g4";
 
 test "stage_b_oracle: ParserExec/Keyword_6" {
     let input = "break;continue;return;";
     let expected = "(program (reset break;) (reset continue;) (reset return;))";
     let result = t::parse_program(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/LL1OptionalBlock_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/LL1OptionalBlock_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/LL1OptionalBlock_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/LL1OptionalBlock_2.g4";
 
 test "stage_b_oracle: ParserExec/LL1OptionalBlock_2" {
     let input = "a";
     let expected = "(a a)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4";
 
 test "stage_b_oracle: ParserExec/LabelAliasingAcrossLabeledAlternatives" {
     let input = "xy";
     let expected = "(start (a (subrule x)) (a y))";
     let result = t::parse_start(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/OpenDeviceStatement_Case1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/OpenDeviceStatement_Case1_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParserExec/OpenDeviceStatement_Case1 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/ParserExec/OpenDeviceStatement_Case1.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case1",
+        },
+    };
+
+test "stage_b_oracle: ParserExec/OpenDeviceStatement_Case1" {
+    let input = "OPEN DEVICE DEVICE";
+    let expected = "(statement OPEN DEVICE DEVICE)";
+    let result = t::parse_statement(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/OpenDeviceStatement_Case2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/OpenDeviceStatement_Case2_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParserExec/OpenDeviceStatement_Case2 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/ParserExec/OpenDeviceStatement_Case2.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case2",
+        },
+    };
+
+test "stage_b_oracle: ParserExec/OpenDeviceStatement_Case2" {
+    let input = "OPEN DEVICE DEVICE";
+    let expected = "(statement OPEN DEVICE DEVICE)";
+    let result = t::parse_statement(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/OpenDeviceStatement_Case3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/OpenDeviceStatement_Case3_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParserExec/OpenDeviceStatement_Case3 (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/ParserExec/OpenDeviceStatement_Case3.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case3",
+        },
+    };
+
+test "stage_b_oracle: ParserExec/OpenDeviceStatement_Case3" {
+    let input = "OPEN DEVICE DEVICE.";
+    let expected = "(statement OPEN DEVICE DEVICE)";
+    let result = t::parse_statement(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/ReferenceToATN_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/ReferenceToATN_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/ReferenceToATN_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/ReferenceToATN_2.g4";
 
 test "stage_b_oracle: ParserExec/ReferenceToATN_2" {
     let input = "a 34 c";
     let expected = "(a a 34 c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/ReservedWordsEscaping_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/ReservedWordsEscaping_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParserExec/ReservedWordsEscaping (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/ParserExec/ReservedWordsEscaping.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/ReservedWordsEscaping",
+        },
+    };
+
+test "stage_b_oracle: ParserExec/ReservedWordsEscaping" {
+    let input = "for for break break for if if for continue";
+    let expected = "(root (continue (for for ) (for for )) (continue break  break  (for for )) (continue if  if ) (continue (continue (for for )) continue))";
+    let result = t::parse_root(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/TokenOffset_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/TokenOffset_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/TokenOffset.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/TokenOffset",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/TokenOffset.g4";
 
 test "stage_b_oracle: ParserExec/TokenOffset" {
     let input = "12 34 56 66";
     let expected = "(a 12 34 56 66)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Wildcard_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/Wildcard_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/Wildcard.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/Wildcard",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/Wildcard.g4";
 
 test "stage_b_oracle: ParserExec/Wildcard" {
     let input = "x=10; abc;;;; y=99;";
     let expected = "(a (assign x = 10 ;) abc ; ; ; ; (assign y = 99 ;))";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEsc
             output_dir: "../../../generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape",
         },
     };
-use { normalize_tree } from "../../grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4";
 
 test "stage_b_oracle: ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape" {
     let input = "u";
     let expected = "(u u)";
     let result = t::parse_u(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/ActionHidesPreds_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/ActionHidesPreds_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/ActionHidesPreds.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/ActionHidesPreds.g4";
 
 test "stage_b_oracle: SemPredEvalParser/ActionHidesPreds" {
     let input = "x x y";
     let expected = "(s (a x) (a x) (a y))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4";
 
 test "stage_b_oracle: SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW" {
     let input = "a!";
     let expected = "(s (e a) !)";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4";
 
 test "stage_b_oracle: SemPredEvalParser/DepedentPredsInGlobalFOLLOW" {
     let input = "a!";
     let expected = "(s (a (e a) !))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored_test.wado
@@ -1,0 +1,22 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado --finalize-stage-b-oracle")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored (ANTLR4 runtime-testsuite).
+// Expected tree: antlr-4.13.2-complete.jar on the action-body-stripped grammar.
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_b_oracle_*]).
+
+use t from "../../grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored",
+        },
+    };
+
+test "stage_b_oracle: SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored" {
+    let input = "a;";
+    let expected = "(s (b (a a)) ;)";
+    let result = t::parse_s(&input);
+    let actual = t::to_string_tree(&result);
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToA
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4";
 
 test "stage_b_oracle: SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException" {
     let input = "a;";
     let expected = "(s (b (a a)) ;)";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/Order_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/Order_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/Order.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/Order",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/Order.g4";
 
 test "stage_b_oracle: SemPredEvalParser/Order" {
     let input = "x y";
     let expected = "(s (a x) (a y))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4";
 
 test "stage_b_oracle: SemPredEvalParser/PredTestedEvenWhenUnAmbig_1" {
     let input = "abc";
     let expected = "(primary abc)";
     let result = t::parse_primary(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/PredicateDependentOnArg_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/PredicateDependentOnArg_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/PredicateDependentOnArg.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/PredicateDependentOnArg.g4";
 
 test "stage_b_oracle: SemPredEvalParser/PredicateDependentOnArg" {
     let input = "a b";
     let expected = "(s (a a) (a b))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4";
 
 test "stage_b_oracle: SemPredEvalParser/PredsInGlobalFOLLOW" {
     let input = "a!";
     let expected = "(s (e a) !)";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/RewindBeforePredEval_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/RewindBeforePredEval_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/RewindBeforePredEval.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/RewindBeforePredEval.g4";
 
 test "stage_b_oracle: SemPredEvalParser/RewindBeforePredEval" {
     let input = "y 3 x 4";
     let expected = "(s (a y 3) (a x 4))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/Simple_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/Simple_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/Simple.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/Simple.g4";
 
 test "stage_b_oracle: SemPredEvalParser/Simple" {
     let input = "x y 3";
     let expected = "(s (a x) (a y) (a 3))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4";
 
 test "stage_b_oracle: SemPredEvalParser/ToLeftWithVaryingPredicate" {
     let input = "x x y";
     let expected = "(s (a x) (a x) (a y))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/ToLeft_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/ToLeft_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/ToLeft.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/ToLeft.g4";
 
 test "stage_b_oracle: SemPredEvalParser/ToLeft" {
     let input = "x x y";
     let expected = "(s (a x) (a x) (a y))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt",
         },
     };
-use { normalize_tree } from "../../grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4";
 
 test "stage_b_oracle: SemPredEvalParser/UnpredicatedPathsInAlt" {
     let input = "x 4";
     let expected = "(s (a x 4))";
     let result = t::parse_s(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/CharSetLiteral_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/CharSetLiteral_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/CharSetLiteral.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/CharSetLiteral",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/CharSetLiteral.g4";
 
 test "stage_b_oracle: Sets/CharSetLiteral" {
     let input = "A a B b";
     let expected = "(a A a B b)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/LexerOptionalSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/LexerOptionalSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/LexerOptionalSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/LexerOptionalSet.g4";
 
 test "stage_b_oracle: Sets/LexerOptionalSet" {
     let input = "ac";
     let expected = "(a ac)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/LexerPlusSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/LexerPlusSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/LexerPlusSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/LexerPlusSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/LexerPlusSet.g4";
 
 test "stage_b_oracle: Sets/LexerPlusSet" {
     let input = "abaac";
     let expected = "(a abaac)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/LexerStarSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/LexerStarSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/LexerStarSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/LexerStarSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/LexerStarSet.g4";
 
 test "stage_b_oracle: Sets/LexerStarSet" {
     let input = "abaac";
     let expected = "(a abaac)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/NotCharSetWithRuleRef3_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/NotCharSetWithRuleRef3_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/NotCharSetWithRuleRef3.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/NotCharSetWithRuleRef3.g4";
 
 test "stage_b_oracle: Sets/NotCharSetWithRuleRef3" {
     let input = "x";
     let expected = "(a x)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/NotCharSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/NotCharSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/NotCharSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/NotCharSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/NotCharSet.g4";
 
 test "stage_b_oracle: Sets/NotCharSet" {
     let input = "x";
     let expected = "(a x)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/NotChar_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/NotChar_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/NotChar.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/NotChar",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/NotChar.g4";
 
 test "stage_b_oracle: Sets/NotChar" {
     let input = "x";
     let expected = "(a x)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/OptionalLexerSingleElement_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/OptionalLexerSingleElement_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/OptionalLexerSingleElement.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/OptionalLexerSingleElement.g4";
 
 test "stage_b_oracle: Sets/OptionalLexerSingleElement" {
     let input = "bc";
     let expected = "(a bc)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/OptionalSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/OptionalSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/OptionalSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/OptionalSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/OptionalSet.g4";
 
 test "stage_b_oracle: Sets/OptionalSet" {
     let input = "ac";
     let expected = "(a a c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/OptionalSingleElement_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/OptionalSingleElement_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/OptionalSingleElement.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/OptionalSingleElement.g4";
 
 test "stage_b_oracle: Sets/OptionalSingleElement" {
     let input = "bc";
     let expected = "(a b c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/ParserNotSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/ParserNotSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/ParserNotSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/ParserNotSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/ParserNotSet.g4";
 
 test "stage_b_oracle: Sets/ParserNotSet" {
     let input = "zz";
     let expected = "(a z z)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/ParserNotTokenWithLabel_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/ParserNotTokenWithLabel_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/ParserNotTokenWithLabel.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/ParserNotTokenWithLabel.g4";
 
 test "stage_b_oracle: Sets/ParserNotTokenWithLabel" {
     let input = "zz";
     let expected = "(a z z)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/ParserNotToken_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/ParserNotToken_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/ParserNotToken.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/ParserNotToken",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/ParserNotToken.g4";
 
 test "stage_b_oracle: Sets/ParserNotToken" {
     let input = "zz";
     let expected = "(a z z)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/ParserSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/ParserSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/ParserSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/ParserSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/ParserSet.g4";
 
 test "stage_b_oracle: Sets/ParserSet" {
     let input = "x";
     let expected = "(a x)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/PlusLexerSingleElement_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/PlusLexerSingleElement_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/PlusLexerSingleElement.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/PlusLexerSingleElement.g4";
 
 test "stage_b_oracle: Sets/PlusLexerSingleElement" {
     let input = "bbbbc";
     let expected = "(a bbbbc)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/PlusSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/PlusSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/PlusSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/PlusSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/PlusSet.g4";
 
 test "stage_b_oracle: Sets/PlusSet" {
     let input = "abaac";
     let expected = "(a a b a a c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/RuleAsSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/RuleAsSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/RuleAsSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/RuleAsSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/RuleAsSet.g4";
 
 test "stage_b_oracle: Sets/RuleAsSet" {
     let input = "b";
     let expected = "(a b)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/SeqDoesNotBecomeSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/SeqDoesNotBecomeSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/SeqDoesNotBecomeSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/SeqDoesNotBecomeSet.g4";
 
 test "stage_b_oracle: Sets/SeqDoesNotBecomeSet" {
     let input = "34";
     let expected = "(a 34)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/StarLexerSingleElement_1_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/StarLexerSingleElement_1_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/StarLexerSingleElement_1.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/StarLexerSingleElement_1.g4";
 
 test "stage_b_oracle: Sets/StarLexerSingleElement_1" {
     let input = "bbbbc";
     let expected = "(a bbbbc)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/StarLexerSingleElement_2_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/StarLexerSingleElement_2_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/StarLexerSingleElement_2.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/StarLexerSingleElement_2.g4";
 
 test "stage_b_oracle: Sets/StarLexerSingleElement_2" {
     let input = "c";
     let expected = "(a c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/StarSet_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/StarSet_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/StarSet.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/StarSet",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/StarSet.g4";
 
 test "stage_b_oracle: Sets/StarSet" {
     let input = "abaac";
     let expected = "(a a b a a c)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints_test.wado
@@ -12,13 +12,11 @@ use t from "../../grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4"
             output_dir: "../../../generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints",
         },
     };
-use { normalize_tree } from "../../grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4";
 
 test "stage_b_oracle: Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints" {
     let input = "abc";
     let expected = "(a abc)";
     let result = t::parse_a(&input);
     let actual = t::to_string_tree(&result);
-    let norm = normalize_tree(&expected);
-    assert actual == norm, `actual:   ${actual}\nexpected: ${norm}`;
+    assert actual == expected, `actual:   ${actual}\nexpected: ${expected}`;
 }

--- a/package-gale/tests/antlr4-compat/stage_c/ParseTrees/TokenAndRuleContextString_output_test.wado
+++ b/package-gale/tests/antlr4-compat/stage_c/ParseTrees/TokenAndRuleContextString_output_test.wado
@@ -1,0 +1,27 @@
+#![generated(by = "package-gale/scripts/extract_antlr4_descriptors.wado")]
+// Do not edit by hand — re-run the generator to regenerate.
+//
+// Source descriptor: ParseTrees/TokenAndRuleContextString (ANTLR4 runtime-testsuite).
+// Triage data: package-gale/tests/antlr4-compat/status.toml ([stage_c_*]).
+//
+// Stage C claim: the generated parser's action-print output
+// (result.output, the p.emit buffer) equals the descriptor's [output].
+
+use t from "../../grammars/ParseTrees/TokenAndRuleContextString.g4"
+    with {
+        generator: {
+            module: "../../../../src/generator.wado",
+            output_dir: "../../../generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString",
+        },
+    };
+
+// triage: the action prints getRuleInvocationStack() ([a, s]); that recognizer accessor is not in the API java2wado maps, so the body is reported and dropped. Same family as the LL1ErrorInfo entry above.
+#[TODO]
+test "stage_c_output: ParseTrees/TokenAndRuleContextString" {
+    let input = "x";
+    let expected = "[a, s]
+(a x)
+";
+    let result = t::parse_s(&input);
+    assert result.output == expected, `output:\n${result.output}\nexpected:\n${expected}`;
+}

--- a/package-gale/tests/antlr4-compat/status.toml
+++ b/package-gale/tests/antlr4-compat/status.toml
@@ -47,19 +47,9 @@
 [todo]
 
 [skip]
-"ParseTrees/AltNum" = "grammar-level <...> StringTemplate directive that the ANTLR4 testsuite substitutes per target before antlr4 ever sees the .g4 — not a self-contained grammar"
-"ParseTrees/TokenAndRuleContextString" = "grammar-level <...> StringTemplate directive that the ANTLR4 testsuite substitutes per target before antlr4 ever sees the .g4 — not a self-contained grammar"
-"Listeners/Basic" = "top-level <ImportListener(...)> / <BasicListener(...)> StringTemplate directives the testsuite substitutes per target — not a self-contained .g4"
-"Listeners/LR" = "top-level <ImportListener(...)> / <LRListener(...)> StringTemplate directives the testsuite substitutes per target — not a self-contained .g4"
-"Listeners/LRWithLabels" = "top-level <ImportListener(...)> / <LRWithLabelsListener(...)> StringTemplate directives the testsuite substitutes per target — not a self-contained .g4"
-"Listeners/RuleGetters_1" = "top-level <ImportListener(...)> / <RuleGetterListener(...)> StringTemplate directives the testsuite substitutes per target — not a self-contained .g4"
-"Listeners/RuleGetters_2" = "top-level <ImportListener(...)> / <RuleGetterListener(...)> StringTemplate directives the testsuite substitutes per target — not a self-contained .g4"
-"Listeners/TokenGetters_1" = "top-level <ImportListener(...)> / <TokenGetterListener(...)> StringTemplate directives the testsuite substitutes per target — not a self-contained .g4"
-"Listeners/TokenGetters_2" = "top-level <ImportListener(...)> / <TokenGetterListener(...)> StringTemplate directives the testsuite substitutes per target — not a self-contained .g4"
-"ParserExec/ParserProperty" = "top-level <ParserPropertyMember()> StringTemplate directive the testsuite substitutes per target — not a self-contained .g4"
+"ParseTrees/AltNum" = "contextSuperClass + <TreeNodeWithAltNumField(...)> make ANTLR4 render alt numbers into node names ((a:3 x (b:2 y) z)); the rendering is a host-side class Gale does not model, so expanding the directive away would silently change what the descriptor tests"
+"ParserExec/ParserProperty" = "<ParserPropertyMember()> declares the member a semantic predicate then calls; dropping it would leave the predicate referencing a method that does not exist"
 "LexerExec/PositionAdjustingLexer" = "@definitions / @members carry <PositionAdjustingLexerDef()> / <PositionAdjustingLexer()> directives that override Java nextToken() — the [output] depends on the host-side implementation, not the .g4"
-"ParserErrors/SingleSetInsertionConsumption" = "trailing <! ... !> StringTemplate comment outside any rule — testsuite descriptor artifact, not a self-contained .g4"
-"ParserErrors/SingleTokenDeletionConsumption" = "trailing <! ... !> StringTemplate comment outside any rule — testsuite descriptor artifact, not a self-contained .g4"
 
 [stage_a_todo]
 # IfIfElseNonGreedyBinding1's parse-accepts-input claim (b) is met
@@ -133,9 +123,22 @@
 "ParseTrees/ExtraTokensAndAltLabels" = "error-recovery path prints differently from ANTLR; flips with error-recovery output alignment."
 "ParserErrors/LL1ErrorInfo" = "the `@init` prints `getExpectedTokens().toString(getVocabulary())`; neither the expected-token set nor the vocabulary is in the recognizer API java2wado maps, so the body is reported and dropped."
 "LeftRecursion/MultipleAlternativesWithCommonLabel_4" = "common alt label across LR alternatives with a return value the print reads; label-to-vals wiring incomplete for this shape."
+"ParseTrees/TokenAndRuleContextString" = "the action prints getRuleInvocationStack() ([a, s]); that recognizer accessor is not in the API java2wado maps, so the body is reported and dropped. Same family as the LL1ErrorInfo entry above."
 
 # Stage C — descriptors whose [output] is not a property of the grammar,
 # so no amount of Stage C work can make Gale reproduce it.
 [stage_c_skip]
-"ParserExec/BuildParseTree_FALSE" = "expected output is `r` only because the ANTLR4 test harness sets buildParseTree=false before running; the grammar prints $ctx.toStringTree() and Gale always builds the tree, so the divergence is a host-option artefact, not a grammar-level gap"
+# The Listeners descriptors print from the generated parse-tree listener
+# the testsuite injects per target. Gale generates no listener — a
+# consumer walks the CST — so the walk's output has no Gale equivalent to
+# produce, at any amount of Stage C work. Their parse trees are pinned by
+# Stage B′ instead, which derives the tree from the oracle and ignores
+# `[output]` entirely.
+"Listeners/Basic" = "output is the generated listener's walk, not a property of the grammar; the tree is pinned by Stage B′"
+"Listeners/LR" = "same as Listeners/Basic"
+"Listeners/LRWithLabels" = "same as Listeners/Basic"
+"Listeners/RuleGetters_1" = "same as Listeners/Basic"
+"Listeners/RuleGetters_2" = "same as Listeners/Basic"
+"Listeners/TokenGetters_1" = "same as Listeners/Basic"
+"ParserExec/BuildParseTree_FALSE" ="expected output is `r` only because the ANTLR4 test harness sets buildParseTree=false before running; the grammar prints $ctx.toStringTree() and Gale always builds the tree, so the divergence is a host-option artefact, not a grammar-level gap"
 "Sets/UnicodeEscapedSMPRangeSetMismatch" = "oracle: TestRig drops the non-ASCII code points from [output] (`ad`) while Gale prints what it actually matched (`a...d`); pinning to the oracle would strictly worsen Gale. Same root cause as the Unicode entries in [stage_b_oracle_skip]."

--- a/package-gale/tests/antlr4-compat/status.toml
+++ b/package-gale/tests/antlr4-compat/status.toml
@@ -110,40 +110,6 @@
 # closed.
 
 [stage_b_oracle_skip]
-# Stripped grammar still doesn't `javac` cleanly — the descriptors below
-# declare return-types via the testsuite's StringTemplate directives
-# (`<IntArg("")>`, `<StringType()>`, `<StringList()>`) directly inside
-# the rule's `returns [...]` bracket. The action-body stripper only
-# reaches `{...}` blocks and `[...]` character classes / rule-arg
-# brackets, not the type-slot inside a `returns` list. ANTLR4's Java
-# target codegens the directive as the literal Java type, which javac
-# then rejects with `> expected` / `illegal start of type`. Bringing
-# these into Stage B′ would require either a smarter stripper that
-# rewrites `returns [<X()> name]` to a stub, or a parallel
-# `_stage_b_oracle_aware.g4` rendering of the descriptor — Stage C-
-# tier work, not worth the complexity for 9 descriptors.
-"LeftRecursion/PrefixOpWithActionAndLabel_1" = "oracle: `returns [<StringType()> result]` — StringTemplate directive in a return-type slot the stripper cannot reach"
-"LeftRecursion/PrefixOpWithActionAndLabel_2" = "oracle: `returns [<StringType()> result]` — same root cause as PrefixOpWithActionAndLabel_1"
-"LeftRecursion/PrefixOpWithActionAndLabel_3" = "oracle: `returns [<StringType()> result]` — same root cause as PrefixOpWithActionAndLabel_1"
-"LeftRecursion/ReturnValueAndActions_1" = "oracle: `returns [<StringList()> ignored]` — StringTemplate directive in a return-type slot the stripper cannot reach"
-"LeftRecursion/ReturnValueAndActions_2" = "oracle: `returns [<StringList()> ignored]` — same root cause as ReturnValueAndActions_1"
-"LeftRecursion/ReturnValueAndActions_3" = "oracle: `returns [<StringList()> ignored]` — same root cause as ReturnValueAndActions_1"
-"LeftRecursion/ReturnValueAndActions_4" = "oracle: `returns [<StringList()> ignored]` — same root cause as ReturnValueAndActions_1"
-"ParserExec/ReservedWordsEscaping" = "oracle: `returns [<IntArg(\"\")> return_]` — StringTemplate directive in a return-type slot the stripper cannot reach"
-"SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored" = "oracle: `returns [<IntArg(\"\")> i]` — StringTemplate directive in a return-type slot the stripper cannot reach"
-
-# Stale — awaiting a re-extract, not blocked. These were parked on a
-# downstream wado-compiler ICE (`WIR pipeline generated invalid core
-# Wasm module`) on the Gale-emitted parser source. Re-measured
-# 2026-07-30: all three grammars generate, compile and run their
-# `to_string_tree` path cleanly, so the ICE is gone. Drop these three
-# entries at the next JDK-equipped re-extract so the oracle pins their
-# trees; they are kept here only because a `_skip` cannot be lifted
-# without the oracle run that emits the test.
-"ParserExec/OpenDeviceStatement_Case1" = "stale: parked on a wado-compiler ICE that no longer reproduces — drop at the next re-extract so the oracle can pin the tree"
-"ParserExec/OpenDeviceStatement_Case2" = "same as OpenDeviceStatement_Case1"
-"ParserExec/OpenDeviceStatement_Case3" = "same as OpenDeviceStatement_Case1"
-
 # Oracle TestRig mojibakes non-ASCII output to `?`. The descriptors
 # below have grammars that accept Unicode characters and emit them as
 # token text; Gale correctly reproduces the actual code points, while

--- a/package-gale/tests/antlr4-compat/status.toml
+++ b/package-gale/tests/antlr4-compat/status.toml
@@ -132,17 +132,17 @@
 "ParserExec/ReservedWordsEscaping" = "oracle: `returns [<IntArg(\"\")> return_]` — StringTemplate directive in a return-type slot the stripper cannot reach"
 "SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored" = "oracle: `returns [<IntArg(\"\")> i]` — StringTemplate directive in a return-type slot the stripper cannot reach"
 
-# wado-compiler downstream — the Gale-emitted parser source triggers
-# `Internal compiler error: WIR pipeline generated invalid core Wasm
-# module` (`wado-compiler/src/codegen.rs:45`) when compiled. The same
-# descriptors' Stage A `_parse_test.wado` files compile fine, so the
-# panic is specific to a code path the Stage B′ test exercises (likely
-# `to_tree(&root).to_string_tree()` over a deeply-nested grammar). Move
-# back to active once the wado-compiler bug is filed and fixed; the
-# oracle's tree is in oracle-pending/ ready to go.
-"ParserExec/OpenDeviceStatement_Case1" = "downstream wado-compiler codegen panic on the Gale-emitted parser source — `WIR pipeline generated invalid core Wasm module` (codegen.rs:45). Stage A parse test for the same descriptor compiles fine, so the panic is specific to the to_string_tree path."
-"ParserExec/OpenDeviceStatement_Case2" = "same wado-compiler codegen panic as OpenDeviceStatement_Case1"
-"ParserExec/OpenDeviceStatement_Case3" = "same wado-compiler codegen panic as OpenDeviceStatement_Case1"
+# Stale — awaiting a re-extract, not blocked. These were parked on a
+# downstream wado-compiler ICE (`WIR pipeline generated invalid core
+# Wasm module`) on the Gale-emitted parser source. Re-measured
+# 2026-07-30: all three grammars generate, compile and run their
+# `to_string_tree` path cleanly, so the ICE is gone. Drop these three
+# entries at the next JDK-equipped re-extract so the oracle pins their
+# trees; they are kept here only because a `_skip` cannot be lifted
+# without the oracle run that emits the test.
+"ParserExec/OpenDeviceStatement_Case1" = "stale: parked on a wado-compiler ICE that no longer reproduces — drop at the next re-extract so the oracle can pin the tree"
+"ParserExec/OpenDeviceStatement_Case2" = "same as OpenDeviceStatement_Case1"
+"ParserExec/OpenDeviceStatement_Case3" = "same as OpenDeviceStatement_Case1"
 
 # Oracle TestRig mojibakes non-ASCII output to `?`. The descriptors
 # below have grammars that accept Unicode characters and emit them as

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/Basic/Basic.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-b6011b9143d628c5",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/Basic.g4",
+    "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/Listeners/Basic/t.wado",
+      "hash": "61d3bcd73d345bdffc4b018efa59f327c038282408b7becc0982065855d6874f",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/Basic/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/Basic/t.wado
@@ -1,0 +1,2039 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/Basic.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_ID {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &SYNC_0);
+        let int_2 = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    if kind == TK_ID {
+        let id = p.expect(TK_ID, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_INT", "TK_ID"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT];
+

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/LR/LR.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/LR/LR.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-e56bd84efac1b634",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/LR.g4",
+    "hash": "8f39eb58884a9c6d69675b6172d4948a5412a101e48acd93ca95d54dd694b322"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/Listeners/LR/t.wado",
+      "hash": "a45059da71151e1d4077e3e4800661e7748677890f596c2ec46c1acd11f72d62",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/LR/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/LR/t.wado
@@ -1,0 +1,2099 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/LR.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+pub global TK_LIT_STAR: i32 = 7;
+pub global TK_LIT_PLUS: i32 = 8;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_star(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_INT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_e_lr_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 3);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e_lr_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_e(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, min_prec: i32 = 0) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_INT"],
+    );
+    return;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> () {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    _parse_e__inner_atom(p, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_STAR {
+            if 2 >= min_prec {
+                if scan_e_lr_0(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let op = p.expect(TK_LIT_STAR, &EMPTY_SYNC);
+                let e_2 = _parse_e(p, 3);
+                p.b.finish_node(p.last_end());
+            } else {
+                break;
+            }
+        } else if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_1(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let op = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let e_2 = _parse_e(p, 2);
+                p.b.finish_node(p.last_end());
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> () {
+    if p.recovering { return; }
+    _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_e(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/LRWithLabels/LRWithLabels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/LRWithLabels/LRWithLabels.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-d6b05635f57067cb",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/LRWithLabels.g4",
+    "hash": "1b70e6b955b2d400125149a5ba9a23c882c76eca3a7750a78ad34b015ff7addc"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/Listeners/LRWithLabels/t.wado",
+      "hash": "5507bfdc96ac14b6c26066e28c5d81726c1fb455fbb291a3a9d5f4d090c9daf7",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/LRWithLabels/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/LRWithLabels/t.wado
@@ -1,0 +1,2265 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/LRWithLabels.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+//! Runtime FOLLOW-continuation gate for tail-greedy loops. Emitted into a
+//! generated parser only when lowering constructed a caller-FOLLOW gate
+//! (`GenContext::emit_follow`); gate-free grammars carry none of this.
+
+/// `follow` is the caller's deterministic K-prefix continuation:
+/// `follow[d]` is the set of token kinds that may appear at input depth
+/// `d` if control belongs to the caller rather than to another iteration
+/// of the loop. An empty `follow` (the common, non-repair case) disables
+/// the gate. The loop yields to the caller — breaking `*`/`+` or skipping
+/// `?` — exactly when EVERY non-empty depth-set matches the upcoming
+/// input, i.e. when the next tokens are unambiguously the caller's
+/// continuation.
+///
+/// Threaded as a defaulted `&EMPTY_FOLLOW` argument through the generated
+/// `parse_*` / `scan_*` functions; repair call sites pass a `FOLLOW_MASK_*`
+/// constant (or forward their own `follow`). This replaces the previous
+/// per-(rule, mask) cloned `__follow_<id>` variants: the mask is data
+/// carried at runtime, not code baked into a specialised function.
+///
+/// `eof_kind` is the token kind reported past the end of the stream, so a
+/// caller continuation ending in EOF gates correctly. `tokens` is the bare
+/// `kinds` array (`&p.kinds` on the parse side, the scan `kinds` array on the
+/// scan side) — gating only reads token kinds, and a flat `&Array<i32>` keeps
+/// scan frames a slot smaller than the `List` wrapper or `&TokenStream`
+/// would, which matters for deeply recursive scan grammars.
+pub global EMPTY_FOLLOW: List<List<i32>> = [];
+
+/// Prepend a static local prefix to an inherited FOLLOW continuation.
+/// Used for the `FollowArg::Combined` case: a callee at the current
+/// rule's tail whose preceding local suffix is nullable, so its
+/// continuation is `prefix` (the optional local elements' per-depth
+/// first sets) followed by the caller's own `follow`. Bounded by
+/// `FOLLOW_MASK_MAX_K` so the result stays small; the only
+/// allocating point on a repaired path (the common Static/Forward
+/// cases pass a reference directly).
+pub fn follow_prepend(prefix: &List<List<i32>>, follow: &List<List<i32>>) -> List<List<i32>> {
+    let mut combined: List<List<i32>> = [];
+    for let depth of prefix {
+        combined.push(*depth);
+    }
+    for let depth of follow {
+        combined.push(*depth);
+    }
+    return combined;
+}
+
+pub fn follow_yields(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>>, eof_kind: i32) -> bool {
+    if follow.is_empty() {
+        return false;
+    }
+    for let mut d = 0; d < follow.len(); d += 1 {
+        let set = &follow[d];
+        if set.is_empty() {
+            // No constraint at this depth — a vacuous match, keep going.
+            continue;
+        }
+        let idx = pos + d;
+        let kind = if idx < tokens.len() { tokens[idx] } else { eof_kind };
+        let mut hit = false;
+        for let t of set {
+            if kind == *t {
+                hit = true;
+                break;
+            }
+        }
+        if !hit {
+            return false;
+        }
+    }
+    return true;
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+pub global TK_LIT_LPAREN: i32 = 7;
+pub global TK_LIT_RPAREN: i32 = 8;
+pub global TK_LIT_COMMA: i32 = 9;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_lparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '(' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ')' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_comma(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ',' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if first_char == ',' {
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_LPAREN => "TK_LIT_LPAREN",
+        TK_LIT_RPAREN => "TK_LIT_RPAREN",
+        TK_LIT_COMMA => "TK_LIT_COMMA",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+pub global RK_ELIST: NodeKind = 2;
+
+global RULE_NAMES: List<String> = ["s", "e", "eList"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+pub enum EAlt {
+    Call,
+    Int,
+}
+
+impl CstStore {
+    pub fn e_alt(&self, node: i32) -> Option<EAlt> {
+        return match self.alt(node) {
+            0 => Option::Some(EAlt::Call),
+            1 => Option::Some(EAlt::Int),
+            _ => null,
+        };
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, follow, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_INT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_e_lr_0(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_e_list(tokens, pos, &FOLLOW_MASK_0, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos, follow);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_LPAREN {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_0(tokens, pos, follow);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_list(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, follow, 0);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos] == TK_LIT_COMMA && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+        let sp = pos;
+        sg_0_done: {
+            sg_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_COMMA { break sg_0; }
+                pos += 1;
+                pos = scan_e(tokens, pos, follow, 0);
+                if pos < 0 { break sg_0; }
+                break sg_0_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let r = _parse_e(p, follow);
+    return;
+}
+
+fn _parse_s(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        p.b.set_alt(1);
+        let int = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_INT"],
+    );
+    return;
+}
+
+fn _parse_e__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> () {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    _parse_e__inner_atom(p, follow, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_LPAREN {
+            if 1 >= min_prec {
+                if scan_e_lr_0(&p.kinds, p.pos, follow) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                p.b.set_alt(0);
+                let lparen = p.expect(TK_LIT_LPAREN, &EMPTY_SYNC);
+                let e_list = _parse_e_list(p, &FOLLOW_MASK_0);
+                let rparen = p.expect(TK_LIT_RPAREN, &EMPTY_SYNC);
+                p.b.finish_node(p.last_end());
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return;
+}
+
+fn _parse_e(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> () {
+    if p.recovering { return; }
+    _parse_e__inner(p, follow, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+}
+
+fn _parse_e_list__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p, follow);
+    loop {
+        if p.recovering { break; }
+        if follow_yields(&p.kinds, p.pos, follow, TK_EOF) { break; }
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.kinds;
+            let mut pos: i32 = p.pos;
+            sg_1_done: {
+                sg_1: {
+                    if pos >= tokens.len() || tokens[pos] != TK_LIT_COMMA { break sg_1; }
+                    pos += 1;
+                    pos = scan_e(tokens, pos, follow, 0);
+                    if pos < 0 { break sg_1; }
+                    break sg_1_done;
+                }
+                break rep_scan;
+            }
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let comma = p.expect(TK_LIT_COMMA, &SYNC_0);
+        let e = _parse_e(p, follow);
+    }
+    return;
+}
+
+fn _parse_e_list(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_ELIST, _start);
+    _parse_e_list__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("eList");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_e(p));
+}
+
+pub fn parse_e_list(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_e_list(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(10);
+    for let mut k = 0; k < 10; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(10);
+    for let mut k = 0; k < 10; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(10);
+    for let mut k = 0; k < 10; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT];
+
+global FOLLOW_MASK_0: List<List<i32>> = [[TK_LIT_RPAREN]];
+

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_1/RuleGetters_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_1/RuleGetters_1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-30239be9065a102b",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/RuleGetters_1.g4",
+    "hash": "ddc38590f35a64a189e937c2aa4aa016a526e2decf03572af3c5ff26acb2d9e6"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/Listeners/RuleGetters_1/t.wado",
+      "hash": "7e74fae53526f6f137ecdd13724113edfe9ac1d0e8e559c9937b8dc23c1e5ce1",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_1/t.wado
@@ -1,0 +1,2124 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/RuleGetters_1.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+pub global RK_B: NodeKind = 2;
+
+global RULE_NAMES: List<String> = ["s", "a", "b"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if _kind_set_0(alt_kind) {
+            let mut best: i32 = -1;
+            pos = start;
+            try_1: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_0: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_b(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    if pos < tokens.len() && _kind_set_0(tokens[pos]) {
+        return pos + 1;
+    }
+    return -1;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner_alt_1(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p);
+    return;
+}
+
+fn _parse_a__inner_scan_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_a__inner_alt_0(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p);
+    let b_2 = _parse_b(p);
+    return;
+}
+
+fn _parse_a__inner_scan_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let kind = p.peek_kind();
+    if _kind_set_0(kind) {
+        if _kind_set_0(p.peek_kind()) {
+            let _sd_tokens = &p.kinds;
+            let _sd_pos = p.pos;
+            let _sd_p_1 = _parse_a__inner_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_0 = _parse_a__inner_scan_0(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 1 {
+                return _parse_a__inner_alt_1(p);
+            }
+            if _sd_best_i == 0 {
+                return _parse_a__inner_alt_0(p);
+            }
+            return _parse_a__inner_alt_0(p);
+        }
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_ID", "TK_INT"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _parse_b__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if _kind_set_0(kind) {
+        let _ = p.expect(kind, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected b",
+        p.peek_span(),
+        ["TK_ID", "TK_INT"],
+    );
+    return;
+}
+
+fn _parse_b(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_B, _start);
+    _parse_b__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("b");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+pub fn parse_b(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_b(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_ID | TK_INT };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_2/RuleGetters_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_2/RuleGetters_2.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-83dee48eed8ba5f7",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/RuleGetters_2.g4",
+    "hash": "ddc38590f35a64a189e937c2aa4aa016a526e2decf03572af3c5ff26acb2d9e6"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/Listeners/RuleGetters_2/t.wado",
+      "hash": "0cf487a4a060434e9ad25bd8411dcc909872013cebe90c4d36cb562537e159a1",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_2/t.wado
@@ -1,0 +1,2124 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/RuleGetters_2.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+pub global RK_B: NodeKind = 2;
+
+global RULE_NAMES: List<String> = ["s", "a", "b"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if _kind_set_0(alt_kind) {
+            let mut best: i32 = -1;
+            pos = start;
+            try_1: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_0: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_b(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    if pos < tokens.len() && _kind_set_0(tokens[pos]) {
+        return pos + 1;
+    }
+    return -1;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner_alt_1(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p);
+    return;
+}
+
+fn _parse_a__inner_scan_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_a__inner_alt_0(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p);
+    let b_2 = _parse_b(p);
+    return;
+}
+
+fn _parse_a__inner_scan_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let kind = p.peek_kind();
+    if _kind_set_0(kind) {
+        if _kind_set_0(p.peek_kind()) {
+            let _sd_tokens = &p.kinds;
+            let _sd_pos = p.pos;
+            let _sd_p_1 = _parse_a__inner_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_0 = _parse_a__inner_scan_0(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 1 {
+                return _parse_a__inner_alt_1(p);
+            }
+            if _sd_best_i == 0 {
+                return _parse_a__inner_alt_0(p);
+            }
+            return _parse_a__inner_alt_0(p);
+        }
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_ID", "TK_INT"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _parse_b__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if _kind_set_0(kind) {
+        let _ = p.expect(kind, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected b",
+        p.peek_span(),
+        ["TK_ID", "TK_INT"],
+    );
+    return;
+}
+
+fn _parse_b(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_B, _start);
+    _parse_b__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("b");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+pub fn parse_b(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_b(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_ID | TK_INT };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_1/TokenGetters_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_1/TokenGetters_1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-84499a2abb159b25",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/TokenGetters_1.g4",
+    "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/Listeners/TokenGetters_1/t.wado",
+      "hash": "30a8f5c06f3409a38c8db4a8a94c719706f57ccc31e5ea8a400531189ae18c8d",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_1/t.wado
@@ -1,0 +1,2039 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/TokenGetters_1.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_ID {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &SYNC_0);
+        let int_2 = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    if kind == TK_ID {
+        let id = p.expect(TK_ID, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_INT", "TK_ID"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT];
+

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_2/TokenGetters_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_2/TokenGetters_2.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-939d0f890cce06d8",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/TokenGetters_2.g4",
+    "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/Listeners/TokenGetters_2/t.wado",
+      "hash": "c4171131a761c5bc71a1cf43ee3dcf2a2b368257e20ec3ab625f64ad021d1be0",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_2/t.wado
@@ -1,0 +1,2039 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/TokenGetters_2.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_ID {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &SYNC_0);
+        let int_2 = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    if kind == TK_ID {
+        let id = p.expect(TK_ID, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_INT", "TK_ID"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT];
+

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString/TokenAndRuleContextString.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString/TokenAndRuleContextString.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-7200e3cc8fd5d741",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/ParseTrees/TokenAndRuleContextString.g4",
+    "hash": "540d104df0edf2d66917d75620498573de808a49eedf7bd53a96b83c5a5efb11"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString/t.wado",
+      "hash": "5d88a59e738e5fc888098a62222df896841c98e7fd189af73db9685a31523e3e",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString/t.wado
@@ -1,0 +1,1906 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/ParseTrees/TokenAndRuleContextString.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    Eof,
+    Error,
+}
+
+pub global TK_EOF: i32 = 0;
+pub global TK_ERROR: i32 = 1;
+pub global TK_LIT_X: i32 = 2;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_lit_x(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'x' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == 'x' {
+            end = try_lit_x(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_X; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = false;
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_X => "TK_LIT_X",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_X { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let lit_x = p.expect(TK_LIT_X, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(3);
+    for let mut k = 0; k < 3; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(3);
+    for let mut k = 0; k < 3; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(3);
+    for let mut k = 0; k < 3; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertionConsumption/SingleSetInsertionConsumption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertionConsumption/SingleSetInsertionConsumption.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-e2eef45b306a6e0c",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/ParserErrors/SingleSetInsertionConsumption.g4",
+    "hash": "be780fb891f1bbfbfaec2220da2248863f300e58833a1cfa9fb899655c53e0fe"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertionConsumption/t.wado",
+      "hash": "e891b80404aa6c0f04996a0ca1344c9d51c26d1824ff06be307af3e6e34a37aa",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertionConsumption/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertionConsumption/t.wado
@@ -1,0 +1,1967 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/ParserErrors/SingleSetInsertionConsumption.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    Eof,
+    Error,
+}
+
+pub global TK_EOF: i32 = 0;
+pub global TK_ERROR: i32 = 1;
+pub global TK_LIT_B: i32 = 2;
+pub global TK_LIT_C: i32 = 3;
+pub global TK_LIT_A: i32 = 4;
+pub global TK_LIT_D: i32 = 5;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_lit_b(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'b' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_c(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'c' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_a(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'a' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_d(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'd' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == 'a' {
+            end = try_lit_a(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_A; }
+        } else if first_char == 'b' {
+            end = try_lit_b(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_B; }
+        } else if first_char == 'c' {
+            end = try_lit_c(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_C; }
+        } else if first_char == 'd' {
+            end = try_lit_d(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_D; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = false;
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_B => "TK_LIT_B",
+        TK_LIT_C => "TK_LIT_C",
+        TK_LIT_A => "TK_LIT_A",
+        TK_LIT_D => "TK_LIT_D",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_MYSET: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["myset", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_myset(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    let gp_0 = pos;
+    let sgk_0 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    if _kind_set_0(sgk_0) {
+        sg_0: {
+            pos = gp_0;
+            sg_0_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_B { break sg_0_0; }
+                pos += 1;
+                break sg_0;
+            }
+            pos = gp_0;
+            sg_0_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_C { break sg_0_1; }
+                pos += 1;
+                break sg_0;
+            }
+            return -1;
+        }
+    } else {
+        return -1;
+    }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_A { return -1; }
+    pos += 1;
+    pos = scan_myset(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_D { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_myset__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let lit_b_or_lit_c = p.expect_set([TK_LIT_B, TK_LIT_C]);
+    return;
+}
+
+fn _parse_myset(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_MYSET, _start);
+    _parse_myset__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("myset");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let lit_a = p.expect(TK_LIT_A, &SYNC_0);
+    let myset = _parse_myset(p);
+    let lit_d = p.expect(TK_LIT_D, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_myset(input, max_errors);
+}
+
+pub fn parse_myset(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_myset(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_LIT_B | TK_LIT_C };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_B, TK_LIT_C];
+

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionConsumption/SingleTokenDeletionConsumption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionConsumption/SingleTokenDeletionConsumption.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-4d48d62113f3fee1",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionConsumption.g4",
+    "hash": "be780fb891f1bbfbfaec2220da2248863f300e58833a1cfa9fb899655c53e0fe"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionConsumption/t.wado",
+      "hash": "471434d78a21ca5cdbff2f6c92163252f9dec9767e1401e970cc1ea81cc8416c",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionConsumption/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionConsumption/t.wado
@@ -1,0 +1,1967 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionConsumption.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    Eof,
+    Error,
+}
+
+pub global TK_EOF: i32 = 0;
+pub global TK_ERROR: i32 = 1;
+pub global TK_LIT_B: i32 = 2;
+pub global TK_LIT_C: i32 = 3;
+pub global TK_LIT_A: i32 = 4;
+pub global TK_LIT_D: i32 = 5;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_lit_b(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'b' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_c(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'c' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_a(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'a' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_d(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'd' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == 'a' {
+            end = try_lit_a(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_A; }
+        } else if first_char == 'b' {
+            end = try_lit_b(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_B; }
+        } else if first_char == 'c' {
+            end = try_lit_c(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_C; }
+        } else if first_char == 'd' {
+            end = try_lit_d(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_D; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = false;
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_B => "TK_LIT_B",
+        TK_LIT_C => "TK_LIT_C",
+        TK_LIT_A => "TK_LIT_A",
+        TK_LIT_D => "TK_LIT_D",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_MYSET: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["myset", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_myset(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    let gp_0 = pos;
+    let sgk_0 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    if _kind_set_0(sgk_0) {
+        sg_0: {
+            pos = gp_0;
+            sg_0_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_B { break sg_0_0; }
+                pos += 1;
+                break sg_0;
+            }
+            pos = gp_0;
+            sg_0_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_C { break sg_0_1; }
+                pos += 1;
+                break sg_0;
+            }
+            return -1;
+        }
+    } else {
+        return -1;
+    }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_A { return -1; }
+    pos += 1;
+    pos = scan_myset(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_D { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_myset__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let lit_b_or_lit_c = p.expect_set([TK_LIT_B, TK_LIT_C]);
+    return;
+}
+
+fn _parse_myset(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_MYSET, _start);
+    _parse_myset__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("myset");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let lit_a = p.expect(TK_LIT_A, &SYNC_0);
+    let myset = _parse_myset(p);
+    let lit_d = p.expect(TK_LIT_D, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_myset(input, max_errors);
+}
+
+pub fn parse_myset(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_myset(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_LIT_B | TK_LIT_C };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_B, TK_LIT_C];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-8542ba9833c00c8f",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4",
+    "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1/t.wado",
+      "hash": "ac95ca49a387bcf25a8da4ba482536bd78cabb2b09219511c5fd4bea7ac033ce",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1/t.wado
@@ -1,0 +1,2164 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    ID,
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_ID: i32 = 0;
+pub global TK_INT: i32 = 1;
+pub global TK_WS: i32 = 2;
+pub global TK_EOF: i32 = 3;
+pub global TK_ERROR: i32 = 4;
+pub global TK_LIT_EQ: i32 = 5;
+pub global TK_LIT_PLUS: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { 'a'..='z' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !(chars[pos] matches { 'a'..='z' }) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_2 = pos;
+    let mut alts_ok_2 = false;
+    alts_2_0: {
+        pos = alts_saved_2;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_2_0; }
+        pos += 1;
+        alts_ok_2 = true;
+    }
+    if !alts_ok_2 {
+        alts_2_1: {
+            pos = alts_saved_2;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_2_1; }
+            pos += 1;
+            alts_ok_2 = true;
+        }
+    }
+    if !alts_ok_2 { return -1; }
+    return pos;
+}
+
+fn try_lit_eq(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '=' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if first_char == '=' {
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_EQ => "TK_LIT_EQ",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct EVals {
+    result: String = "",
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_ID {
+            let mut best: i32 = -1;
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_EQ { break try_0; }
+                pos += 1;
+                pos = scan_e(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_lr_2(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_2(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p);
+    if !p.speculating {
+        p.emit(`${e.result}\n`);
+    }
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_alt_0(p: &mut Parser, vals: EVals = EVals {}) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let id = p.expect(TK_ID, &SYNC_0);
+    let eq = p.expect(TK_LIT_EQ, &SYNC_1);
+    let e1 = _parse_e(p, 2);
+    if !p.speculating {
+        vals.result = `(${p.token_text(id)}=${e1.result})`;
+    }
+    return vals;
+}
+
+fn _parse_e__inner_scan_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_ID { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_EQ { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2147483647);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_e__inner_alt_1(p: &mut Parser, vals: EVals = EVals {}) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let id = p.expect(TK_ID, &EMPTY_SYNC);
+    if !p.speculating {
+        vals.result = p.token_text(id);
+    }
+    return vals;
+}
+
+fn _parse_e__inner_scan_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, vals: EVals = EVals {}, min_prec: i32 = 0) -> EVals {
+    let mut vals = vals;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let _sd_tokens = &p.kinds;
+        let _sd_pos = p.pos;
+        let _sd_p_0 = _parse_e__inner_scan_0(_sd_tokens, _sd_pos);
+        let _sd_p_1 = _parse_e__inner_scan_1(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
+        }
+        if _sd_best_i == 0 {
+            return _parse_e__inner_alt_0(p, vals);
+        }
+        if _sd_best_i == 1 {
+            return _parse_e__inner_alt_1(p, vals);
+        }
+        return _parse_e__inner_alt_1(p, vals);
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_ID"],
+    );
+    return vals;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    let vals = EVals {};
+    let mut _lr_acc = _parse_e__inner_atom(p, vals, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_2(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let e1 = _lr_acc;
+                let mut vals = EVals {};
+                let plus = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let e2 = _parse_e(p, 2);
+                if !p.speculating {
+                    vals.result = `(${e1.result}+${e2.result})`;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return _lr_acc;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    if p.recovering { return EVals {}; }
+    let __vals = _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+    return __vals;
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_e(p); });
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_EQ];
+global SYNC_1: List<i32> = [TK_ID];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-fc1d346535bb08d3",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4",
+    "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2/t.wado",
+      "hash": "fe14d89d8f6ce0780881f1854acf12d16d19309581aef528eda5dd35db3f35dc",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2/t.wado
@@ -1,0 +1,2164 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    ID,
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_ID: i32 = 0;
+pub global TK_INT: i32 = 1;
+pub global TK_WS: i32 = 2;
+pub global TK_EOF: i32 = 3;
+pub global TK_ERROR: i32 = 4;
+pub global TK_LIT_EQ: i32 = 5;
+pub global TK_LIT_PLUS: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { 'a'..='z' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !(chars[pos] matches { 'a'..='z' }) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_2 = pos;
+    let mut alts_ok_2 = false;
+    alts_2_0: {
+        pos = alts_saved_2;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_2_0; }
+        pos += 1;
+        alts_ok_2 = true;
+    }
+    if !alts_ok_2 {
+        alts_2_1: {
+            pos = alts_saved_2;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_2_1; }
+            pos += 1;
+            alts_ok_2 = true;
+        }
+    }
+    if !alts_ok_2 { return -1; }
+    return pos;
+}
+
+fn try_lit_eq(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '=' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if first_char == '=' {
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_EQ => "TK_LIT_EQ",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct EVals {
+    result: String = "",
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_ID {
+            let mut best: i32 = -1;
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_EQ { break try_0; }
+                pos += 1;
+                pos = scan_e(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_lr_2(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_2(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p);
+    if !p.speculating {
+        p.emit(`${e.result}\n`);
+    }
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_alt_0(p: &mut Parser, vals: EVals = EVals {}) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let id = p.expect(TK_ID, &SYNC_0);
+    let eq = p.expect(TK_LIT_EQ, &SYNC_1);
+    let e1 = _parse_e(p, 2);
+    if !p.speculating {
+        vals.result = `(${p.token_text(id)}=${e1.result})`;
+    }
+    return vals;
+}
+
+fn _parse_e__inner_scan_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_ID { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_EQ { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2147483647);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_e__inner_alt_1(p: &mut Parser, vals: EVals = EVals {}) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let id = p.expect(TK_ID, &EMPTY_SYNC);
+    if !p.speculating {
+        vals.result = p.token_text(id);
+    }
+    return vals;
+}
+
+fn _parse_e__inner_scan_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, vals: EVals = EVals {}, min_prec: i32 = 0) -> EVals {
+    let mut vals = vals;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let _sd_tokens = &p.kinds;
+        let _sd_pos = p.pos;
+        let _sd_p_0 = _parse_e__inner_scan_0(_sd_tokens, _sd_pos);
+        let _sd_p_1 = _parse_e__inner_scan_1(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
+        }
+        if _sd_best_i == 0 {
+            return _parse_e__inner_alt_0(p, vals);
+        }
+        if _sd_best_i == 1 {
+            return _parse_e__inner_alt_1(p, vals);
+        }
+        return _parse_e__inner_alt_1(p, vals);
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_ID"],
+    );
+    return vals;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    let vals = EVals {};
+    let mut _lr_acc = _parse_e__inner_atom(p, vals, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_2(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let e1 = _lr_acc;
+                let mut vals = EVals {};
+                let plus = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let e2 = _parse_e(p, 2);
+                if !p.speculating {
+                    vals.result = `(${e1.result}+${e2.result})`;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return _lr_acc;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    if p.recovering { return EVals {}; }
+    let __vals = _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+    return __vals;
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_e(p); });
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_EQ];
+global SYNC_1: List<i32> = [TK_ID];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-7d08f41a3235744e",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4",
+    "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3/t.wado",
+      "hash": "ed99669e4a947f3c2be1f915308dca5bd967e1fb91f8aba927528094e4cd5612",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3/t.wado
@@ -1,0 +1,2164 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    ID,
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_ID: i32 = 0;
+pub global TK_INT: i32 = 1;
+pub global TK_WS: i32 = 2;
+pub global TK_EOF: i32 = 3;
+pub global TK_ERROR: i32 = 4;
+pub global TK_LIT_EQ: i32 = 5;
+pub global TK_LIT_PLUS: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { 'a'..='z' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !(chars[pos] matches { 'a'..='z' }) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_2 = pos;
+    let mut alts_ok_2 = false;
+    alts_2_0: {
+        pos = alts_saved_2;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_2_0; }
+        pos += 1;
+        alts_ok_2 = true;
+    }
+    if !alts_ok_2 {
+        alts_2_1: {
+            pos = alts_saved_2;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_2_1; }
+            pos += 1;
+            alts_ok_2 = true;
+        }
+    }
+    if !alts_ok_2 { return -1; }
+    return pos;
+}
+
+fn try_lit_eq(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '=' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if first_char == '=' {
+            end = try_lit_eq(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_EQ; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_EQ => "TK_LIT_EQ",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct EVals {
+    result: String = "",
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_ID {
+            let mut best: i32 = -1;
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_EQ { break try_0; }
+                pos += 1;
+                pos = scan_e(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_lr_2(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_2(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p);
+    if !p.speculating {
+        p.emit(`${e.result}\n`);
+    }
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_alt_0(p: &mut Parser, vals: EVals = EVals {}) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let id = p.expect(TK_ID, &SYNC_0);
+    let eq = p.expect(TK_LIT_EQ, &SYNC_1);
+    let e1 = _parse_e(p, 2);
+    if !p.speculating {
+        vals.result = `(${p.token_text(id)}=${e1.result})`;
+    }
+    return vals;
+}
+
+fn _parse_e__inner_scan_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_ID { return -1; }
+    pos += 1;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_EQ { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2147483647);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_e__inner_alt_1(p: &mut Parser, vals: EVals = EVals {}) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let id = p.expect(TK_ID, &EMPTY_SYNC);
+    if !p.speculating {
+        vals.result = p.token_text(id);
+    }
+    return vals;
+}
+
+fn _parse_e__inner_scan_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_ID { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, vals: EVals = EVals {}, min_prec: i32 = 0) -> EVals {
+    let mut vals = vals;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        let _sd_tokens = &p.kinds;
+        let _sd_pos = p.pos;
+        let _sd_p_0 = _parse_e__inner_scan_0(_sd_tokens, _sd_pos);
+        let _sd_p_1 = _parse_e__inner_scan_1(_sd_tokens, _sd_pos);
+        let mut _sd_best_i: i32 = -1;
+        let mut _sd_best_p: i32 = -1;
+        if _sd_p_0 > _sd_best_p {
+            _sd_best_p = _sd_p_0;
+            _sd_best_i = 0;
+        }
+        if _sd_p_1 > _sd_best_p {
+            _sd_best_p = _sd_p_1;
+            _sd_best_i = 1;
+        }
+        if _sd_best_i == 0 {
+            return _parse_e__inner_alt_0(p, vals);
+        }
+        if _sd_best_i == 1 {
+            return _parse_e__inner_alt_1(p, vals);
+        }
+        return _parse_e__inner_alt_1(p, vals);
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_ID"],
+    );
+    return vals;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    let vals = EVals {};
+    let mut _lr_acc = _parse_e__inner_atom(p, vals, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_2(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let e1 = _lr_acc;
+                let mut vals = EVals {};
+                let plus = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let e2 = _parse_e(p, 2);
+                if !p.speculating {
+                    vals.result = `(${e1.result}+${e2.result})`;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return _lr_acc;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    if p.recovering { return EVals {}; }
+    let __vals = _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+    return __vals;
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_e(p); });
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_EQ];
+global SYNC_1: List<i32> = [TK_ID];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-55dd948e9dc09b16",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_1.g4",
+    "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_1/t.wado",
+      "hash": "aafd83e7e2d3103c4078418308bdf8f8608cb3a9266836d751845693f1ee3dc2",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_1/t.wado
@@ -1,0 +1,2150 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_1.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_INT: i32 = 0;
+pub global TK_WS: i32 = 1;
+pub global TK_EOF: i32 = 2;
+pub global TK_ERROR: i32 = 3;
+pub global TK_LIT_STAR: i32 = 4;
+pub global TK_LIT_PLUS: i32 = 5;
+pub global TK_LIT_LPAREN: i32 = 6;
+pub global TK_LIT_RPAREN: i32 = 7;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_1 = pos;
+    let mut alts_ok_1 = false;
+    alts_1_0: {
+        pos = alts_saved_1;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_1_0; }
+        pos += 1;
+        alts_ok_1 = true;
+    }
+    if !alts_ok_1 {
+        alts_1_1: {
+            pos = alts_saved_1;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_1_1; }
+            pos += 1;
+            alts_ok_1 = true;
+        }
+    }
+    if !alts_ok_1 { return -1; }
+    return pos;
+}
+
+fn try_lit_star(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_lparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '(' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ')' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        TK_LIT_LPAREN => "TK_LIT_LPAREN",
+        TK_LIT_RPAREN => "TK_LIT_RPAREN",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct EVals {
+    v: i32 = 0,
+    ignored: List<String> = [],
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_LIT_LPAREN {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_LPAREN { break try_1; }
+                pos += 1;
+                pos = scan_e(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_RPAREN { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_lr_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 3);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e_lr_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p);
+    if !p.speculating {
+        p.emit(`${e.v}\n`);
+    }
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, vals: EVals = EVals {}, min_prec: i32 = 0) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &EMPTY_SYNC);
+        if !p.speculating {
+            vals.v = p.token_int(int);
+        }
+        return vals;
+    }
+    if kind == TK_LIT_LPAREN {
+        let lparen = p.expect(TK_LIT_LPAREN, &SYNC_0);
+        let x = _parse_e(p);
+        let rparen = p.expect(TK_LIT_RPAREN, &EMPTY_SYNC);
+        if !p.speculating {
+            vals.v = x.v;
+        }
+        return vals;
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_INT", "TK_LIT_LPAREN"],
+    );
+    return vals;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    let vals = EVals {};
+    let mut _lr_acc = _parse_e__inner_atom(p, vals, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_STAR {
+            if 2 >= min_prec {
+                if scan_e_lr_0(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let a = _lr_acc;
+                let mut vals = EVals {};
+                let star = p.expect(TK_LIT_STAR, &EMPTY_SYNC);
+                let b = _parse_e(p, 3);
+                if !p.speculating {
+                    vals.v = a.v * b.v;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_1(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let a = _lr_acc;
+                let mut vals = EVals {};
+                let plus = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let b = _parse_e(p, 2);
+                if !p.speculating {
+                    vals.v = a.v + b.v;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return _lr_acc;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    if p.recovering { return EVals {}; }
+    let __vals = _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+    return __vals;
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_e(p); });
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT, TK_LIT_LPAREN];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-1ff0ff2b6b58c78e",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_2.g4",
+    "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_2/t.wado",
+      "hash": "be4c8e1da799a190b92fe77ea0c6840815377983ce156cf28d797266209f260c",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_2/t.wado
@@ -1,0 +1,2150 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_2.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_INT: i32 = 0;
+pub global TK_WS: i32 = 1;
+pub global TK_EOF: i32 = 2;
+pub global TK_ERROR: i32 = 3;
+pub global TK_LIT_STAR: i32 = 4;
+pub global TK_LIT_PLUS: i32 = 5;
+pub global TK_LIT_LPAREN: i32 = 6;
+pub global TK_LIT_RPAREN: i32 = 7;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_1 = pos;
+    let mut alts_ok_1 = false;
+    alts_1_0: {
+        pos = alts_saved_1;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_1_0; }
+        pos += 1;
+        alts_ok_1 = true;
+    }
+    if !alts_ok_1 {
+        alts_1_1: {
+            pos = alts_saved_1;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_1_1; }
+            pos += 1;
+            alts_ok_1 = true;
+        }
+    }
+    if !alts_ok_1 { return -1; }
+    return pos;
+}
+
+fn try_lit_star(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_lparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '(' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ')' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        TK_LIT_LPAREN => "TK_LIT_LPAREN",
+        TK_LIT_RPAREN => "TK_LIT_RPAREN",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct EVals {
+    v: i32 = 0,
+    ignored: List<String> = [],
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_LIT_LPAREN {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_LPAREN { break try_1; }
+                pos += 1;
+                pos = scan_e(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_RPAREN { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_lr_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 3);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e_lr_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p);
+    if !p.speculating {
+        p.emit(`${e.v}\n`);
+    }
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, vals: EVals = EVals {}, min_prec: i32 = 0) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &EMPTY_SYNC);
+        if !p.speculating {
+            vals.v = p.token_int(int);
+        }
+        return vals;
+    }
+    if kind == TK_LIT_LPAREN {
+        let lparen = p.expect(TK_LIT_LPAREN, &SYNC_0);
+        let x = _parse_e(p);
+        let rparen = p.expect(TK_LIT_RPAREN, &EMPTY_SYNC);
+        if !p.speculating {
+            vals.v = x.v;
+        }
+        return vals;
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_INT", "TK_LIT_LPAREN"],
+    );
+    return vals;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    let vals = EVals {};
+    let mut _lr_acc = _parse_e__inner_atom(p, vals, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_STAR {
+            if 2 >= min_prec {
+                if scan_e_lr_0(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let a = _lr_acc;
+                let mut vals = EVals {};
+                let star = p.expect(TK_LIT_STAR, &EMPTY_SYNC);
+                let b = _parse_e(p, 3);
+                if !p.speculating {
+                    vals.v = a.v * b.v;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_1(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let a = _lr_acc;
+                let mut vals = EVals {};
+                let plus = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let b = _parse_e(p, 2);
+                if !p.speculating {
+                    vals.v = a.v + b.v;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return _lr_acc;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    if p.recovering { return EVals {}; }
+    let __vals = _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+    return __vals;
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_e(p); });
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT, TK_LIT_LPAREN];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-4e6e02a58699299b",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_3.g4",
+    "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_3/t.wado",
+      "hash": "84abcc2bd09a1f665ff9869a3704c89337e0d531d08993af148079736f6fce80",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_3/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_3/t.wado
@@ -1,0 +1,2150 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_3.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_INT: i32 = 0;
+pub global TK_WS: i32 = 1;
+pub global TK_EOF: i32 = 2;
+pub global TK_ERROR: i32 = 3;
+pub global TK_LIT_STAR: i32 = 4;
+pub global TK_LIT_PLUS: i32 = 5;
+pub global TK_LIT_LPAREN: i32 = 6;
+pub global TK_LIT_RPAREN: i32 = 7;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_1 = pos;
+    let mut alts_ok_1 = false;
+    alts_1_0: {
+        pos = alts_saved_1;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_1_0; }
+        pos += 1;
+        alts_ok_1 = true;
+    }
+    if !alts_ok_1 {
+        alts_1_1: {
+            pos = alts_saved_1;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_1_1; }
+            pos += 1;
+            alts_ok_1 = true;
+        }
+    }
+    if !alts_ok_1 { return -1; }
+    return pos;
+}
+
+fn try_lit_star(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_lparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '(' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ')' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        TK_LIT_LPAREN => "TK_LIT_LPAREN",
+        TK_LIT_RPAREN => "TK_LIT_RPAREN",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct EVals {
+    v: i32 = 0,
+    ignored: List<String> = [],
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_LIT_LPAREN {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_LPAREN { break try_1; }
+                pos += 1;
+                pos = scan_e(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_RPAREN { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_lr_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 3);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e_lr_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p);
+    if !p.speculating {
+        p.emit(`${e.v}\n`);
+    }
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, vals: EVals = EVals {}, min_prec: i32 = 0) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &EMPTY_SYNC);
+        if !p.speculating {
+            vals.v = p.token_int(int);
+        }
+        return vals;
+    }
+    if kind == TK_LIT_LPAREN {
+        let lparen = p.expect(TK_LIT_LPAREN, &SYNC_0);
+        let x = _parse_e(p);
+        let rparen = p.expect(TK_LIT_RPAREN, &EMPTY_SYNC);
+        if !p.speculating {
+            vals.v = x.v;
+        }
+        return vals;
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_INT", "TK_LIT_LPAREN"],
+    );
+    return vals;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    let vals = EVals {};
+    let mut _lr_acc = _parse_e__inner_atom(p, vals, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_STAR {
+            if 2 >= min_prec {
+                if scan_e_lr_0(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let a = _lr_acc;
+                let mut vals = EVals {};
+                let star = p.expect(TK_LIT_STAR, &EMPTY_SYNC);
+                let b = _parse_e(p, 3);
+                if !p.speculating {
+                    vals.v = a.v * b.v;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_1(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let a = _lr_acc;
+                let mut vals = EVals {};
+                let plus = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let b = _parse_e(p, 2);
+                if !p.speculating {
+                    vals.v = a.v + b.v;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return _lr_acc;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    if p.recovering { return EVals {}; }
+    let __vals = _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+    return __vals;
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_e(p); });
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT, TK_LIT_LPAREN];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-5752f12e23140fae",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_4.g4",
+    "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_4/t.wado",
+      "hash": "518b1a80a8a065d7998c3cf21320c04d7184b2c1fd9464f660c8acaf3e7c7546",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_4/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_4/t.wado
@@ -1,0 +1,2150 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_4.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_INT: i32 = 0;
+pub global TK_WS: i32 = 1;
+pub global TK_EOF: i32 = 2;
+pub global TK_ERROR: i32 = 3;
+pub global TK_LIT_STAR: i32 = 4;
+pub global TK_LIT_PLUS: i32 = 5;
+pub global TK_LIT_LPAREN: i32 = 6;
+pub global TK_LIT_RPAREN: i32 = 7;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_1 = pos;
+    let mut alts_ok_1 = false;
+    alts_1_0: {
+        pos = alts_saved_1;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_1_0; }
+        pos += 1;
+        alts_ok_1 = true;
+    }
+    if !alts_ok_1 {
+        alts_1_1: {
+            pos = alts_saved_1;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_1_1; }
+            pos += 1;
+            alts_ok_1 = true;
+        }
+    }
+    if !alts_ok_1 { return -1; }
+    return pos;
+}
+
+fn try_lit_star(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_lparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '(' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ')' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        TK_LIT_LPAREN => "TK_LIT_LPAREN",
+        TK_LIT_RPAREN => "TK_LIT_RPAREN",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct EVals {
+    v: i32 = 0,
+    ignored: List<String> = [],
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_LIT_LPAREN {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_LPAREN { break try_1; }
+                pos += 1;
+                pos = scan_e(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_RPAREN { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_lr_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 3);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e_lr_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p);
+    if !p.speculating {
+        p.emit(`${e.v}\n`);
+    }
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, vals: EVals = EVals {}, min_prec: i32 = 0) -> EVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &EMPTY_SYNC);
+        if !p.speculating {
+            vals.v = p.token_int(int);
+        }
+        return vals;
+    }
+    if kind == TK_LIT_LPAREN {
+        let lparen = p.expect(TK_LIT_LPAREN, &SYNC_0);
+        let x = _parse_e(p);
+        let rparen = p.expect(TK_LIT_RPAREN, &EMPTY_SYNC);
+        if !p.speculating {
+            vals.v = x.v;
+        }
+        return vals;
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_INT", "TK_LIT_LPAREN"],
+    );
+    return vals;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    let vals = EVals {};
+    let mut _lr_acc = _parse_e__inner_atom(p, vals, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_STAR {
+            if 2 >= min_prec {
+                if scan_e_lr_0(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let a = _lr_acc;
+                let mut vals = EVals {};
+                let star = p.expect(TK_LIT_STAR, &EMPTY_SYNC);
+                let b = _parse_e(p, 3);
+                if !p.speculating {
+                    vals.v = a.v * b.v;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_1(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let a = _lr_acc;
+                let mut vals = EVals {};
+                let plus = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let b = _parse_e(p, 2);
+                if !p.speculating {
+                    vals.v = a.v + b.v;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return _lr_acc;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> EVals {
+    if p.recovering { return EVals {}; }
+    let __vals = _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+    return __vals;
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_e(p); });
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(8);
+    for let mut k = 0; k < 8; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT, TK_LIT_LPAREN];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/Basic/Basic.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-b6011b9143d628c5",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/Basic.g4",
+    "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/Listeners/Basic/t.wado",
+      "hash": "61d3bcd73d345bdffc4b018efa59f327c038282408b7becc0982065855d6874f",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/Basic/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/Basic/t.wado
@@ -1,0 +1,2039 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/Basic.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_ID {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &SYNC_0);
+        let int_2 = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    if kind == TK_ID {
+        let id = p.expect(TK_ID, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_INT", "TK_ID"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LR/LR.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LR/LR.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-e56bd84efac1b634",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/LR.g4",
+    "hash": "8f39eb58884a9c6d69675b6172d4948a5412a101e48acd93ca95d54dd694b322"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/Listeners/LR/t.wado",
+      "hash": "a45059da71151e1d4077e3e4800661e7748677890f596c2ec46c1acd11f72d62",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LR/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LR/t.wado
@@ -1,0 +1,2099 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/LR.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+pub global TK_LIT_STAR: i32 = 7;
+pub global TK_LIT_PLUS: i32 = 8;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_star(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '*' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_plus(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '+' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_lit_star(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_STAR; }
+        } else if first_char == '+' {
+            end = try_lit_plus(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_PLUS; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_STAR => "TK_LIT_STAR",
+        TK_LIT_PLUS => "TK_LIT_PLUS",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "e"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_INT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_e_lr_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_STAR { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 3);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e_lr_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_PLUS { return -1; }
+    pos += 1;
+    pos = scan_e(tokens, pos, 2);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_STAR {
+            if 2 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_0(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else if suffix_kind == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_1(tokens, pos);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_e(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, min_prec: i32 = 0) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_INT"],
+    );
+    return;
+}
+
+fn _parse_e__inner(p: &mut Parser, min_prec: i32 = 0) -> () {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    _parse_e__inner_atom(p, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_STAR {
+            if 2 >= min_prec {
+                if scan_e_lr_0(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let op = p.expect(TK_LIT_STAR, &EMPTY_SYNC);
+                let e_2 = _parse_e(p, 3);
+                p.b.finish_node(p.last_end());
+            } else {
+                break;
+            }
+        } else if _sk == TK_LIT_PLUS {
+            if 1 >= min_prec {
+                if scan_e_lr_1(&p.kinds, p.pos) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                let op = p.expect(TK_LIT_PLUS, &EMPTY_SYNC);
+                let e_2 = _parse_e(p, 2);
+                p.b.finish_node(p.last_end());
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return;
+}
+
+fn _parse_e(p: &mut Parser, min_prec: i32 = 0) -> () {
+    if p.recovering { return; }
+    _parse_e__inner(p, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_e(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LRWithLabels/LRWithLabels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LRWithLabels/LRWithLabels.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-d6b05635f57067cb",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/LRWithLabels.g4",
+    "hash": "1b70e6b955b2d400125149a5ba9a23c882c76eca3a7750a78ad34b015ff7addc"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/Listeners/LRWithLabels/t.wado",
+      "hash": "5507bfdc96ac14b6c26066e28c5d81726c1fb455fbb291a3a9d5f4d090c9daf7",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LRWithLabels/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LRWithLabels/t.wado
@@ -1,0 +1,2265 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/LRWithLabels.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+//! Runtime FOLLOW-continuation gate for tail-greedy loops. Emitted into a
+//! generated parser only when lowering constructed a caller-FOLLOW gate
+//! (`GenContext::emit_follow`); gate-free grammars carry none of this.
+
+/// `follow` is the caller's deterministic K-prefix continuation:
+/// `follow[d]` is the set of token kinds that may appear at input depth
+/// `d` if control belongs to the caller rather than to another iteration
+/// of the loop. An empty `follow` (the common, non-repair case) disables
+/// the gate. The loop yields to the caller — breaking `*`/`+` or skipping
+/// `?` — exactly when EVERY non-empty depth-set matches the upcoming
+/// input, i.e. when the next tokens are unambiguously the caller's
+/// continuation.
+///
+/// Threaded as a defaulted `&EMPTY_FOLLOW` argument through the generated
+/// `parse_*` / `scan_*` functions; repair call sites pass a `FOLLOW_MASK_*`
+/// constant (or forward their own `follow`). This replaces the previous
+/// per-(rule, mask) cloned `__follow_<id>` variants: the mask is data
+/// carried at runtime, not code baked into a specialised function.
+///
+/// `eof_kind` is the token kind reported past the end of the stream, so a
+/// caller continuation ending in EOF gates correctly. `tokens` is the bare
+/// `kinds` array (`&p.kinds` on the parse side, the scan `kinds` array on the
+/// scan side) — gating only reads token kinds, and a flat `&Array<i32>` keeps
+/// scan frames a slot smaller than the `List` wrapper or `&TokenStream`
+/// would, which matters for deeply recursive scan grammars.
+pub global EMPTY_FOLLOW: List<List<i32>> = [];
+
+/// Prepend a static local prefix to an inherited FOLLOW continuation.
+/// Used for the `FollowArg::Combined` case: a callee at the current
+/// rule's tail whose preceding local suffix is nullable, so its
+/// continuation is `prefix` (the optional local elements' per-depth
+/// first sets) followed by the caller's own `follow`. Bounded by
+/// `FOLLOW_MASK_MAX_K` so the result stays small; the only
+/// allocating point on a repaired path (the common Static/Forward
+/// cases pass a reference directly).
+pub fn follow_prepend(prefix: &List<List<i32>>, follow: &List<List<i32>>) -> List<List<i32>> {
+    let mut combined: List<List<i32>> = [];
+    for let depth of prefix {
+        combined.push(*depth);
+    }
+    for let depth of follow {
+        combined.push(*depth);
+    }
+    return combined;
+}
+
+pub fn follow_yields(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>>, eof_kind: i32) -> bool {
+    if follow.is_empty() {
+        return false;
+    }
+    for let mut d = 0; d < follow.len(); d += 1 {
+        let set = &follow[d];
+        if set.is_empty() {
+            // No constraint at this depth — a vacuous match, keep going.
+            continue;
+        }
+        let idx = pos + d;
+        let kind = if idx < tokens.len() { tokens[idx] } else { eof_kind };
+        let mut hit = false;
+        for let t of set {
+            if kind == *t {
+                hit = true;
+                break;
+            }
+        }
+        if !hit {
+            return false;
+        }
+    }
+    return true;
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+pub global TK_LIT_LPAREN: i32 = 7;
+pub global TK_LIT_RPAREN: i32 = 8;
+pub global TK_LIT_COMMA: i32 = 9;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_lparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '(' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_rparen(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ')' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_comma(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ',' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '(' {
+            end = try_lit_lparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_LPAREN; }
+        } else if first_char == ')' {
+            end = try_lit_rparen(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_RPAREN; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if first_char == ',' {
+            end = try_lit_comma(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_COMMA; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_LPAREN => "TK_LIT_LPAREN",
+        TK_LIT_RPAREN => "TK_LIT_RPAREN",
+        TK_LIT_COMMA => "TK_LIT_COMMA",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_E: NodeKind = 1;
+pub global RK_ELIST: NodeKind = 2;
+
+global RULE_NAMES: List<String> = ["s", "e", "eList"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+pub enum EAlt {
+    Call,
+    Int,
+}
+
+impl CstStore {
+    pub fn e_alt(&self, node: i32) -> Option<EAlt> {
+        return match self.alt(node) {
+            0 => Option::Some(EAlt::Call),
+            1 => Option::Some(EAlt::Int),
+            _ => null,
+        };
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, follow, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_e_atom(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_INT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_e_lr_0(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_LPAREN { return -1; }
+    pos += 1;
+    pos = scan_e_list(tokens, pos, &FOLLOW_MASK_0, 0);
+    if pos < 0 { return -1; }
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_RPAREN { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_e(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_e_atom(tokens, pos, follow);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_LIT_LPAREN {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_e_lr_0(tokens, pos, follow);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn scan_e_list(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_e(tokens, pos, follow, 0);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos] == TK_LIT_COMMA && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+        let sp = pos;
+        sg_0_done: {
+            sg_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_COMMA { break sg_0; }
+                pos += 1;
+                pos = scan_e(tokens, pos, follow, 0);
+                if pos < 0 { break sg_0; }
+                break sg_0_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let r = _parse_e(p, follow);
+    return;
+}
+
+fn _parse_s(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_e__inner_atom(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        p.b.set_alt(1);
+        let int = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected e",
+        p.peek_span(),
+        ["TK_INT"],
+    );
+    return;
+}
+
+fn _parse_e__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> () {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_E, _start);
+    _parse_e__inner_atom(p, follow, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_LIT_LPAREN {
+            if 1 >= min_prec {
+                if scan_e_lr_0(&p.kinds, p.pos, follow) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_E, _start);
+                p.b.set_alt(0);
+                let lparen = p.expect(TK_LIT_LPAREN, &EMPTY_SYNC);
+                let e_list = _parse_e_list(p, &FOLLOW_MASK_0);
+                let rparen = p.expect(TK_LIT_RPAREN, &EMPTY_SYNC);
+                p.b.finish_node(p.last_end());
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return;
+}
+
+fn _parse_e(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> () {
+    if p.recovering { return; }
+    _parse_e__inner(p, follow, min_prec);
+    if p.recovering {
+        p.push_rule_stack("e");
+    }
+}
+
+fn _parse_e_list__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let e = _parse_e(p, follow);
+    loop {
+        if p.recovering { break; }
+        if follow_yields(&p.kinds, p.pos, follow, TK_EOF) { break; }
+        let mut rep_scan_pos: i32 = -1;
+        rep_scan: {
+            let tokens = &p.kinds;
+            let mut pos: i32 = p.pos;
+            sg_1_done: {
+                sg_1: {
+                    if pos >= tokens.len() || tokens[pos] != TK_LIT_COMMA { break sg_1; }
+                    pos += 1;
+                    pos = scan_e(tokens, pos, follow, 0);
+                    if pos < 0 { break sg_1; }
+                    break sg_1_done;
+                }
+                break rep_scan;
+            }
+            if pos <= p.pos { break rep_scan; }
+            rep_scan_pos = pos;
+        }
+        if rep_scan_pos < 0 { break; }
+        let comma = p.expect(TK_LIT_COMMA, &SYNC_0);
+        let e = _parse_e(p, follow);
+    }
+    return;
+}
+
+fn _parse_e_list(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_ELIST, _start);
+    _parse_e_list__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("eList");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_e(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_e(p));
+}
+
+pub fn parse_e_list(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_e_list(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(10);
+    for let mut k = 0; k < 10; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(10);
+    for let mut k = 0; k < 10; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(10);
+    for let mut k = 0; k < 10; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT];
+
+global FOLLOW_MASK_0: List<List<i32>> = [[TK_LIT_RPAREN]];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_1/RuleGetters_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_1/RuleGetters_1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-30239be9065a102b",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/RuleGetters_1.g4",
+    "hash": "ddc38590f35a64a189e937c2aa4aa016a526e2decf03572af3c5ff26acb2d9e6"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_1/t.wado",
+      "hash": "7e74fae53526f6f137ecdd13724113edfe9ac1d0e8e559c9937b8dc23c1e5ce1",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_1/t.wado
@@ -1,0 +1,2124 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/RuleGetters_1.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+pub global RK_B: NodeKind = 2;
+
+global RULE_NAMES: List<String> = ["s", "a", "b"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if _kind_set_0(alt_kind) {
+            let mut best: i32 = -1;
+            pos = start;
+            try_1: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_0: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_b(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    if pos < tokens.len() && _kind_set_0(tokens[pos]) {
+        return pos + 1;
+    }
+    return -1;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner_alt_1(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p);
+    return;
+}
+
+fn _parse_a__inner_scan_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_a__inner_alt_0(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p);
+    let b_2 = _parse_b(p);
+    return;
+}
+
+fn _parse_a__inner_scan_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let kind = p.peek_kind();
+    if _kind_set_0(kind) {
+        if _kind_set_0(p.peek_kind()) {
+            let _sd_tokens = &p.kinds;
+            let _sd_pos = p.pos;
+            let _sd_p_1 = _parse_a__inner_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_0 = _parse_a__inner_scan_0(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 1 {
+                return _parse_a__inner_alt_1(p);
+            }
+            if _sd_best_i == 0 {
+                return _parse_a__inner_alt_0(p);
+            }
+            return _parse_a__inner_alt_0(p);
+        }
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_ID", "TK_INT"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _parse_b__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if _kind_set_0(kind) {
+        let _ = p.expect(kind, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected b",
+        p.peek_span(),
+        ["TK_ID", "TK_INT"],
+    );
+    return;
+}
+
+fn _parse_b(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_B, _start);
+    _parse_b__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("b");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+pub fn parse_b(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_b(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_ID | TK_INT };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_2/RuleGetters_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_2/RuleGetters_2.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-83dee48eed8ba5f7",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/RuleGetters_2.g4",
+    "hash": "ddc38590f35a64a189e937c2aa4aa016a526e2decf03572af3c5ff26acb2d9e6"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_2/t.wado",
+      "hash": "0cf487a4a060434e9ad25bd8411dcc909872013cebe90c4d36cb562537e159a1",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_2/t.wado
@@ -1,0 +1,2124 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/RuleGetters_2.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+pub global RK_B: NodeKind = 2;
+
+global RULE_NAMES: List<String> = ["s", "a", "b"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if _kind_set_0(alt_kind) {
+            let mut best: i32 = -1;
+            pos = start;
+            try_1: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_0: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_b(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    if pos < tokens.len() && _kind_set_0(tokens[pos]) {
+        return pos + 1;
+    }
+    return -1;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner_alt_1(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p);
+    return;
+}
+
+fn _parse_a__inner_scan_1(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_a__inner_alt_0(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p);
+    let b_2 = _parse_b(p);
+    return;
+}
+
+fn _parse_a__inner_scan_0(tokens: &Array<i32>, pos: i32) -> i32 {
+    let mut pos = pos;
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    pos = scan_b(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    return pos;
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let kind = p.peek_kind();
+    if _kind_set_0(kind) {
+        if _kind_set_0(p.peek_kind()) {
+            let _sd_tokens = &p.kinds;
+            let _sd_pos = p.pos;
+            let _sd_p_1 = _parse_a__inner_scan_1(_sd_tokens, _sd_pos);
+            let _sd_p_0 = _parse_a__inner_scan_0(_sd_tokens, _sd_pos);
+            let mut _sd_best_i: i32 = -1;
+            let mut _sd_best_p: i32 = -1;
+            if _sd_p_0 > _sd_best_p {
+                _sd_best_p = _sd_p_0;
+                _sd_best_i = 0;
+            }
+            if _sd_p_1 > _sd_best_p {
+                _sd_best_p = _sd_p_1;
+                _sd_best_i = 1;
+            }
+            if _sd_best_i == 1 {
+                return _parse_a__inner_alt_1(p);
+            }
+            if _sd_best_i == 0 {
+                return _parse_a__inner_alt_0(p);
+            }
+            return _parse_a__inner_alt_0(p);
+        }
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_ID", "TK_INT"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _parse_b__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if _kind_set_0(kind) {
+        let _ = p.expect(kind, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected b",
+        p.peek_span(),
+        ["TK_ID", "TK_INT"],
+    );
+    return;
+}
+
+fn _parse_b(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_B, _start);
+    _parse_b__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("b");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+pub fn parse_b(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_b(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_ID | TK_INT };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_1/TokenGetters_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_1/TokenGetters_1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-84499a2abb159b25",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/TokenGetters_1.g4",
+    "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_1/t.wado",
+      "hash": "30a8f5c06f3409a38c8db4a8a94c719706f57ccc31e5ea8a400531189ae18c8d",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_1/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_1/t.wado
@@ -1,0 +1,2039 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/TokenGetters_1.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_ID {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &SYNC_0);
+        let int_2 = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    if kind == TK_ID {
+        let id = p.expect(TK_ID, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_INT", "TK_ID"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_2/TokenGetters_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_2/TokenGetters_2.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-939d0f890cce06d8",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/Listeners/TokenGetters_2.g4",
+    "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_2/t.wado",
+      "hash": "c4171131a761c5bc71a1cf43ee3dcf2a2b368257e20ec3ab625f64ad021d1be0",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_2/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_2/t.wado
@@ -1,0 +1,2039 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/Listeners/TokenGetters_2.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    MULT,
+    ADD,
+    INT,
+    ID,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_MULT: i32 = 0;
+pub global TK_ADD: i32 = 1;
+pub global TK_INT: i32 = 2;
+pub global TK_ID: i32 = 3;
+pub global TK_WS: i32 = 4;
+pub global TK_EOF: i32 = 5;
+pub global TK_ERROR: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_MULT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '*' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_ADD(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != '+' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { '0'..='9' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() { break rep_0; }
+            if !((chars[pos] matches { '0'..='9' })) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { 'a'..='z' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() { break rep_1; }
+            if !((chars[pos] matches { 'a'..='z' })) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() { return -1; }
+    if !((chars[pos] matches { ' ' | '\t' | '\n' })) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_2 = pos;
+        rep_2: {
+            if pos >= chars.len() { break rep_2; }
+            if !((chars[pos] matches { ' ' | '\t' | '\n' })) { break rep_2; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_2;
+        break;
+    }
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\t' || first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '*' {
+            end = try_MULT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_MULT; }
+        } else if first_char == '+' {
+            end = try_ADD(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ADD; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_MULT => "MULT",
+        TK_ADD => "ADD",
+        TK_INT => "INT",
+        TK_ID => "ID",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_INT {
+            pos = start;
+            try_0: {
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_INT { break try_0; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_ID {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_ID { break try_1; }
+                pos += 1;
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let kind = p.peek_kind();
+    if kind == TK_INT {
+        let int = p.expect(TK_INT, &SYNC_0);
+        let int_2 = p.expect(TK_INT, &EMPTY_SYNC);
+        return;
+    }
+    if kind == TK_ID {
+        let id = p.expect(TK_ID, &EMPTY_SYNC);
+        return;
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_INT", "TK_ID"],
+    );
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_INT];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParseTrees/TokenAndRuleContextString/TokenAndRuleContextString.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParseTrees/TokenAndRuleContextString/TokenAndRuleContextString.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-7200e3cc8fd5d741",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/ParseTrees/TokenAndRuleContextString.g4",
+    "hash": "540d104df0edf2d66917d75620498573de808a49eedf7bd53a96b83c5a5efb11"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/ParseTrees/TokenAndRuleContextString/t.wado",
+      "hash": "5d88a59e738e5fc888098a62222df896841c98e7fd189af73db9685a31523e3e",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParseTrees/TokenAndRuleContextString/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParseTrees/TokenAndRuleContextString/t.wado
@@ -1,0 +1,1906 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/ParseTrees/TokenAndRuleContextString.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    Eof,
+    Error,
+}
+
+pub global TK_EOF: i32 = 0;
+pub global TK_ERROR: i32 = 1;
+pub global TK_LIT_X: i32 = 2;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_lit_x(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'x' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == 'x' {
+            end = try_lit_x(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_X; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = false;
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_X => "TK_LIT_X",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_A: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["s", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_X { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let r = _parse_a(p);
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_a__inner(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let lit_x = p.expect(TK_LIT_X, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_a(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    _parse_a__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_a(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(3);
+    for let mut k = 0; k < 3; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(3);
+    for let mut k = 0; k < 3; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(3);
+    for let mut k = 0; k < 3; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-7d6dcf4d3e116f36",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case1.g4",
+    "hash": "150bd511e2898329b4a1be0d94cbab3775c9d762da1821db48a2acd09867e922"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case1/open_device_statement.wado",
+      "hash": "92414497185d10660f2b4e9cfe580237721f2f43c6adbdb6dbfba96663881b63",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case1/open_device_statement.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case1/open_device_statement.wado
@@ -1,0 +1,2346 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case1.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+//! Runtime FOLLOW-continuation gate for tail-greedy loops. Emitted into a
+//! generated parser only when lowering constructed a caller-FOLLOW gate
+//! (`GenContext::emit_follow`); gate-free grammars carry none of this.
+
+/// `follow` is the caller's deterministic K-prefix continuation:
+/// `follow[d]` is the set of token kinds that may appear at input depth
+/// `d` if control belongs to the caller rather than to another iteration
+/// of the loop. An empty `follow` (the common, non-repair case) disables
+/// the gate. The loop yields to the caller — breaking `*`/`+` or skipping
+/// `?` — exactly when EVERY non-empty depth-set matches the upcoming
+/// input, i.e. when the next tokens are unambiguously the caller's
+/// continuation.
+///
+/// Threaded as a defaulted `&EMPTY_FOLLOW` argument through the generated
+/// `parse_*` / `scan_*` functions; repair call sites pass a `FOLLOW_MASK_*`
+/// constant (or forward their own `follow`). This replaces the previous
+/// per-(rule, mask) cloned `__follow_<id>` variants: the mask is data
+/// carried at runtime, not code baked into a specialised function.
+///
+/// `eof_kind` is the token kind reported past the end of the stream, so a
+/// caller continuation ending in EOF gates correctly. `tokens` is the bare
+/// `kinds` array (`&p.kinds` on the parse side, the scan `kinds` array on the
+/// scan side) — gating only reads token kinds, and a flat `&Array<i32>` keeps
+/// scan frames a slot smaller than the `List` wrapper or `&TokenStream`
+/// would, which matters for deeply recursive scan grammars.
+pub global EMPTY_FOLLOW: List<List<i32>> = [];
+
+/// Prepend a static local prefix to an inherited FOLLOW continuation.
+/// Used for the `FollowArg::Combined` case: a callee at the current
+/// rule's tail whose preceding local suffix is nullable, so its
+/// continuation is `prefix` (the optional local elements' per-depth
+/// first sets) followed by the caller's own `follow`. Bounded by
+/// `FOLLOW_MASK_MAX_K` so the result stays small; the only
+/// allocating point on a repaired path (the common Static/Forward
+/// cases pass a reference directly).
+pub fn follow_prepend(prefix: &List<List<i32>>, follow: &List<List<i32>>) -> List<List<i32>> {
+    let mut combined: List<List<i32>> = [];
+    for let depth of prefix {
+        combined.push(*depth);
+    }
+    for let depth of follow {
+        combined.push(*depth);
+    }
+    return combined;
+}
+
+pub fn follow_yields(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>>, eof_kind: i32) -> bool {
+    if follow.is_empty() {
+        return false;
+    }
+    for let mut d = 0; d < follow.len(); d += 1 {
+        let set = &follow[d];
+        if set.is_empty() {
+            // No constraint at this depth — a vacuous match, keep going.
+            continue;
+        }
+        let idx = pos + d;
+        let kind = if idx < tokens.len() { tokens[idx] } else { eof_kind };
+        let mut hit = false;
+        for let t of set {
+            if kind == *t {
+                hit = true;
+                break;
+            }
+        }
+        if !hit {
+            return false;
+        }
+    }
+    return true;
+}
+pub enum TokenKind {
+    OPT1,
+    OPT2,
+    OPT3,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_OPT1: i32 = 0;
+pub global TK_OPT2: i32 = 1;
+pub global TK_OPT3: i32 = 2;
+pub global TK_WS: i32 = 3;
+pub global TK_EOF: i32 = 4;
+pub global TK_ERROR: i32 = 5;
+pub global TK_LIT_DOT: i32 = 6;
+pub global TK_LIT_OPEN: i32 = 7;
+pub global TK_LIT_DEVICE: i32 = 8;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_OPT1(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '1' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_OPT2(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '2' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_OPT3(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '3' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_1 = pos;
+    let mut alts_ok_1 = false;
+    alts_1_0: {
+        pos = alts_saved_1;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_1_0; }
+        pos += 1;
+        alts_ok_1 = true;
+    }
+    if !alts_ok_1 {
+        alts_1_1: {
+            pos = alts_saved_1;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_1_1; }
+            pos += 1;
+            alts_ok_1 = true;
+        }
+    }
+    if !alts_ok_1 { return -1; }
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            let alts_saved_2 = pos;
+            let mut alts_ok_2 = false;
+            alts_2_0: {
+                pos = alts_saved_2;
+                if pos >= chars.len() || chars[pos] != ' ' { break alts_2_0; }
+                pos += 1;
+                alts_ok_2 = true;
+            }
+            if !alts_ok_2 {
+                alts_2_1: {
+                    pos = alts_saved_2;
+                    if pos >= chars.len() || chars[pos] != '\n' { break alts_2_1; }
+                    pos += 1;
+                    alts_ok_2 = true;
+                }
+            }
+            if !alts_ok_2 { break rep_0; }
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_dot(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '.' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_open(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'O' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'P' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'E' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 'N' { return -1; }
+    return pos + 4;
+}
+
+fn try_lit_device(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'D' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'E' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'V' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 'I' { return -1; }
+    if pos + 4 >= chars.len() || chars[pos + 4] != 'C' { return -1; }
+    if pos + 5 >= chars.len() || chars[pos + 5] != 'E' { return -1; }
+    return pos + 6;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        let mut best_channel: i32 = 0;
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; best_channel = 1; }
+        } else if first_char == '.' {
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; best_channel = 0; }
+        } else if first_char == 'D' {
+            end = try_lit_device(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DEVICE; best_channel = 0; }
+        } else if first_char == 'O' {
+            end = try_lit_open(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_OPEN; best_channel = 0; }
+            end = try_OPT1(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT1; best_channel = 0; }
+            end = try_OPT2(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT2; best_channel = 0; }
+            end = try_OPT3(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT3; best_channel = 0; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = false;
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else if best_channel != 0 {
+                ts.push_trivia(best_kind, tok_start, best_end, best_channel);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_OPT1 => "OPT1",
+        TK_OPT2 => "OPT2",
+        TK_OPT3 => "OPT3",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_DOT => "TK_LIT_DOT",
+        TK_LIT_OPEN => "TK_LIT_OPEN",
+        TK_LIT_DEVICE => "TK_LIT_DEVICE",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_PROGRAM: NodeKind = 0;
+pub global RK_STATEMENT: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["program", "statement"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_program(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos] == TK_LIT_OPEN {
+        let sp = pos;
+        pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_DOT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_statement(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_OPEN { return -1; }
+    pos += 1;
+    sg_0_done: {
+        sg_0: {
+            if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_0; }
+            pos += 1;
+            if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                let sp = pos;
+                let gp_1 = pos;
+                let sgk_1 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                if _kind_set_0(sgk_1) {
+                    sg_1: {
+                        pos = gp_1;
+                        sg_1_0: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_1_0; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = gp_1;
+                        sg_1_1: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_1_1; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = gp_1;
+                        sg_1_2: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_1_2; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = -1;
+                    }
+                } else {
+                    pos = -1;
+                }
+                if pos < 0 { pos = sp; }
+            }
+            break sg_0_done;
+        }
+        return -1;
+    }
+    while pos < tokens.len() && tokens[pos] == TK_LIT_DEVICE && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+        let sp = pos;
+        sg_2_done: {
+            sg_2: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_2; }
+                pos += 1;
+                if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                    let sp = pos;
+                    let gp_3 = pos;
+                    let sgk_3 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                    if _kind_set_0(sgk_3) {
+                        sg_3: {
+                            pos = gp_3;
+                            sg_3_0: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_3_0; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = gp_3;
+                            sg_3_1: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_3_1; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = gp_3;
+                            sg_3_2: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_3_2; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = -1;
+                        }
+                    } else {
+                        pos = -1;
+                    }
+                    if pos < 0 { pos = sp; }
+                }
+                break sg_2_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    return pos;
+}
+
+fn _parse_program__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let mut _plus_first = true;
+    loop {
+        if p.recovering { break; }
+        if !_plus_first {
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.kinds;
+                let mut pos: i32 = p.pos;
+                pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+                if pos < 0 { break rep_scan; }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 {
+                if p.peek_kind() == TK_LIT_OPEN {
+                    let _rec_pos = p.pos;
+                    let _rec_cp = p.b.checkpoint();
+                    let _rec_sav = p.recovering;
+                    let _rec_spec = p.speculating;
+                    p.speculating = true;
+                    _parse_statement(p, &EMPTY_FOLLOW);
+                    p.speculating = _rec_spec;
+                    p.recovering = _rec_sav;
+                    p.pos = _rec_pos;
+                    p.b.truncate(_rec_cp);
+                }
+                break;
+            }
+        }
+        _plus_first = false;
+        let statement = _parse_statement(p, &EMPTY_FOLLOW);
+    }
+    let dot = p.expect(TK_LIT_DOT, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_program(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_PROGRAM, _start);
+    _parse_program__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("program");
+    }
+}
+
+fn _parse_statement__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let _rule_start_tok = p.pos;
+    let lit_open = p.expect(TK_LIT_OPEN, &SYNC_0);
+    let mut _plus_first = true;
+    loop {
+        if p.recovering { break; }
+        if !_plus_first {
+            if follow_yields(&p.kinds, p.pos, follow, TK_EOF) { break; }
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.kinds;
+                let mut pos: i32 = p.pos;
+                sg_4_done: {
+                    sg_4: {
+                        if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_4; }
+                        pos += 1;
+                        if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                            let sp = pos;
+                            let gp_5 = pos;
+                            let sgk_5 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                            if _kind_set_0(sgk_5) {
+                                sg_5: {
+                                    pos = gp_5;
+                                    sg_5_0: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_5_0; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = gp_5;
+                                    sg_5_1: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_5_1; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = gp_5;
+                                    sg_5_2: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_5_2; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = -1;
+                                }
+                            } else {
+                                pos = -1;
+                            }
+                            if pos < 0 { pos = sp; }
+                        }
+                        break sg_4_done;
+                    }
+                    break rep_scan;
+                }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+        }
+        _plus_first = false;
+        let lit_device = p.expect(TK_LIT_DEVICE, &SYNC_1);
+        let mut opt_scan_pos: i32 = -1;
+        opt_scan: {
+            let tokens = &p.kinds;
+            let mut pos: i32 = p.pos;
+            let gp_6 = pos;
+            let sgk_6 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+            if _kind_set_0(sgk_6) {
+                sg_6: {
+                    pos = gp_6;
+                    sg_6_0: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_6_0; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    pos = gp_6;
+                    sg_6_1: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_6_1; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    pos = gp_6;
+                    sg_6_2: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_6_2; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    break opt_scan;
+                }
+            } else {
+                break opt_scan;
+            }
+            opt_scan_pos = pos;
+        }
+        if !(follow_yields(&p.kinds, p.pos, follow, TK_EOF)) && (opt_scan_pos >= 0) {
+            let opt1_or_opt2_or_opt3 = p.expect_set([TK_OPT1, TK_OPT2, TK_OPT3]);
+        }
+    }
+    if !p.speculating {
+        p.emit(`${p.rule_text(_rule_start_tok)}\n`);
+    }
+    return;
+}
+
+fn _parse_statement(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_STATEMENT, _start);
+    _parse_statement__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("statement");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_program(input, max_errors);
+}
+
+pub fn parse_program(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_program(p));
+}
+
+pub fn parse_statement(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_statement(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_OPT1 | TK_OPT2 | TK_OPT3 };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_DEVICE];
+global SYNC_1: List<i32> = [TK_OPT1, TK_OPT2, TK_OPT3];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-7eaca01e9531e506",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case2.g4",
+    "hash": "09b70ed5e0fe15e7bca784b725980f263bcfd0da3a8f9108d60bbeb4a7b7ef5c"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case2/open_device_statement.wado",
+      "hash": "c555ec0e5ec37c849387a8b69ea47ee80b9d9505a4a5ae18da495e7d7faae495",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case2/open_device_statement.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case2/open_device_statement.wado
@@ -1,0 +1,2352 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case2.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+//! Runtime FOLLOW-continuation gate for tail-greedy loops. Emitted into a
+//! generated parser only when lowering constructed a caller-FOLLOW gate
+//! (`GenContext::emit_follow`); gate-free grammars carry none of this.
+
+/// `follow` is the caller's deterministic K-prefix continuation:
+/// `follow[d]` is the set of token kinds that may appear at input depth
+/// `d` if control belongs to the caller rather than to another iteration
+/// of the loop. An empty `follow` (the common, non-repair case) disables
+/// the gate. The loop yields to the caller — breaking `*`/`+` or skipping
+/// `?` — exactly when EVERY non-empty depth-set matches the upcoming
+/// input, i.e. when the next tokens are unambiguously the caller's
+/// continuation.
+///
+/// Threaded as a defaulted `&EMPTY_FOLLOW` argument through the generated
+/// `parse_*` / `scan_*` functions; repair call sites pass a `FOLLOW_MASK_*`
+/// constant (or forward their own `follow`). This replaces the previous
+/// per-(rule, mask) cloned `__follow_<id>` variants: the mask is data
+/// carried at runtime, not code baked into a specialised function.
+///
+/// `eof_kind` is the token kind reported past the end of the stream, so a
+/// caller continuation ending in EOF gates correctly. `tokens` is the bare
+/// `kinds` array (`&p.kinds` on the parse side, the scan `kinds` array on the
+/// scan side) — gating only reads token kinds, and a flat `&Array<i32>` keeps
+/// scan frames a slot smaller than the `List` wrapper or `&TokenStream`
+/// would, which matters for deeply recursive scan grammars.
+pub global EMPTY_FOLLOW: List<List<i32>> = [];
+
+/// Prepend a static local prefix to an inherited FOLLOW continuation.
+/// Used for the `FollowArg::Combined` case: a callee at the current
+/// rule's tail whose preceding local suffix is nullable, so its
+/// continuation is `prefix` (the optional local elements' per-depth
+/// first sets) followed by the caller's own `follow`. Bounded by
+/// `FOLLOW_MASK_MAX_K` so the result stays small; the only
+/// allocating point on a repaired path (the common Static/Forward
+/// cases pass a reference directly).
+pub fn follow_prepend(prefix: &List<List<i32>>, follow: &List<List<i32>>) -> List<List<i32>> {
+    let mut combined: List<List<i32>> = [];
+    for let depth of prefix {
+        combined.push(*depth);
+    }
+    for let depth of follow {
+        combined.push(*depth);
+    }
+    return combined;
+}
+
+pub fn follow_yields(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>>, eof_kind: i32) -> bool {
+    if follow.is_empty() {
+        return false;
+    }
+    for let mut d = 0; d < follow.len(); d += 1 {
+        let set = &follow[d];
+        if set.is_empty() {
+            // No constraint at this depth — a vacuous match, keep going.
+            continue;
+        }
+        let idx = pos + d;
+        let kind = if idx < tokens.len() { tokens[idx] } else { eof_kind };
+        let mut hit = false;
+        for let t of set {
+            if kind == *t {
+                hit = true;
+                break;
+            }
+        }
+        if !hit {
+            return false;
+        }
+    }
+    return true;
+}
+pub enum TokenKind {
+    OPT1,
+    OPT2,
+    OPT3,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_OPT1: i32 = 0;
+pub global TK_OPT2: i32 = 1;
+pub global TK_OPT3: i32 = 2;
+pub global TK_WS: i32 = 3;
+pub global TK_EOF: i32 = 4;
+pub global TK_ERROR: i32 = 5;
+pub global TK_LIT_DOT: i32 = 6;
+pub global TK_LIT_OPEN: i32 = 7;
+pub global TK_LIT_DEVICE: i32 = 8;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_OPT1(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '1' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_OPT2(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '2' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_OPT3(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '3' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_1 = pos;
+    let mut alts_ok_1 = false;
+    alts_1_0: {
+        pos = alts_saved_1;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_1_0; }
+        pos += 1;
+        alts_ok_1 = true;
+    }
+    if !alts_ok_1 {
+        alts_1_1: {
+            pos = alts_saved_1;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_1_1; }
+            pos += 1;
+            alts_ok_1 = true;
+        }
+    }
+    if !alts_ok_1 { return -1; }
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            let alts_saved_2 = pos;
+            let mut alts_ok_2 = false;
+            alts_2_0: {
+                pos = alts_saved_2;
+                if pos >= chars.len() || chars[pos] != ' ' { break alts_2_0; }
+                pos += 1;
+                alts_ok_2 = true;
+            }
+            if !alts_ok_2 {
+                alts_2_1: {
+                    pos = alts_saved_2;
+                    if pos >= chars.len() || chars[pos] != '\n' { break alts_2_1; }
+                    pos += 1;
+                    alts_ok_2 = true;
+                }
+            }
+            if !alts_ok_2 { break rep_0; }
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_dot(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '.' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_open(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'O' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'P' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'E' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 'N' { return -1; }
+    return pos + 4;
+}
+
+fn try_lit_device(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'D' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'E' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'V' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 'I' { return -1; }
+    if pos + 4 >= chars.len() || chars[pos + 4] != 'C' { return -1; }
+    if pos + 5 >= chars.len() || chars[pos + 5] != 'E' { return -1; }
+    return pos + 6;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        let mut best_channel: i32 = 0;
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; best_channel = 1; }
+        } else if first_char == '.' {
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; best_channel = 0; }
+        } else if first_char == 'D' {
+            end = try_lit_device(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DEVICE; best_channel = 0; }
+        } else if first_char == 'O' {
+            end = try_lit_open(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_OPEN; best_channel = 0; }
+            end = try_OPT1(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT1; best_channel = 0; }
+            end = try_OPT2(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT2; best_channel = 0; }
+            end = try_OPT3(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT3; best_channel = 0; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = false;
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else if best_channel != 0 {
+                ts.push_trivia(best_kind, tok_start, best_end, best_channel);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_OPT1 => "OPT1",
+        TK_OPT2 => "OPT2",
+        TK_OPT3 => "OPT3",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_DOT => "TK_LIT_DOT",
+        TK_LIT_OPEN => "TK_LIT_OPEN",
+        TK_LIT_DEVICE => "TK_LIT_DEVICE",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_PROGRAM: NodeKind = 0;
+pub global RK_STATEMENT: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["program", "statement"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_program(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos] == TK_LIT_OPEN {
+        let sp = pos;
+        pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_DOT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_statement(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_OPEN { return -1; }
+    pos += 1;
+    sg_0_done: {
+        sg_0: {
+            if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_0; }
+            pos += 1;
+            if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                let sp = pos;
+                let gp_1 = pos;
+                let sgk_1 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                if _kind_set_0(sgk_1) {
+                    sg_1: {
+                        pos = gp_1;
+                        sg_1_0: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_1_0; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = gp_1;
+                        sg_1_1: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_1_1; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = gp_1;
+                        sg_1_2: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_1_2; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = -1;
+                    }
+                } else {
+                    pos = -1;
+                }
+                if pos < 0 { pos = sp; }
+            }
+            break sg_0_done;
+        }
+        return -1;
+    }
+    while pos < tokens.len() && tokens[pos] == TK_LIT_DEVICE && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+        let sp = pos;
+        sg_2_done: {
+            sg_2: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_2; }
+                pos += 1;
+                if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                    let sp = pos;
+                    let gp_3 = pos;
+                    let sgk_3 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                    if _kind_set_0(sgk_3) {
+                        sg_3: {
+                            pos = gp_3;
+                            sg_3_0: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_3_0; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = gp_3;
+                            sg_3_1: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_3_1; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = gp_3;
+                            sg_3_2: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_3_2; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = -1;
+                        }
+                    } else {
+                        pos = -1;
+                    }
+                    if pos < 0 { pos = sp; }
+                }
+                break sg_2_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    return pos;
+}
+
+fn _parse_program__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let mut _plus_first = true;
+    loop {
+        if p.recovering { break; }
+        if !_plus_first {
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.kinds;
+                let mut pos: i32 = p.pos;
+                pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+                if pos < 0 { break rep_scan; }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 {
+                if p.peek_kind() == TK_LIT_OPEN {
+                    let _rec_pos = p.pos;
+                    let _rec_cp = p.b.checkpoint();
+                    let _rec_sav = p.recovering;
+                    let _rec_spec = p.speculating;
+                    p.speculating = true;
+                    _parse_statement(p, &EMPTY_FOLLOW);
+                    p.speculating = _rec_spec;
+                    p.recovering = _rec_sav;
+                    p.pos = _rec_pos;
+                    p.b.truncate(_rec_cp);
+                }
+                break;
+            }
+        }
+        _plus_first = false;
+        let statement = _parse_statement(p, &EMPTY_FOLLOW);
+    }
+    let dot = p.expect(TK_LIT_DOT, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_program(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_PROGRAM, _start);
+    _parse_program__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("program");
+    }
+}
+
+fn _parse_statement__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let _rule_start_tok = p.pos;
+    let lit_open = p.expect(TK_LIT_OPEN, &SYNC_0);
+    let mut _plus_first = true;
+    loop {
+        if p.recovering { break; }
+        if !_plus_first {
+            if follow_yields(&p.kinds, p.pos, follow, TK_EOF) { break; }
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.kinds;
+                let mut pos: i32 = p.pos;
+                sg_4_done: {
+                    sg_4: {
+                        if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_4; }
+                        pos += 1;
+                        if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                            let sp = pos;
+                            let gp_5 = pos;
+                            let sgk_5 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                            if _kind_set_0(sgk_5) {
+                                sg_5: {
+                                    pos = gp_5;
+                                    sg_5_0: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_5_0; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = gp_5;
+                                    sg_5_1: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_5_1; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = gp_5;
+                                    sg_5_2: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_5_2; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = -1;
+                                }
+                            } else {
+                                pos = -1;
+                            }
+                            if pos < 0 { pos = sp; }
+                        }
+                        break sg_4_done;
+                    }
+                    break rep_scan;
+                }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+        }
+        _plus_first = false;
+        let lit_device = p.expect(TK_LIT_DEVICE, &SYNC_1);
+        let mut opt_scan_pos: i32 = -1;
+        opt_scan: {
+            let tokens = &p.kinds;
+            let mut pos: i32 = p.pos;
+            let gp_6 = pos;
+            let sgk_6 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+            if _kind_set_0(sgk_6) {
+                sg_6: {
+                    pos = gp_6;
+                    sg_6_0: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_6_0; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    pos = gp_6;
+                    sg_6_1: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_6_1; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    pos = gp_6;
+                    sg_6_2: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_6_2; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    break opt_scan;
+                }
+            } else {
+                break opt_scan;
+            }
+            opt_scan_pos = pos;
+        }
+        if !(follow_yields(&p.kinds, p.pos, follow, TK_EOF)) && (opt_scan_pos >= 0) {
+            if p.peek_kind() == TK_OPT1 {
+                let opt1 = p.expect(TK_OPT1, &EMPTY_SYNC);
+            } else if p.peek_kind() == TK_OPT2 {
+                let opt2 = p.expect(TK_OPT2, &EMPTY_SYNC);
+            } else {
+                let opt3 = p.expect(TK_OPT3, &EMPTY_SYNC);
+            }
+        }
+    }
+    if !p.speculating {
+        p.emit(`${p.rule_text(_rule_start_tok)}\n`);
+    }
+    return;
+}
+
+fn _parse_statement(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_STATEMENT, _start);
+    _parse_statement__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("statement");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_program(input, max_errors);
+}
+
+pub fn parse_program(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_program(p));
+}
+
+pub fn parse_statement(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_statement(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_OPT1 | TK_OPT2 | TK_OPT3 };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_DEVICE];
+global SYNC_1: List<i32> = [TK_OPT1, TK_OPT2, TK_OPT3];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-ecedd277b785d87e",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case3.g4",
+    "hash": "09b70ed5e0fe15e7bca784b725980f263bcfd0da3a8f9108d60bbeb4a7b7ef5c"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case3/open_device_statement.wado",
+      "hash": "b7720479ea3e38a322ea88f3756f0625afcaa73faa8590a22b3ef2405219e7e1",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case3/open_device_statement.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case3/open_device_statement.wado
@@ -1,0 +1,2352 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case3.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+//! Runtime FOLLOW-continuation gate for tail-greedy loops. Emitted into a
+//! generated parser only when lowering constructed a caller-FOLLOW gate
+//! (`GenContext::emit_follow`); gate-free grammars carry none of this.
+
+/// `follow` is the caller's deterministic K-prefix continuation:
+/// `follow[d]` is the set of token kinds that may appear at input depth
+/// `d` if control belongs to the caller rather than to another iteration
+/// of the loop. An empty `follow` (the common, non-repair case) disables
+/// the gate. The loop yields to the caller — breaking `*`/`+` or skipping
+/// `?` — exactly when EVERY non-empty depth-set matches the upcoming
+/// input, i.e. when the next tokens are unambiguously the caller's
+/// continuation.
+///
+/// Threaded as a defaulted `&EMPTY_FOLLOW` argument through the generated
+/// `parse_*` / `scan_*` functions; repair call sites pass a `FOLLOW_MASK_*`
+/// constant (or forward their own `follow`). This replaces the previous
+/// per-(rule, mask) cloned `__follow_<id>` variants: the mask is data
+/// carried at runtime, not code baked into a specialised function.
+///
+/// `eof_kind` is the token kind reported past the end of the stream, so a
+/// caller continuation ending in EOF gates correctly. `tokens` is the bare
+/// `kinds` array (`&p.kinds` on the parse side, the scan `kinds` array on the
+/// scan side) — gating only reads token kinds, and a flat `&Array<i32>` keeps
+/// scan frames a slot smaller than the `List` wrapper or `&TokenStream`
+/// would, which matters for deeply recursive scan grammars.
+pub global EMPTY_FOLLOW: List<List<i32>> = [];
+
+/// Prepend a static local prefix to an inherited FOLLOW continuation.
+/// Used for the `FollowArg::Combined` case: a callee at the current
+/// rule's tail whose preceding local suffix is nullable, so its
+/// continuation is `prefix` (the optional local elements' per-depth
+/// first sets) followed by the caller's own `follow`. Bounded by
+/// `FOLLOW_MASK_MAX_K` so the result stays small; the only
+/// allocating point on a repaired path (the common Static/Forward
+/// cases pass a reference directly).
+pub fn follow_prepend(prefix: &List<List<i32>>, follow: &List<List<i32>>) -> List<List<i32>> {
+    let mut combined: List<List<i32>> = [];
+    for let depth of prefix {
+        combined.push(*depth);
+    }
+    for let depth of follow {
+        combined.push(*depth);
+    }
+    return combined;
+}
+
+pub fn follow_yields(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>>, eof_kind: i32) -> bool {
+    if follow.is_empty() {
+        return false;
+    }
+    for let mut d = 0; d < follow.len(); d += 1 {
+        let set = &follow[d];
+        if set.is_empty() {
+            // No constraint at this depth — a vacuous match, keep going.
+            continue;
+        }
+        let idx = pos + d;
+        let kind = if idx < tokens.len() { tokens[idx] } else { eof_kind };
+        let mut hit = false;
+        for let t of set {
+            if kind == *t {
+                hit = true;
+                break;
+            }
+        }
+        if !hit {
+            return false;
+        }
+    }
+    return true;
+}
+pub enum TokenKind {
+    OPT1,
+    OPT2,
+    OPT3,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_OPT1: i32 = 0;
+pub global TK_OPT2: i32 = 1;
+pub global TK_OPT3: i32 = 2;
+pub global TK_WS: i32 = 3;
+pub global TK_EOF: i32 = 4;
+pub global TK_ERROR: i32 = 5;
+pub global TK_LIT_DOT: i32 = 6;
+pub global TK_LIT_OPEN: i32 = 7;
+pub global TK_LIT_DEVICE: i32 = 8;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_OPT1(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '1' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_OPT2(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '2' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_OPT3(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'O' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'P' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'T' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '-' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != '3' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_1 = pos;
+    let mut alts_ok_1 = false;
+    alts_1_0: {
+        pos = alts_saved_1;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_1_0; }
+        pos += 1;
+        alts_ok_1 = true;
+    }
+    if !alts_ok_1 {
+        alts_1_1: {
+            pos = alts_saved_1;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_1_1; }
+            pos += 1;
+            alts_ok_1 = true;
+        }
+    }
+    if !alts_ok_1 { return -1; }
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            let alts_saved_2 = pos;
+            let mut alts_ok_2 = false;
+            alts_2_0: {
+                pos = alts_saved_2;
+                if pos >= chars.len() || chars[pos] != ' ' { break alts_2_0; }
+                pos += 1;
+                alts_ok_2 = true;
+            }
+            if !alts_ok_2 {
+                alts_2_1: {
+                    pos = alts_saved_2;
+                    if pos >= chars.len() || chars[pos] != '\n' { break alts_2_1; }
+                    pos += 1;
+                    alts_ok_2 = true;
+                }
+            }
+            if !alts_ok_2 { break rep_0; }
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_lit_dot(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '.' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_open(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'O' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'P' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'E' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 'N' { return -1; }
+    return pos + 4;
+}
+
+fn try_lit_device(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != 'D' { return -1; }
+    if pos + 1 >= chars.len() || chars[pos + 1] != 'E' { return -1; }
+    if pos + 2 >= chars.len() || chars[pos + 2] != 'V' { return -1; }
+    if pos + 3 >= chars.len() || chars[pos + 3] != 'I' { return -1; }
+    if pos + 4 >= chars.len() || chars[pos + 4] != 'C' { return -1; }
+    if pos + 5 >= chars.len() || chars[pos + 5] != 'E' { return -1; }
+    return pos + 6;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        let mut best_channel: i32 = 0;
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; best_channel = 1; }
+        } else if first_char == '.' {
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; best_channel = 0; }
+        } else if first_char == 'D' {
+            end = try_lit_device(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DEVICE; best_channel = 0; }
+        } else if first_char == 'O' {
+            end = try_lit_open(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_OPEN; best_channel = 0; }
+            end = try_OPT1(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT1; best_channel = 0; }
+            end = try_OPT2(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT2; best_channel = 0; }
+            end = try_OPT3(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_OPT3; best_channel = 0; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = false;
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else if best_channel != 0 {
+                ts.push_trivia(best_kind, tok_start, best_end, best_channel);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_OPT1 => "OPT1",
+        TK_OPT2 => "OPT2",
+        TK_OPT3 => "OPT3",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_DOT => "TK_LIT_DOT",
+        TK_LIT_OPEN => "TK_LIT_OPEN",
+        TK_LIT_DEVICE => "TK_LIT_DEVICE",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_PROGRAM: NodeKind = 0;
+pub global RK_STATEMENT: NodeKind = 1;
+
+global RULE_NAMES: List<String> = ["program", "statement"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+fn scan_program(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && tokens[pos] == TK_LIT_OPEN {
+        let sp = pos;
+        pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_DOT { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_statement(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_LIT_OPEN { return -1; }
+    pos += 1;
+    sg_0_done: {
+        sg_0: {
+            if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_0; }
+            pos += 1;
+            if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                let sp = pos;
+                let gp_1 = pos;
+                let sgk_1 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                if _kind_set_0(sgk_1) {
+                    sg_1: {
+                        pos = gp_1;
+                        sg_1_0: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_1_0; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = gp_1;
+                        sg_1_1: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_1_1; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = gp_1;
+                        sg_1_2: {
+                            if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_1_2; }
+                            pos += 1;
+                            break sg_1;
+                        }
+                        pos = -1;
+                    }
+                } else {
+                    pos = -1;
+                }
+                if pos < 0 { pos = sp; }
+            }
+            break sg_0_done;
+        }
+        return -1;
+    }
+    while pos < tokens.len() && tokens[pos] == TK_LIT_DEVICE && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+        let sp = pos;
+        sg_2_done: {
+            sg_2: {
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_2; }
+                pos += 1;
+                if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                    let sp = pos;
+                    let gp_3 = pos;
+                    let sgk_3 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                    if _kind_set_0(sgk_3) {
+                        sg_3: {
+                            pos = gp_3;
+                            sg_3_0: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_3_0; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = gp_3;
+                            sg_3_1: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_3_1; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = gp_3;
+                            sg_3_2: {
+                                if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_3_2; }
+                                pos += 1;
+                                break sg_3;
+                            }
+                            pos = -1;
+                        }
+                    } else {
+                        pos = -1;
+                    }
+                    if pos < 0 { pos = sp; }
+                }
+                break sg_2_done;
+            }
+            pos = -1;
+        }
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    return pos;
+}
+
+fn _parse_program__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let mut _plus_first = true;
+    loop {
+        if p.recovering { break; }
+        if !_plus_first {
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.kinds;
+                let mut pos: i32 = p.pos;
+                pos = scan_statement(tokens, pos, &EMPTY_FOLLOW, 0);
+                if pos < 0 { break rep_scan; }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 {
+                if p.peek_kind() == TK_LIT_OPEN {
+                    let _rec_pos = p.pos;
+                    let _rec_cp = p.b.checkpoint();
+                    let _rec_sav = p.recovering;
+                    let _rec_spec = p.speculating;
+                    p.speculating = true;
+                    _parse_statement(p, &EMPTY_FOLLOW);
+                    p.speculating = _rec_spec;
+                    p.recovering = _rec_sav;
+                    p.pos = _rec_pos;
+                    p.b.truncate(_rec_cp);
+                }
+                break;
+            }
+        }
+        _plus_first = false;
+        let statement = _parse_statement(p, &EMPTY_FOLLOW);
+    }
+    let dot = p.expect(TK_LIT_DOT, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_program(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_PROGRAM, _start);
+    _parse_program__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("program");
+    }
+}
+
+fn _parse_statement__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let _rule_start_tok = p.pos;
+    let lit_open = p.expect(TK_LIT_OPEN, &SYNC_0);
+    let mut _plus_first = true;
+    loop {
+        if p.recovering { break; }
+        if !_plus_first {
+            if follow_yields(&p.kinds, p.pos, follow, TK_EOF) { break; }
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.kinds;
+                let mut pos: i32 = p.pos;
+                sg_4_done: {
+                    sg_4: {
+                        if pos >= tokens.len() || tokens[pos] != TK_LIT_DEVICE { break sg_4; }
+                        pos += 1;
+                        if pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                            let sp = pos;
+                            let gp_5 = pos;
+                            let sgk_5 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                            if _kind_set_0(sgk_5) {
+                                sg_5: {
+                                    pos = gp_5;
+                                    sg_5_0: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_5_0; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = gp_5;
+                                    sg_5_1: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_5_1; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = gp_5;
+                                    sg_5_2: {
+                                        if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_5_2; }
+                                        pos += 1;
+                                        break sg_5;
+                                    }
+                                    pos = -1;
+                                }
+                            } else {
+                                pos = -1;
+                            }
+                            if pos < 0 { pos = sp; }
+                        }
+                        break sg_4_done;
+                    }
+                    break rep_scan;
+                }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+        }
+        _plus_first = false;
+        let lit_device = p.expect(TK_LIT_DEVICE, &SYNC_1);
+        let mut opt_scan_pos: i32 = -1;
+        opt_scan: {
+            let tokens = &p.kinds;
+            let mut pos: i32 = p.pos;
+            let gp_6 = pos;
+            let sgk_6 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+            if _kind_set_0(sgk_6) {
+                sg_6: {
+                    pos = gp_6;
+                    sg_6_0: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT1 { break sg_6_0; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    pos = gp_6;
+                    sg_6_1: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT2 { break sg_6_1; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    pos = gp_6;
+                    sg_6_2: {
+                        if pos >= tokens.len() || tokens[pos] != TK_OPT3 { break sg_6_2; }
+                        pos += 1;
+                        break sg_6;
+                    }
+                    break opt_scan;
+                }
+            } else {
+                break opt_scan;
+            }
+            opt_scan_pos = pos;
+        }
+        if !(follow_yields(&p.kinds, p.pos, follow, TK_EOF)) && (opt_scan_pos >= 0) {
+            if p.peek_kind() == TK_OPT1 {
+                let opt1 = p.expect(TK_OPT1, &EMPTY_SYNC);
+            } else if p.peek_kind() == TK_OPT2 {
+                let opt2 = p.expect(TK_OPT2, &EMPTY_SYNC);
+            } else {
+                let opt3 = p.expect(TK_OPT3, &EMPTY_SYNC);
+            }
+        }
+    }
+    if !p.speculating {
+        p.emit(`${p.rule_text(_rule_start_tok)}\n`);
+    }
+    return;
+}
+
+fn _parse_statement(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_STATEMENT, _start);
+    _parse_statement__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("statement");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_program(input, max_errors);
+}
+
+pub fn parse_program(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_program(p));
+}
+
+pub fn parse_statement(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_statement(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(9);
+    for let mut k = 0; k < 9; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_OPT1 | TK_OPT2 | TK_OPT3 };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_LIT_DEVICE];
+global SYNC_1: List<i32> = [TK_OPT1, TK_OPT2, TK_OPT3];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-fe600c4e82ebbc18",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/ParserExec/ReservedWordsEscaping.g4",
+    "hash": "1255013e85ee5370b81b22637b60dcc49fe82706c1f6a539154d35e5cd605b9e"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/ParserExec/ReservedWordsEscaping/g.wado",
+      "hash": "99e21ec23c51692b2a16d7d8381af7d81ddd5c7bc3b59c96bcf2743313edfc48",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReservedWordsEscaping/g.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReservedWordsEscaping/g.wado
@@ -1,0 +1,2401 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/ParserExec/ReservedWordsEscaping.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+//! Runtime FOLLOW-continuation gate for tail-greedy loops. Emitted into a
+//! generated parser only when lowering constructed a caller-FOLLOW gate
+//! (`GenContext::emit_follow`); gate-free grammars carry none of this.
+
+/// `follow` is the caller's deterministic K-prefix continuation:
+/// `follow[d]` is the set of token kinds that may appear at input depth
+/// `d` if control belongs to the caller rather than to another iteration
+/// of the loop. An empty `follow` (the common, non-repair case) disables
+/// the gate. The loop yields to the caller — breaking `*`/`+` or skipping
+/// `?` — exactly when EVERY non-empty depth-set matches the upcoming
+/// input, i.e. when the next tokens are unambiguously the caller's
+/// continuation.
+///
+/// Threaded as a defaulted `&EMPTY_FOLLOW` argument through the generated
+/// `parse_*` / `scan_*` functions; repair call sites pass a `FOLLOW_MASK_*`
+/// constant (or forward their own `follow`). This replaces the previous
+/// per-(rule, mask) cloned `__follow_<id>` variants: the mask is data
+/// carried at runtime, not code baked into a specialised function.
+///
+/// `eof_kind` is the token kind reported past the end of the stream, so a
+/// caller continuation ending in EOF gates correctly. `tokens` is the bare
+/// `kinds` array (`&p.kinds` on the parse side, the scan `kinds` array on the
+/// scan side) — gating only reads token kinds, and a flat `&Array<i32>` keeps
+/// scan frames a slot smaller than the `List` wrapper or `&TokenStream`
+/// would, which matters for deeply recursive scan grammars.
+pub global EMPTY_FOLLOW: List<List<i32>> = [];
+
+/// Prepend a static local prefix to an inherited FOLLOW continuation.
+/// Used for the `FollowArg::Combined` case: a callee at the current
+/// rule's tail whose preceding local suffix is nullable, so its
+/// continuation is `prefix` (the optional local elements' per-depth
+/// first sets) followed by the caller's own `follow`. Bounded by
+/// `FOLLOW_MASK_MAX_K` so the result stays small; the only
+/// allocating point on a repaired path (the common Static/Forward
+/// cases pass a reference directly).
+pub fn follow_prepend(prefix: &List<List<i32>>, follow: &List<List<i32>>) -> List<List<i32>> {
+    let mut combined: List<List<i32>> = [];
+    for let depth of prefix {
+        combined.push(*depth);
+    }
+    for let depth of follow {
+        combined.push(*depth);
+    }
+    return combined;
+}
+
+pub fn follow_yields(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>>, eof_kind: i32) -> bool {
+    if follow.is_empty() {
+        return false;
+    }
+    for let mut d = 0; d < follow.len(); d += 1 {
+        let set = &follow[d];
+        if set.is_empty() {
+            // No constraint at this depth — a vacuous match, keep going.
+            continue;
+        }
+        let idx = pos + d;
+        let kind = if idx < tokens.len() { tokens[idx] } else { eof_kind };
+        let mut hit = false;
+        for let t of set {
+            if kind == *t {
+                hit = true;
+                break;
+            }
+        }
+        if !hit {
+            return false;
+        }
+    }
+    return true;
+}
+pub enum TokenKind {
+    FOR,
+    BREAK,
+    IF,
+    CONTINUE_,
+    Eof,
+    Error,
+}
+
+pub global TK_FOR: i32 = 0;
+pub global TK_BREAK: i32 = 1;
+pub global TK_IF: i32 = 2;
+pub global TK_CONTINUE_: i32 = 3;
+pub global TK_EOF: i32 = 4;
+pub global TK_ERROR: i32 = 5;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_FOR(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'f' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'o' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'r' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != ' ' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_BREAK(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'b' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'r' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'a' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'k' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != ' ' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_IF(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'i' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'f' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != ' ' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn try_CONTINUE_(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || chars[pos] != 'c' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'o' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'n' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 't' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'i' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'n' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'u' { return -1; }
+    pos += 1;
+    if pos >= chars.len() || chars[pos] != 'e' { return -1; }
+    pos += 1;
+    return pos;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == 'b' {
+            end = try_BREAK(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_BREAK; }
+        } else if first_char == 'c' {
+            end = try_CONTINUE_(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_CONTINUE_; }
+        } else if first_char == 'f' {
+            end = try_FOR(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_FOR; }
+        } else if first_char == 'i' {
+            end = try_IF(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_IF; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = false;
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_FOR => "FOR",
+        TK_BREAK => "BREAK",
+        TK_IF => "IF",
+        TK_CONTINUE_ => "CONTINUE_",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_ROOT: NodeKind = 0;
+pub global RK_CONTINUE: NodeKind = 1;
+pub global RK_ARGS: NodeKind = 2;
+pub global RK_FOR: NodeKind = 3;
+
+global RULE_NAMES: List<String> = ["root", "continue", "args", "for"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+pub enum ContinueAlt {
+    else_,
+    int,
+    class,
+}
+
+impl CstStore {
+    pub fn continue_alt(&self, node: i32) -> Option<ContinueAlt> {
+        return match self.alt(node) {
+            0 => Option::Some(ContinueAlt::else_),
+            1 => Option::Some(ContinueAlt::else_),
+            2 => Option::Some(ContinueAlt::int),
+            3 => Option::Some(ContinueAlt::class),
+            _ => null,
+        };
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct ContinueVals {
+    return: i32 = 0,
+}
+
+struct ArgsVals {
+    else: i32 = 0,
+    return: i32 = 0,
+}
+
+fn scan_root(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_continue(tokens, pos, &EMPTY_FOLLOW, 0);
+    if pos < 0 { return -1; }
+    while pos < tokens.len() && _kind_set_0(tokens[pos]) && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+        let sp = pos;
+        pos = scan_continue(tokens, pos, &EMPTY_FOLLOW, 0);
+        if pos < 0 { pos = sp; break; }
+        if pos == sp { break; }
+    }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_continue_atom(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_FOR {
+            pos = start;
+            try_0: {
+                pos = scan_for(tokens, pos, &follow_prepend(&FOLLOW_MASK_0, follow), 0);
+                if pos < 0 { break try_0; }
+                if pos < tokens.len() && tokens[pos] == TK_FOR && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                    let sp = pos;
+                    pos = scan_for(tokens, pos, &EMPTY_FOLLOW, 0);
+                    if pos < 0 { pos = sp; }
+                }
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_BREAK {
+            pos = start;
+            try_1: {
+                if pos >= tokens.len() || tokens[pos] != TK_BREAK { break try_1; }
+                pos += 1;
+                if pos >= tokens.len() || tokens[pos] != TK_BREAK { break try_1; }
+                pos += 1;
+                while pos < tokens.len() && tokens[pos] == TK_BREAK {
+                    let sp = pos;
+                    if pos >= tokens.len() || tokens[pos] != TK_BREAK { pos = -1; } else { pos += 1; }
+                    if pos < 0 { pos = sp; break; }
+                    if pos == sp { break; }
+                }
+                let gp_0 = pos;
+                let sgk_0 = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+                if _kind_set_1(sgk_0) {
+                    sg_0: {
+                        pos = gp_0;
+                        sg_0_0: {
+                            pos = scan_for(tokens, pos, follow, 0);
+                            if pos < 0 { break sg_0_0; }
+                            break sg_0;
+                        }
+                        pos = gp_0;
+                        sg_0_1: {
+                            if pos >= tokens.len() || tokens[pos] != TK_IF { break sg_0_1; }
+                            pos += 1;
+                            break sg_0;
+                        }
+                        pos = gp_0;
+                    }
+                }
+                break scan_alts;
+            }
+            return -1;
+        } else if alt_kind == TK_IF {
+            pos = start;
+            try_2: {
+                if pos >= tokens.len() || tokens[pos] != TK_IF { break try_2; }
+                pos += 1;
+                while pos < tokens.len() && tokens[pos] == TK_IF && !(follow_yields(tokens, pos, follow, TK_EOF)) {
+                    let sp = pos;
+                    if pos >= tokens.len() || tokens[pos] != TK_IF { pos = -1; } else { pos += 1; }
+                    if pos < 0 { pos = sp; break; }
+                    if pos == sp { break; }
+                }
+                break scan_alts;
+            }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_continue_lr_3(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_CONTINUE_ { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn scan_continue(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = scan_continue_atom(tokens, pos, follow);
+    if pos < 0 { return -1; }
+    loop {
+        let suffix_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+        let _lr_pos0 = pos;
+        if suffix_kind == TK_CONTINUE_ {
+            if 1 >= min_prec {
+                let lr_saved_pos = pos;
+                pos = scan_continue_lr_3(tokens, pos, follow);
+                if pos < 0 { pos = lr_saved_pos; break; }
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+        if pos == _lr_pos0 {
+            break;
+        }
+    }
+    return pos;
+}
+
+fn scan_args(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_for(tokens, pos, follow, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_for(tokens: &Array<i32>, pos: i32, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> i32 {
+    let mut pos = pos;
+    if pos >= tokens.len() || tokens[pos] != TK_FOR { return -1; }
+    pos += 1;
+    return pos;
+}
+
+fn _parse_root__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let _rule_start_tok = p.pos;
+    if !p.speculating {
+        if !(0 == 0) {
+            p.no_viable("failed semantic predicate", p.peek_span(), []);
+            return;
+        }
+    }
+    let mut _plus_first = true;
+    loop {
+        if p.recovering { break; }
+        if !_plus_first {
+            if follow_yields(&p.kinds, p.pos, follow, TK_EOF) { break; }
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.kinds;
+                let mut pos: i32 = p.pos;
+                pos = scan_continue(tokens, pos, &EMPTY_FOLLOW, 0);
+                if pos < 0 { break rep_scan; }
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 {
+                if _kind_set_0(p.peek_kind()) {
+                    let _rec_pos = p.pos;
+                    let _rec_cp = p.b.checkpoint();
+                    let _rec_sav = p.recovering;
+                    let _rec_spec = p.speculating;
+                    p.speculating = true;
+                    _parse_continue(p, &EMPTY_FOLLOW);
+                    p.speculating = _rec_spec;
+                    p.recovering = _rec_sav;
+                    p.pos = _rec_pos;
+                    p.b.truncate(_rec_cp);
+                }
+                break;
+            }
+        }
+        _plus_first = false;
+        let continue_ = _parse_continue(p, &EMPTY_FOLLOW);
+    }
+    if !p.speculating {
+        p.emit(`${p.rule_text(_rule_start_tok)}`);
+    }
+    return;
+}
+
+fn _parse_root(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_ROOT, _start);
+    _parse_root__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("root");
+    }
+}
+
+fn _parse_continue__inner_atom(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, vals: ContinueVals = ContinueVals {}, min_prec: i32 = 0) -> ContinueVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let kind = p.peek_kind();
+    if kind == TK_FOR {
+        p.b.set_alt(0);
+        let for_ = _parse_for(p, &follow_prepend(&FOLLOW_MASK_0, follow));
+        if !(follow_yields(&p.kinds, p.pos, follow, TK_EOF)) && (p.peek_kind() == TK_FOR) {
+            let for_ = _parse_for(p, &EMPTY_FOLLOW);
+        }
+        if !p.speculating {
+            if !(1 == 1) {
+                p.no_viable("failed semantic predicate", p.peek_span(), []);
+                return vals;
+            }
+        }
+        return vals;
+    }
+    if kind == TK_BREAK {
+        p.b.set_alt(1);
+        let break_ = p.expect(TK_BREAK, &SYNC_0);
+        let mut _plus_first = true;
+        loop {
+            if p.recovering { break; }
+            if !_plus_first {
+                let mut rep_scan_pos: i32 = -1;
+                rep_scan: {
+                    let tokens = &p.kinds;
+                    let mut pos: i32 = p.pos;
+                    if pos >= tokens.len() || tokens[pos] != TK_BREAK { break rep_scan; }
+                    pos += 1;
+                    if pos <= p.pos { break rep_scan; }
+                    rep_scan_pos = pos;
+                }
+                if rep_scan_pos < 0 { break; }
+            }
+            _plus_first = false;
+            let break_ = p.expect(TK_BREAK, &EMPTY_SYNC);
+        }
+        let grp_kind = p.peek_kind();
+        if grp_kind == TK_FOR {
+            let for_ = _parse_for(p, follow);
+        } else if grp_kind == TK_IF {
+            let if_ = p.expect(TK_IF, &EMPTY_SYNC);
+        }
+        return vals;
+    }
+    if kind == TK_IF {
+        p.b.set_alt(2);
+        let if__item = p.expect(TK_IF, &EMPTY_SYNC);
+        loop {
+            if p.recovering { break; }
+            if follow_yields(&p.kinds, p.pos, follow, TK_EOF) { break; }
+            let mut rep_scan_pos: i32 = -1;
+            rep_scan: {
+                let tokens = &p.kinds;
+                let mut pos: i32 = p.pos;
+                if pos >= tokens.len() || tokens[pos] != TK_IF { break rep_scan; }
+                pos += 1;
+                if pos <= p.pos { break rep_scan; }
+                rep_scan_pos = pos;
+            }
+            if rep_scan_pos < 0 { break; }
+            let if_ = p.expect(TK_IF, &EMPTY_SYNC);
+        }
+        return vals;
+    }
+    p.no_viable(
+        "expected continue",
+        p.peek_span(),
+        ["TK_FOR", "TK_BREAK", "TK_IF"],
+    );
+    return vals;
+}
+
+fn _parse_continue__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> ContinueVals {
+    let _cp = p.b.checkpoint();
+    let _start = p.peek_start();
+    p.b.start_node(RK_CONTINUE, _start);
+    let vals = ContinueVals {};
+    let mut _lr_acc = _parse_continue__inner_atom(p, follow, vals, min_prec);
+    p.b.finish_node(p.last_end());
+    loop {
+        if p.recovering { break; }
+        let _sk = p.peek_kind();
+        if _sk == TK_CONTINUE_ {
+            if 1 >= min_prec {
+                if scan_continue_lr_3(&p.kinds, p.pos, follow) < 0 {
+                    break;
+                }
+                p.b.start_node_at(_cp, RK_CONTINUE, _start);
+                p.b.set_alt(3);
+                let continue_ = _lr_acc;
+                let mut vals = ContinueVals {};
+                let continue__2 = p.expect(TK_CONTINUE_, &EMPTY_SYNC);
+                if !p.speculating {
+                    vals.return = 0;
+                }
+                p.b.finish_node(p.last_end());
+                _lr_acc = vals;
+            } else {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    return _lr_acc;
+}
+
+fn _parse_continue(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, min_prec: i32 = 0) -> ContinueVals {
+    if p.recovering { return ContinueVals {}; }
+    let __vals = _parse_continue__inner(p, follow, min_prec);
+    if p.recovering {
+        p.push_rule_stack("continue");
+    }
+    return __vals;
+}
+
+fn _parse_args__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, else_: i32 = 0) -> ArgsVals {
+    let start = p.peek_start();
+    let mut vals = ArgsVals {};
+    vals.else = else_;
+    let for_ = _parse_for(p, follow);
+    return vals;
+}
+
+fn _parse_args(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW, else_: i32 = 0) -> ArgsVals {
+    if p.recovering { return ArgsVals {}; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_ARGS, _start);
+    let __vals = _parse_args__inner(p, follow, else_);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("args");
+    }
+    return __vals;
+}
+
+fn _parse_for__inner(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    let start = p.peek_start();
+    let for_ = p.expect(TK_FOR, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_for(p: &mut Parser, follow: &List<List<i32>> = &EMPTY_FOLLOW) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_FOR, _start);
+    _parse_for__inner(p, follow);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("for");
+    }
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_root(input, max_errors);
+}
+
+pub fn parse_root(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_root(p));
+}
+
+pub fn parse_continue(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_continue(p); });
+}
+
+pub fn parse_args(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_args(p); });
+}
+
+pub fn parse_for(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_for(p));
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(6);
+    for let mut k = 0; k < 6; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+fn _kind_set_0(k: i32) -> bool {
+    return k matches { TK_BREAK | TK_FOR | TK_IF };
+}
+
+fn _kind_set_1(k: i32) -> bool {
+    return k matches { TK_FOR | TK_IF };
+}
+
+global EMPTY_SYNC: List<i32> = [];
+global SYNC_0: List<i32> = [TK_BREAK];
+
+global FOLLOW_MASK_0: List<List<i32>> = [[TK_FOR]];
+

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
@@ -1,0 +1,20 @@
+{
+  "version": 2,
+  "invocation": "kiln-e825ffff4663fe4d",
+  "generator": "local:src/generator.wado",
+  "generator_source_hash": "d291f4aa35d79601f4656d3c03c2285b08b5aee70e7a83ce1cc1477100d0693d",
+  "primary": {
+    "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4",
+    "hash": "8553bb8579e273475bec5dffac33d751cf4e86039144543bdd5a11d5cdf332a7"
+  },
+  "inputs": [],
+  "reads": [],
+  "options_hash": "f5bf06e9e06286b8da5f142f5963fb1151ef69e24cc669678e8eb7a54a579884",
+  "outputs": [
+    {
+      "path": "tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/t.wado",
+      "hash": "f69570428231a31bfc98589e34485664e0dace7bd50f0cc4c981681daad71f73",
+      "entry": true
+    }
+  ]
+}

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/t.wado
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/t.wado
@@ -1,0 +1,2125 @@
+#![generated(by = "gale", sources = ["tests/antlr4-compat/grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4"])]
+
+//! Core lexing vocabulary shared by every generated parser and by Gale's
+//! own front end: source spans, lazy token-text slices, tokens, and the
+//! parse-error type. Prelude-only and self-contained so it can be both
+//! imported as a module (by Gale's `token`/`lexer`/`parser`/`ir`) and
+//! `#include_str`'d verbatim into generated parsers.
+
+/// Span represents a byte range in source text.
+pub struct Span {
+    pub start: i32,
+    pub end: i32,
+}
+
+impl Span {
+    pub fn new(start: i32, end: i32) -> Span {
+        return Span { start, end };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn merge(&self, other: &Span) -> Span {
+        let start = if self.start < other.start { self.start } else { other.start };
+        let end = if self.end > other.end { self.end } else { other.end };
+        return Span { start, end };
+    }
+}
+
+impl Eq for Span {
+    fn eq(&self, other: &Self) -> bool {
+        return self.start == other.start && self.end == other.end;
+    }
+}
+
+/// LexerSlice is a lazy reference to a range of characters in the source input.
+/// It avoids allocating a String for every token during tokenization.
+pub struct LexerSlice {
+    pub chars: &List<char>,
+    pub start: i32,
+    pub end: i32,
+}
+
+impl LexerSlice {
+    pub fn new(chars: &List<char>, start: i32, end: i32) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start, end };
+    }
+
+    pub fn empty(chars: &List<char>) -> LexerSlice with stores[chars] {
+        return LexerSlice { chars, start: 0, end: 0 };
+    }
+
+    pub fn from_string(s: String) -> LexerSlice {
+        let chars = s.chars().collect();
+        return LexerSlice { chars: &chars, start: 0, end: chars.len() };
+    }
+
+    pub fn is_empty(&self) -> bool {
+        return self.start >= self.end;
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.end - self.start;
+    }
+
+    pub fn push_to(&self, out: &mut String) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            out.push(self.chars[i]);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut s = String::with_capacity(self.end - self.start);
+        self.push_to(&mut s);
+        return s;
+    }
+
+    pub fn eq_str(a: &String, b: &LexerSlice) -> bool {
+        let a_chars = a.chars();
+        let mut a_iter = a_chars;
+        let mut i = b.start;
+        loop {
+            let a_next = a_iter.next();
+            if i >= b.end {
+                return a_next matches { None };
+            }
+            if let Some(ac) = a_next {
+                if ac != b.chars[i] {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            i += 1;
+        }
+    }
+}
+
+impl Display for LexerSlice {
+    fn fmt(&self, f: &mut Formatter) {
+        for let mut i = self.start; i < self.end; i += 1 {
+            f.write_char(self.chars[i]);
+        }
+    }
+}
+
+impl Eq for LexerSlice {
+    fn eq(&self, other: &Self) -> bool {
+        let len = self.end - self.start;
+        if len != other.end - other.start {
+            return false;
+        }
+        for let mut i = 0; i < len; i += 1 {
+            if self.chars[self.start + i] != other.chars[other.start + i] {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+/// The 0-based column of char index `i`: the number of chars since the last
+/// newline. ANTLR4's `getCharPositionInLine()` (over the live match cursor) and
+/// `_tokenStartCharPositionInLine` (over the token's start) are both this.
+/// Scans back to the line start, so the cost is the column, not the offset —
+/// a lexer predicate may call it once per candidate rule per token.
+pub fn char_pos_in_line(chars: &List<char>, i: i32) -> i32 {
+    let mut j = if i < chars.len() { i } else { chars.len() };
+    let mut col = 0;
+    while j > 0 && chars[j - 1] != '\n' {
+        col += 1;
+        j -= 1;
+    }
+    return col;
+}
+
+/// Token represents a lexed token with its kind, text, and position.
+/// Leading trivia (whitespace, comments) is attached to each token.
+/// `channel` is the ANTLR4 channel id (0 = default, 1 = HIDDEN; named
+/// channels resolve to integer ids declared in the grammar).
+pub struct Token {
+    pub kind: i32,
+    pub text: LexerSlice,
+    pub span: Span,
+    pub leading_trivia: List<Token>,
+    pub channel: i32,
+}
+
+impl Token {
+    pub fn new(kind: i32, text: LexerSlice, span: Span) -> Token {
+        return Token { kind, text, span, leading_trivia: [], channel: 0 };
+    }
+
+    pub fn with_trivia(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>) -> Token {
+        return Token { kind, text, span, leading_trivia, channel: 0 };
+    }
+
+    pub fn with_channel(kind: i32, text: LexerSlice, span: Span, leading_trivia: List<Token>, channel: i32) -> Token {
+        return Token { kind, text, span, leading_trivia, channel };
+    }
+}
+
+// Note: Token Eq is intentionally omitted. Auto-derived Eq on recursive structs
+// with reference-containing fields triggers a compiler bug
+// (see wado-compiler/tests/fixtures/recursive_struct_ref_eq.wado).
+
+/// Per-token recovery flags (a bitset stored in `TokenStream.flags`). A normal
+/// lexed token has `none()`. The bits mark tokens the error-resilient parser
+/// created or set aside during recovery, so the tree builder and diagnostics can
+/// render them without a side table:
+///
+/// - `Synthetic` — a zero-width token the parser *inserted* to stand in for
+///   a required terminal that was absent (its `kinds[i]` is the expected kind).
+/// - `Skipped` — a real lexed token the parser *deleted* during recovery
+///   (it belongs to no rule; preserved for lossless round-trip).
+/// - `LexError` — a fast mirror of the `TK_ERROR` kind: a char run that
+///   matched no lexer rule.
+pub flags TokenFlags {
+    Synthetic,
+    Skipped,
+    LexError,
+}
+
+/// TokenStream is the struct-of-arrays token storage for generated parsers.
+/// A "token" is an `i32` index into these parallel arrays; no per-token
+/// aggregate is ever allocated. The hot fields (`kinds` / `starts` / `ends`)
+/// are read on every scan/dispatch step as a single `array.get i32`; the
+/// trivia and source-char data are cold, materialised on demand only by the
+/// diagnostic / round-trip paths.
+///
+/// `Token` above stays the value-typed vocabulary for Gale's own `.g4` front
+/// end; the generated-parser runtime uses `TokenStream` instead.
+///
+/// Layout invariant: the per-token arrays (`kinds` / `starts` / `ends` /
+/// `triv_lo` / `triv_hi` / `flags`) always share a length, because
+/// `push_token` is the only writer and advances all of them together. Hidden /
+/// skip tokens ("trivia") live in the flat `triv_*` arrays in source order;
+/// each parser token owns the half-open range `[triv_lo[i], triv_hi[i])`.
+pub struct TokenStream {
+    pub kinds: List<i32>,
+    pub starts: List<i32>,
+    pub ends: List<i32>,
+    pub triv_lo: List<i32>,
+    pub triv_hi: List<i32>,
+    pub chars: &List<char>,
+    pub triv_kinds: List<i32>,
+    pub triv_starts: List<i32>,
+    pub triv_ends: List<i32>,
+    pub triv_chans: List<i32>,
+    pub flags: List<TokenFlags>,
+    /// Text the lexer's executed actions printed, in tokenization order
+    /// (Stage C). Empty unless the lexer was generated with action execution
+    /// on. Defaulted so existing construction sites keep compiling.
+    pub output: String = "",
+}
+
+impl TokenStream {
+    /// Empty stream over `chars` (a borrow of the source char list, like
+    /// `LexerSlice`). Pre-size every array — trivia included — to ~one token
+    /// per four chars; trivia tracks token count, so `[]` would re-grow from
+    /// zero every parse.
+    pub fn new(chars: &List<char>) -> TokenStream with stores[chars] {
+        let cap = chars.len() / 4 + 1;
+        return TokenStream {
+            kinds: List::with_capacity(cap),
+            starts: List::with_capacity(cap),
+            ends: List::with_capacity(cap),
+            triv_lo: List::with_capacity(cap),
+            triv_hi: List::with_capacity(cap),
+            chars,
+            triv_kinds: List::with_capacity(cap),
+            triv_starts: List::with_capacity(cap),
+            triv_ends: List::with_capacity(cap),
+            triv_chans: List::with_capacity(cap),
+            flags: List::with_capacity(cap),
+        };
+    }
+
+    pub fn len(&self) -> i32 {
+        return self.kinds.len();
+    }
+
+    /// The next trivia index — the lexer records this as a token's `triv_lo`
+    /// before accumulating that token's leading trivia, and again as `triv_hi`
+    /// after.
+    pub fn trivia_mark(&self) -> i32 {
+        return self.triv_kinds.len();
+    }
+
+    /// Append one hidden / skip token to the flat trivia arrays.
+    pub fn push_trivia(&mut self, kind: i32, start: i32, end: i32, channel: i32) {
+        self.triv_kinds.push(kind);
+        self.triv_starts.push(start);
+        self.triv_ends.push(end);
+        self.triv_chans.push(channel);
+    }
+
+    /// Append one parser (default-channel) token. The sole writer of the
+    /// per-token arrays, so their lengths stay in lockstep by construction.
+    pub fn push_token(&mut self, kind: i32, start: i32, end: i32, triv_lo: i32, triv_hi: i32) {
+        self.push_token_flagged(kind, start, end, triv_lo, triv_hi, TokenFlags::none());
+    }
+
+    /// Append a token carrying recovery `flags`, returning its index. The
+    /// real lockstep writer; `push_token` is the `flags = 0` common case.
+    pub fn push_token_flagged(
+        &mut self,
+        kind: i32,
+        start: i32,
+        end: i32,
+        triv_lo: i32,
+        triv_hi: i32,
+        flags: TokenFlags,
+    ) -> i32 {
+        let idx = self.kinds.len();
+        self.kinds.push(kind);
+        self.starts.push(start);
+        self.ends.push(end);
+        self.triv_lo.push(triv_lo);
+        self.triv_hi.push(triv_hi);
+        self.flags.push(flags);
+        return idx;
+    }
+
+    /// Append a zero-width synthetic token at byte offset `at`, standing in for
+    /// a required terminal of kind `expected_kind` that the parser inserted
+    /// during recovery. Returns the new token index. The token owns no trivia.
+    pub fn push_synthetic(&mut self, expected_kind: i32, at: i32) -> i32 {
+        let m = self.trivia_mark();
+        return self.push_token_flagged(expected_kind, at, at, m, m, TokenFlags::Synthetic);
+    }
+
+    pub fn flags_at(&self, i: i32) -> TokenFlags {
+        return self.flags[i];
+    }
+
+    pub fn set_flag(&mut self, i: i32, flag: TokenFlags) {
+        self.flags[i] = self.flags[i] | flag;
+    }
+
+    /// Mark token `i` as deleted by recovery (preserved, but bound to no rule).
+    pub fn mark_skipped(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::Skipped);
+    }
+
+    /// Mark token `i` as a lexer error (a char run that matched no rule). The
+    /// lexer sets this alongside the `TK_ERROR` kind so consumers can test the
+    /// flag without knowing the grammar's `TK_ERROR` id.
+    pub fn mark_lex_error(&mut self, i: i32) {
+        self.set_flag(i, TokenFlags::LexError);
+    }
+
+    pub fn is_synthetic(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Synthetic != TokenFlags::none();
+    }
+
+    pub fn is_skipped(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::Skipped != TokenFlags::none();
+    }
+
+    pub fn is_lex_error(&self, i: i32) -> bool {
+        return self.flags[i] & TokenFlags::LexError != TokenFlags::none();
+    }
+
+    pub fn kind_at(&self, i: i32) -> i32 {
+        return self.kinds[i];
+    }
+
+    pub fn span_at(&self, i: i32) -> Span {
+        return Span::new(self.starts[i], self.ends[i]);
+    }
+
+    pub fn is_empty_text(&self, i: i32) -> bool {
+        return self.starts[i] >= self.ends[i];
+    }
+
+    /// Append `chars[start..end]` to `out` (no allocation).
+    pub fn push_text(&self, out: &mut String, start: i32, end: i32) {
+        for let mut j = start; j < end; j += 1 {
+            out.push(self.chars[j]);
+        }
+    }
+
+    /// Materialise token `i`'s text as an owned `String` (cold path).
+    pub fn token_text(&self, i: i32) -> String {
+        let start = self.starts[i];
+        let end = self.ends[i];
+        let mut s = String::with_capacity(end - start);
+        self.push_text(&mut s, start, end);
+        return s;
+    }
+
+    /// Append token `i`'s text to `out` (no allocation).
+    pub fn push_token_text(&self, out: &mut String, i: i32) {
+        self.push_text(out, self.starts[i], self.ends[i]);
+    }
+
+    /// Append token `i`'s text with whitespace rendered as escapes, matching
+    /// ANTLR4's `Trees.toStringTree` node text (spaces are left alone). Used by
+    /// tree rendering only; `$text` and friends keep the raw text.
+    pub fn push_token_text_escaped(&self, out: &mut String, i: i32) {
+        for let mut j = self.starts[i]; j < self.ends[i]; j += 1 {
+            match self.chars[j] {
+                '\n' => out.push_str(&"\\n"),
+                '\r' => out.push_str(&"\\r"),
+                '\t' => out.push_str(&"\\t"),
+                c => out.push(c),
+            }
+        }
+    }
+
+    /// Append the text of token `i`'s leading trivia, in source order.
+    pub fn push_leading_trivia_text(&self, out: &mut String, i: i32) {
+        for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+            self.push_text(out, self.triv_starts[j], self.triv_ends[j]);
+        }
+    }
+
+    /// `$text` for a rule spanning tokens `[start_tok, end_tok]`: the token
+    /// texts with each token's leading *hidden-channel* trivia interleaved
+    /// (`triv_chans != 0`), matching ANTLR's `TokenStream.getText(interval)`.
+    /// `skip` trivia (channel 0, removed from the stream) is excluded, and so is
+    /// the start token's own leading trivia (the interval begins at the token).
+    pub fn rule_text(&self, start_tok: i32, end_tok: i32) -> String {
+        let mut out = String::new();
+        for let mut i = start_tok; i <= end_tok; i += 1 {
+            if i > start_tok {
+                for let mut j = self.triv_lo[i]; j < self.triv_hi[i]; j += 1 {
+                    if self.triv_chans[j] != 0 {
+                        self.push_text(&mut out, self.triv_starts[j], self.triv_ends[j]);
+                    }
+                }
+            }
+            self.push_token_text(&mut out, i);
+        }
+        return out;
+    }
+}
+
+
+/// ParseError represents a parse failure with location and expected tokens.
+///
+/// `message` is the local "expected X, got Y" description, kept free of
+/// position and rule context so it stays composable. `line`/`col` are a
+/// 1-based line and 0-based column (ANTLR4 `Token` convention) resolved
+/// from `span.start` against the source at error-construction time;
+/// `Parser::error` fills them in. `rule_stack` records the chain of parser
+/// rules that were active when the error was raised, innermost first — each
+/// rule entry wrapper pushes its own name as the `Err` propagates outward,
+/// so the last element is the start rule and the first is the rule the
+/// failing token sat in. The `Display` impl renders all of this into a
+/// human-readable diagnostic.
+pub struct ParseError {
+    pub message: String,
+    pub span: Span,
+    pub expected: List<String>,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub rule_stack: List<String> = [],
+}
+
+impl ParseError {
+    pub fn new(message: String, span: Span, expected: List<String>) -> ParseError {
+        return ParseError { message, span, expected };
+    }
+
+    /// Construct a ParseError whose position is already resolved. Used by
+    /// `Parser::error`, which has the source on hand to compute line/col.
+    pub fn at(message: String, span: Span, expected: List<String>, line: i32, col: i32) -> ParseError {
+        return ParseError { message, span, expected, line, col, rule_stack: [] };
+    }
+
+    /// Render the rule chain as `outer > ... > inner` (start rule first).
+    /// `rule_stack` is stored innermost-first, so iterate it in reverse.
+    /// Consecutive duplicates are collapsed: a left-recursive rule re-enters
+    /// itself once per precedence level, which would otherwise print
+    /// `expr > expr > expr` for a deep expression.
+    pub fn rule_path(&self) -> String {
+        let mut out = String::with_capacity(self.rule_stack.len() * 8);
+        let n = self.rule_stack.len();
+        let mut written = 0;
+        for let mut i = 0; i < n; i += 1 {
+            let name = &self.rule_stack[n - 1 - i];
+            if written > 0 && *name == self.rule_stack[n - i] {
+                continue;
+            }
+            if written > 0 {
+                out.push_str(&" > ");
+            }
+            out.push_str(name);
+            written += 1;
+        }
+        return out;
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`parse error at ${self.line}:${self.col}: ${self.message}`);
+        if !self.rule_stack.is_empty() {
+            f.write_str(&`\n  in rule: ${self.rule_path()}`);
+        }
+    }
+}
+//! Diagnostics emitted by the error-resilient parser. A parse always returns a
+//! tree; `Diagnostic`s say where and how it was repaired. Inlined into every
+//! generated parser alongside the recovery runtime. Imports `Span` from
+//! `lex.wado`; that import is stripped at `#include_str` time.
+
+
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl Severity {
+    pub fn label(&self) -> String {
+        return match *self {
+            Error => "error",
+            Warning => "warning",
+            Info => "info",
+            Hint => "hint",
+        };
+    }
+}
+
+/// What went wrong, independent of the specific tokens. Tooling can switch on
+/// this without parsing the human message.
+pub enum DiagnosticCode {
+    UnexpectedToken,  // a token that fits nowhere in the current rule
+    MissingToken,  // a required terminal was absent (one was inserted)
+    ExtraToken,  // a spurious terminal was deleted
+    NoViableAlternative,  // alternative dispatch found no match
+    UnterminatedConstruct,  // EOF reached inside a rule (missing closer)
+    LexError,  // a char run matched no lexer rule (TK_ERROR)
+}
+
+impl DiagnosticCode {
+    pub fn name(&self) -> String {
+        return match *self {
+            UnexpectedToken => "unexpected-token",
+            MissingToken => "missing-token",
+            ExtraToken => "extra-token",
+            NoViableAlternative => "no-viable-alternative",
+            UnterminatedConstruct => "unterminated-construct",
+            LexError => "lex-error",
+        };
+    }
+}
+
+/// The repair the parser applied at this site, so a fixit/IDE can describe it.
+pub enum RecoveryAction {
+    Inserted,  // synthesised a missing terminal
+    Deleted,  // skipped one spurious terminal
+    SkippedTo,  // skipped a run up to a synchronizing token
+    FilledMissing,  // hit EOF; filled remaining required terminals
+    None,  // reported only, no edit
+}
+
+/// A secondary location attached to a diagnostic, e.g. "'(' opened here" for an
+/// unterminated group.
+pub struct RelatedInfo {
+    pub message: String,
+    pub span: Span,
+}
+
+/// A single parse diagnostic. `expected`/`found` carry token-kind ids (not
+/// names) so tooling reuses the grammar's own name tables; `message` is the
+/// pre-rendered human text. `line`/`col` are 1-based line and 0-based column
+/// (ANTLR4 `Token` convention) resolved from `span.start`.
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: DiagnosticCode,
+    pub message: String,
+    pub span: Span,
+    pub line: i32 = 1,
+    pub col: i32 = 0,
+    pub expected: List<i32> = [],
+    pub found: i32 = -1,
+    pub rule_stack: List<String> = [],
+    pub recovery: RecoveryAction = RecoveryAction::None,
+    pub related: List<RelatedInfo> = [],
+}
+
+impl Diagnostic {
+    /// A bare error diagnostic with position resolved; callers fill the
+    /// optional fields (`expected`, `rule_stack`, `related`, ...) as needed.
+    pub fn error(code: DiagnosticCode, message: String, span: Span, line: i32, col: i32) -> Diagnostic {
+        return Diagnostic {
+            severity: Severity::Error,
+            code,
+            message,
+            span,
+            line,
+            col,
+        };
+    }
+
+    pub fn is_error(&self) -> bool {
+        return self.severity matches { Error };
+    }
+}
+
+impl Display for Diagnostic {
+    fn fmt(&self, f: &mut Formatter) {
+        f.write_str(&`${self.severity.label()}[${self.code.name()}] at ${self.line}:${self.col}: ${self.message}`);
+        for let r of &self.related {
+            f.write_str(&`\n  note: ${r.message}`);
+        }
+    }
+}
+
+/// Resolve a char index to (line, column): 1-based line, 0-based column
+/// (ANTLR4 `Token` convention). A linear scan; the parser resolves at most a
+/// handful of positions per parse, so this stays off the hot path.
+pub fn line_col(chars: &List<char>, pos: i32) -> [i32, i32] {
+    let mut line = 1;
+    let mut col = 0;
+    let cap = if pos < chars.len() { pos } else { chars.len() };
+    for let mut i = 0; i < cap; i += 1 {
+        if chars[i] == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    return [line, col];
+}
+//! The single (untyped) concrete syntax tree produced by every generated
+//! error-resilient parser, stored as a flat columnar event stream that is
+//! itself the tree (the single source of truth), the `TreeBuilder` the parser
+//! drives to construct it, and the `ParseResult` the parser returns.
+//!
+//! The parser records a flat pre-order event stream directly into parallel
+//! columns (an `EventTag` tag plus `i32` payloads); there is no per-node object
+//! tree and no walk/convert
+//! step. `finish()` runs one linear pass (`finalize`) that fills the derived
+//! columns (`span.end`, `flags`, subtree extent) so every query stays O(1).
+//! Consumers read the store as a cursor — a `(&CstStore, index)` pair threaded
+//! as unbundled scalars — so traversal allocates nothing and copies nothing.
+//!
+//! A node is the row index of its `Open`; the root is row 0. The store holds
+//! no reference to the token stream, so `ParseResult` owns both the store and
+//! the stream it indexes without a self-referential borrow. Functions that need
+//! terminal text or kinds take a `&TokenStream` argument.
+//!
+//! Error tokens are first-class and lossless: `Miss` (an inserted synthetic
+//! terminal), `Skip` (a real terminal deleted during recovery), and a
+//! `<error>` region node (kind `K_ERROR`) together capture every recovery edit
+//! (insert / delete / region) so the original input round-trips. The token-
+//! stream flags (`TokenFlags::Synthetic` / `Skipped`, see `lex.wado`) carry the same
+//! facts at the terminal level.
+//!
+//! Imports `TokenStream` from `lex.wado` and `Diagnostic` from `diag.wado`;
+//! those imports are stripped at `#include_str` time (see `gen_runtime` in
+//! `codegen.wado`), where the fragments are concatenated into one module.
+
+
+/// A node's kind: a parser-rule id (`0..num_rules`, in grammar declaration
+/// order) or the reserved `K_ERROR` sentinel for a recovery region node. A
+/// newtype over `i32` so the generated parser can give it a name-aware
+/// `Display` (`Inspect` shows `name(id)`); the name table is grammar-specific,
+/// so codegen emits those impls.
+pub type NodeKind = i32;
+
+/// The reserved kind for a `<error>` region node — a run of skipped tokens or
+/// a partial sub-parse swept up during panic-mode recovery. Never collides with
+/// a real rule id (those are non-negative).
+pub global K_ERROR: NodeKind = -1;
+
+/// Derived per-node condition bits (the `flags` column, valid on an `Open` row).
+///
+/// - `Error` — this node, or some descendant, contains a recovery edit (a
+///   missing/skipped terminal or an error region). Bubbles up so a consumer can
+///   prune clean subtrees in one check.
+/// - `Incomplete` — this node is missing a required terminal that the parser
+///   had to insert (it has a `Miss` child).
+pub flags NodeFlags {
+    Error,
+    Incomplete,
+}
+
+/// Event-stream row tag. Every row is a triple `(tag, a, b)`; `a` / `b` carry
+/// the tag-specific payload below.
+///
+/// - `Open`  — `a` = node kind, `b` = start byte offset (also the finalized
+///   `span.start`).
+/// - `Close` — `a` = end byte offset; `b` is stamped with the matching open's
+///   kind during `finalize`, so a linear walk knows whether to exit a rule.
+/// - `Tok` / `Miss` / `Skip` — `a` = token index into the `TokenStream`.
+pub enum EventTag {
+    Open,
+    Close,
+    Tok,
+    Miss,
+    Skip,
+}
+
+/// The flat CST: parallel columns, one row per event, in pre-order. `tag`,
+/// `a`, `b` and `alt` are written during the parse; `end`, `flags` and `next`
+/// are derived by `finalize` (in `TreeBuilder::finish`). A node is addressed by
+/// the row index of its `Open` row. Columns are `pub` so a linear walk
+/// (`highlight_walk`) can read them in a tight loop; external consumers use the
+/// `impl CstStore` cursor methods below for O(1) queries and child navigation.
+pub struct CstStore {
+    pub tag: List<EventTag>,
+    pub a: List<i32>,
+    pub b: List<i32>,
+    /// The matched labeled-alternative index for an `Open` row (grammar
+    /// declaration order), or -1 when unlabeled / unset / non-open.
+    alt: List<i32>,
+    /// `span.end` for an `Open` row (max of its close offset and every child
+    /// end); derived.
+    end: List<i32>,
+    /// The `NodeFlags` for an `Open` row; derived.
+    flags: List<NodeFlags>,
+    /// Row index just past this `Open` node's whole subtree, so a random-
+    /// access consumer skips a subtree in O(1); derived.
+    next: List<i32>,
+}
+
+/// What a direct child slot is. A plain discriminant enum (no payload), so it
+/// is an `i32` — matching over it allocates nothing. `child_kind` yields it
+/// so a consumer can `match` a child instead of chaining `is_node` / `is_token`.
+pub enum ChildKind {
+    Node,
+    Token,
+    Missing,
+    Skipped,
+}
+
+/// The read cursor over the flat store. Every method is `&self` over an `i32`
+/// row index — no node / cursor value is constructed, so traversal allocates
+/// nothing. The raw `tag` / `a` / `b` columns stay `pub` for the internal
+/// `highlight_walk` flat scan; external consumers use these methods.
+impl CstStore {
+    /// Number of event rows (upper bound for a flat scan; row 0 is the root).
+    pub fn row_count(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Kind of the node at row `i`.
+    pub fn kind(&self, i: i32) -> NodeKind {
+        return self.a[i] as NodeKind;
+    }
+
+    /// Byte span of the node at row `i`.
+    pub fn span(&self, i: i32) -> Span {
+        return Span::new(self.b[i], self.end[i]);
+    }
+
+    /// Matched labeled-alternative index of the node at row `i` (-1 when unset).
+    pub fn alt(&self, i: i32) -> i32 {
+        return self.alt[i];
+    }
+
+    /// True when the node at row `i`, or some descendant, carries a recovery edit.
+    pub fn is_error(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Error != NodeFlags::none();
+    }
+
+    /// True when the node at row `i` is missing a required terminal.
+    pub fn is_incomplete(&self, i: i32) -> bool {
+        return self.flags[i] & NodeFlags::Incomplete != NodeFlags::none();
+    }
+
+    /// True when row `i` is a rule / error node (has a kind, span, children).
+    pub fn is_node(&self, i: i32) -> bool {
+        return self.tag[i] matches { Open };
+    }
+
+    /// True when row `i` is a terminal (real, missing, or skipped).
+    pub fn is_token(&self, i: i32) -> bool {
+        let t = self.tag[i];
+        return t matches { Tok | Miss | Skip };
+    }
+
+    /// The `ChildKind` of the (child) row `i`.
+    pub fn child_kind(&self, i: i32) -> ChildKind {
+        return match self.tag[i] {
+            Open => ChildKind::Node,
+            Miss => ChildKind::Missing,
+            Skip => ChildKind::Skipped,
+            _ => ChildKind::Token,
+        };
+    }
+
+    /// Token-stream index of the terminal at row `i` (valid when `is_token`).
+    pub fn token_index(&self, i: i32) -> i32 {
+        return self.a[i];
+    }
+
+    /// Row of the first direct child of node `i` (a node or a terminal), or -1
+    /// when `i` has no children. Pair with `next_sibling` to walk children:
+    /// `for let mut c = s.first_child(i); c >= 0; c = s.next_sibling(c) { … }`.
+    pub fn first_child(&self, i: i32) -> i32 {
+        let c = i + 1;
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the next direct child after `child`, or -1 when `child` is the
+    /// last (the next row is the parent's close). A child node is skipped in
+    /// O(1) via its subtree extent. Returns -1 for a row with no parent (the
+    /// root), rather than indexing past the columns.
+    pub fn next_sibling(&self, child: i32) -> i32 {
+        let c = if self.tag[child] matches { Open } { self.next[child] } else { child + 1 };
+        if c >= self.tag.len() || self.tag[c] matches { Close } {
+            return -1;
+        }
+        return c;
+    }
+
+    /// Row of the first direct child node of rule `kind` under row `i`, or -1.
+    /// Used by sub-tree rendering (an ANTLR4 descriptor whose `[output]` is a
+    /// labelled child subtree, not the start rule's full tree).
+    pub fn find_child(&self, i: i32, kind: NodeKind) -> i32 {
+        let k = kind as i32;
+        for let mut c = self.first_child(i); c >= 0; c = self.next_sibling(c) {
+            if self.tag[c] matches { Open } && self.a[c] == k {
+                return c;
+            }
+        }
+        return -1;
+    }
+
+    /// ANTLR4-style S-expression for the subtree at row `i`: `(name child ...)`,
+    /// tokens as their text with whitespace escaped (`\n`, `\r`, `\t`, as
+    /// `Trees.toStringTree` does); a childless node renders as its bare name, no
+    /// parens (ANTLR4's `Trees.toStringTree`). `rule_names[kind]` names rule
+    /// nodes (`K_ERROR` renders `<error>`); `token_names[kind]` names missing
+    /// terminals. Real terminals with empty text (e.g. EOF) are omitted;
+    /// missing/skipped terminals render markers.
+    pub fn to_string_tree(
+        &self,
+        i: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(256);
+        cst_to_string_tree_impl(&mut out, self, i, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+fn cst_to_string_tree_impl(
+    out: &mut String,
+    s: &CstStore,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) {
+    let name = if s.a[i] == K_ERROR as i32 { "<error>" } else { rule_names[s.a[i]] };
+    if i + 1 >= s.tag.len() || s.tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        return;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < s.next[i] {
+        match s.tag[c] {
+            Open => {
+                out.push_str(&" ");
+                cst_to_string_tree_impl(out, s, c, toks, rule_names, token_names);
+                c = s.next[c];
+            },
+            Tok => {
+                if !toks.is_empty_text(s.a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, s.a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(s.a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, s.a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+            _ => c += 1,
+        }
+    }
+    out.push_str(&")");
+}
+
+/// What a parse returns: the flat CST store, the token stream its terminal
+/// indices point into, and any diagnostics. A clean parse leaves `diagnostics`
+/// empty. Owns both `cst` and `tokens` outright (the store borrows nothing), so
+/// the result is a freely movable value. The root node is row 0 of `cst`.
+pub struct ParseResult {
+    pub cst: CstStore,
+    pub tokens: TokenStream,
+    pub diagnostics: List<Diagnostic>,
+    /// Text emitted by executed actions via `p.emit(...)`, in execution
+    /// order (Stage C). Empty unless the parser was generated with action
+    /// execution on. Defaulted so existing construction sites and tests keep
+    /// compiling.
+    pub output: String = "",
+}
+
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        for let d of &self.diagnostics {
+            if d.is_error() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// True when the parse produced no error-severity diagnostics.
+    pub fn ok(&self) -> bool {
+        return !self.has_errors();
+    }
+}
+
+/// Widen the parent open's span end and error bit from a just-closed child.
+/// `stack` must already have the child popped, so its top is the parent (if any).
+fn bubble_to_parent(stack: &List<i32>, end: &mut List<i32>, flags: &mut List<NodeFlags>, child: i32) {
+    if stack.len() > 0 {
+        let parent = stack[stack.len() - 1];
+        if end[child] > end[parent] {
+            end[parent] = end[child];
+        }
+        flags[parent] = flags[parent] | flags[child] & NodeFlags::Error;
+    }
+}
+
+/// The builder the generated parser drives. It appends events into the flat
+/// columns (`start_node` / `token` / `missing` / `skip` / `finish_node`) and
+/// finalises them in `finish()`. It is purely structural — it stores token
+/// *indices*, never the stream itself; the parser owns the `TokenStream`,
+/// appending synthetic "missing" tokens and marking skipped ones on its own
+/// copy. `open` is the stack of currently-open row indices (`set_alt` targets
+/// the innermost).
+pub struct TreeBuilder {
+    tag: List<EventTag>,
+    a: List<i32>,
+    b: List<i32>,
+    alt: List<i32>,
+    open: List<i32>,
+    /// Row of the most recently closed node (`-1` before any). Backs
+    /// `$ctx.toStringTree()` in a left-recursive rule's `@after`: precedence
+    /// climbing folds each level shut before `@after` runs, so the current
+    /// context is the just-finished node, not anything still on `open`.
+    last_finished: i32,
+}
+
+impl TreeBuilder {
+    pub fn new() -> TreeBuilder {
+        return TreeBuilder { tag: [], a: [], b: [], alt: [], open: [], last_finished: -1 };
+    }
+
+    /// Pre-size the event columns to `rows`, avoiding the grow-from-empty
+    /// reallocations (each column would otherwise double `log2(rows)` times).
+    /// The parser passes ~`4 × tokens` — measured `rows ≈ 3.44 × tokens`, so this
+    /// sizes just above the final length: no grow, and only ~16% over-fill (a
+    /// doubling grow from under-sizing over-fills far more). Right-size, not big.
+    pub fn with_capacity(rows: i32) -> TreeBuilder {
+        return TreeBuilder {
+            tag: List::with_capacity(rows),
+            a: List::with_capacity(rows),
+            b: List::with_capacity(rows),
+            alt: List::with_capacity(rows),
+            open: [],
+            last_finished: -1,
+        };
+    }
+
+    fn push_row(&mut self, tag: EventTag, a: i32, b: i32) {
+        self.tag.push(tag);
+        self.a.push(a);
+        self.b.push(b);
+        self.alt.push(-1);
+    }
+
+    /// Open a rule node of `kind` starting at byte offset `start`.
+    pub fn start_node(&mut self, kind: NodeKind, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, kind as i32, start);
+        self.open.push(row);
+    }
+
+    /// Open a `<error>` region node (kind `K_ERROR`) at byte offset `start`.
+    pub fn start_error(&mut self, start: i32) {
+        let row = self.tag.len();
+        self.push_row(EventTag::Open, K_ERROR as i32, start);
+        self.open.push(row);
+    }
+
+    /// Stamp the matched labeled-alternative index on the innermost currently
+    /// open node. The generated parser calls this once it commits to a labeled
+    /// alternative; it is a no-op shape for unlabeled rules (never emitted).
+    pub fn set_alt(&mut self, alt: i32) {
+        self.alt[self.open[self.open.len() - 1]] = alt;
+    }
+
+    /// A position in the event stream to retro-open a node at. Used for
+    /// left-associative wrapping (precedence climbing): capture a checkpoint
+    /// before the first operand, then `start_node_at` to make a new node whose
+    /// first child is everything recorded since the checkpoint.
+    pub fn checkpoint(&self) -> i32 {
+        return self.tag.len();
+    }
+
+    /// Retro-open a node of `kind` (starting at byte offset `start`) at a
+    /// previously captured `checkpoint`, so all events recorded since wrap
+    /// inside it. Close it with the matching `finish_node`. Re-using the same
+    /// checkpoint across loop iterations nests left-associatively. At the call
+    /// site every row in `[checkpoint, len)` is balanced and the open stack
+    /// holds only ancestors with index `< checkpoint`, so the insert never
+    /// shifts a live open index and pushing `checkpoint` keeps `open` monotonic.
+    pub fn start_node_at(&mut self, checkpoint: i32, kind: NodeKind, start: i32) {
+        self.tag.insert(checkpoint, EventTag::Open);
+        self.a.insert(checkpoint, kind as i32);
+        self.b.insert(checkpoint, start);
+        self.alt.insert(checkpoint, -1);
+        self.open.push(checkpoint);
+    }
+
+    /// Discard every event recorded since `checkpoint`, rolling the builder
+    /// back to that point. Used by a *speculative* parse that runs only to
+    /// localise a deep error (and then restores the cursor): under the emitter
+    /// the speculative subtree must not leak into the real tree, so the caller
+    /// brackets it with `checkpoint()` / `truncate()`.
+    pub fn truncate(&mut self, checkpoint: i32) {
+        while self.tag.len() > checkpoint {
+            let _ = self.tag.pop();
+            let _ = self.a.pop();
+            let _ = self.b.pop();
+            let _ = self.alt.pop();
+        }
+        while self.open.len() > 0 && self.open[self.open.len() - 1] >= checkpoint {
+            let _ = self.open.pop();
+        }
+    }
+
+    /// Close the innermost open node at byte offset `end`.
+    pub fn finish_node(&mut self, end: i32) {
+        self.push_row(EventTag::Close, end, 0);
+        self.last_finished = self.open[self.open.len() - 1];
+        let _ = self.open.pop();
+    }
+
+    /// Append a real terminal (`idx` into the stream) to the open node.
+    pub fn token(&mut self, idx: i32) {
+        self.push_row(EventTag::Tok, idx, 0);
+    }
+
+    /// Append an inserted synthetic terminal. `syn_idx` is the index returned
+    /// by `TokenStream::push_synthetic`.
+    pub fn missing(&mut self, syn_idx: i32) {
+        self.push_row(EventTag::Miss, syn_idx, 0);
+    }
+
+    /// Append a skipped real terminal. The caller marks `idx` with
+    /// `TokenStream::mark_skipped` first.
+    pub fn skip(&mut self, idx: i32) {
+        self.push_row(EventTag::Skip, idx, 0);
+    }
+
+    /// Finalise the store: one linear pass that fills `end` / `flags` / `next`
+    /// and stamps each `Close` row with its open's kind. Deferring all
+    /// aggregation to here (rather than patching in `finish_node`) is what makes
+    /// the retro-open `start_node_at` correct: the pass sees the final structure,
+    /// so a wrapped subtree's error bit bubbles into the wrap node even though
+    /// the wrap was inserted after its children closed. Valid once the root node
+    /// has been closed; an open left unterminated by a truncated stream is folded
+    /// to the stream end (its `next` never stays 0), so traversal terminates.
+    pub fn finish(&self) -> CstStore {
+        let n = self.tag.len();
+        let mut b: List<i32> = List::with_capacity(n);
+        let mut end: List<i32> = List::with_capacity(n);
+        let mut flags: List<NodeFlags> = List::with_capacity(n);
+        let mut next: List<i32> = List::with_capacity(n);
+        for let mut r = 0; r < n; r += 1 {
+            b.push(self.b[r]);
+            end.push(0);
+            flags.push(NodeFlags::none());
+            next.push(0);
+        }
+        let mut stack: List<i32> = [];
+        for let mut r = 0; r < n; r += 1 {
+            match self.tag[r] {
+                Open => {
+                    flags[r] = if self.a[r] == K_ERROR as i32 { NodeFlags::Error } else { NodeFlags::none() };
+                    end[r] = self.b[r];
+                    stack.push(r);
+                },
+                Miss => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Incomplete | NodeFlags::Error;
+                },
+                Skip => {
+                    let oi = stack[stack.len() - 1];
+                    flags[oi] = flags[oi] | NodeFlags::Error;
+                },
+                Close => {
+                    let oi = stack[stack.len() - 1];
+                    let _ = stack.pop();
+                    if self.a[r] > end[oi] {
+                        end[oi] = self.a[r];
+                    }
+                    b[r] = self.a[oi];
+                    next[oi] = r + 1;
+                    bubble_to_parent(&stack, &mut end, &mut flags, oi);
+                },
+                Tok => {
+                },
+            }
+        }
+        while stack.len() > 0 {
+            let oi = stack[stack.len() - 1];
+            let _ = stack.pop();
+            next[oi] = n;
+            bubble_to_parent(&stack, &mut end, &mut flags, oi);
+        }
+        return CstStore { tag: self.tag, a: self.a, b, alt: self.alt, end, flags, next };
+    }
+
+    /// Render the S-expression of the innermost currently-open node — the rule
+    /// under construction — from the raw (not-yet-finalised) events. Backs
+    /// `$ctx.toStringTree()` in a non-LR rule's `@after`, which runs after the
+    /// body but before `finish_node`, so the node is still open and its children
+    /// are complete.
+    pub fn render_open(&self, toks: &TokenStream, rule_names: &List<String>, token_names: &List<String>) -> String {
+        if self.open.len() == 0 {
+            return String::new();
+        }
+        return self.render_from(self.open[self.open.len() - 1], toks, rule_names, token_names);
+    }
+
+    /// Render the most recently closed node. Backs `$ctx.toStringTree()` in a
+    /// left-recursive rule's `@after`, where the level's node is already folded
+    /// shut (see `last_finished`).
+    pub fn render_last_finished(
+        &self,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        if self.last_finished < 0 {
+            return String::new();
+        }
+        return self.render_from(self.last_finished, toks, rule_names, token_names);
+    }
+
+    fn render_from(
+        &self,
+        root: i32,
+        toks: &TokenStream,
+        rule_names: &List<String>,
+        token_names: &List<String>,
+    ) -> String {
+        let mut out = String::with_capacity(128);
+        let _ = render_builder_node(&mut out, &self.tag, &self.a, root, toks, rule_names, token_names);
+        return out;
+    }
+}
+
+/// Render the subtree rooted at the `Open` row `i`, returning the row after
+/// its `Close`. Events are balanced (`start_node` / `finish_node` pair), so a
+/// linear walk with recursion at each child `Open` stands in for the finalised
+/// `next` column. Works for a closed root (stops at its `Close`) and for a
+/// still-open root (no `Close`, so the walk closes it at the event end) —
+/// mirrors `cst_to_string_tree_impl`.
+fn render_builder_node(
+    out: &mut String,
+    tag: &List<EventTag>,
+    a: &List<i32>,
+    i: i32,
+    toks: &TokenStream,
+    rule_names: &List<String>,
+    token_names: &List<String>,
+) -> i32 {
+    let name = if a[i] == K_ERROR as i32 { "<error>" } else { rule_names[a[i]] };
+    if i + 1 >= tag.len() || tag[i + 1] matches { Close } {
+        out.push_str(&name);
+        if i + 1 < tag.len() {
+            return i + 2;
+        }
+        return i + 1;
+    }
+    out.push_str(&"(");
+    out.push_str(&name);
+    let mut c = i + 1;
+    while c < tag.len() {
+        match tag[c] {
+            Open => {
+                out.push_str(&" ");
+                c = render_builder_node(out, tag, a, c, toks, rule_names, token_names);
+            },
+            Close => {
+                out.push_str(&")");
+                return c + 1;
+            },
+            Tok => {
+                if !toks.is_empty_text(a[c]) {
+                    out.push_str(&" ");
+                    toks.push_token_text_escaped(out, a[c]);
+                }
+                c += 1;
+            },
+            Miss => {
+                out.push_str(&` <missing ${token_names[toks.kind_at(a[c])]}>`);
+                c += 1;
+            },
+            Skip => {
+                out.push_str(&" <skip ");
+                toks.push_token_text_escaped(out, a[c]);
+                out.push_str(&">");
+                c += 1;
+            },
+        }
+    }
+    out.push_str(&")");
+    return c;
+}
+//! Consumer-facing tree / token utilities exposed by every generated
+//! parser: S-expression normalisation (`normalize_tree`) and the
+//! ANTLR4-format token-stream dump (`to_lexer_string`) used by the
+//! compatibility suite. Always emitted. The generated parser code never calls
+//! these itself; consumers (driver tests, the ANTLR4-compat suite) import them
+//! from the generated module. The `./lex.wado` import is stripped at
+//! `#include_str` time.
+
+
+/// Normalize a multi-line S-expression string for comparison.
+/// Collapses whitespace runs to single spaces and trims, while preserving
+/// whitespace inside double-quoted strings.
+pub fn normalize_tree(s: &String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_string = false;
+    let mut space_pending = false;
+    for let c of s.chars() {
+        if in_string {
+            out.push(c);
+            if c == '"' {
+                in_string = false;
+            }
+        } else if c == ' ' || c == '\n' || c == '\r' || c == '\t' {
+            if out.len() > 0 {
+                space_pending = true;
+            }
+        } else {
+            if space_pending {
+                out.push(' ');
+                space_pending = false;
+            }
+            if c == '"' {
+                in_string = true;
+            }
+            out.push(c);
+        }
+    }
+    return out;
+}
+
+/// Produce an ANTLR4-style `Token.toString()` dump of the token stream:
+///
+///   [@<idx>,<start>:<end>='<text>',<<type>>,<line>:<col>]\n  (per token)
+///
+/// Used by Stage L (token-stream equivalence) tests against the upstream
+/// `LexerExec` / etc. `[output]` blocks.
+///
+/// - `tokens` is the `TokenStream` returned by the generated
+///   `tokenize(input)`. Skip-channel trivia (channel 0) is discarded; only
+///   non-default-channel trivia is interleaved.
+/// - `eof_kind` is the value of the generated `TK_EOF` constant; EOF
+///   tokens print as `<EOF>` text with type id `-1`.
+///
+/// Type IDs are remapped from Gale's 0-based numbering to ANTLR4's
+/// 1-based: `kind + 1` for explicit lexer rules, `-1` for EOF. Lexer-only
+/// grammars never introduce implicit literals, so the contiguous
+/// `0..num_lexer_rules` range maps directly onto ANTLR4's
+/// `1..num_lexer_rules+1`.
+///
+/// Text escaping follows ANTLR4's `CommonToken.toString` format (observed
+/// via the published jar as a black-box oracle): only `\n`, `\r`, `\t` are
+/// escaped; backslashes and quotes pass through unchanged.
+///
+/// Whatever the lexer's actions printed precedes the dump, as it does on
+/// ANTLR4's stdout.
+pub fn to_lexer_string(tokens: &TokenStream, eof_kind: i32) -> String {
+    let chars = tokens.chars;
+    // Char index where each line begins; built once so each token's `line:col`
+    // is an O(log n) binary search (`line_col_from_starts`) not an O(pos) rescan.
+    let mut line_starts: List<i32> = [0];
+    for let mut i = 0; i < chars.len(); i += 1 {
+        if chars[i] == '\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let mut out = String::with_capacity(tokens.output.len() + tokens.len() * 32);
+    out.push_str(&tokens.output);
+    let mut index = 0;
+    for let mut i = 0; i < tokens.len(); i += 1 {
+        // Non-default-channel trivia (`-> channel(HIDDEN)`) is parked in this
+        // token's trivia range; ANTLR4 still dumps it in source order with a
+        // `channel=N` attribute, so interleave it ahead of the host token.
+        // Skip trivia (channel 0) is discarded — neither printed nor indexed
+        // (matching ANTLR4's `Lexer.skip()`).
+        let lo = tokens.triv_lo[i];
+        let hi = tokens.triv_hi[i];
+        for let mut t = lo; t < hi; t += 1 {
+            if tokens.triv_chans[t] != 0 {
+                emit_lexer_token(
+                    &mut out,
+                    tokens,
+                    tokens.triv_kinds[t],
+                    tokens.triv_starts[t],
+                    tokens.triv_ends[t],
+                    tokens.triv_chans[t],
+                    &line_starts,
+                    index,
+                    eof_kind,
+                );
+                index += 1;
+            }
+        }
+        emit_lexer_token(
+            &mut out,
+            tokens,
+            tokens.kinds[i],
+            tokens.starts[i],
+            tokens.ends[i],
+            0,
+            &line_starts,
+            index,
+            eof_kind,
+        );
+        index += 1;
+    }
+    return out;
+}
+
+/// Renders a single token in ANTLR4's `CommonToken.toString` format, used by
+/// `to_lexer_string` for both main-stream tokens and interleaved
+/// non-default-channel trivia. `channel=N` is printed only for non-default
+/// channels, matching ANTLR4.
+fn emit_lexer_token(
+    out: &mut String,
+    tokens: &TokenStream,
+    kind: i32,
+    start: i32,
+    end: i32,
+    channel: i32,
+    line_starts: &List<i32>,
+    index: i32,
+    eof_kind: i32,
+) {
+    let is_eof = kind == eof_kind;
+    let mut text_buf = String::with_capacity(16);
+    if is_eof {
+        text_buf.push_str(&"<EOF>");
+    } else {
+        for let mut j = start; j < end; j += 1 {
+            let c = tokens.chars[j];
+            match c {
+                '\n' => text_buf.push_str(&"\\n"),
+                '\r' => text_buf.push_str(&"\\r"),
+                '\t' => text_buf.push_str(&"\\t"),
+                _ => text_buf.push(c),
+            }
+        }
+    }
+    let type_id = if is_eof { -1 } else { kind + 1 };
+    let line_col = line_col_from_starts(line_starts, start);
+    let line = line_col.0;
+    let col = line_col.1;
+    let end_inclusive = end - 1;
+    let channel_attr = if channel != 0 { `channel=${channel},` } else { String::from("") };
+    out.push_str(&`[@${index},${start}:${end_inclusive}='${text_buf}',<${type_id}>,${channel_attr}${line}:${col}]\n`);
+}
+
+/// Compute (line, column) from the precomputed `line_starts` table (char
+/// index where each line begins). Binary search for the greatest
+/// `line_starts[j] <= pos`: that line is `j + 1` and the column is the
+/// offset past its start. O(log lines) per call.
+fn line_col_from_starts(line_starts: &List<i32>, pos: i32) -> [i32, i32] {
+    let mut lo = 0;
+    let mut hi = line_starts.len() - 1;
+    while lo < hi {
+        let mid = (lo + hi + 1) / 2;
+        if line_starts[mid] <= pos {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return [lo + 1, pos - line_starts[lo]];
+}
+pub enum TokenKind {
+    ID,
+    INT,
+    WS,
+    Eof,
+    Error,
+}
+
+pub global TK_ID: i32 = 0;
+pub global TK_INT: i32 = 1;
+pub global TK_WS: i32 = 2;
+pub global TK_EOF: i32 = 3;
+pub global TK_ERROR: i32 = 4;
+pub global TK_LIT_SEMI: i32 = 5;
+pub global TK_LIT_DOT: i32 = 6;
+
+struct Lexer {
+    chars: List<char>,
+    pos: i32,
+}
+
+impl Lexer {
+    fn new(input: &String) -> Lexer {
+        return Lexer { chars: input.to_chars(), pos: 0 };
+    }
+
+    fn at_end(&self) -> bool {
+        return self.pos >= self.chars.len();
+    }
+
+    fn slice(&self, start: i32, end: i32) -> LexerSlice with stores[self] {
+        return LexerSlice::new(&self.chars, start, end);
+    }
+}
+
+fn try_ID(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { 'a'..='z' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_0 = pos;
+        rep_0: {
+            if pos >= chars.len() || !(chars[pos] matches { 'a'..='z' }) { break rep_0; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_0;
+        break;
+    }
+    return pos;
+}
+
+fn try_INT(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { return -1; }
+    pos += 1;
+    loop {
+        let rep_saved_1 = pos;
+        rep_1: {
+            if pos >= chars.len() || !(chars[pos] matches { '0'..='9' }) { break rep_1; }
+            pos += 1;
+            continue;
+        }
+        pos = rep_saved_1;
+        break;
+    }
+    return pos;
+}
+
+fn try_WS(chars: &List<char>, start: i32) -> i32 {
+    let mut pos = start;
+    let alts_saved_2 = pos;
+    let mut alts_ok_2 = false;
+    alts_2_0: {
+        pos = alts_saved_2;
+        if pos >= chars.len() || chars[pos] != ' ' { break alts_2_0; }
+        pos += 1;
+        alts_ok_2 = true;
+    }
+    if !alts_ok_2 {
+        alts_2_1: {
+            pos = alts_saved_2;
+            if pos >= chars.len() || chars[pos] != '\n' { break alts_2_1; }
+            pos += 1;
+            alts_ok_2 = true;
+        }
+    }
+    if !alts_ok_2 { return -1; }
+    return pos;
+}
+
+fn try_lit_semi(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != ';' { return -1; }
+    return pos + 1;
+}
+
+fn try_lit_dot(chars: &List<char>, start: i32) -> i32 {
+    let pos = start;
+    if pos + 0 >= chars.len() || chars[pos + 0] != '.' { return -1; }
+    return pos + 1;
+}
+
+pub fn tokenize(input: &String) -> TokenStream {
+    let mut lexer = Lexer::new(input);
+    let mut ts = TokenStream::new(&lexer.chars);
+    let mut triv_lo = ts.trivia_mark();
+    while !lexer.at_end() {
+        let start = lexer.pos;
+        let mut best_end: i32 = -1;
+        let mut best_kind: i32 = TK_ERROR;
+        let mut end: i32 = -1;
+        let first_char = lexer.chars[start];
+        if first_char == '\n' || first_char == ' ' {
+            end = try_WS(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_WS; }
+        } else if first_char == '.' {
+            end = try_lit_dot(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_DOT; }
+        } else if first_char == ';' {
+            end = try_lit_semi(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_LIT_SEMI; }
+        } else if 'a' <= first_char <= 'z' {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+        } else if '0' <= first_char <= '9' {
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        } else {
+            end = try_ID(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_ID; }
+            end = try_INT(&lexer.chars, start);
+            if end > best_end { best_end = end; best_kind = TK_INT; }
+        }
+        if best_end <= start {
+            ts.push_token(TK_ERROR, start, start + 1, triv_lo, ts.trivia_mark());
+            triv_lo = ts.trivia_mark();
+            lexer.pos = start + 1;
+        } else {
+            let tok_start = start;
+            let is_skip = best_kind matches { TK_WS };
+            if is_skip {
+                ts.push_trivia(best_kind, tok_start, best_end, 0);
+            } else {
+                ts.push_token(best_kind, tok_start, best_end, triv_lo, ts.trivia_mark());
+                triv_lo = ts.trivia_mark();
+            }
+            lexer.pos = best_end;
+        }
+    }
+    ts.push_token(TK_EOF, lexer.pos, lexer.pos, triv_lo, ts.trivia_mark());
+    return ts;
+}
+
+pub fn token_kind_name(kind: i32) -> String {
+    return match kind {
+        TK_ID => "ID",
+        TK_INT => "INT",
+        TK_WS => "WS",
+        TK_EOF => "Eof",
+        TK_ERROR => "Error",
+        TK_LIT_SEMI => "TK_LIT_SEMI",
+        TK_LIT_DOT => "TK_LIT_DOT",
+        _ => "Unknown",
+    };
+}
+
+pub global RK_S: NodeKind = 0;
+pub global RK_B: NodeKind = 1;
+pub global RK_A: NodeKind = 2;
+
+global RULE_NAMES: List<String> = ["s", "b", "a"];
+
+impl Display for NodeKind {
+    fn fmt(&self, f: &mut Formatter) {
+        if *self == K_ERROR {
+            f.write_str(&"<error>");
+        } else {
+            f.write_str(&RULE_NAMES[*self as i32]);
+        }
+    }
+}
+
+impl Inspect for NodeKind {
+    fn inspect(&self, f: &mut Formatter) {
+        self.fmt(f);
+        f.write_str(&`(${*self as i32})`);
+    }
+}
+
+struct Parser {
+    tokens: TokenStream,
+    kinds: Array<i32>,
+    pos: i32,
+    pending: Option<ParseError>,
+    recovering: bool,
+    pending_code: DiagnosticCode,
+    speculating: bool,
+    max_errors: i32,
+    b: TreeBuilder,
+    diagnostics: List<Diagnostic>,
+    output: String,
+}
+
+impl Parser {
+    fn new(tokens: TokenStream) -> Parser {
+        let kinds = tokens.kinds.to_array();
+        return Parser { tokens, kinds, pos: 0, pending: null, recovering: false, pending_code: DiagnosticCode::UnexpectedToken, speculating: false, max_errors: i32::MAX, b: TreeBuilder::with_capacity(tokens.len() * 4), diagnostics: [], output: "" };
+    }
+
+    fn emit(&mut self, s: String) {
+        self.output.push_str(&s);
+    }
+
+    fn token_text(&self, i: i32) -> String {
+        return self.tokens.token_text(i);
+    }
+
+    fn token_kind(&self, i: i32) -> i32 {
+        return self.tokens.kind_at(i);
+    }
+
+    fn token_int(&self, i: i32) -> i32 {
+        let sp = self.tokens.span_at(i);
+        let mut acc: i32 = 0;
+        let mut neg = false;
+        let mut j = sp.start;
+        if j < sp.end && self.tokens.chars[j] == '-' {
+            neg = true;
+            j += 1;
+        }
+        while j < sp.end {
+            let c = self.tokens.chars[j];
+            if c >= '0' && c <= '9' {
+                acc = acc * 10 + (c as i32 - '0' as i32);
+            }
+            j += 1;
+        }
+        return if neg { -acc } else { acc };
+    }
+
+    fn token_line(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).0;
+    }
+
+    fn token_col(&self, i: i32) -> i32 {
+        return line_col(self.tokens.chars, self.tokens.span_at(i).start).1;
+    }
+
+    fn token_start(&self, i: i32) -> i32 {
+        return self.tokens.starts[i];
+    }
+
+    fn la(&self, k: i32) -> i32 {
+        return self.peek_at(k - 1);
+    }
+
+    fn lt(&self, k: i32) -> i32 {
+        let idx = self.pos + k - 1;
+        if idx >= self.kinds.len() { return self.kinds.len() - 1; }
+        if idx < 0 { return 0; }
+        return idx;
+    }
+
+    fn text_span(&self, start: i32, end: i32) -> String {
+        let mut out = String::new();
+        let hi = if end < self.tokens.chars.len() { end } else { self.tokens.chars.len() };
+        for let mut i = start; i < hi; i += 1 {
+            out.push(self.tokens.chars[i]);
+        }
+        return out;
+    }
+
+    fn text_between(&self, lo: i32, hi: i32) -> String {
+        return self.tokens.rule_text(lo, hi);
+    }
+
+    fn rule_text(&self, start_tok: i32) -> String {
+        return self.tokens.rule_text(start_tok, self.pos - 1);
+    }
+
+    fn input_text(&self) -> String {
+        return self.text_span(0, self.tokens.chars.len());
+    }
+
+    fn rule_string_tree(&self) -> String {
+        return self.b.render_open(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn rule_string_tree_final(&self) -> String {
+        return self.b.render_last_finished(&self.tokens, &RULE_NAMES, &CTX_TOKEN_NAMES);
+    }
+
+    fn error(&self, message: String, span: Span, expected: List<String>) -> ParseError {
+        let lc = line_col(self.tokens.chars, span.start);
+        return ParseError::at(message, span, expected, lc.0, lc.1);
+    }
+
+    fn fail(&mut self, message: String, span: Span, expected: List<String>, code: DiagnosticCode) {
+        let e = self.error(message, span, expected);
+        let take = if let Some(cur) = &self.pending { e.span.start > cur.span.start } else { true };
+        if take {
+            self.pending = Option::Some(e);
+            self.pending_code = code;
+        }
+        self.recovering = true;
+    }
+
+    fn no_viable(&mut self, message: String, span: Span, expected: List<String>) {
+        self.fail(message, span, expected, DiagnosticCode::NoViableAlternative);
+    }
+
+    fn push_rule_stack(&mut self, name: String) {
+        if let Some(e) = &mut self.pending {
+            e.rule_stack.push(name);
+        }
+    }
+
+    fn pending_message(&self) -> String {
+        if let Some(e) = &self.pending { return e.message; }
+        return String::from("");
+    }
+
+    fn in_set(&self, k: i32, set: &List<i32>) -> bool {
+        for let x of set { if *x == k { return true; } }
+        return false;
+    }
+
+    fn report_extra(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::ExtraToken, `extraneous input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn report_missing(&mut self, kind: i32, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        let name = token_kind_name(kind);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::MissingToken, `missing ${name}`, span, lc.0, lc.1));
+    }
+
+    fn report_unexpected(&mut self, span: Span) {
+        if self.diagnostics.len() >= self.max_errors { self.recovering = true; return; }
+        let lc = line_col(self.tokens.chars, span.start);
+        self.diagnostics.push(Diagnostic::error(DiagnosticCode::UnexpectedToken, `unexpected input "${self.tokens.token_text(self.pos)}"`, span, lc.0, lc.1));
+    }
+
+    fn peek_start(&self) -> i32 {
+        return self.tokens.starts[self.pos];
+    }
+
+    fn peek_span(&self) -> Span {
+        return self.tokens.span_at(self.pos);
+    }
+
+    fn peek_kind(&self) -> i32 {
+        return self.kinds[self.pos];
+    }
+
+    fn peek_at(&self, offset: i32) -> i32 {
+        let idx = self.pos + offset;
+        if idx >= self.kinds.len() { return TK_EOF; }
+        return self.kinds[idx];
+    }
+
+    fn advance(&mut self) -> i32 {
+        let i = self.pos;
+        self.pos += 1;
+        return i;
+    }
+
+    fn last_end(&self) -> i32 {
+        if self.pos == 0 { return 0; }
+        return self.tokens.ends[self.pos - 1];
+    }
+
+    fn expect(&mut self, kind: i32, sync: &List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] == kind {
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.speculating {
+            let name = token_kind_name(kind);
+            self.fail(`expected ${name}, got "${self.tokens.token_text(self.pos)}"`, self.tokens.span_at(self.pos), [name], DiagnosticCode::UnexpectedToken);
+            return self.pos;
+        }
+        if self.peek_at(1) == kind {
+            self.report_extra(self.tokens.span_at(self.pos));
+            let _sk = self.advance();
+            self.tokens.mark_skipped(_sk);
+            self.b.skip(_sk);
+            if kind == TK_EOF {
+                self.b.token(self.pos);
+                return self.pos;
+            }
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        if self.in_set(self.kinds[self.pos], sync) {
+            self.report_missing(kind, self.tokens.span_at(self.pos));
+            let _syn = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn);
+            return _syn;
+        }
+        if !sync.is_empty() {
+            self.report_unexpected(self.tokens.span_at(self.pos));
+            if self.kinds[self.pos] != TK_EOF {
+                self.b.start_error(self.tokens.span_at(self.pos).start);
+                loop {
+                    let _k = self.kinds[self.pos];
+                    if _k == TK_EOF || _k == kind || self.in_set(_k, sync) { break; }
+                    let _sk = self.advance();
+                    self.tokens.mark_skipped(_sk);
+                    self.b.skip(_sk);
+                }
+                self.b.finish_node(self.last_end());
+            }
+            if self.kinds[self.pos] == kind {
+                if kind == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+            let _syn2 = self.tokens.push_synthetic(kind, self.tokens.span_at(self.pos).start);
+            self.b.missing(_syn2);
+            return _syn2;
+        }
+        let name = token_kind_name(kind);
+        self.fail(
+            `expected ${name}, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            [name],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn any(&mut self) -> i32 {
+        if self.recovering { return self.pos; }
+        if self.kinds[self.pos] != TK_EOF {
+            let _i = self.advance();
+            self.b.token(_i);
+            return _i;
+        }
+        self.fail(
+            `expected any token, got "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["any token"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_not(&mut self, excluded: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        if k != TK_EOF {
+            let mut blocked = false;
+            for let x of excluded {
+                if x == k {
+                    blocked = true;
+                    break;
+                }
+            }
+            if !blocked {
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["set complement"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+
+    fn expect_set(&mut self, included: List<i32>) -> i32 {
+        if self.recovering { return self.pos; }
+        let k = self.kinds[self.pos];
+        for let x of included {
+            if x == k {
+                if k == TK_EOF {
+                    self.b.token(self.pos);
+                    return self.pos;
+                }
+                let _i = self.advance();
+                self.b.token(_i);
+                return _i;
+            }
+        }
+        self.fail(
+            `unexpected token "${self.tokens.token_text(self.pos)}"`,
+            self.tokens.span_at(self.pos),
+            ["token set"],
+            DiagnosticCode::UnexpectedToken,
+        );
+        return self.pos;
+    }
+}
+
+struct BVals {
+    i: i32 = 0,
+}
+
+struct AVals {
+    i: i32 = 0,
+}
+
+fn scan_s(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let start = pos;
+    let mut pos = pos;
+    let alt_kind = if pos < tokens.len() { tokens[pos] } else { TK_EOF };
+    scan_alts: {
+        if alt_kind == TK_ID {
+            let mut best: i32 = -1;
+            pos = start;
+            try_0: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_0; }
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_SEMI { break try_0; }
+                pos += 1;
+                if pos > best { best = pos; }
+            }
+            pos = start;
+            try_1: {
+                pos = scan_b(tokens, pos, 0);
+                if pos < 0 { break try_1; }
+                if pos >= tokens.len() || tokens[pos] != TK_LIT_DOT { break try_1; }
+                pos += 1;
+                if pos > best { best = pos; }
+            }
+            if best >= 0 { pos = best; break scan_alts; }
+            return -1;
+        } else {
+            return -1;
+        }
+    }
+    return pos;
+}
+
+fn scan_b(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    let scan_start = pos;
+    let mut pos = pos;
+    pos = scan_a(tokens, pos, 0);
+    if pos < 0 { return -1; }
+    if pos == scan_start { return -1; }
+    return pos;
+}
+
+fn scan_a(tokens: &Array<i32>, pos: i32, min_prec: i32 = 0) -> i32 {
+    if pos < tokens.len() && tokens[pos] == TK_ID {
+        return pos + 1;
+    }
+    return -1;
+}
+
+fn _parse_s__inner_alt_0(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p, 2);
+    let semicolon = p.expect(TK_LIT_SEMI, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_s__inner_alt_1(p: &mut Parser) -> () {
+    let start = p.peek_start();
+    let b = _parse_b(p, 2);
+    let dot = p.expect(TK_LIT_DOT, &EMPTY_SYNC);
+    return;
+}
+
+fn _parse_s__inner(p: &mut Parser) -> () {
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        if p.peek_kind() == TK_ID {
+            if p.peek_at(1) == TK_LIT_SEMI {
+                return _parse_s__inner_alt_0(p);
+            } else if p.peek_at(1) == TK_LIT_DOT {
+                return _parse_s__inner_alt_1(p);
+            }
+        }
+    }
+    p.no_viable(
+        "expected s",
+        p.peek_span(),
+        ["TK_ID"],
+    );
+    return;
+}
+
+fn _parse_s(p: &mut Parser) -> () {
+    if p.recovering { return; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_S, _start);
+    _parse_s__inner(p);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("s");
+    }
+}
+
+fn _parse_b__inner(p: &mut Parser, i: i32 = 0) -> BVals {
+    let start = p.peek_start();
+    let mut vals = BVals {};
+    vals.i = i;
+    let a = _parse_a(p, i);
+    return vals;
+}
+
+fn _parse_b(p: &mut Parser, i: i32 = 0) -> BVals {
+    if p.recovering { return BVals {}; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_B, _start);
+    let __vals = _parse_b__inner(p, i);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("b");
+    }
+    return __vals;
+}
+
+fn _parse_a__inner_alt_0(p: &mut Parser, vals: AVals = AVals {}) -> AVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let id = p.expect(TK_ID, &EMPTY_SYNC);
+    if !p.speculating {
+        p.emit(`alt 1\n`);
+    }
+    return vals;
+}
+
+fn _parse_a__inner_alt_1(p: &mut Parser, vals: AVals = AVals {}) -> AVals {
+    let start = p.peek_start();
+    let mut vals = vals;
+    let id = p.expect(TK_ID, &EMPTY_SYNC);
+    if !p.speculating {
+        p.emit(`alt 2\n`);
+    }
+    return vals;
+}
+
+fn _parse_a__inner(p: &mut Parser, i: i32 = 0) -> AVals {
+    let mut vals = AVals {};
+    vals.i = i;
+    let kind = p.peek_kind();
+    if kind == TK_ID {
+        if (vals.i == 1) {
+            return _parse_a__inner_alt_0(p, vals);
+        } else if (vals.i == 2) {
+            return _parse_a__inner_alt_1(p, vals);
+        } else {
+            p.no_viable("no viable alternative", p.peek_span(), []);
+            return vals;
+        }
+    }
+    p.no_viable(
+        "expected a",
+        p.peek_span(),
+        ["TK_ID"],
+    );
+    return vals;
+}
+
+fn _parse_a(p: &mut Parser, i: i32 = 0) -> AVals {
+    if p.recovering { return AVals {}; }
+    let _start = p.peek_start();
+    p.b.start_node(RK_A, _start);
+    let __vals = _parse_a__inner(p, i);
+    p.b.finish_node(p.last_end());
+    if p.recovering {
+        p.push_rule_stack("a");
+    }
+    return __vals;
+}
+
+fn _run_parse_entry(input: &String, max_errors: i32, entry: fn(&mut Parser)) -> ParseResult {
+    assert max_errors >= 1, `max_errors must be >= 1, got ${max_errors}`;
+    let tokens = tokenize(input);
+    let mut p = Parser::new(tokens);
+    p.output = p.tokens.output;
+    p.max_errors = max_errors;
+    entry(&mut p);
+    if p.recovering && p.diagnostics.len() < max_errors {
+        if let Some(e) = &p.pending {
+            let lc = line_col(p.tokens.chars, e.span.start);
+            let mut d = Diagnostic::error(p.pending_code, e.message, e.span, lc.0, lc.1);
+            d.rule_stack = e.rule_stack;
+            p.diagnostics.push(d);
+        }
+    }
+    return ParseResult { cst: p.b.finish(), tokens: p.tokens, diagnostics: p.diagnostics, output: p.output };
+}
+
+pub fn parse(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return parse_s(input, max_errors);
+}
+
+pub fn parse_s(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| _parse_s(p));
+}
+
+pub fn parse_b(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_b(p); });
+}
+
+pub fn parse_a(input: &String, max_errors: i32 = i32::MAX) -> ParseResult {
+    return _run_parse_entry(input, max_errors, |p: &mut Parser| { let _ = _parse_a(p); });
+}
+
+fn _ctx_token_names() -> List<String> {
+    let mut v: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        v.push(token_kind_name(k));
+    }
+    return v;
+}
+
+global CTX_TOKEN_NAMES: List<String> = _ctx_token_names();
+
+pub fn to_string_tree(result: &ParseResult) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    return result.cst.to_string_tree(0, &result.tokens, &RULE_NAMES, &token_names);
+}
+
+pub fn to_string_subtree(result: &ParseResult, rule: &String) -> String {
+    let mut token_names: List<String> = List::with_capacity(7);
+    for let mut k = 0; k < 7; k += 1 {
+        token_names.push(token_kind_name(k));
+    }
+    let mut _kind: i32 = -1;
+    for let mut i = 0; i < RULE_NAMES.len(); i += 1 {
+        if RULE_NAMES[i] == *rule {
+            _kind = i;
+            break;
+        }
+    }
+    let _sub = result.cst.find_child(0, _kind as NodeKind);
+    if _sub >= 0 {
+        return result.cst.to_string_tree(_sub, &result.tokens, &RULE_NAMES, &token_names);
+    }
+    return String::new();
+}
+
+global EMPTY_SYNC: List<i32> = [];
+


### PR DESCRIPTION
Extends the Stage B′ JVM-oracle corpus, and fixes two comparators that can pass without checking what they claim to check.

## Two comparators that could pass without comparing

**Stage B′ compares the oracle tree verbatim.** `normalize_tree` collapses whitespace runs so a hand-written driver test can indent its expected tree. The oracle's tree is already one line, so collapsing can only lose information — and it does whenever a token's own text carries whitespace: with `BREAK: 'break '`, ANTLR renders `break  break `, the token's trailing space plus the child separator. Normalizing the expected side alone turns that into a mismatch against a parser that is rendering correctly.

**A tree render ends at its closing paren.** An `[output]` that continues past it is host-side print output the descriptor emits alongside its tree, so Stage B's normalizer rejects it. Without that rule, `(a 1 2)\n1\n2` is accepted as a single tree and a listener's print lines get pinned as tree content.

## Stage B′ reaches descriptors whose `[output]` is host-side

Stage B′ derives its expected tree from the published ANTLR4 jar and ignores the descriptor's `[output]` entirely. So a descriptor whose `[output]` is a host-language artefact is still reachable: the artefact has to leave the grammar loadable, not be reproducible in Gale.

That covers the `Listeners` category, whose grammars carry the testsuite's listener-scaffolding directives, and descriptors declaring types through StringTemplate directives in a `returns [...]` slot. 98 descriptors are oracle-pinned, none marked `#[TODO]`. `[stage_b_oracle_skip]` holds seven, all the case where TestRig encodes non-ASCII as `?`, so the oracle's own output is not a valid pin.

The action-template expansion table covers the helpers those grammars need. Helpers naming host-side scaffolding — a generated listener class or import — expand to nothing, which is sound because the corpus compares parse trees and the scaffolding is not observable in one. A helper that changes what the parser *produces* must not join that group, so `TreeNodeWithAltNumField` (renders alt numbers into node names), `ParserPropertyMember` (declares the member a semantic predicate calls) and `PositionAdjustingLexer` (overrides `nextToken()`) stay `[skip]` rather than being stubbed out — expanding them away would leave a test that no longer tests what its descriptor is for. StringTemplate comments delimited by `<!` and `!>` are dropped wherever they appear.

## Triage

`[skip]` holds three descriptors, each on a directive that changes what the parser produces.

The Listeners Stage C output-compares are `[stage_c_skip]`: the expected output is the generated listener's walk, and Gale generates no listener, so no amount of Stage C work reaches it. Their parse trees are pinned by Stage B′ instead. `ParseTrees/TokenAndRuleContextString` is `[stage_c_todo]` — it prints `getRuleInvocationStack()`, a recognizer accessor java2wado does not map, which is a gap that can close.

## Docs

`antlr4-compatibility.md` documents the Stage B tree detector, the expansion-table policy, and that Stage B and Stage B′ do not share a comparator. Its triage-bucket reference lists the buckets the extractor reads, and quotes the jar-version comment the extractor emits.

`TODO.md` is ordered by priority, with an explicit order of attack. Stage B′ is described as the fallback for descriptors Stage B cannot compare, so coverage is read per descriptor rather than per directory — a category with no `stage_b_oracle/` directory can equally mean every comparable descriptor is already covered by Stage B. Stage C's output-compare is recorded as running across the seven parser categories, with lexer action output compared by Stage A claim (d).