### PR TITLE
docs: align the data section WEP with the implementation

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -87,17 +87,9 @@ It can contain any text, including JSON, YAML, or test expectations.
 
 #### Accessing Data
 
-The data section is accessible via the compiler API through `Module::data_section()`, which returns `Option<&str>`. This enables tooling like test frameworks to embed expected results directly in source files.
+The data section is accessible via the compiler API on the parsed module, which enables tooling like test frameworks to embed expected results directly in source files.
 
-```rust
-// Compiler API example
-let parsed = wado_compiler::parse(source);
-if let Some(data) = parsed.ast.data_section() {
-    // Process the data section content
-}
-```
-
-The data section content can be accessed at runtime using the `#data` compile-time location literal. See [Compile-Time Location Literals](#compile-time-location-literals).
+Within Wado code, the content is available through the `#data` compile-time location literal. See [Compile-Time Location Literals](#compile-time-location-literals).
 
 ### Identifiers
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -91,8 +91,8 @@ The data section is accessible via the compiler API through `Module::data_sectio
 
 ```rust
 // Compiler API example
-let result = wado_compiler::compile_file(path)?;
-if let Some(data) = result.module.data_section() {
+let parsed = wado_compiler::parse(source);
+if let Some(data) = parsed.ast.data_section() {
     // Process the data section content
 }
 ```

--- a/docs/wep-2026-01-12-data-section.md
+++ b/docs/wep-2026-01-12-data-section.md
@@ -38,19 +38,14 @@ This is the data section.
 It can contain any text.
 ```
 
-Lexical rules:
+- The marker must start at column 1 and be alone on its line — only a newline or EOF may follow it. Anywhere else, `__DATA__` is an ordinary identifier.
+- Everything after the marker line, verbatim to EOF, is the content. The marker line is excluded and the content is not trimmed.
+- The content is never tokenized, so it may hold text that is not valid Wado.
+- A module has at most one data section, and `wado format` re-emits it unchanged.
 
-- The marker must start at column 1 and be alone on its line — only a newline or EOF may follow it.
-- Everything after the marker line, verbatim to EOF, is the content. The marker line itself is excluded; the content is not trimmed.
-- The content is never tokenized, so it may hold any text, including text that is not valid Wado.
-- A module has at most one data section.
-- `__DATA__` that violates the placement rules (indented, or with trailing content on its line) is an ordinary identifier.
+### Accessing the Content
 
-`wado format` round-trips the section: the marker and its content are re-emitted unchanged after the formatted source.
-
-### Accessing the Content from Wado: `#data`
-
-The `#data` compile-time literal expands to the module's data section as a `String` constant. Using it in a module with no data section is a compile error.
+The `#data` compile-time literal expands to the module's data section as a `String`. Using it in a module with no data section is a compile error.
 
 ```wado
 export fn run() with Stdout {
@@ -65,22 +60,11 @@ Hello from the data section!
 
 The literal yields raw text. There is no format-parsing form: a program that wants structured data parses the text itself (`core:json`, `core:cbor`, …), keeping the compiler free of format knowledge.
 
-### Compiler API
-
-`Module::data_section()` returns `Option<&str>` and is populated by the lexer, so it is available right after parsing, before type checking:
-
-```rust
-let parsed = wado_compiler::parse(source);
-if let Some(data) = parsed.ast.data_section() {
-    // Process the data section content
-}
-```
-
-The content is carried through the pipeline: the TIR and NIR module nodes each expose `data_section()` and `with_data_section()`.
+For tooling, the compiler exposes the content on the parsed module as `Option<&str>`, so a test runner or IDE can read it without compiling the file.
 
 ### E2E Test Format
 
-Compiler E2E fixtures (`wado-compiler/tests/fixtures/*.wado`) put their test specification in the data section as strict JSON — `serde_json` parses it, so comments are not allowed.
+Compiler E2E fixtures put their test specification in the data section as strict JSON — comments are not allowed.
 
 ```wado
 export fn run() with Stdout {
@@ -93,9 +77,7 @@ __DATA__
 }
 ```
 
-The target world comes from the top-level key: no world key means `wasi:cli/command`, `"test": {}` selects the test world, and `"wasi:http/service": {...}` the HTTP world. A fixture with no data section at all defaults to the test world, so a library-shaped source doubles as a fixture verbatim.
-
-The harness reads the section as text (`extract_data_section`) rather than compiling the fixture first, which keeps spec extraction independent of whether the fixture compiles — a fixture asserting `compile_error` still has a readable spec. The full field table lives in [`wado-compiler/CLAUDE.md`](../wado-compiler/CLAUDE.md).
+The target world comes from the top-level key: no world key means `wasi:cli/command`, `"test": {}` selects the test world, and `"wasi:http/service": {...}` the HTTP world. A fixture with no data section at all defaults to the test world, so a library-shaped source doubles as a fixture verbatim. The full field table lives in [`wado-compiler/CLAUDE.md`](../wado-compiler/CLAUDE.md).
 
 ## Consequences
 
@@ -104,7 +86,7 @@ The harness reads the section as text (`extract_data_section`) rather than compi
 - Self-contained tests: expectations live with the test source
 - Module-scoped: each file has an independent data section, unlike Ruby
 - Explicit access: `#data` makes the dependency visible at the use site
-- Tooling-friendly: available after parsing, and readable as plain text without parsing at all
+- Tooling-friendly: readable as plain text, without compiling the file
 - Strict JSON in fixtures: unambiguous, no dialect to implement
 
 ### Negative
@@ -135,7 +117,7 @@ Rejected: implicit globals conflict with Wado's explicit philosophy.
 let content: String;
 ```
 
-Rejected: it introduces a declaration whose value comes from nowhere visible, and it needs its own rules for placement, type, and duplicates. `#data` is an expression that reads exactly where the data is used, and reuses the compile-time literal machinery.
+Rejected: it introduces a declaration whose value comes from nowhere visible, and it needs its own rules for placement, type, and duplicates. `#data` is an expression that reads exactly where the data is used.
 
 ### Compile-Time Format Parsing
 

--- a/docs/wep-2026-01-12-data-section.md
+++ b/docs/wep-2026-01-12-data-section.md
@@ -4,7 +4,7 @@ Status: Implemented
 
 ## Context
 
-E2E testing of the Wado compiler needs test metadata (expected stdout, stderr, exit code, target world) co-located with the test source. Programs also benefit from embedding static text (configuration, fixtures, documents) without a companion file.
+A module often carries static text that belongs with it — configuration, fixtures, embedded documents, metadata a tool reads — and a companion file for it drifts from the source it describes.
 
 Several languages provide similar mechanisms:
 
@@ -60,34 +60,16 @@ Hello from the data section!
 
 The literal yields raw text. There is no format-parsing form: a program that wants structured data parses the text itself (`core:json`, `core:cbor`, …), keeping the compiler free of format knowledge.
 
-For tooling, the compiler exposes the content on the parsed module as `Option<&str>`, so a test runner or IDE can read it without compiling the file.
-
-### E2E Test Format
-
-Compiler E2E fixtures put their test specification in the data section as strict JSON — comments are not allowed.
-
-```wado
-export fn run() with Stdout {
-    println("Hello");
-}
-
-__DATA__
-{
-  "stdout": "Hello\n"
-}
-```
-
-The target world comes from the top-level key: no world key means `wasi:cli/command`, `"test": {}` selects the test world, and `"wasi:http/service": {...}` the HTTP world. A fixture with no data section at all defaults to the test world, so a library-shaped source doubles as a fixture verbatim. The full field table lives in [`wado-compiler/CLAUDE.md`](../wado-compiler/CLAUDE.md).
+For tooling, the compiler exposes the content on the parsed module, so a tool can read it without compiling the file.
 
 ## Consequences
 
 ### Positive
 
-- Self-contained tests: expectations live with the test source
+- Self-contained: the data travels with the module that owns it
 - Module-scoped: each file has an independent data section, unlike Ruby
 - Explicit access: `#data` makes the dependency visible at the use site
 - Tooling-friendly: readable as plain text, without compiling the file
-- Strict JSON in fixtures: unambiguous, no dialect to implement
 
 ### Negative
 
@@ -139,17 +121,17 @@ Rejected: less declarative, and its compile-time evaluation is less obvious than
 ### Comment-Based Directives
 
 ```wado
-// CHECK-STDOUT: Hello
-// CHECK-EXIT: 0
+// key: value
+// other: value
 ```
 
-Rejected: less structured, and complex expectations are hard to express.
+Rejected: the payload is bound to the comment syntax, so it cannot hold arbitrary text, and multi-line data is awkward to write and to read back.
 
-### Separate Expectation Files
+### Separate Data Files
 
 ```
-tests/hello.wado
-tests/hello.expected.json
+hello.wado
+hello.data.json
 ```
 
-Rejected: file proliferation, and the two drift apart.
+Rejected: file proliferation, and the pair drifts apart.

--- a/docs/wep-2026-01-12-data-section.md
+++ b/docs/wep-2026-01-12-data-section.md
@@ -1,11 +1,10 @@
 # WEP: Data Section (`__DATA__`)
 
-**Date:** 2026-01-12
-**Status:** Proposed
+Status: Implemented
 
 ## Context
 
-For E2E testing of the Wado compiler, we need a way to embed test metadata (expected stdout, stderr, exit code) within test fixture files. Rather than maintaining separate files for test inputs and expected outputs, a self-contained format is preferable.
+E2E testing of the Wado compiler needs test metadata (expected stdout, stderr, exit code, target world) co-located with the test source. Programs also benefit from embedding static text (configuration, fixtures, documents) without a companion file.
 
 Several languages provide similar mechanisms:
 
@@ -14,28 +13,23 @@ Several languages provide similar mechanisms:
 | Perl     | `__DATA__` / `__END__` | `<DATA>` filehandle | Per-package             |
 | Ruby     | `__END__`              | `DATA` IO object    | Global (main file only) |
 
-Other testing approaches include:
+The requirements:
 
-- **Cram tests**: Shell session format with `$` prefixed commands
-- **LLVM lit/FileCheck**: `RUN:` and `CHECK:` directives in comments
-- **OCaml ppx_expect**: `[%expect {...}]` blocks with auto-promotion
-- **Snapshot testing**: External golden files in `testdata/` or `__snapshots__/`
-
-We want a solution that:
-
-1. Keeps test data co-located with test source
-2. Is module-scoped (not global like Ruby)
-3. Aligns with Wado's explicit design philosophy
-4. Supports structured data (JSON) for test metadata
+1. Keep data co-located with source
+2. Module-scoped, not global like Ruby
+3. Explicit access, matching Wado's design philosophy
+4. Readable by tooling without a full compilation
 
 ## Decision
 
-### The `__DATA__` Keyword
+### The `__DATA__` Marker
 
-The `__DATA__` keyword marks the end of Wado source code and the beginning of a data section:
+`__DATA__` ends the source code and starts the data section:
 
 ```wado
-fn main() {
+use { println } from "core:cli";
+
+fn run() with Stdout {
     println("Hello, World!");
 }
 
@@ -44,161 +38,113 @@ This is the data section.
 It can contain any text.
 ```
 
-- `__DATA__` must appear at the start of a line (no leading whitespace)
-- Everything after `__DATA__` until EOF is the data section content
-- The `__DATA__` line itself is not included in the content
-- Each module (file) can have its own data section
+Lexical rules:
 
-### The `#[data]` Attribute
+- The marker must start at column 1 and be alone on its line — only a newline or EOF may follow it.
+- Everything after the marker line, verbatim to EOF, is the content. The marker line itself is excluded; the content is not trimmed.
+- The content is never tokenized, so it may hold any text, including text that is not valid Wado.
+- A module has at most one data section.
+- `__DATA__` that violates the placement rules (indented, or with trailing content on its line) is an ordinary identifier.
 
-To access the data section from within Wado code, use the `#[data]` attribute:
+`wado format` round-trips the section: the marker and its content are re-emitted unchanged after the formatted source.
+
+### Accessing the Content from Wado: `#data`
+
+The `#data` compile-time literal expands to the module's data section as a `String` constant. Using it in a module with no data section is a compile error.
 
 ```wado
-#[data]
-let content: String;
-
-fn main() {
-    println(content);  // Prints the data section
+export fn run() with Stdout {
+    println(#data);
 }
 
 __DATA__
 Hello from the data section!
 ```
 
-Rules:
+`#data` is one of the compile-time location literals; see [Compile-Time Location Literals](./wep-2026-01-23-compile-time-location-literals.md).
 
-- `#[data]` can only be applied to module-level `let` bindings
-- The binding must have type `String`
-- Compile error if `#[data]` is used without a `__DATA__` section
-- Compile error if multiple `#[data]` bindings exist in a module
+The literal yields raw text. There is no format-parsing form: a program that wants structured data parses the text itself (`core:json`, `core:cbor`, …), keeping the compiler free of format knowledge.
 
-### Future Extension: Structured Data
+### Compiler API
 
-In a future version, `#[data("format")]` will parse the data section:
+`Module::data_section()` returns `Option<&str>` and is populated by the lexer, so it is available right after parsing, before type checking:
+
+```rust
+let parsed = wado_compiler::parse(source);
+if let Some(data) = parsed.ast.data_section() {
+    // Process the data section content
+}
+```
+
+The content is carried through the pipeline: the TIR and NIR module nodes each expose `data_section()` and `with_data_section()`.
+
+### E2E Test Format
+
+Compiler E2E fixtures (`wado-compiler/tests/fixtures/*.wado`) put their test specification in the data section as strict JSON — `serde_json` parses it, so comments are not allowed.
 
 ```wado
-#[data("json")]
-let config: TreeMap<String, Any>;
-
-#[data("jsonc")]  // JSON with comments
-let test_spec: TestSpec;
+export fn run() with Stdout {
+    println("Hello");
+}
 
 __DATA__
 {
-  "exit": 0,
   "stdout": "Hello\n"
 }
 ```
 
-Supported formats (future):
+The target world comes from the top-level key: no world key means `wasi:cli/command`, `"test": {}` selects the test world, and `"wasi:http/service": {...}` the HTTP world. A fixture with no data section at all defaults to the test world, so a library-shaped source doubles as a fixture verbatim.
 
-- `"json"` - Standard JSON
-- `"jsonc"` - JSON with `//` and `/* */` comments
-
-Parse errors become compile errors, ensuring invalid test data is caught early.
-
-### Compiler API for Tooling
-
-The compiler exposes an API for tools (test runners, IDEs) to access data sections without full compilation:
-
-```rust
-// In wado-compiler
-impl Module {
-    /// Returns the data section content, if present.
-    /// This is available after parsing, before type checking.
-    pub fn data_section(&self) -> Option<&str>;
-}
-```
-
-This allows test harnesses to:
-
-1. Parse only the data section (fast)
-2. Extract test expectations as JSON
-3. Run the compiled program
-4. Compare actual vs expected output
-
-### E2E Test Format
-
-For compiler E2E tests, the data section uses JSONC format:
-
-```wado
-// tests/fixtures/hello.wado
-fn main() {
-    println("Hello");
-    eprintln("Warning");
-}
-
-__DATA__
-{
-  // Expected behavior
-  "exit": 0,
-  "stdout": "Hello\n",
-  "stderr": "Warning\n"
-}
-```
-
-Test specification schema:
-
-```typescript
-interface TestSpec {
-  // Expected exit code (default: 0)
-  exit?: number;
-
-  // Expected stdout (exact match)
-  stdout?: string;
-
-  // Expected stderr (exact match)
-  stderr?: string;
-
-  // Alternative: pattern matching
-  stdout_contains?: string[];
-  stderr_contains?: string[];
-
-  // Compiler behavior
-  compile_error?: string; // Expected compilation failure
-}
-```
+The harness reads the section as text (`extract_data_section`) rather than compiling the fixture first, which keeps spec extraction independent of whether the fixture compiles — a fixture asserting `compile_error` still has a readable spec. The full field table lives in [`wado-compiler/CLAUDE.md`](../wado-compiler/CLAUDE.md).
 
 ## Consequences
 
 ### Positive
 
-- **Self-contained tests**: Test expectations live with test source
-- **Module-scoped**: Each file has independent data section (unlike Ruby)
-- **Explicit access**: `#[data]` attribute makes data usage visible
-- **Early error detection**: JSON parse errors are compile-time errors
-- **Tooling-friendly**: Compiler API enables fast test extraction
-- **No YAML**: Uses JSON/JSONC which is strict and unambiguous
+- Self-contained tests: expectations live with the test source
+- Module-scoped: each file has an independent data section, unlike Ruby
+- Explicit access: `#data` makes the dependency visible at the use site
+- Tooling-friendly: available after parsing, and readable as plain text without parsing at all
+- Strict JSON in fixtures: unambiguous, no dialect to implement
 
 ### Negative
 
-- **Single data section per file**: Cannot have multiple named sections (could extend later with `__DATA__:name` if needed)
-- **Text only initially**: Binary data requires encoding (base64) until future extensions
-- **New syntax**: `__DATA__` is a new top-level construct to learn
+- One unnamed section per file; multiple sections would need an extension such as `__DATA__:name`
+- Text only — binary payloads need encoding (`#include_bytes` covers the binary case from a separate file)
+- `__DATA__` is a top-level construct with no analogue elsewhere in the syntax
 
 ### Neutral
 
-- Similar to Perl/Ruby, so familiar to developers from those ecosystems
-- The `#[data]` attribute pattern is consistent with other Wado attributes
-
-## Implementation Notes
-
-1. **Lexer**: Recognize `__DATA__` as end-of-source marker
-2. **Parser**: Store data section content in AST's Module node
-3. **Compiler API**: Expose `Module::data_section()` after parsing
-4. **Codegen**: For `#[data]`, emit the string as a constant
-5. **Test harness**: Parse data section as JSONC, run program, compare results
+- Familiar to developers coming from Perl and Ruby
+- `#data` shares its compile-time evaluation model with `#file`, `#line`, `#function`, and `#include_str`
 
 ## Alternatives Considered
 
 ### Magic Global Variable
 
 ```wado
-// Ruby-style
-println(DATA);  // Magic global
+println(DATA);  // Ruby-style
 ```
 
-Rejected: Implicit globals conflict with Wado's explicit philosophy.
+Rejected: implicit globals conflict with Wado's explicit philosophy.
+
+### `#[data]` Attribute on a Binding
+
+```wado
+#[data]
+let content: String;
+```
+
+Rejected: it introduces a declaration whose value comes from nowhere visible, and it needs its own rules for placement, type, and duplicates. `#data` is an expression that reads exactly where the data is used, and reuses the compile-time literal machinery.
+
+### Compile-Time Format Parsing
+
+```wado
+#[data("json")]
+let config: TreeMap<String, Any>;
+```
+
+Rejected: it puts format parsers and their diagnostics in the compiler, and pins the parsed shape to types the compiler must know. Parsing the raw text in Wado keeps formats in the standard library.
 
 ### Built-in Function
 
@@ -206,17 +152,16 @@ Rejected: Implicit globals conflict with Wado's explicit philosophy.
 let content = builtin::data();
 ```
 
-Rejected: Less declarative; harder to optimize (compile-time evaluation less obvious).
+Rejected: less declarative, and its compile-time evaluation is less obvious than a `#`-prefixed literal.
 
 ### Comment-Based Directives
 
 ```wado
 // CHECK-STDOUT: Hello
 // CHECK-EXIT: 0
-fn main() { println("Hello"); }
 ```
 
-Rejected: Less structured; harder to parse complex expectations; LLVM-style is powerful but complex.
+Rejected: less structured, and complex expectations are hard to express.
 
 ### Separate Expectation Files
 
@@ -225,4 +170,4 @@ tests/hello.wado
 tests/hello.expected.json
 ```
 
-Rejected: File proliferation; harder to keep in sync; less self-contained.
+Rejected: file proliferation, and the two drift apart.


### PR DESCRIPTION
The `__DATA__` WEP states the design the compiler implements, and `docs/spec.md` agrees with it.

## `docs/wep-2026-01-12-data-section.md`

Status is `Implemented`. The scope is the language-level mechanism:

- Marker: starts at column 1, alone on its line; the content runs verbatim to EOF, is never tokenized, is at most one per module, and survives `wado format` unchanged. `__DATA__` anywhere else is an ordinary identifier.
- Access: the `#data` compile-time literal expands to the section as a `String`, and is a compile error in a module without one. It yields raw text, so structured data is parsed by the program (`core:json`, `core:cbor`, …) rather than by the compiler.
- Tooling reads the content off the parsed module, without compiling the file.

The fixture spec format — its JSON shape and world-selection keys — belongs to `wado test` and stays in `wado-compiler/CLAUDE.md`, so the WEP does not describe it.

The `#[data]` attribute, compile-time format parsing, a magic global, a builtin function, comment directives, and separate data files sit in Alternatives Considered with their rejection reasons.

## `docs/spec.md`

The Accessing Data section points at the compiler API on the parsed module and at `#data`, without Rust snippets.