### PR TITLE
feat(stdlib): add f32::mul_add and f64::mul_add

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -977,7 +977,7 @@ See [`core:prelude`](./stdlib-core-prelude.md) for the full API.
 f64::sin(x)    f64::cos(x)    f64::sqrt(x)
 f64::abs(x)    f64::ceil(x)   f64::floor(x)
 f64::pow(x, y) f64::ln(x)     f64::exp(x)
-f64::mul_add(x, y, z)          // x * y + z, rounded once
+f64::mul_add(x, y, z)          // x * y + z, rounded once (software FMA)
 
 x.is_nan()     x.is_finite()    // where x is f64 or f32
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -977,6 +977,7 @@ See [`core:prelude`](./stdlib-core-prelude.md) for the full API.
 f64::sin(x)    f64::cos(x)    f64::sqrt(x)
 f64::abs(x)    f64::ceil(x)   f64::floor(x)
 f64::pow(x, y) f64::ln(x)     f64::exp(x)
+f64::mul_add(x, y, z)          // x * y + z, rounded once
 
 x.is_nan()     x.is_finite()    // where x is f64 or f32
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -977,7 +977,7 @@ See [`core:prelude`](./stdlib-core-prelude.md) for the full API.
 f64::sin(x)    f64::cos(x)    f64::sqrt(x)
 f64::abs(x)    f64::ceil(x)   f64::floor(x)
 f64::pow(x, y) f64::ln(x)     f64::exp(x)
-f64::mul_add(x, y, z)          // x * y + z, rounded once (software FMA)
+f64::mul_add(x, y, z)
 
 x.is_nan()     x.is_finite()    // where x is f64 or f32
 

--- a/docs/stdlib-core-prelude.md
+++ b/docs/stdlib-core-prelude.md
@@ -2074,6 +2074,13 @@ Euclidean distance: sqrt(x^2 + y^2)
 
 Floating-point remainder of x/y
 
+#### `pub fn mul_add(x: f32, y: f32, z: f32) -> f32`
+
+x _ y + z, rounded once instead of twice.
+
+Wasm has no scalar FMA instruction, so this is a software
+implementation — slower than `x * y + z`.
+
 #### `pub fn is_nan(&self) -> bool`
 
 #### `pub fn is_finite(&self) -> bool`
@@ -2315,6 +2322,13 @@ Euclidean distance: sqrt(x^2 + y^2)
 #### `pub fn fmod(x: f64, y: f64) -> f64`
 
 Floating-point remainder of x/y
+
+#### `pub fn mul_add(x: f64, y: f64, z: f64) -> f64`
+
+x _ y + z, rounded once instead of twice.
+
+Wasm has no scalar FMA instruction, so this is a software
+implementation — slower than `x * y + z`.
 
 #### `pub fn is_nan(&self) -> bool`
 

--- a/docs/stdlib-core-prelude.md
+++ b/docs/stdlib-core-prelude.md
@@ -2076,7 +2076,7 @@ Floating-point remainder of x/y
 
 #### `pub fn mul_add(x: f32, y: f32, z: f32) -> f32`
 
-x _ y + z, rounded once instead of twice.
+`x * y + z`, rounded once instead of twice.
 
 Wasm has no scalar FMA instruction, so this is a software
 implementation — slower than `x * y + z`.
@@ -2325,7 +2325,7 @@ Floating-point remainder of x/y
 
 #### `pub fn mul_add(x: f64, y: f64, z: f64) -> f64`
 
-x _ y + z, rounded once instead of twice.
+`x * y + z`, rounded once instead of twice.
 
 Wasm has no scalar FMA instruction, so this is a software
 implementation — slower than `x * y + z`.

--- a/mise.toml
+++ b/mise.toml
@@ -517,8 +517,7 @@ description = "Rebuild bundled libm Wasm module"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# STRIP=none overrides the workspace release profile so the wat keeps the
-# name section, which the generated Wasm carries into debug builds.
+# STRIP=none keeps the name section the workspace release profile strips.
 cd wado-bundled-libm && CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_STRIP=none cargo build --release && cd ..
 WAT_FILE="wado-compiler/lib/core/libm.wat"
 WAT_TMP="${WAT_FILE}.tmp"

--- a/mise.toml
+++ b/mise.toml
@@ -517,8 +517,10 @@ description = "Rebuild bundled libm Wasm module"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-cd wado-bundled-libm && CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_LTO=true cargo build --release && cd ..
-WAT_FILE="wado-compiler/lib/builtins/wado-bundled-libm.wat"
+# STRIP=none overrides the workspace release profile so the wat keeps the
+# name section, which the generated Wasm carries into debug builds.
+cd wado-bundled-libm && CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_LTO=true CARGO_PROFILE_RELEASE_STRIP=none cargo build --release && cd ..
+WAT_FILE="wado-compiler/lib/core/libm.wat"
 WAT_TMP="${WAT_FILE}.tmp"
 cargo run --bin wado-dev-tools -- wasm2wat target/wasm32-unknown-unknown/release/wado_bundled_libm.wasm > "$WAT_TMP"
 if cmp -s "$WAT_TMP" "$WAT_FILE"; then

--- a/wado-bundled-libm/src/lib.rs
+++ b/wado-bundled-libm/src/lib.rs
@@ -141,6 +141,13 @@ pub extern "C" fn libm_fmod(x: f64, y: f64) -> f64 {
     libm::fmod(x, y)
 }
 
+// Fused multiply-add (f64)
+
+#[unsafe(no_mangle)]
+pub extern "C" fn libm_fma(x: f64, y: f64, z: f64) -> f64 {
+    libm::fma(x, y, z)
+}
+
 // Trigonometric functions (f32)
 
 #[unsafe(no_mangle)]
@@ -269,6 +276,13 @@ pub extern "C" fn libm_hypotf(x: f32, y: f32) -> f32 {
 #[unsafe(no_mangle)]
 pub extern "C" fn libm_fmodf(x: f32, y: f32) -> f32 {
     libm::fmodf(x, y)
+}
+
+// Fused multiply-add (f32)
+
+#[unsafe(no_mangle)]
+pub extern "C" fn libm_fmaf(x: f32, y: f32, z: f32) -> f32 {
+    libm::fmaf(x, y, z)
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/wado-compiler/lib/core/libm.wat
+++ b/wado-compiler/lib/core/libm.wat
@@ -7,18 +7,17 @@
   (type (;5;) (func (param i32 f64)))
   (type (;6;) (func (param i32 f32)))
   (type (;7;) (func (param f64 i32) (result f64)))
-  (type (;8;) (func))
-  (type (;9;) (func (param i32)))
-  (type (;10;) (func (param f32 i32) (result f32)))
-  (type (;11;) (func (param f64 f64 i32) (result f64)))
-  (type (;12;) (func (param i32 i32 i32 i32 i32) (result i32)))
-  (type (;13;) (func (param i32 f64 i32)))
-  (type (;14;) (func (param i32 i64 i64 i32)))
+  (type (;8;) (func (param f32 f32 f32) (result f32)))
+  (type (;9;) (func))
+  (type (;10;) (func (param i32)))
+  (type (;11;) (func (param f32 i32) (result f32)))
+  (type (;12;) (func (param f64 f64 i32) (result f64)))
+  (type (;13;) (func (param i32 i32 i32 i32 i32) (result i32)))
+  (type (;14;) (func (param i32 f64 i32)))
   (type (;15;) (func (param i32 i64 i64 i64 i64)))
+  (type (;16;) (func (param i32 i64 i64 i32)))
   (memory (;0;) 17)
   (global $__stack_pointer (;0;) (mut i32) (i32.const 1048576))
-  (global (;1;) i32 (i32.const 1053712))
-  (global (;2;) i32 (i32.const 1053712))
   (export "memory" (memory 0))
   (export "libm_acos" (func $libm_acos))
   (export "libm_acosf" (func $libm_acosf))
@@ -46,6 +45,8 @@
   (export "libm_expf" (func $libm_expf))
   (export "libm_expm1" (func $libm_expm1))
   (export "libm_expm1f" (func $libm_expm1f))
+  (export "libm_fma" (func $libm_fma))
+  (export "libm_fmaf" (func $libm_fmaf))
   (export "libm_fmod" (func $libm_fmod))
   (export "libm_fmodf" (func $libm_fmodf))
   (export "libm_hypot" (func $libm_hypot))
@@ -68,8 +69,6 @@
   (export "libm_tanf" (func $libm_tanf))
   (export "libm_tanh" (func $libm_tanh))
   (export "libm_tanhf" (func $libm_tanhf))
-  (export "__data_end" (global 1))
-  (export "__heap_base" (global 2))
   (func $libm_acos (;0;) (type 0) (param f64) (result f64)
     (local i64 i32 f64 f64)
     (block ;; label = @1
@@ -150,7 +149,7 @@
                                   (f64.const -0x1.33a271c8a2d4bp+1 (;=-2.403394911734414;))))
                               (f64.const 0x1p+0 (;=1;))))
                           (local.tee 3
-                            (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+                            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
                               (local.get 0))))
                         (f64.div
                           (f64.sub
@@ -175,7 +174,7 @@
                     (f64.const 0x1.921fb54442d18p+0 (;=1.5707963267948966;))
                     (f64.add
                       (local.tee 4
-                        (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+                        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
                           (local.tee 0
                             (f64.mul
                               (f64.add
@@ -310,7 +309,7 @@
         (local.get 1)
         (i64.const -1)))
   )
-  (func $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E (;1;) (type 0) (param f64) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt (;1;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 f64 i64 i32 i32 i32 i32 i64 i64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -333,12 +332,9 @@
                 (i32.const -2047))
               (i32.const -2047)))
           (br_if 1 (;@2;)
-            (i64.eq
-              (local.get 2)
-              (i64.const -9223372036854775808)))
-          (br_if 1 (;@2;)
-            (i64.eqz
-              (local.get 2)))
+            (f64.eq
+              (local.get 0)
+              (f64.const 0x0p+0 (;=0;))))
           (br_if 1 (;@2;)
             (i64.eq
               (local.get 2)
@@ -380,7 +376,7 @@
         (local.set 8
           (local.tee 7
             (i32.shl
-              (i32.load16_u offset=1053232
+              (i32.load16_u offset=1057456
                 (i32.shl
                   (i32.and
                     (i32.wrap_i64
@@ -406,9 +402,6 @@
                             (i32.wrap_i64
                               (i64.shr_u
                                 (i64.mul
-                                  (local.tee 2
-                                    (i64.extend_i32_u
-                                      (local.get 7)))
                                   (i64.extend_i32_u
                                     (local.tee 6
                                       (i32.shl
@@ -416,13 +409,16 @@
                                           (i64.shr_u
                                             (i64.mul
                                               (i64.extend_i32_u
-                                                (local.get 8))
+                                                (local.get 6))
                                               (i64.extend_i32_u
-                                                (local.get 6)))
+                                                (local.get 8)))
                                             (i64.const 32)))
                                         (i32.ne
                                           (local.get 9)
-                                          (i32.const 0))))))
+                                          (i32.const 0)))))
+                                  (local.tee 2
+                                    (i64.extend_i32_u
+                                      (local.get 7))))
                                 (i64.const 32))))))
                       (local.get 2))
                     (i64.const 31))))
@@ -450,9 +446,9 @@
             (i32.add
               (local.get 1)
               (i32.const 32))
-            (local.get 10)
-            (i64.const 0)
             (local.get 11)
+            (i64.const 0)
+            (local.get 10)
             (i64.const 0))
           (call $__multi3
             (i32.add
@@ -528,8 +524,8 @@
                     (local.tee 2
                       (i64.add
                         (i64.add
-                          (local.get 2)
-                          (local.get 11))
+                          (local.get 11)
+                          (local.get 2))
                         (i64.const 1)))))
                 (i64.and
                   (i64.xor
@@ -598,7 +594,7 @@
                                 (f32.const -0x1.69cb5cp-1 (;=-0.70662963;)))
                               (f32.const 0x1p+0 (;=1;))))
                           (local.tee 3
-                            (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
+                            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf
                               (local.get 0))))
                         (f32.div
                           (f32.sub
@@ -623,7 +619,7 @@
                     (f32.const 0x1.921fb4p+0 (;=1.5707963;))
                     (f32.add
                       (local.tee 4
-                        (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
+                        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf
                           (local.tee 0
                             (f32.mul
                               (f32.add
@@ -706,7 +702,7 @@
         (local.get 1)
         (i32.const -1)))
   )
-  (func $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE (;3;) (type 1) (param f32) (result f32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf (;3;) (type 1) (param f32) (result f32)
     (local i32 f32 i32 i32 i32 i32 i32 i64)
     (block ;; label = @1
       (block ;; label = @2
@@ -720,12 +716,9 @@
                 (i32.const -2139095040))
               (i32.const -2130706433)))
           (br_if 2 (;@1;)
-            (i32.eq
-              (local.get 1)
-              (i32.const -2147483648)))
-          (br_if 2 (;@1;)
-            (i32.eqz
-              (local.get 1)))
+            (f32.eq
+              (local.get 0)
+              (f32.const 0x0p+0 (;=0;))))
           (br_if 2 (;@1;)
             (i32.eq
               (local.get 1)
@@ -748,7 +741,7 @@
         (local.set 5
           (local.tee 4
             (i32.shl
-              (i32.load16_u offset=1053232
+              (i32.load16_u offset=1057456
                 (i32.and
                   (i32.shr_u
                     (local.get 1)
@@ -784,9 +777,6 @@
                           (i32.wrap_i64
                             (i64.shr_u
                               (i64.mul
-                                (local.tee 8
-                                  (i64.extend_i32_u
-                                    (local.get 4)))
                                 (i64.extend_i32_u
                                   (local.tee 7
                                     (i32.shl
@@ -794,12 +784,15 @@
                                         (i64.shr_u
                                           (i64.mul
                                             (i64.extend_i32_u
-                                              (local.get 5))
+                                              (local.get 7))
                                             (i64.extend_i32_u
-                                              (local.get 7)))
+                                              (local.get 5)))
                                           (i64.const 32)))
                                       (i32.eqz
-                                        (local.get 3))))))
+                                        (local.get 3)))))
+                                (local.tee 8
+                                  (i64.extend_i32_u
+                                    (local.get 4))))
                               (i64.const 32))))))
                     (local.get 8))
                   (i64.const 31)))
@@ -850,8 +843,8 @@
                   (local.tee 3
                     (i32.add
                       (i32.add
-                        (local.get 3)
-                        (local.get 7))
+                        (local.get 7)
+                        (local.get 3))
                       (i32.const 1))))
                 (i32.and
                   (i32.xor
@@ -883,11 +876,11 @@
             (i32.const 1049)))
         (return
           (f64.add
-            (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3log3log
               (local.get 0))
             (f64.const 0x1.62e42fefa39efp-1 (;=0.6931471805599453;)))))
       (return
-        (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3log3log
           (f64.add
             (f64.add
               (local.get 0)
@@ -896,7 +889,7 @@
               (f64.const -0x1p+0 (;=-1;))
               (f64.add
                 (local.get 0)
-                (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
                   (f64.add
                     (f64.mul
                       (local.get 0)
@@ -906,10 +899,10 @@
       (f64.add
         (local.get 0)
         (f64.const -0x1p+0 (;=-1;))))
-    (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5log1p5log1p
       (f64.add
         (local.get 0)
-        (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
           (f64.add
             (f64.mul
               (local.get 0)
@@ -918,7 +911,7 @@
               (local.get 0)
               (local.get 0))))))
   )
-  (func $_ZN4libm4math3log3log17h781c40c93ff4fcfcE (;5;) (type 0) (param f64) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math3log3log (;5;) (type 0) (param f64) (result f64)
     (local i64 i32 i64 i32 f64 f64)
     (block ;; label = @1
       (block ;; label = @2
@@ -1073,7 +1066,7 @@
           (f64.const 0x0p+0 (;=0;)))))
     (local.get 0)
   )
-  (func $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E (;6;) (type 0) (param f64) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math5log1p5log1p (;6;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 f64 f64 f64)
     (local.set 1
       (i32.sub
@@ -1288,11 +1281,11 @@
             (i32.const 1166016512)))
         (return
           (f32.add
-            (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4logf4logf
               (local.get 0))
             (f32.const 0x1.62e43p-1 (;=0.6931472;)))))
       (return
-        (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4logf4logf
           (f32.add
             (f32.add
               (local.get 0)
@@ -1301,7 +1294,7 @@
               (f32.const -0x1p+0 (;=-1;))
               (f32.add
                 (local.get 0)
-                (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf
                   (f32.add
                     (f32.mul
                       (local.get 0)
@@ -1311,10 +1304,10 @@
       (f32.add
         (local.get 0)
         (f32.const -0x1p+0 (;=-1;))))
-    (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6log1pf6log1pf
       (f32.add
         (local.get 0)
-        (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf
           (f32.add
             (f32.mul
               (local.get 0)
@@ -1323,7 +1316,7 @@
               (local.get 0)
               (local.get 0))))))
   )
-  (func $_ZN4libm4math4logf4logf17h7b88872ed73a994aE (;8;) (type 1) (param f32) (result f32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math4logf4logf (;8;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 f32)
     (block ;; label = @1
       (block ;; label = @2
@@ -1444,7 +1437,7 @@
                       (f32.const 0x1.999c26p-2 (;=0.40000972;))))))))
           (local.get 4))))
   )
-  (func $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E (;9;) (type 1) (param f32) (result f32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math6log1pf6log1pf (;9;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 f32)
     (local.set 1
       (i32.sub
@@ -1689,7 +1682,7 @@
                           (f64.const -0x1.33a271c8a2d4bp+1 (;=-2.403394911734414;))))
                       (f64.const 0x1p+0 (;=1;)))))
                 (local.set 4
-                  (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
                     (local.get 0)))
                 (br_if 1 (;@5;)
                   (i32.gt_u
@@ -1724,10 +1717,10 @@
                                   (local.get 5))))
                             (local.get 0)))
                         (f64.mul
+                          (local.get 3)
                           (f64.add
                             (local.get 4)
-                            (local.get 4))
-                          (local.get 3))))
+                            (local.get 4)))))
                     (f64.const 0x1.921fb54442d18p-1 (;=0.7853981633974483;))))
                 (br 2 (;@4;)))
               (br_if 3 (;@2;)
@@ -1794,8 +1787,8 @@
                       (f64.add
                         (local.get 4)
                         (f64.mul
-                          (local.get 4)
-                          (local.get 3))))
+                          (local.get 3)
+                          (local.get 4))))
                     (local.get 0))
                   (f64.const -0x1.1a62633145c07p-54 (;=-0.00000000000000006123233995736766;))))))
           (return
@@ -1857,7 +1850,7 @@
                           (local.tee 3
                             (f64.add
                               (local.tee 3
-                                (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+                                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
                                   (f64.promote_f32
                                     (local.tee 1
                                       (f32.mul
@@ -1990,13 +1983,13 @@
               (local.get 0)
               (local.get 0)))
           (local.set 2
-            (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5log1p5log1p
               (f64.add
                 (local.get 2)
                 (f64.div
                   (local.get 0)
                   (f64.add
-                    (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+                    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
                       (f64.add
                         (local.get 0)
                         (f64.const 0x1p+0 (;=1;))))
@@ -2004,12 +1997,12 @@
           (br 2 (;@1;)))
         (local.set 2
           (f64.add
-            (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3log3log
               (local.get 2))
             (f64.const 0x1.62e42fefa39efp-1 (;=0.6931471805599453;))))
         (br 1 (;@1;)))
       (local.set 2
-        (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3log3log
           (f64.add
             (f64.add
               (local.get 2)
@@ -2018,7 +2011,7 @@
               (f64.const 0x1p+0 (;=1;))
               (f64.add
                 (local.get 2)
-                (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
                   (f64.add
                     (f64.mul
                       (local.get 0)
@@ -2077,13 +2070,13 @@
               (local.get 0)
               (local.get 0)))
           (local.set 2
-            (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6log1pf6log1pf
               (f32.add
                 (local.get 2)
                 (f32.div
                   (local.get 4)
                   (f32.add
-                    (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
+                    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf
                       (f32.add
                         (local.get 4)
                         (f32.const 0x1p+0 (;=1;))))
@@ -2091,12 +2084,12 @@
           (br 2 (;@1;)))
         (local.set 2
           (f32.add
-            (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4logf4logf
               (local.get 2))
             (f32.const 0x1.62e43p-1 (;=0.6931472;))))
         (br 1 (;@1;)))
       (local.set 2
-        (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4logf4logf
           (f32.add
             (f32.add
               (local.get 2)
@@ -2105,7 +2098,7 @@
               (f32.const 0x1p+0 (;=1;))
               (f32.add
                 (local.get 2)
-                (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf
                   (f32.add
                     (f32.mul
                       (local.get 0)
@@ -2125,10 +2118,10 @@
         (i32.const 0)))
   )
   (func $libm_atan (;14;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math4atan4atan17hb57e8f80d0bd9eddE
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4atan4atan
       (local.get 0))
   )
-  (func $_ZN4libm4math4atan4atan17hb57e8f80d0bd9eddE (;15;) (type 0) (param f64) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math4atan4atan (;15;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 i32 f64 f64 f64)
     (local.set 1
       (i32.sub
@@ -2302,7 +2295,7 @@
             (f64.neg
               (local.tee 0
                 (f64.sub
-                  (f64.load offset=1053536
+                  (f64.load offset=1053080
                     (local.tee 3
                       (i32.shl
                         (local.get 4)
@@ -2314,7 +2307,7 @@
                         (f64.add
                           (local.get 7)
                           (local.get 6)))
-                      (f64.load offset=1053568
+                      (f64.load offset=1053112
                         (local.get 3)))
                     (local.get 0)))))
             (local.get 0)
@@ -2362,7 +2355,7 @@
             (i32.wrap_i64
               (local.get 2)))))
       (return
-        (call $_ZN4libm4math4atan4atan17hb57e8f80d0bd9eddE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4atan4atan
           (local.get 0))))
     (local.set 6
       (i32.or
@@ -2422,7 +2415,7 @@
                   (local.get 7)
                   (i32.const 2146435072)))
               (return
-                (f64.load offset=1053616
+                (f64.load offset=1057712
                   (i32.shl
                     (local.get 6)
                     (i32.const 3)))))
@@ -2450,7 +2443,7 @@
                       (i32.const 67108864))
                     (local.get 3))))
               (local.set 8
-                (call $_ZN4libm4math4atan4atan17hb57e8f80d0bd9eddE
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4atan4atan
                   (f64.abs
                     (f64.div
                       (local.get 0)
@@ -2476,7 +2469,7 @@
                   (local.get 8)
                   (f64.const -0x1.1a62633145c07p-53 (;=-0.00000000000000012246467991473532;))))))
           (local.set 8
-            (f64.load offset=1053648
+            (f64.load offset=1057744
               (i32.shl
                 (local.get 6)
                 (i32.const 3)))))
@@ -2513,7 +2506,7 @@
               (local.get 1)))
           (i32.const 1065353216)))
       (return
-        (call $_ZN4libm4math5atanf5atanf17h0afe9904700c13b3E
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5atanf5atanf
           (local.get 0))))
     (local.set 5
       (i32.or
@@ -2560,7 +2553,7 @@
                       (local.get 4)
                       (i32.const 2139095040)))
                   (return
-                    (f32.load offset=1053680
+                    (f32.load offset=1057776
                       (i32.shl
                         (local.get 5)
                         (i32.const 2)))))
@@ -2596,7 +2589,7 @@
                     (i32.const 218103808))
                   (local.get 2))))
             (local.set 6
-              (call $_ZN4libm4math5atanf5atanf17h0afe9904700c13b3E
+              (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5atanf5atanf
                 (f32.abs
                   (f32.div
                     (local.get 0)
@@ -2622,7 +2615,7 @@
                 (local.get 6)
                 (f32.const 0x1.777a5cp-24 (;=0.00000008742278;))))))
         (local.set 6
-          (f32.load offset=1053696
+          (f32.load offset=1057792
             (i32.shl
               (local.get 5)
               (i32.const 2)))))
@@ -2632,7 +2625,7 @@
       (f32.const 0x1.921fb6p+0 (;=1.5707964;))
       (local.get 0))
   )
-  (func $_ZN4libm4math5atanf5atanf17h0afe9904700c13b3E (;18;) (type 1) (param f32) (result f32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math5atanf5atanf (;18;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 i32 i32 f32 f32)
     (local.set 1
       (i32.sub
@@ -2770,7 +2763,7 @@
             (select
               (local.tee 0
                 (f32.sub
-                  (f32.load offset=1048600
+                  (f32.load offset=1057296
                     (local.tee 4
                       (i32.shl
                         (local.get 5)
@@ -2782,7 +2775,7 @@
                         (f32.add
                           (local.get 7)
                           (local.get 3)))
-                      (f32.load offset=1048616
+                      (f32.load offset=1057312
                         (local.get 4)))
                     (local.get 0))))
               (f32.neg
@@ -2813,7 +2806,7 @@
     (local.get 0)
   )
   (func $libm_atanf (;19;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math5atanf5atanf17h0afe9904700c13b3E
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5atanf5atanf
       (local.get 0))
   )
   (func $libm_atanh (;20;) (type 0) (param f64) (result f64)
@@ -2842,7 +2835,7 @@
             (i32.const 1022)))
         (local.set 2
           (f64.mul
-            (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5log1p5log1p
               (f64.add
                 (local.tee 2
                   (f64.div
@@ -2860,7 +2853,7 @@
             (i32.const 991)))
         (local.set 2
           (f64.mul
-            (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5log1p5log1p
               (f64.add
                 (local.tee 0
                   (f64.add
@@ -2915,7 +2908,7 @@
             (i32.const 1056964608)))
         (local.set 2
           (f32.mul
-            (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6log1pf6log1pf
               (f32.add
                 (local.tee 2
                   (f32.div
@@ -2933,7 +2926,7 @@
             (i32.const 796917760)))
         (local.set 2
           (f32.mul
-            (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6log1pf6log1pf
               (f32.add
                 (local.tee 4
                   (f32.add
@@ -3056,7 +3049,7 @@
                 (local.get 6)))
             (i32.const 12))))
       (local.set 11
-        (call $_ZN4libm4math3fma3fma17hfec38a2f137b951cE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3fma3fma
           (local.tee 7
             (f64.mul
               (f64.sub
@@ -3106,7 +3099,7 @@
                     (f64.const 0x1.5555555555555p-2 (;=0.3333333333333333;)))))
               (f64.reinterpret_i64
                 (i64.or
-                  (i64.load offset=1052864
+                  (i64.load offset=1053144
                     (i32.shl
                       (local.tee 10
                         (i32.and
@@ -3174,7 +3167,7 @@
                                           (local.get 9)))
                                       (f64.add
                                         (f64.add
-                                          (call $_ZN4libm4math3fma3fma17hfec38a2f137b951cE
+                                          (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3fma3fma
                                             (local.get 7)
                                             (local.get 8)
                                             (f64.neg
@@ -3210,7 +3203,7 @@
                     (f64.const -0x1.8p-52 (;=-0.00000000000000033306690738754696;))))
                 (f64.const 0x1p-75 (;=0.000000000000000000000026469779601696886;))))))
         (local.set 9
-          (call $_ZN4libm4math3fma3fma17hfec38a2f137b951cE
+          (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3fma3fma
             (local.get 8)
             (local.get 8)
             (f64.neg
@@ -3247,7 +3240,7 @@
                                               (local.get 7)))
                                           (local.get 13))
                                         (f64.add
-                                          (call $_ZN4libm4math3fma3fma17hfec38a2f137b951cE
+                                          (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3fma3fma
                                             (local.get 8)
                                             (local.get 7)
                                             (f64.neg
@@ -3338,8 +3331,8 @@
     (f64.reinterpret_i64
       (local.get 2))
   )
-  (func $_ZN4libm4math3fma3fma17hfec38a2f137b951cE (;23;) (type 4) (param f64 f64 f64) (result f64)
-    (local i32 i64 i64 i32 i64 i64 i32 i32 i64 i64 i32 i64 i64 i64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math3fma3fma (;23;) (type 4) (param f64 f64 f64) (result f64)
+    (local i32 i64 i64 i32 i64 i64 i32 i32 i64 i64 i64 i64 i32 i64)
     (global.set $__stack_pointer
       (local.tee 3
         (i32.sub
@@ -3453,188 +3446,187 @@
               (local.get 1))
             (local.get 2)))
         (br 1 (;@1;)))
-      (local.set 13
-        (i32.add
-          (local.get 10)
-          (i32.const -1076)))
       (block ;; label = @2
         (block ;; label = @3
+          (br_if 0 (;@3;)
+            (i32.gt_s
+              (local.get 10)
+              (i32.const 2046)))
+          (local.set 13
+            (i64.or
+              (i64.and
+                (i64.shl
+                  (local.get 12)
+                  (i64.const 1))
+                (i64.const 9007199254740990))
+              (i64.const 9007199254740992)))
+          (local.set 12
+            (i64.const 0))
+          (call $__multi3
+            (local.get 3)
+            (i64.or
+              (i64.and
+                (i64.shl
+                  (local.get 8)
+                  (i64.const 1))
+                (i64.const 9007199254740990))
+              (i64.const 9007199254740992))
+            (i64.const 0)
+            (i64.or
+              (i64.and
+                (i64.shl
+                  (local.get 5)
+                  (i64.const 1))
+                (i64.const 9007199254740990))
+              (i64.const 9007199254740992))
+            (i64.const 0))
+          (local.set 14
+            (i64.load offset=8
+              (local.get 3)))
+          (local.set 5
+            (i64.load
+              (local.get 3)))
           (block ;; label = @4
             (br_if 0 (;@4;)
               (i32.gt_s
-                (local.get 10)
-                (i32.const 2046)))
-            (local.set 14
-              (i64.or
-                (i64.and
-                  (i64.shl
-                    (local.get 12)
-                    (i64.const 1))
-                  (i64.const 9007199254740990))
-                (i64.const 9007199254740992)))
-            (local.set 12
-              (i64.const 0))
-            (call $__multi3
-              (local.get 3)
-              (i64.or
-                (i64.and
-                  (i64.shl
-                    (local.get 8)
-                    (i64.const 1))
-                  (i64.const 9007199254740990))
-                (i64.const 9007199254740992))
-              (i64.const 0)
-              (i64.or
-                (i64.and
-                  (i64.shl
-                    (local.get 5)
-                    (i64.const 1))
-                  (i64.const 9007199254740990))
-                (i64.const 9007199254740992))
-              (i64.const 0))
-            (local.set 15
-              (i64.load offset=8
-                (local.get 3)))
-            (local.set 8
-              (i64.load
-                (local.get 3)))
+                (local.tee 6
+                  (i32.sub
+                    (local.tee 15
+                      (i32.add
+                        (local.get 10)
+                        (i32.const -1076)))
+                    (local.tee 9
+                      (i32.add
+                        (i32.add
+                          (local.get 6)
+                          (local.get 9))
+                        (i32.const -2152)))))
+                (i32.const 0)))
             (block ;; label = @5
               (br_if 0 (;@5;)
-                (i32.gt_s
-                  (local.tee 6
-                    (i32.sub
-                      (local.get 13)
-                      (local.tee 9
-                        (i32.add
-                          (i32.add
-                            (local.get 9)
-                            (local.get 6))
-                          (i32.const -2152)))))
-                  (i32.const 0)))
-              (block ;; label = @6
-                (br_if 0 (;@6;)
-                  (i32.ne
-                    (local.get 13)
-                    (local.get 9)))
-                (local.set 5
-                  (local.get 14))
-                (local.set 9
-                  (local.get 13))
-                (br 4 (;@2;)))
-              (block ;; label = @6
-                (br_if 0 (;@6;)
-                  (i32.ge_s
-                    (local.get 6)
-                    (i32.const -63)))
-                (local.set 5
-                  (i64.const 1))
-                (br 4 (;@2;)))
-              (local.set 12
-                (i64.const 0))
-              (local.set 5
-                (i64.or
-                  (i64.shr_u
-                    (local.get 14)
-                    (i64.extend_i32_u
-                      (i32.and
-                        (i32.sub
-                          (i32.const 0)
-                          (local.get 6))
-                        (i32.const 63))))
-                  (i64.extend_i32_u
-                    (i64.ne
-                      (i64.shl
-                        (local.get 14)
-                        (i64.extend_i32_u
-                          (i32.and
-                            (local.get 6)
-                            (i32.const 63))))
-                      (i64.const 0)))))
-              (br 3 (;@2;)))
-            (block ;; label = @5
-              (block ;; label = @6
-                (br_if 0 (;@6;)
-                  (i32.lt_u
-                    (local.get 6)
-                    (i32.const 64)))
-                (local.set 9
-                  (i32.add
-                    (local.get 10)
-                    (i32.const -1140)))
-                (br_if 1 (;@5;)
-                  (local.tee 10
-                    (i32.add
-                      (local.get 6)
-                      (i32.const -64))))
-                (br 3 (;@3;)))
-              (local.set 5
-                (i64.shl
-                  (local.get 14)
-                  (i64.extend_i32_u
-                    (local.get 6))))
-              (local.set 12
-                (i64.shr_u
-                  (local.get 14)
-                  (i64.extend_i32_u
-                    (i32.sub
-                      (i32.const 64)
-                      (local.get 6)))))
+                (i32.ne
+                  (local.get 15)
+                  (local.get 9)))
+              (local.set 8
+                (local.get 13))
+              (local.set 9
+                (local.get 15))
               (br 3 (;@2;)))
             (block ;; label = @5
               (br_if 0 (;@5;)
                 (i32.le_u
-                  (local.get 6)
-                  (i32.const 127)))
+                  (local.tee 10
+                    (i32.sub
+                      (i32.const 0)
+                      (local.get 6)))
+                  (i32.const 63)))
               (local.set 8
                 (i64.const 1))
-              (local.set 15
-                (i64.const 0))
-              (br 2 (;@3;)))
-            (local.set 5
+              (br 3 (;@2;)))
+            (local.set 12
               (i64.const 0))
             (local.set 8
               (i64.or
-                (local.tee 8
-                  (i64.or
-                    (i64.shl
-                      (local.get 15)
-                      (local.tee 12
-                        (i64.extend_i32_u
-                          (i32.sub
-                            (i32.const 128)
-                            (local.get 6)))))
-                    (i64.shr_u
-                      (local.get 8)
-                      (local.tee 16
-                        (i64.extend_i32_u
-                          (local.get 10))))))
+                (i64.shr_u
+                  (local.get 13)
+                  (i64.extend_i32_u
+                    (local.get 10)))
                 (i64.extend_i32_u
                   (i64.ne
                     (i64.shl
-                      (local.get 8)
-                      (local.get 12))
+                      (local.get 13)
+                      (i64.extend_i32_u
+                        (local.get 6)))
                     (i64.const 0)))))
-            (local.set 15
-              (i64.shr_u
-                (local.get 15)
-                (local.get 16)))
-            (local.set 12
-              (local.get 14))
             (br 2 (;@2;)))
-          (local.set 0
-            (select
-              (local.get 2)
-              (f64.mul
-                (local.get 0)
-                (local.get 1))
-              (i32.eq
+          (block ;; label = @4
+            (block ;; label = @5
+              (br_if 0 (;@5;)
+                (i32.lt_u
+                  (local.get 6)
+                  (i32.const 64)))
+              (local.set 9
+                (i32.add
+                  (local.get 10)
+                  (i32.const -1140)))
+              (br_if 1 (;@4;)
+                (local.tee 10
+                  (i32.add
+                    (local.get 6)
+                    (i32.const -64))))
+              (local.set 8
+                (i64.const 0))
+              (local.set 12
+                (local.get 13))
+              (br 3 (;@2;)))
+            (local.set 8
+              (i64.shl
                 (local.get 13)
-                (i32.const 971))))
-          (br 2 (;@1;)))
-        (local.set 5
-          (i64.const 0))
-        (local.set 12
-          (local.get 14)))
+                (i64.extend_i32_u
+                  (local.get 6))))
+            (local.set 12
+              (i64.shr_u
+                (local.get 13)
+                (i64.extend_i32_u
+                  (i32.sub
+                    (i32.const 64)
+                    (local.get 6)))))
+            (br 2 (;@2;)))
+          (block ;; label = @4
+            (br_if 0 (;@4;)
+              (i32.le_u
+                (local.get 6)
+                (i32.const 127)))
+            (local.set 5
+              (i64.const 1))
+            (local.set 8
+              (i64.const 0))
+            (local.set 14
+              (i64.const 0))
+            (local.set 12
+              (local.get 13))
+            (br 2 (;@2;)))
+          (local.set 8
+            (i64.const 0))
+          (local.set 5
+            (i64.or
+              (local.tee 16
+                (i64.or
+                  (i64.shr_u
+                    (local.get 5)
+                    (local.tee 12
+                      (i64.extend_i32_u
+                        (local.get 10))))
+                  (i64.shl
+                    (local.get 14)
+                    (local.tee 5
+                      (i64.extend_i32_u
+                        (i32.sub
+                          (i32.const 128)
+                          (local.get 6)))))))
+              (i64.extend_i32_u
+                (i64.ne
+                  (i64.shl
+                    (local.get 16)
+                    (local.get 5))
+                  (i64.const 0)))))
+          (local.set 14
+            (i64.shr_u
+              (local.get 14)
+              (local.get 12)))
+          (local.set 12
+            (local.get 13))
+          (br 1 (;@2;)))
+        (local.set 0
+          (select
+            (local.get 2)
+            (f64.mul
+              (local.get 0)
+              (local.get 1))
+            (i32.eq
+              (local.get 10)
+              (i32.const 2047))))
+        (br 1 (;@1;)))
       (block ;; label = @2
         (block ;; label = @3
           (block ;; label = @4
@@ -3650,29 +3642,29 @@
                         (i64.gt_s
                           (local.tee 7
                             (i64.xor
-                              (local.get 4)
-                              (local.get 7)))
+                              (local.get 7)
+                              (local.get 4)))
                           (i64.const -1)))))
                   (local.set 4
                     (select
                       (local.tee 4
                         (i64.sub
-                          (local.get 8)
-                          (local.get 5)))
+                          (local.get 5)
+                          (local.get 8)))
                       (i64.sub
                         (i64.const 0)
                         (local.get 4))
-                      (local.tee 13
+                      (local.tee 15
                         (i64.gt_s
                           (local.tee 11
                             (i64.sub
-                              (local.get 15)
-                              (i64.add
-                                (local.get 12)
+                              (i64.sub
+                                (local.get 14)
                                 (i64.extend_i32_u
                                   (i64.lt_u
-                                    (local.get 8)
-                                    (local.get 5))))))
+                                    (local.get 5)
+                                    (local.get 8))))
+                              (local.get 12)))
                           (i64.const -1)))))
                   (local.set 10
                     (select
@@ -3680,7 +3672,7 @@
                         (local.get 7)
                         (i64.const 0))
                       (local.get 6)
-                      (local.get 13)))
+                      (local.get 15)))
                   (br_if 1 (;@6;)
                     (i32.eqz
                       (i64.eqz
@@ -3692,10 +3684,10 @@
                                 (i64.const -1)
                                 (i64.const 0)
                                 (i64.ne
-                                  (local.get 8)
-                                  (local.get 5)))
+                                  (local.get 5)
+                                  (local.get 8)))
                               (local.get 11))
-                            (local.get 13))))))
+                            (local.get 15))))))
                   (br_if 2 (;@5;)
                     (i32.eqz
                       (i64.eqz
@@ -3716,7 +3708,7 @@
                   (i64.add
                     (i64.add
                       (local.get 12)
-                      (local.get 15))
+                      (local.get 14))
                     (i64.extend_i32_u
                       (i64.lt_u
                         (local.tee 4
@@ -3727,19 +3719,19 @@
               (local.set 4
                 (i64.or
                   (i64.or
-                    (i64.shr_u
-                      (local.get 4)
-                      (i64.sub
-                        (i64.const 1)
-                        (local.tee 11
-                          (i64.clz
-                            (local.get 7)))))
                     (i64.shl
                       (local.get 7)
                       (local.tee 5
                         (i64.add
-                          (local.get 11)
-                          (i64.const -1)))))
+                          (local.tee 11
+                            (i64.clz
+                              (local.get 7)))
+                          (i64.const -1))))
+                    (i64.shr_u
+                      (local.get 4)
+                      (i64.sub
+                        (i64.const 1)
+                        (local.get 11))))
                   (i64.extend_i32_u
                     (i64.ne
                       (i64.shl
@@ -3757,37 +3749,40 @@
                 (i32.eqz
                   (local.get 10)))
               (br 2 (;@3;)))
-            (local.set 6
-              (i32.sub
-                (local.get 9)
-                (local.tee 13
-                  (i32.add
-                    (i32.wrap_i64
-                      (local.tee 7
-                        (i64.clz
-                          (local.get 4))))
-                    (i32.const -1)))))
             (block ;; label = @5
               (br_if 0 (;@5;)
-                (i64.ne
-                  (local.get 7)
-                  (i64.const 0)))
+                (i64.eqz
+                  (local.tee 7
+                    (i64.clz
+                      (local.get 4)))))
+              (local.set 6
+                (i32.sub
+                  (local.get 9)
+                  (local.tee 15
+                    (i32.add
+                      (i32.wrap_i64
+                        (local.get 7))
+                      (i32.const -1)))))
               (local.set 4
-                (i64.or
-                  (i64.and
-                    (local.get 4)
-                    (i64.const 1))
-                  (i64.shr_u
-                    (local.get 4)
-                    (i64.const 1))))
+                (i64.shl
+                  (local.get 4)
+                  (i64.extend_i32_u
+                    (local.get 15))))
               (br_if 2 (;@3;)
                 (local.get 10))
               (br 1 (;@4;)))
             (local.set 4
-              (i64.shl
-                (local.get 4)
-                (i64.extend_i32_u
-                  (local.get 13))))
+              (i64.or
+                (i64.and
+                  (local.get 4)
+                  (i64.const 1))
+                (i64.shr_u
+                  (local.get 4)
+                  (i64.const 1))))
+            (local.set 6
+              (i32.add
+                (local.get 9)
+                (i32.const 1)))
             (br_if 1 (;@3;)
               (local.get 10)))
           (local.set 10
@@ -3838,9 +3833,9 @@
                       (local.get 10)))
                   (f64.const 0x1p-969 (;=0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002004168360008973;))))
               (br_if 1 (;@4;)
-                (i32.le_u
+                (i32.lt_u
                   (local.get 6)
-                  (i32.const -1992)))
+                  (i32.const -1991)))
               (local.set 6
                 (i32.add
                   (local.get 6)
@@ -3873,82 +3868,73 @@
                 (local.get 0)
                 (f64.const 0x1p+1023 (;=89884656743115800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;))))
             (br 2 (;@2;)))
+          (local.set 6
+            (i32.add
+              (local.get 6)
+              (i32.const 1938)))
+          (local.set 0
+            (f64.mul
+              (local.get 0)
+              (f64.const 0x1p-969 (;=0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002004168360008973;))))
+          (br 1 (;@2;)))
+        (block ;; label = @3
+          (br_if 0 (;@3;)
+            (f64.eq
+              (local.tee 2
+                (select
+                  (f64.const -0x1p+63 (;=-9223372036854776000;))
+                  (f64.const 0x1p+63 (;=9223372036854776000;))
+                  (local.get 10)))
+              (local.get 0)))
+          (block ;; label = @4
+            (br_if 0 (;@4;)
+              (i64.eqz
+                (i64.and
+                  (local.get 4)
+                  (i64.const 2047))))
+            (local.set 0
+              (f64.sub
+                (f64.add
+                  (local.tee 0
+                    (f64.convert_i64_s
+                      (select
+                        (i64.sub
+                          (i64.const 0)
+                          (local.tee 4
+                            (i64.or
+                              (i64.or
+                                (i64.and
+                                  (local.get 4)
+                                  (i64.const 1))
+                                (i64.shr_u
+                                  (local.get 4)
+                                  (i64.const 1)))
+                              (i64.const 4611686018427387904))))
+                        (local.get 4)
+                        (local.get 10))))
+                  (local.get 0))
+                (local.get 2))))
           (local.set 0
             (f64.mul
               (local.get 0)
               (f64.const 0x1p-969 (;=0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002004168360008973;))))
           (local.set 6
-            (i32.add
-              (select
-                (local.get 6)
-                (i32.const -2960)
-                (i32.gt_u
-                  (local.get 6)
-                  (i32.const -2960)))
-              (i32.const 1938)))
+            (i32.const -116))
           (br 1 (;@2;)))
-        (block ;; label = @3
-          (block ;; label = @4
-            (block ;; label = @5
-              (br_if 0 (;@5;)
-                (f64.eq
-                  (local.tee 2
-                    (select
-                      (f64.const -0x1p+63 (;=-9223372036854776000;))
-                      (f64.const 0x1p+63 (;=9223372036854776000;))
-                      (local.get 10)))
-                  (local.get 0)))
-              (br_if 1 (;@4;)
-                (i32.eqz
-                  (i64.eqz
-                    (i64.and
-                      (local.get 4)
-                      (i64.const 2047)))))
-              (br 2 (;@3;)))
-            (local.set 0
-              (f64.copysign
-                (f64.const 0x1p-1022 (;=0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022250738585072014;))
-                (local.get 0)))
-            (br 3 (;@1;)))
-          (local.set 0
-            (f64.sub
-              (f64.add
-                (local.tee 0
-                  (f64.convert_i64_s
-                    (select
-                      (i64.sub
-                        (i64.const 0)
-                        (local.tee 4
-                          (i64.or
-                            (i64.or
-                              (i64.and
-                                (local.get 4)
-                                (i64.const 1))
-                              (i64.shr_u
-                                (local.get 4)
-                                (i64.const 1)))
-                            (i64.const 4611686018427387904))))
-                      (local.get 4)
-                      (local.get 10))))
-                (local.get 0))
-              (local.get 2))))
         (local.set 0
-          (f64.mul
-            (local.get 0)
-            (f64.const 0x1p-969 (;=0.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002004168360008973;))))
-        (local.set 6
-          (i32.const -116)))
+          (f64.copysign
+            (f64.const 0x1p-1022 (;=0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022250738585072014;))
+            (local.get 0)))
+        (br 1 (;@1;)))
       (local.set 0
         (f64.mul
           (local.get 0)
           (f64.reinterpret_i64
             (i64.shl
               (i64.extend_i32_u
-                (i32.and
-                  (i32.add
-                    (local.get 6)
-                    (i32.const 1023))
-                  (i32.const 2047)))
+                (i32.add
+                  (local.get 6)
+                  (i32.const 1023)))
               (i64.const 52))))))
     (global.set $__stack_pointer
       (i32.add
@@ -4075,7 +4061,7 @@
                     (i32.gt_u
                       (local.get 2)
                       (i32.const 2146435071)))
-                  (call $_ZN4libm4math8rem_pio28rem_pio217hcfd3034c1d4391f0E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math8rem_pio28rem_pio2
                     (i32.add
                       (local.get 1)
                       (i32.const 8))
@@ -4102,7 +4088,7 @@
                       (local.get 2)
                       (i32.const 1044816030))))
                 (local.set 3
-                  (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_cos5k_cos
                     (local.get 0)
                     (f64.const 0x0p+0 (;=0;))))
                 (br 5 (;@1;)))
@@ -4157,7 +4143,7 @@
                     (local.get 3)))))
             (br 3 (;@1;)))
           (local.set 3
-            (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_cos5k_cos
               (local.get 0)
               (local.get 3)))
           (br 2 (;@1;)))
@@ -4209,7 +4195,7 @@
         (br 1 (;@1;)))
       (local.set 3
         (f64.neg
-          (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
+          (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_cos5k_cos
             (local.get 0)
             (local.get 3)))))
     (global.set $__stack_pointer
@@ -4218,7 +4204,7 @@
         (i32.const 32)))
     (local.get 3)
   )
-  (func $_ZN4libm4math8rem_pio28rem_pio217hcfd3034c1d4391f0E (;26;) (type 5) (param i32 f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math8rem_pio28rem_pio2 (;26;) (type 5) (param i32 f64)
     (local i32 i64 i32 i32 i32 i32 i32 f64 i32 i32)
     (global.set $__stack_pointer
       (local.tee 2
@@ -4265,10 +4251,8 @@
                     (i32.add
                       (local.get 2)
                       (i32.const 8)))
-                  (i64.store
-                    (i32.add
-                      (local.get 2)
-                      (i32.const 8))
+                  (i64.store offset=8
+                    (local.get 2)
                     (i64.const 0))
                   (i64.store
                     (local.get 2)
@@ -4337,21 +4321,17 @@
                       (br_if 0 (;@9;)
                         (i32.eqz
                           (local.get 10)))))
-                  (i64.store
-                    (i32.add
-                      (local.get 2)
-                      (i32.const 40))
+                  (i64.store offset=40
+                    (local.get 2)
                     (i64.const 0))
-                  (i64.store
-                    (i32.add
-                      (local.get 2)
-                      (i32.const 32))
+                  (i64.store offset=32
+                    (local.get 2)
                     (i64.const 0))
                   (i64.store offset=24
                     (local.get 2)
                     (i64.const 0))
                   (local.set 4
-                    (call $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hd7141cf13a36ffbcE
+                    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math14rem_pio2_large14rem_pio2_large
                       (local.get 2)
                       (select
                         (local.get 11)
@@ -4411,7 +4391,7 @@
                       (i32.ne
                         (local.get 5)
                         (i32.const 1075388923)))
-                    (call $_ZN4libm4math8rem_pio28rem_pio26medium17h661801483d1aa963E
+                    (call $_RNvNvNtNtCskrL9OOIMpwY_4libm4math8rem_pio28rem_pio26medium
                       (local.get 0)
                       (local.get 1)
                       (i32.const 1075388923))
@@ -4623,12 +4603,12 @@
                 (local.get 9))
               (f64.const -0x1.0b4611a626331p-34 (;=-0.00000000006077100506506192;))))
           (br 2 (;@1;)))
-        (call $_ZN4libm4math8rem_pio28rem_pio26medium17h661801483d1aa963E
+        (call $_RNvNvNtNtCskrL9OOIMpwY_4libm4math8rem_pio28rem_pio26medium
           (local.get 0)
           (local.get 1)
           (local.get 5))
         (br 1 (;@1;)))
-      (call $_ZN4libm4math8rem_pio28rem_pio26medium17h661801483d1aa963E
+      (call $_RNvNvNtNtCskrL9OOIMpwY_4libm4math8rem_pio28rem_pio26medium
         (local.get 0)
         (local.get 1)
         (i32.const 1074977148)))
@@ -4637,7 +4617,7 @@
         (local.get 2)
         (i32.const 48)))
   )
-  (func $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E (;27;) (type 2) (param f64 f64) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_cos5k_cos (;27;) (type 2) (param f64 f64) (result f64)
     (local f64 f64 f64)
     (f64.add
       (local.tee 4
@@ -4733,7 +4713,7 @@
                             (i32.gt_u
                               (local.get 4)
                               (i32.const 2139095039)))
-                          (call $_ZN4libm4math9rem_pio2f9rem_pio2f17h3b6adc3e5afb8880E
+                          (call $_RNvNtNtCskrL9OOIMpwY_4libm4math9rem_pio2f9rem_pio2f
                             (local.get 1)
                             (local.get 0))
                           (local.set 2
@@ -5139,7 +5119,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $_ZN4libm4math9rem_pio2f9rem_pio2f17h3b6adc3e5afb8880E (;29;) (type 6) (param i32 f32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math9rem_pio2f9rem_pio2f (;29;) (type 6) (param i32 f32)
     (local i32 f64 i32 i32 i32 f64)
     (global.set $__stack_pointer
       (local.tee 2
@@ -5183,7 +5163,7 @@
                         (i32.const -150)))
                     (i32.const 23))))))
           (local.set 5
-            (call $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hd7141cf13a36ffbcE
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math14rem_pio2_large14rem_pio2_large
               (local.get 2)
               (i32.const 1)
               (i32.add
@@ -5272,7 +5252,7 @@
           (local.set 0
             (f64.mul
               (f64.mul
-                (call $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3exp3exp
                   (f64.add
                     (local.get 0)
                     (f64.const -0x1.62066151add8bp+10 (;=-1416.0996898839683;))))
@@ -5283,7 +5263,7 @@
           (f64.mul
             (f64.add
               (local.tee 0
-                (call $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3exp3exp
                   (local.get 0)))
               (f64.div
                 (f64.const 0x1p+0 (;=1;))
@@ -5300,7 +5280,7 @@
             (f64.div
               (f64.mul
                 (local.tee 0
-                  (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5expm15expm1
                     (local.get 0)))
                 (local.get 0))
               (f64.add
@@ -5327,7 +5307,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE (;31;) (type 0) (param f64) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math3exp3exp (;31;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 i32 f64 f64 f64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -5419,7 +5399,7 @@
                       (f64.mul
                         (local.get 0)
                         (f64.const 0x1.71547652b82fep+0 (;=1.4426950408889634;)))
-                      (f64.load offset=1053600
+                      (f64.load offset=1053016
                         (i32.shl
                           (local.get 3)
                           (i32.const 3))))))
@@ -5504,7 +5484,7 @@
         (i32.eqz
           (local.get 4)))
       (local.set 5
-        (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn6scalbn
           (local.get 5)
           (local.get 4))))
     (global.set $__stack_pointer
@@ -5513,7 +5493,7 @@
         (i32.const 16)))
     (local.get 5)
   )
-  (func $_ZN4libm4math5expm15expm117hf425b3a732f15702E (;32;) (type 0) (param f64) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math5expm15expm1 (;32;) (type 0) (param f64) (result f64)
     (local i32 i64 i32 f64 f64 f64 f64)
     (f64.store offset=8
       (local.tee 1
@@ -5836,7 +5816,7 @@
           (local.set 0
             (f32.mul
               (f32.mul
-                (call $_ZN4libm4math4expf4expf17hedd2067d7b29c452E
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4expf4expf
                   (f32.add
                     (local.get 0)
                     (f32.const -0x1.45c778p+7 (;=-162.88959;))))
@@ -5847,7 +5827,7 @@
           (f32.mul
             (f32.add
               (local.tee 0
-                (call $_ZN4libm4math4expf4expf17hedd2067d7b29c452E
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4expf4expf
                   (local.get 0)))
               (f32.div
                 (f32.const 0x1p+0 (;=1;))
@@ -5864,7 +5844,7 @@
             (f32.div
               (f32.mul
                 (local.tee 0
-                  (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6expm1f6expm1f
                     (local.get 0)))
                 (local.get 0))
               (f32.add
@@ -5891,7 +5871,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $_ZN4libm4math4expf4expf17hedd2067d7b29c452E (;34;) (type 1) (param f32) (result f32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math4expf4expf (;34;) (type 1) (param f32) (result f32)
     (local i32 i32 i32 i32 f32 f32 f32)
     (global.set $__stack_pointer
       (local.tee 1
@@ -5995,7 +5975,7 @@
                     (f32.mul
                       (local.get 0)
                       (f32.const 0x1.715476p+0 (;=1.442695;)))
-                    (f32.load offset=1052728
+                    (f32.load offset=1057264
                       (i32.shl
                         (local.get 3)
                         (i32.const 2))))))
@@ -6063,7 +6043,7 @@
         (i32.eqz
           (local.get 4)))
       (local.set 5
-        (call $_ZN4libm4math6scalbn7scalbnf17ha430054e259e38a4E
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn7scalbnf
           (local.get 5)
           (local.get 4))))
     (global.set $__stack_pointer
@@ -6072,7 +6052,7 @@
         (i32.const 16)))
     (local.get 5)
   )
-  (func $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E (;35;) (type 1) (param f32) (result f32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math6expm1f6expm1f (;35;) (type 1) (param f32) (result f32)
     (local i32 i32 i32 f32 f32 f32 f32)
     (local.set 1
       (i32.sub
@@ -6367,7 +6347,7 @@
     (local.get 0)
   )
   (func $libm_exp (;36;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3exp3exp
       (local.get 0))
   )
   (func $libm_exp2 (;37;) (type 0) (param f64) (result f64)
@@ -6468,10 +6448,10 @@
             (f64.const 0x1p+1023 (;=89884656743115800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;))))
         (br 1 (;@1;)))
       (local.set 0
-        (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn6scalbn
           (f64.add
             (local.tee 7
-              (f64.load offset=1048632
+              (f64.load offset=1053168
                 (local.tee 6
                   (i32.and
                     (i32.shl
@@ -6496,7 +6476,7 @@
                       (f64.add
                         (local.get 4)
                         (f64.const -0x1.8p+44 (;=-26388279066624;))))
-                    (f64.load offset=1048640
+                    (f64.load offset=1053176
                       (local.get 6)))))
               (f64.add
                 (f64.mul
@@ -6524,7 +6504,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE (;38;) (type 7) (param f64 i32) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn6scalbn (;38;) (type 7) (param f64 i32) (result f64)
     (block ;; label = @1
       (block ;; label = @2
         (block ;; label = @3
@@ -6595,11 +6575,9 @@
       (f64.reinterpret_i64
         (i64.shl
           (i64.extend_i32_u
-            (i32.and
-              (i32.add
-                (local.get 1)
-                (i32.const 1023))
-              (i32.const 2047)))
+            (i32.add
+              (local.get 1)
+              (i32.const 1023)))
           (i64.const 52))))
   )
   (func $libm_exp2f (;39;) (type 1) (param f32) (result f32)
@@ -6681,7 +6659,7 @@
         (f64.add
           (f64.add
             (local.tee 5
-              (f64.load offset=1052736
+              (f64.load offset=1057328
                 (i32.shl
                   (i32.and
                     (local.tee 3
@@ -6732,19 +6710,100 @@
             (i64.const 52)))))
   )
   (func $libm_expf (;40;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math4expf4expf17hedd2067d7b29c452E
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4expf4expf
       (local.get 0))
   )
   (func $libm_expm1 (;41;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5expm15expm1
       (local.get 0))
   )
   (func $libm_expm1f (;42;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6expm1f6expm1f
       (local.get 0))
   )
-  (func $libm_fmod (;43;) (type 2) (param f64 f64) (result f64)
-    (local i32 i64 i64 i64 i64 i64 i64 i64 i64 i32 i32 i32 i64)
+  (func $libm_fma (;43;) (type 4) (param f64 f64 f64) (result f64)
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3fma3fma
+      (local.get 0)
+      (local.get 1)
+      (local.get 2))
+  )
+  (func $libm_fmaf (;44;) (type 8) (param f32 f32 f32) (result f32)
+    (local f64 f64 f64 i64 i32)
+    (block ;; label = @1
+      (br_if 0 (;@1;)
+        (i64.ne
+          (i64.and
+            (local.tee 6
+              (i64.reinterpret_f64
+                (local.tee 5
+                  (f64.add
+                    (local.tee 3
+                      (f64.mul
+                        (f64.promote_f32
+                          (local.get 0))
+                        (f64.promote_f32
+                          (local.get 1))))
+                    (local.tee 4
+                      (f64.promote_f32
+                        (local.get 2)))))))
+            (i64.const 536870911))
+          (i64.const 268435456)))
+      (br_if 0 (;@1;)
+        (i64.eq
+          (i64.and
+            (local.get 6)
+            (i64.const 9218868437227405312))
+          (i64.const 9218868437227405312)))
+      (block ;; label = @2
+        (br_if 0 (;@2;)
+          (f64.ne
+            (f64.sub
+              (local.get 5)
+              (local.get 3))
+            (local.get 4)))
+        (br_if 1 (;@1;)
+          (f64.eq
+            (f64.sub
+              (local.get 5)
+              (local.get 4))
+            (local.get 3))))
+      (local.set 5
+        (f64.reinterpret_i64
+          (select
+            (i64.add
+              (local.get 6)
+              (i64.const -1))
+            (i64.or
+              (local.get 6)
+              (i64.const 1))
+            (i32.xor
+              (local.tee 7
+                (i64.lt_s
+                  (local.get 6)
+                  (i64.const 0)))
+              (f64.lt
+                (select
+                  (f64.add
+                    (local.get 3)
+                    (f64.sub
+                      (local.get 4)
+                      (local.get 5)))
+                  (f64.add
+                    (f64.sub
+                      (local.get 3)
+                      (local.get 5))
+                    (local.get 4))
+                  (i32.xor
+                    (local.get 7)
+                    (f64.lt
+                      (local.get 3)
+                      (local.get 4))))
+                (f64.const 0x0p+0 (;=0;))))))))
+    (f32.demote_f64
+      (local.get 5))
+  )
+  (func $libm_fmod (;45;) (type 2) (param f64 f64) (result f64)
+    (local i32 i64 i64 i64 i64 i64 i64 i64 i64 i32 i32 i32)
     (global.set $__stack_pointer
       (local.tee 2
         (i32.sub
@@ -6757,47 +6816,49 @@
             (block ;; label = @5
               (block ;; label = @6
                 (br_if 0 (;@6;)
-                  (i64.gt_s
-                    (local.tee 4
-                      (i64.and
-                        (local.tee 3
-                          (i64.reinterpret_f64
-                            (local.get 0)))
-                        (i64.const 9223372036854775807)))
-                    (i64.const 9218868437227405311)))
+                  (i64.eq
+                    (i64.and
+                      (local.tee 3
+                        (i64.reinterpret_f64
+                          (local.get 0)))
+                      (i64.const 9218868437227405312))
+                    (i64.const 9218868437227405312)))
                 (br_if 0 (;@6;)
                   (i64.eqz
                     (i64.and
                       (i64.sub
                         (i64.const 0)
-                        (local.tee 5
+                        (local.tee 4
                           (i64.reinterpret_f64
                             (local.get 1))))
                       (i64.const 9218868437227405312))))
                 (br_if 5 (;@1;)
                   (i64.lt_u
-                    (local.get 4)
+                    (local.tee 5
+                      (i64.and
+                        (local.get 3)
+                        (i64.const 9223372036854775807)))
                     (local.tee 6
                       (i64.and
-                        (local.get 5)
+                        (local.get 4)
                         (i64.const 9223372036854775807)))))
                 (block ;; label = @7
                   (br_if 0 (;@7;)
                     (i64.lt_u
                       (local.tee 4
                         (i64.sub
-                          (local.get 4)
+                          (local.get 5)
                           (i64.and
                             (local.tee 7
                               (select
                                 (i64.const 0)
-                                (local.tee 5
+                                (local.tee 4
                                   (i64.add
-                                    (local.get 4)
+                                    (local.get 5)
                                     (i64.const -4503599627370496)))
                                 (i64.gt_u
-                                  (local.get 5)
-                                  (local.get 4))))
+                                  (local.get 4)
+                                  (local.get 5))))
                             (i64.const 9218868437227405312))))
                       (local.tee 10
                         (i64.shl
@@ -6836,13 +6897,13 @@
                       (local.tee 12
                         (i32.sub
                           (i32.wrap_i64
-                            (local.tee 6
+                            (local.tee 3
                               (i64.shr_u
                                 (local.get 7)
                                 (i64.const 52))))
                           (local.tee 11
                             (i32.wrap_i64
-                              (local.tee 3
+                              (local.tee 6
                                 (i64.shr_u
                                   (local.get 8)
                                   (i64.const 52)))))))
@@ -6850,8 +6911,8 @@
                   (block ;; label = @8
                     (br_if 0 (;@8;)
                       (i64.eq
-                        (local.get 6)
-                        (local.get 3)))
+                        (local.get 3)
+                        (local.get 6)))
                     (loop ;; label = @9
                       (local.set 4
                         (i64.shl
@@ -6893,14 +6954,14 @@
                 (br_if 2 (;@4;)
                   (i64.le_u
                     (local.get 5)
-                    (local.tee 6
+                    (local.tee 3
                       (i64.load offset=136
                         (local.get 2)))))
                 (call $__umodti3
                   (local.get 2)
                   (i64.load offset=128
                     (local.get 2))
-                  (local.get 6)
+                  (local.get 3)
                   (local.get 5)
                   (i64.const 0))
                 (local.set 4
@@ -6915,7 +6976,7 @@
                       (local.get 1)))
                   (local.get 0)))
               (br 4 (;@1;)))
-            (call $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h4d91c9c4a6b3b2e4E)
+            (call $_RNvNtNtCsdkdt1aaAg1T_4core9panicking11panic_const23panic_const_rem_by_zero)
             (unreachable))
           (block ;; label = @4
             (block ;; label = @5
@@ -6923,135 +6984,129 @@
                 (block ;; label = @7
                   (block ;; label = @8
                     (block ;; label = @9
+                      (br_if 0 (;@9;)
+                        (i64.ge_u
+                          (local.get 5)
+                          (i64.const 4611686018427387904)))
+                      (br_if 1 (;@8;)
+                        (i64.ge_u
+                          (local.get 4)
+                          (local.get 10)))
                       (block ;; label = @10
                         (br_if 0 (;@10;)
+                          (i64.eqz
+                            (i64.and
+                              (local.get 5)
+                              (local.tee 3
+                                (i64.add
+                                  (local.get 5)
+                                  (i64.const -1))))))
+                        (br_if 3 (;@7;)
+                          (i64.le_u
+                            (local.tee 7
+                              (i64.shl
+                                (local.get 5)
+                                (local.tee 10
+                                  (i64.extend_i32_u
+                                    (local.tee 13
+                                      (i32.add
+                                        (i32.wrap_i64
+                                          (i64.clz
+                                            (local.get 5)))
+                                        (i32.const -2)))))))
+                            (i64.const 2305843009213693952)))
+                        (br_if 4 (;@6;)
                           (i64.ge_u
-                            (local.get 5)
+                            (local.get 7)
                             (i64.const 4611686018427387904)))
-                        (br_if 1 (;@9;)
+                        (br_if 5 (;@5;)
                           (i64.ge_u
                             (local.get 4)
-                            (local.get 10)))
+                            (local.tee 8
+                              (i64.shl
+                                (local.get 7)
+                                (i64.const 1)))))
+                        (call $__udivti3
+                          (i32.add
+                            (local.get 2)
+                            (i32.const 112))
+                          (i64.const 0)
+                          (local.tee 5
+                            (i64.sub
+                              (i64.const -9223372036854775808)
+                              (local.get 8)))
+                          (local.get 8)
+                          (i64.const 0))
+                        (call $__multi3
+                          (i32.add
+                            (local.get 2)
+                            (i32.const 96))
+                          (local.tee 3
+                            (i64.load offset=112
+                              (local.get 2)))
+                          (local.tee 6
+                            (i64.load offset=120
+                              (local.get 2)))
+                          (local.get 8)
+                          (i64.const 0))
+                        (call $__multi3
+                          (i32.add
+                            (local.get 2)
+                            (i32.const 80))
+                          (local.get 3)
+                          (i64.add
+                            (local.get 6)
+                            (i64.const 1))
+                          (i64.shl
+                            (local.get 4)
+                            (i64.const 1))
+                          (i64.const 0))
+                        (local.set 3
+                          (i64.sub
+                            (i64.sub
+                              (local.get 5)
+                              (i64.load offset=104
+                                (local.get 2)))
+                            (i64.extend_i32_u
+                              (i64.ne
+                                (local.tee 4
+                                  (i64.load offset=96
+                                    (local.get 2)))
+                                (i64.const 0)))))
+                        (local.set 6
+                          (i64.sub
+                            (i64.const 0)
+                            (local.get 4)))
+                        (local.set 4
+                          (i64.load offset=88
+                            (local.get 2)))
+                        (local.set 5
+                          (i64.load offset=80
+                            (local.get 2)))
                         (block ;; label = @11
                           (br_if 0 (;@11;)
-                            (i64.eqz
-                              (i64.and
-                                (local.get 5)
-                                (local.tee 6
-                                  (i64.add
-                                    (local.get 5)
-                                    (i64.const -1))))))
-                          (br_if 3 (;@8;)
-                            (i64.le_u
-                              (local.tee 7
-                                (i64.shl
-                                  (local.get 5)
-                                  (local.tee 10
-                                    (i64.extend_i32_u
-                                      (i32.and
-                                        (local.tee 13
-                                          (i32.add
-                                            (i32.wrap_i64
-                                              (i64.clz
-                                                (local.get 5)))
-                                            (i32.const -2)))
-                                        (i32.const 63))))))
-                              (i64.const 2305843009213693952)))
-                          (br_if 4 (;@7;)
-                            (i64.ge_u
-                              (local.get 7)
-                              (i64.const 4611686018427387904)))
-                          (br_if 5 (;@6;)
-                            (i64.ge_u
-                              (local.get 4)
-                              (local.tee 8
-                                (i64.shl
-                                  (local.get 7)
-                                  (i64.const 1)))))
-                          (call $__udivti3
-                            (i32.add
-                              (local.get 2)
-                              (i32.const 112))
-                            (i64.const 0)
-                            (local.tee 6
-                              (i64.sub
-                                (i64.const -9223372036854775808)
-                                (local.get 8)))
-                            (local.get 8)
-                            (i64.const 0))
-                          (call $__multi3
-                            (i32.add
-                              (local.get 2)
-                              (i32.const 96))
-                            (local.tee 5
-                              (i64.load offset=112
-                                (local.get 2)))
-                            (i64.load offset=120
-                              (local.get 2))
-                            (local.get 8)
-                            (i64.const 0))
-                          (call $__multi3
-                            (i32.add
-                              (local.get 2)
-                              (i32.const 80))
-                            (local.get 5)
-                            (i64.const 1)
-                            (local.tee 14
-                              (i64.shl
-                                (local.get 4)
-                                (i64.const 1)))
-                            (i64.const 0))
-                          (local.set 6
-                            (i64.sub
-                              (i64.sub
-                                (local.get 6)
-                                (i64.load offset=104
-                                  (local.get 2)))
-                              (i64.extend_i32_u
-                                (i64.ne
-                                  (local.tee 4
-                                    (i64.load offset=96
-                                      (local.get 2)))
-                                  (i64.const 0)))))
-                          (local.set 3
-                            (i64.sub
-                              (i64.const 0)
-                              (local.get 4)))
-                          (local.set 4
-                            (i64.load offset=88
-                              (local.get 2)))
-                          (block ;; label = @12
-                            (br_if 0 (;@12;)
-                              (i32.gt_u
-                                (local.tee 12
-                                  (i32.add
-                                    (local.get 13)
-                                    (local.get 12)))
-                                (i32.const 62)))
-                            (local.set 5
-                              (i64.load offset=80
-                                (local.get 2)))
-                            (br 8 (;@4;)))
-                          (local.set 5
-                            (i64.mul
-                              (local.get 14)
-                              (local.get 5)))
+                            (i32.lt_u
+                              (local.tee 12
+                                (i32.add
+                                  (local.get 13)
+                                  (local.get 12)))
+                              (i32.const 63)))
                           (loop ;; label = @12
                             (call $__multi3
                               (i32.add
                                 (local.get 2)
                                 (i32.const 64))
-                              (local.get 3)
-                              (local.get 6)
                               (local.get 4)
-                              (i64.const 0))
+                              (i64.const 0)
+                              (local.get 6)
+                              (local.get 3))
                             (local.set 4
                               (i64.add
-                                (i64.load offset=72
-                                  (local.get 2))
                                 (i64.shr_u
                                   (local.get 5)
-                                  (i64.const 1))))
+                                  (i64.const 1))
+                                (i64.load offset=72
+                                  (local.get 2))))
                             (local.set 5
                               (i64.load offset=64
                                 (local.get 2)))
@@ -7061,95 +7116,94 @@
                                   (i32.add
                                     (local.get 12)
                                     (i32.const -63)))
-                                (i32.const 62)))
-                            (br 8 (;@4;))))
-                        (br_if 5 (;@5;)
-                          (i32.lt_u
-                            (local.get 12)
-                            (i32.const 64)))
-                        (br 8 (;@2;)))
-                      (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
-                        (i32.const 34))
-                      (unreachable))
-                    (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
-                      (i32.const 30))
+                                (i32.const 62)))))
+                        (call $__ashlti3
+                          (i32.add
+                            (local.get 2)
+                            (i32.const 48))
+                          (local.get 5)
+                          (local.get 4)
+                          (local.get 12))
+                        (call $__multi3
+                          (i32.add
+                            (local.get 2)
+                            (i32.const 32))
+                          (local.get 6)
+                          (local.get 3)
+                          (i64.shr_u
+                            (local.get 4)
+                            (i64.extend_i32_u
+                              (i32.xor
+                                (local.get 12)
+                                (i32.const 63))))
+                          (i64.const 0))
+                        (call $__multi3
+                          (i32.add
+                            (local.get 2)
+                            (i32.const 16))
+                          (i64.add
+                            (i64.add
+                              (i64.add
+                                (i64.load offset=40
+                                  (local.get 2))
+                                (i64.and
+                                  (i64.load offset=56
+                                    (local.get 2))
+                                  (i64.const 9223372036854775807)))
+                              (i64.extend_i32_u
+                                (i64.lt_u
+                                  (i64.add
+                                    (local.tee 4
+                                      (i64.load offset=32
+                                        (local.get 2)))
+                                    (i64.load offset=48
+                                      (local.get 2)))
+                                  (local.get 4))))
+                            (i64.const 2))
+                          (i64.const 0)
+                          (local.get 8)
+                          (i64.const 0))
+                        (local.set 4
+                          (i64.shr_u
+                            (i64.sub
+                              (local.tee 4
+                                (i64.load offset=24
+                                  (local.get 2)))
+                              (select
+                                (i64.const 0)
+                                (local.get 7)
+                                (i64.gt_u
+                                  (local.get 7)
+                                  (local.get 4))))
+                            (local.get 10)))
+                        (br 7 (;@3;)))
+                      (br_if 5 (;@4;)
+                        (i32.lt_u
+                          (local.get 12)
+                          (i32.const 64)))
+                      (br 7 (;@2;)))
+                    (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
+                      (i32.const 34))
                     (unreachable))
-                  (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
-                    (i32.const 43))
+                  (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
+                    (i32.const 30))
                   (unreachable))
-                (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+                (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
                   (i32.const 43))
                 (unreachable))
-              (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
-                (i32.const 23))
+              (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
+                (i32.const 43))
               (unreachable))
-            (local.set 4
-              (i64.and
-                (i64.shl
-                  (local.get 4)
-                  (i64.extend_i32_u
-                    (local.get 12)))
-                (local.get 6)))
-            (br 1 (;@3;)))
-          (call $__ashlti3
-            (i32.add
-              (local.get 2)
-              (i32.const 48))
-            (local.get 5)
-            (local.get 4)
-            (local.get 12))
-          (call $__multi3
-            (i32.add
-              (local.get 2)
-              (i32.const 32))
-            (local.get 3)
-            (local.get 6)
-            (i64.shr_u
-              (local.get 4)
-              (i64.extend_i32_u
-                (i32.xor
-                  (local.get 12)
-                  (i32.const 63))))
-            (i64.const 0))
-          (call $__multi3
-            (i32.add
-              (local.get 2)
-              (i32.const 16))
-            (i64.add
-              (i64.add
-                (i64.add
-                  (i64.load offset=40
-                    (local.get 2))
-                  (i64.and
-                    (i64.load offset=56
-                      (local.get 2))
-                    (i64.const 9223372036854775807)))
-                (i64.extend_i32_u
-                  (i64.lt_u
-                    (i64.add
-                      (local.tee 4
-                        (i64.load offset=32
-                          (local.get 2)))
-                      (i64.load offset=48
-                        (local.get 2)))
-                    (local.get 4))))
-              (i64.const 2))
-            (i64.const 0)
-            (local.get 8)
-            (i64.const 0))
+            (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
+              (i32.const 23))
+            (unreachable))
           (local.set 4
-            (i64.shr_u
-              (i64.sub
-                (local.tee 4
-                  (i64.load offset=24
-                    (local.get 2)))
-                (select
-                  (i64.const 0)
-                  (local.get 7)
-                  (i64.gt_u
-                    (local.get 7)
-                    (local.get 4))))
-              (local.get 10))))
+            (i64.and
+              (i64.shl
+                (local.get 4)
+                (i64.extend_i32_u
+                  (local.get 12)))
+              (local.get 3))))
         (br_if 0 (;@2;)
           (i64.eqz
             (local.get 4)))
@@ -7158,31 +7212,29 @@
             (i64.add
               (i64.add
                 (i64.shl
+                  (local.get 4)
                   (i64.extend_i32_u
-                    (i32.sub
-                      (local.get 11)
-                      (local.tee 12
-                        (select
-                          (local.tee 12
-                            (i32.sub
-                              (i32.const 52)
-                              (i32.xor
-                                (i32.wrap_i64
-                                  (i64.clz
-                                    (local.get 4)))
-                                (i32.const 63))))
-                          (local.get 11)
-                          (i32.lt_u
-                            (local.get 12)
-                            (local.get 11))))))
-                  (i64.const 52))
+                    (local.tee 12
+                      (select
+                        (local.tee 12
+                          (i32.sub
+                            (i32.const 52)
+                            (i32.xor
+                              (i32.wrap_i64
+                                (i64.clz
+                                  (local.get 4)))
+                              (i32.const 63))))
+                        (local.get 11)
+                        (i32.lt_u
+                          (local.get 12)
+                          (local.get 11))))))
                 (local.get 9))
               (i64.shl
-                (local.get 4)
                 (i64.extend_i32_u
-                  (i32.and
-                    (local.get 12)
-                    (i32.const 63)))))))
+                  (i32.sub
+                    (local.get 11)
+                    (local.get 12)))
+                (i64.const 52)))))
         (br 1 (;@1;)))
       (local.set 0
         (f64.reinterpret_i64
@@ -7193,16 +7245,16 @@
         (i32.const 144)))
     (local.get 0)
   )
-  (func $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h4d91c9c4a6b3b2e4E (;44;) (type 8)
-    (call $_ZN4core9panicking9panic_fmt17h6651313c3e2c6c2fE)
+  (func $_RNvNtNtCsdkdt1aaAg1T_4core9panicking11panic_const23panic_const_rem_by_zero (;46;) (type 9)
+    (call $_RNvNtCsdkdt1aaAg1T_4core9panicking9panic_fmt)
     (unreachable)
   )
-  (func $_ZN4core9panicking5panic17h0149fc8f1656305aE (;45;) (type 9) (param i32)
-    (call $_ZN4core9panicking9panic_fmt17h6651313c3e2c6c2fE)
+  (func $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic (;47;) (type 10) (param i32)
+    (call $_RNvNtCsdkdt1aaAg1T_4core9panicking9panic_fmt)
     (unreachable)
   )
-  (func $libm_fmodf (;46;) (type 3) (param f32 f32) (result f32)
-    (local i32 i32 i32 i32 i32 i32 i32 i32 i64 i64 i64)
+  (func $libm_fmodf (;48;) (type 3) (param f32 f32) (result f32)
+    (local i32 i32 i32 i32 i32 i32 i32 i32 i64 i64 i64 i64)
     (block ;; label = @1
       (block ;; label = @2
         (block ;; label = @3
@@ -7210,75 +7262,77 @@
             (block ;; label = @5
               (block ;; label = @6
                 (br_if 0 (;@6;)
-                  (i32.gt_s
-                    (local.tee 3
-                      (i32.and
-                        (local.tee 2
-                          (i32.reinterpret_f32
-                            (local.get 0)))
-                        (i32.const 2147483647)))
-                    (i32.const 2139095039)))
+                  (i32.eq
+                    (i32.and
+                      (local.tee 2
+                        (i32.reinterpret_f32
+                          (local.get 0)))
+                      (i32.const 2139095040))
+                    (i32.const 2139095040)))
                 (br_if 0 (;@6;)
                   (i32.eqz
                     (i32.and
                       (i32.sub
                         (i32.const 0)
-                        (local.tee 4
+                        (local.tee 3
                           (i32.reinterpret_f32
                             (local.get 1))))
                       (i32.const 2139095040))))
                 (br_if 5 (;@1;)
                   (i32.lt_u
-                    (local.get 3)
                     (local.tee 4
                       (i32.and
-                        (local.get 4)
+                        (local.get 2)
+                        (i32.const 2147483647)))
+                    (local.tee 3
+                      (i32.and
+                        (local.get 3)
                         (i32.const 2147483647)))))
                 (block ;; label = @7
                   (br_if 0 (;@7;)
                     (i32.lt_u
                       (local.tee 5
                         (i32.sub
-                          (local.get 3)
+                          (local.get 4)
                           (i32.and
                             (local.tee 6
                               (select
                                 (i32.const 0)
                                 (local.tee 5
                                   (i32.add
-                                    (local.get 3)
+                                    (local.get 4)
                                     (i32.const -8388608)))
                                 (i32.gt_u
                                   (local.get 5)
-                                  (local.get 3))))
+                                  (local.get 4))))
                             (i32.const 2139095040))))
                       (local.tee 9
                         (i32.shl
-                          (local.tee 3
+                          (local.tee 4
                             (i32.sub
-                              (local.get 4)
+                              (local.get 3)
                               (local.tee 8
                                 (i32.and
                                   (local.tee 7
                                     (select
                                       (i32.const 0)
-                                      (local.tee 3
+                                      (local.tee 4
                                         (i32.add
-                                          (local.get 4)
+                                          (local.get 3)
                                           (i32.const -8388608)))
                                       (i32.gt_u
-                                        (local.get 3)
-                                        (local.get 4))))
+                                        (local.get 4)
+                                        (local.get 3))))
                                   (i32.const 2139095040)))))
                           (i32.const 1)))))
                   (br_if 2 (;@5;)
                     (i32.eq
-                      (local.get 4)
+                      (local.get 3)
                       (local.get 8)))
                   (local.set 5
                     (i32.rem_u
                       (local.get 5)
-                      (local.get 3))))
+                      (local.get 4))))
                 (local.set 8
                   (i32.and
                     (local.get 2)
@@ -7290,14 +7344,14 @@
                         (i32.shr_u
                           (local.get 6)
                           (i32.const 23))
-                        (local.tee 4
+                        (local.tee 3
                           (i32.shr_u
                             (local.get 7)
                             (i32.const 23)))))
                     (i32.const 32)))
                 (br_if 2 (;@4;)
                   (i32.le_u
-                    (local.get 3)
+                    (local.get 4)
                     (i32.wrap_i64
                       (i64.shr_u
                         (local.tee 10
@@ -7307,12 +7361,12 @@
                             (i64.extend_i32_u
                               (local.get 2))))
                         (i64.const 32)))))
-                (local.set 3
+                (local.set 2
                   (i32.wrap_i64
                     (i64.rem_u
                       (local.get 10)
                       (i64.extend_i32_u
-                        (local.get 3)))))
+                        (local.get 4)))))
                 (br 3 (;@3;)))
               (return
                 (f32.div
@@ -7321,7 +7375,7 @@
                       (local.get 0)
                       (local.get 1)))
                   (local.get 0))))
-            (call $_ZN4core9panicking11panic_const23panic_const_rem_by_zero17h4d91c9c4a6b3b2e4E)
+            (call $_RNvNtNtCsdkdt1aaAg1T_4core9panicking11panic_const23panic_const_rem_by_zero)
             (unreachable))
           (block ;; label = @4
             (block ;; label = @5
@@ -7331,7 +7385,7 @@
                     (block ;; label = @9
                       (br_if 0 (;@9;)
                         (i32.ge_u
-                          (local.get 3)
+                          (local.get 4)
                           (i32.const 1073741824)))
                       (br_if 1 (;@8;)
                         (i32.ge_u
@@ -7341,151 +7395,147 @@
                         (br_if 0 (;@10;)
                           (i32.eqz
                             (i32.and
-                              (local.get 3)
+                              (local.get 4)
                               (local.tee 6
                                 (i32.add
-                                  (local.get 3)
+                                  (local.get 4)
                                   (i32.const -1))))))
                         (br_if 3 (;@7;)
                           (i32.le_u
-                            (local.tee 6
+                            (local.tee 4
                               (i32.shl
-                                (local.get 3)
-                                (local.tee 7
+                                (local.get 4)
+                                (local.tee 6
                                   (i32.add
                                     (i32.clz
-                                      (local.get 3))
+                                      (local.get 4))
                                     (i32.const -2)))))
                             (i32.const 536870912)))
                         (br_if 4 (;@6;)
                           (i32.ge_u
-                            (local.get 6)
+                            (local.get 4)
                             (i32.const 1073741824)))
                         (br_if 5 (;@5;)
                           (i32.ge_u
                             (local.get 5)
-                            (local.tee 3
+                            (local.tee 7
                               (i32.shl
-                                (local.get 6)
+                                (local.get 4)
                                 (i32.const 1)))))
-                        (local.set 12
-                          (i64.sub
-                            (local.tee 10
-                              (i64.shl
-                                (i64.extend_i32_u
-                                  (i32.sub
-                                    (i32.const -2147483648)
-                                    (local.get 3)))
-                                (i64.const 32)))
-                            (i64.mul
-                              (local.tee 10
-                                (i64.div_u
-                                  (local.get 10)
-                                  (local.tee 11
-                                    (i64.extend_i32_u
-                                      (local.get 3)))))
-                              (local.get 11))))
                         (local.set 10
                           (i64.mul
-                            (i64.or
-                              (i64.and
-                                (local.get 10)
-                                (i64.const 4294967295))
+                            (i64.add
+                              (local.tee 13
+                                (i64.div_u
+                                  (local.tee 11
+                                    (i64.shl
+                                      (i64.extend_i32_u
+                                        (i32.sub
+                                          (i32.const -2147483648)
+                                          (local.get 7)))
+                                      (i64.const 32)))
+                                  (local.tee 12
+                                    (i64.extend_i32_u
+                                      (local.get 7)))))
                               (i64.const 4294967296))
                             (i64.extend_i32_u
                               (i32.shl
                                 (local.get 5)
                                 (i32.const 1)))))
+                        (local.set 11
+                          (i64.sub
+                            (local.get 11)
+                            (i64.mul
+                              (local.get 13)
+                              (local.get 12))))
                         (block ;; label = @11
                           (br_if 0 (;@11;)
                             (i32.lt_u
-                              (local.tee 3
+                              (local.tee 2
                                 (i32.add
-                                  (local.get 7)
+                                  (local.get 6)
                                   (local.get 2)))
                               (i32.const 31)))
                           (loop ;; label = @12
                             (local.set 10
                               (i64.add
+                                (i64.mul
+                                  (i64.shr_u
+                                    (local.get 10)
+                                    (i64.const 32))
+                                  (local.get 11))
                                 (i64.and
                                   (i64.shl
                                     (local.get 10)
                                     (i64.const 31))
-                                  (i64.const 9223372032559808512))
-                                (i64.mul
-                                  (local.get 12)
-                                  (i64.shr_u
-                                    (local.get 10)
-                                    (i64.const 32)))))
+                                  (i64.const 9223372032559808512))))
                             (br_if 0 (;@12;)
                               (i32.gt_u
-                                (local.tee 3
+                                (local.tee 2
                                   (i32.add
-                                    (local.get 3)
+                                    (local.get 2)
                                     (i32.const -31)))
                                 (i32.const 30)))))
-                        (local.set 3
+                        (local.set 2
                           (i32.shr_u
                             (i32.sub
-                              (local.tee 3
+                              (local.tee 2
                                 (i32.wrap_i64
                                   (i64.shr_u
                                     (i64.mul
-                                      (i64.and
-                                        (i64.add
-                                          (i64.shr_u
-                                            (i64.add
-                                              (i64.mul
-                                                (local.get 12)
+                                      (i64.add
+                                        (i64.shr_u
+                                          (i64.add
+                                            (i64.mul
+                                              (local.get 11)
+                                              (i64.extend_i32_u
+                                                (i32.shr_u
+                                                  (i32.wrap_i64
+                                                    (i64.shr_u
+                                                      (local.get 10)
+                                                      (i64.const 32)))
+                                                  (i32.xor
+                                                    (local.get 2)
+                                                    (i32.const 31)))))
+                                            (i64.and
+                                              (i64.shl
+                                                (local.get 10)
                                                 (i64.extend_i32_u
-                                                  (i32.shr_u
-                                                    (i32.wrap_i64
-                                                      (i64.shr_u
-                                                        (local.get 10)
-                                                        (i64.const 32)))
-                                                    (i32.xor
-                                                      (local.get 3)
-                                                      (i32.const 31)))))
-                                              (i64.and
-                                                (i64.shl
-                                                  (local.get 10)
-                                                  (i64.extend_i32_u
-                                                    (local.get 3)))
-                                                (i64.const 9223372036854775807)))
-                                            (i64.const 32))
-                                          (i64.const 2))
-                                        (i64.const 4294967295))
-                                      (local.get 11))
+                                                  (local.get 2)))
+                                              (i64.const 9223372036854775807)))
+                                          (i64.const 32))
+                                        (i64.const 2))
+                                      (local.get 12))
                                     (i64.const 32))))
                               (select
                                 (i32.const 0)
-                                (local.get 6)
+                                (local.get 4)
                                 (i32.gt_u
-                                  (local.get 6)
-                                  (local.get 3))))
-                            (local.get 7)))
+                                  (local.get 4)
+                                  (local.get 2))))
+                            (local.get 6)))
                         (br 7 (;@3;)))
                       (br_if 5 (;@4;)
                         (i32.lt_u
                           (local.get 2)
                           (i32.const 32)))
                       (br 7 (;@2;)))
-                    (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+                    (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
                       (i32.const 34))
                     (unreachable))
-                  (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+                  (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
                     (i32.const 30))
                   (unreachable))
-                (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+                (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
                   (i32.const 43))
                 (unreachable))
-              (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+              (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
                 (i32.const 43))
               (unreachable))
-            (call $_ZN4core9panicking5panic17h0149fc8f1656305aE
+            (call $_RNvNtCsdkdt1aaAg1T_4core9panicking5panic
               (i32.const 23))
             (unreachable))
-          (local.set 3
+          (local.set 2
             (i32.and
               (i32.shl
                 (local.get 5)
@@ -7493,38 +7543,38 @@
               (local.get 6))))
         (br_if 0 (;@2;)
           (i32.eqz
-            (local.get 3)))
+            (local.get 2)))
         (return
           (f32.reinterpret_i32
             (i32.add
               (i32.add
                 (i32.shl
-                  (i32.sub
-                    (local.get 4)
-                    (local.tee 2
-                      (select
-                        (local.tee 2
-                          (i32.sub
-                            (i32.const 23)
-                            (i32.xor
-                              (i32.clz
-                                (local.get 3))
-                              (i32.const 31))))
+                  (local.get 2)
+                  (local.tee 4
+                    (select
+                      (local.tee 4
+                        (i32.sub
+                          (i32.const 23)
+                          (i32.xor
+                            (i32.clz
+                              (local.get 2))
+                            (i32.const 31))))
+                      (local.get 3)
+                      (i32.lt_u
                         (local.get 4)
-                        (i32.lt_u
-                          (local.get 2)
-                          (local.get 4)))))
-                  (i32.const 23))
+                        (local.get 3)))))
                 (local.get 8))
               (i32.shl
-                (local.get 3)
-                (local.get 2))))))
+                (i32.sub
+                  (local.get 3)
+                  (local.get 4))
+                (i32.const 23))))))
       (local.set 0
         (f32.reinterpret_i32
           (local.get 8))))
     (local.get 0)
   )
-  (func $libm_hypot (;47;) (type 2) (param f64 f64) (result f64)
+  (func $libm_hypot (;49;) (type 2) (param f64 f64) (result f64)
     (local i64 i64 i64 i64 f64 f64 f64 f64)
     (local.set 1
       (f64.reinterpret_i64
@@ -7618,7 +7668,7 @@
         (local.set 1
           (f64.mul
             (local.get 6)
-            (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
               (f64.add
                 (local.tee 7
                   (f64.mul
@@ -7686,7 +7736,7 @@
         (local.get 1)))
     (local.get 0)
   )
-  (func $libm_hypotf (;48;) (type 3) (param f32 f32) (result f32)
+  (func $libm_hypotf (;50;) (type 3) (param f32 f32) (result f32)
     (local i32 i32 i32 f32 f64)
     (local.set 1
       (f32.reinterpret_i32
@@ -7774,7 +7824,7 @@
       (local.set 1
         (f32.mul
           (local.get 5)
-          (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
+          (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf
             (f32.demote_f64
               (f64.add
                 (f64.mul
@@ -7789,11 +7839,11 @@
                   (local.get 6))))))))
     (local.get 1)
   )
-  (func $libm_log (;49;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math3log3log17h781c40c93ff4fcfcE
+  (func $libm_log (;51;) (type 0) (param f64) (result f64)
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3log3log
       (local.get 0))
   )
-  (func $libm_log10 (;50;) (type 0) (param f64) (result f64)
+  (func $libm_log10 (;52;) (type 0) (param f64) (result f64)
     (local i64 i32 i64 i32 f64 f64 f64 f64 f64 f64)
     (block ;; label = @1
       (block ;; label = @2
@@ -7979,7 +8029,7 @@
           (f64.const 0x0p+0 (;=0;)))))
     (local.get 0)
   )
-  (func $libm_log10f (;51;) (type 1) (param f32) (result f32)
+  (func $libm_log10f (;53;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 f32 f32)
     (block ;; label = @1
       (block ;; label = @2
@@ -8122,15 +8172,15 @@
                 (local.get 5))
               (f32.const -0x1.09d5b2p-15 (;=-0.00003168997;)))))))
   )
-  (func $libm_log1p (;52;) (type 0) (param f64) (result f64)
-    (call $_ZN4libm4math5log1p5log1p17h5d4b372f78bb46e9E
+  (func $libm_log1p (;54;) (type 0) (param f64) (result f64)
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5log1p5log1p
       (local.get 0))
   )
-  (func $libm_log1pf (;53;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math6log1pf6log1pf17h4c967d18f426e9e4E
+  (func $libm_log1pf (;55;) (type 1) (param f32) (result f32)
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6log1pf6log1pf
       (local.get 0))
   )
-  (func $libm_log2 (;54;) (type 0) (param f64) (result f64)
+  (func $libm_log2 (;56;) (type 0) (param f64) (result f64)
     (local i64 i32 i64 i32 f64 f64 f64 f64 f64)
     (block ;; label = @1
       (block ;; label = @2
@@ -8309,7 +8359,7 @@
           (f64.const 0x0p+0 (;=0;)))))
     (local.get 0)
   )
-  (func $libm_log2f (;55;) (type 1) (param f32) (result f32)
+  (func $libm_log2f (;57;) (type 1) (param f32) (result f32)
     (local i32 i32 f32 f32)
     (block ;; label = @1
       (block ;; label = @2
@@ -8445,11 +8495,11 @@
             (local.get 1)
             (i32.const 23)))))
   )
-  (func $libm_logf (;56;) (type 1) (param f32) (result f32)
-    (call $_ZN4libm4math4logf4logf17h7b88872ed73a994aE
+  (func $libm_logf (;58;) (type 1) (param f32) (result f32)
+    (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4logf4logf
       (local.get 0))
   )
-  (func $libm_pow (;57;) (type 2) (param f64 f64) (result f64)
+  (func $libm_pow (;59;) (type 2) (param f64 f64) (result f64)
     (local f64 i64 i32 i32 i32 i64 i32 i64 i32 i32 i32 i32 i32 f64 f64 f64 f64)
     (local.set 2
       (f64.const 0x1p+0 (;=1;)))
@@ -8665,7 +8715,7 @@
               (local.get 7)
               (i64.const 0)))
           (return
-            (call $_ZN4libm4math4sqrt4sqrt17h3b6b03f022c75fd4E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt4sqrt
               (local.get 0))))
         (return
           (select
@@ -8798,7 +8848,7 @@
               (f64.sub
                 (local.tee 2
                   (f64.add
-                    (f64.load offset=1053504
+                    (f64.load offset=1053048
                       (local.tee 6
                         (i32.shl
                           (local.get 8)
@@ -8816,7 +8866,7 @@
                                         (f64.const 0x1p+0 (;=1;))
                                         (f64.add
                                           (local.tee 0
-                                            (f64.load offset=1053488
+                                            (f64.load offset=1053032
                                               (local.get 6)))
                                           (local.tee 16
                                             (f64.reinterpret_i64
@@ -8949,7 +8999,7 @@
                               (f64.add
                                 (f64.add
                                   (local.tee 17
-                                    (f64.load offset=1053520
+                                    (f64.load offset=1053064
                                       (local.get 6)))
                                   (f64.add
                                     (local.get 2)
@@ -9320,7 +9370,7 @@
                     (i64.const 4294967295)))))
             (br 1 (;@3;)))
           (local.set 1
-            (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn6scalbn
               (local.get 1)
               (local.get 8))))
         (return
@@ -9364,7 +9414,7 @@
             (i32.const 1)))))
     (local.get 2)
   )
-  (func $libm_powf (;58;) (type 3) (param f32 f32) (result f32)
+  (func $libm_powf (;60;) (type 3) (param f32 f32) (result f32)
     (local f32 i32 i32 i32 f32 i32 i32 i32 i32 f32 f32 f32)
     (local.set 2
       (f32.const 0x1p+0 (;=1;)))
@@ -9628,7 +9678,7 @@
                 (f32.sub
                   (local.tee 2
                     (f32.add
-                      (f32.load offset=1048584
+                      (f32.load offset=1057280
                         (local.tee 7
                           (i32.shl
                             (local.get 3)
@@ -9646,7 +9696,7 @@
                                           (f32.const 0x1p+0 (;=1;))
                                           (f32.add
                                             (local.tee 0
-                                              (f32.load offset=1048576
+                                              (f32.load offset=1057272
                                                 (local.get 7)))
                                             (local.tee 12
                                               (f32.reinterpret_i32
@@ -9770,7 +9820,7 @@
                                 (f32.add
                                   (f32.add
                                     (local.tee 6
-                                      (f32.load offset=1048592
+                                      (f32.load offset=1057288
                                         (local.get 7)))
                                     (f32.add
                                       (local.get 2)
@@ -9876,7 +9926,7 @@
             (f32.const 0x1p+0 (;=1;))
             (local.get 0))))
       (return
-        (call $_ZN4libm4math4sqrt5sqrtf17h8c1b66187740c44bE
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4sqrt5sqrtf
           (local.get 0))))
     (block ;; label = @1
       (block ;; label = @2
@@ -10100,14 +10150,14 @@
             (local.get 5)))
         (br 1 (;@1;)))
       (local.set 0
-        (call $_ZN4libm4math6scalbn7scalbnf17ha430054e259e38a4E
+        (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn7scalbnf
           (local.get 0)
           (local.get 3))))
     (f32.mul
       (local.get 11)
       (local.get 0))
   )
-  (func $_ZN4libm4math6scalbn7scalbnf17ha430054e259e38a4E (;59;) (type 10) (param f32 i32) (result f32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn7scalbnf (;61;) (type 11) (param f32 i32) (result f32)
     (block ;; label = @1
       (block ;; label = @2
         (block ;; label = @3
@@ -10184,7 +10234,7 @@
             (i32.const 1065353216))
           (i32.const 2139095040))))
   )
-  (func $libm_sin (;60;) (type 0) (param f64) (result f64)
+  (func $libm_sin (;62;) (type 0) (param f64) (result f64)
     (local i32 i32 f64 f64 f64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -10213,7 +10263,7 @@
                     (i32.gt_u
                       (local.get 2)
                       (i32.const 2146435071)))
-                  (call $_ZN4libm4math8rem_pio28rem_pio217hcfd3034c1d4391f0E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math8rem_pio28rem_pio2
                     (i32.add
                       (local.get 1)
                       (i32.const 8))
@@ -10236,7 +10286,7 @@
                 (br 5 (;@1;)))
               (local.set 0
                 (f64.neg
-                  (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_cos5k_cos
                     (local.get 0)
                     (local.get 3))))
               (br 4 (;@1;)))
@@ -10286,7 +10336,7 @@
                     (local.get 3)))))
             (br 3 (;@1;)))
           (local.set 0
-            (call $_ZN4libm4math5k_cos5k_cos17h5eb36bbcae756a29E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_cos5k_cos
               (local.get 0)
               (local.get 3)))
           (br 2 (;@1;)))
@@ -10405,7 +10455,7 @@
         (i32.const 32)))
     (local.get 0)
   )
-  (func $libm_sinf (;61;) (type 1) (param f32) (result f32)
+  (func $libm_sinf (;63;) (type 1) (param f32) (result f32)
     (local i32 f64 i32 i32 f64 f64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -10445,7 +10495,7 @@
                         (i32.gt_u
                           (local.get 4)
                           (i32.const 2139095039)))
-                      (call $_ZN4libm4math9rem_pio2f9rem_pio2f17h3b6adc3e5afb8880E
+                      (call $_RNvNtNtCskrL9OOIMpwY_4libm4math9rem_pio2f9rem_pio2f
                         (local.get 1)
                         (local.get 0))
                       (local.set 2
@@ -10858,7 +10908,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $libm_sinh (;62;) (type 0) (param f64) (result f64)
+  (func $libm_sinh (;64;) (type 0) (param f64) (result f64)
     (local f64 f64 i64)
     (local.set 1
       (f64.copysign
@@ -10880,14 +10930,14 @@
             (local.get 1))
           (f64.mul
             (f64.mul
-              (call $_ZN4libm4math3exp3exp17h8eb8b2450c3bf8abE
+              (call $_RNvNtNtCskrL9OOIMpwY_4libm4math3exp3exp
                 (f64.add
                   (local.get 2)
                   (f64.const -0x1.62066151add8bp+10 (;=-1416.0996898839683;))))
               (f64.const 0x1p+1021 (;=22471164185778950000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;)))
             (f64.const 0x1p+1021 (;=22471164185778950000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;))))))
     (local.set 2
-      (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
+      (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5expm15expm1
         (local.get 2)))
     (block ;; label = @1
       (br_if 0 (;@1;)
@@ -10925,7 +10975,7 @@
                 (f64.const 0x1p+0 (;=1;))))))))
     (local.get 0)
   )
-  (func $libm_sinhf (;63;) (type 1) (param f32) (result f32)
+  (func $libm_sinhf (;65;) (type 1) (param f32) (result f32)
     (local f32 f32 i32)
     (local.set 1
       (f32.copysign
@@ -10947,14 +10997,14 @@
             (local.get 1))
           (f32.mul
             (f32.mul
-              (call $_ZN4libm4math4expf4expf17hedd2067d7b29c452E
+              (call $_RNvNtNtCskrL9OOIMpwY_4libm4math4expf4expf
                 (f32.add
                   (local.get 2)
                   (f32.const -0x1.45c778p+7 (;=-162.88959;))))
               (f32.const 0x1p+117 (;=166153500000000000000000000000000000;)))
             (f32.const 0x1p+117 (;=166153500000000000000000000000000000;))))))
     (local.set 2
-      (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
+      (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6expm1f6expm1f
         (local.get 2)))
     (block ;; label = @1
       (br_if 0 (;@1;)
@@ -10992,7 +11042,7 @@
                 (f32.const 0x1p+0 (;=1;))))))))
     (local.get 0)
   )
-  (func $libm_tan (;64;) (type 0) (param f64) (result f64)
+  (func $libm_tan (;66;) (type 0) (param f64) (result f64)
     (local i32 i32)
     (global.set $__stack_pointer
       (local.tee 1
@@ -11017,13 +11067,13 @@
             (i32.gt_u
               (local.get 2)
               (i32.const 2146435071)))
-          (call $_ZN4libm4math8rem_pio28rem_pio217hcfd3034c1d4391f0E
+          (call $_RNvNtNtCskrL9OOIMpwY_4libm4math8rem_pio28rem_pio2
             (i32.add
               (local.get 1)
               (i32.const 8))
             (local.get 0))
           (local.set 0
-            (call $_ZN4libm4math5k_tan5k_tan17he70947e0d23fd5ccE
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_tan5k_tan
               (f64.load offset=8
                 (local.get 1))
               (f64.load offset=24
@@ -11044,7 +11094,7 @@
             (local.get 2)
             (i32.const 1044381696)))
         (local.set 0
-          (call $_ZN4libm4math5k_tan5k_tan17he70947e0d23fd5ccE
+          (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_tan5k_tan
             (local.get 0)
             (f64.const 0x0p+0 (;=0;))
             (i32.const 0)))
@@ -11070,7 +11120,7 @@
         (i32.const 32)))
     (local.get 0)
   )
-  (func $_ZN4libm4math5k_tan5k_tan17he70947e0d23fd5ccE (;65;) (type 11) (param f64 f64 i32) (result f64)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math5k_tan5k_tan (;67;) (type 12) (param f64 f64 i32) (result f64)
     (local i64 i32 f64 f64 f64)
     (block ;; label = @1
       (br_if 0 (;@1;)
@@ -11240,7 +11290,7 @@
         (local.get 3)
         (i64.const 0)))
   )
-  (func $libm_tanf (;66;) (type 1) (param f32) (result f32)
+  (func $libm_tanf (;68;) (type 1) (param f32) (result f32)
     (local i32 f64 i32 i32 f64 f64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -11276,7 +11326,7 @@
                 (i32.gt_u
                   (local.get 4)
                   (i32.const 2139095039)))
-              (call $_ZN4libm4math9rem_pio2f9rem_pio2f17h3b6adc3e5afb8880E
+              (call $_RNvNtNtCskrL9OOIMpwY_4libm4math9rem_pio2f9rem_pio2f
                 (local.get 1)
                 (local.get 0))
               (local.set 0
@@ -11601,7 +11651,7 @@
         (i32.const 16)))
     (local.get 0)
   )
-  (func $libm_tanh (;67;) (type 0) (param f64) (result f64)
+  (func $libm_tanh (;69;) (type 0) (param f64) (result f64)
     (local i32 f64 i64)
     (global.set $__stack_pointer
       (local.tee 1
@@ -11640,7 +11690,7 @@
             (f64.div
               (f64.neg
                 (local.tee 2
-                  (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5expm15expm1
                     (f64.mul
                       (local.get 2)
                       (f64.const -0x1p+1 (;=-2;))))))
@@ -11659,7 +11709,7 @@
               (f64.div
                 (f64.const 0x1p+1 (;=2;))
                 (f64.add
-                  (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5expm15expm1
                     (f64.add
                       (local.get 2)
                       (local.get 2)))
@@ -11675,7 +11725,7 @@
       (local.set 2
         (f64.div
           (local.tee 2
-            (call $_ZN4libm4math5expm15expm117hf425b3a732f15702E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math5expm15expm1
               (f64.add
                 (local.get 2)
                 (local.get 2))))
@@ -11695,7 +11745,7 @@
           (local.get 0))
         (i64.const 0)))
   )
-  (func $libm_tanhf (;68;) (type 1) (param f32) (result f32)
+  (func $libm_tanhf (;70;) (type 1) (param f32) (result f32)
     (local i32 f32 i32)
     (global.set $__stack_pointer
       (local.tee 1
@@ -11735,7 +11785,7 @@
             (f32.div
               (f32.neg
                 (local.tee 2
-                  (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6expm1f6expm1f
                     (f32.mul
                       (local.get 2)
                       (f32.const -0x1p+1 (;=-2;))))))
@@ -11754,7 +11804,7 @@
               (f32.div
                 (f32.const 0x1p+1 (;=2;))
                 (f32.add
-                  (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
+                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6expm1f6expm1f
                     (f32.add
                       (local.get 2)
                       (local.get 2)))
@@ -11770,7 +11820,7 @@
       (local.set 2
         (f32.div
           (local.tee 2
-            (call $_ZN4libm4math6expm1f6expm1f17h8c93774ba8d4df49E
+            (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6expm1f6expm1f
               (f32.add
                 (local.get 2)
                 (local.get 2))))
@@ -11790,59 +11840,42 @@
           (local.get 0))
         (i32.const 0)))
   )
-  (func $_ZN4core9panicking9panic_fmt17h6651313c3e2c6c2fE (;69;) (type 8)
+  (func $_RNvNtCsdkdt1aaAg1T_4core9panicking9panic_fmt (;71;) (type 9)
     (unreachable)
   )
-  (func $_ZN4libm4math14rem_pio2_large14rem_pio2_large17hd7141cf13a36ffbcE (;70;) (type 12) (param i32 i32 i32 i32 i32) (result i32)
-    (local i32 i32 i32 i32 i32 i32 i32 f64 i32 i32 i32 i32 i32 i32 i32 i32 i32 f64 f64 i64 i64 i64 i32 i32 i32)
+  (func $_RNvNtNtCskrL9OOIMpwY_4libm4math14rem_pio2_large14rem_pio2_large (;72;) (type 13) (param i32 i32 i32 i32 i32) (result i32)
+    (local i32 i32 i32 i32 i32 i32 i32 f64 i32 i32 i32 i32 i32 i32 i32 f64 f64 i64 i64 i64 i32 i32 i32)
     (global.set $__stack_pointer
       (local.tee 5
         (i32.sub
           (global.get $__stack_pointer)
           (i32.const 560))))
-    (local.set 6
-      (i32.const 0))
-    (block ;; label = @1
-      (br_if 0 (;@1;)
-        (local.tee 7
-          (i32.eqz
-            (i32.const 160))))
-      (memory.fill
-        (local.get 5)
-        (i32.const 0)
-        (i32.const 160)))
-    (block ;; label = @1
-      (br_if 0 (;@1;)
-        (local.get 7))
-      (memory.fill
-        (i32.add
-          (local.get 5)
-          (i32.const 160))
-        (i32.const 0)
-        (i32.const 160)))
-    (block ;; label = @1
-      (br_if 0 (;@1;)
-        (local.get 7))
-      (memory.fill
-        (i32.add
-          (local.get 5)
-          (i32.const 320))
-        (i32.const 0)
-        (i32.const 160)))
-    (block ;; label = @1
-      (br_if 0 (;@1;)
-        (i32.eqz
-          (i32.const 80)))
-      (memory.fill
-        (i32.add
-          (local.get 5)
-          (i32.const 480))
-        (i32.const 0)
-        (i32.const 80)))
-    (local.set 9
+    (memory.fill
+      (local.get 5)
+      (i32.const 0)
+      (i32.const 160))
+    (memory.fill
       (i32.add
-        (local.tee 8
-          (i32.load offset=1052888
+        (local.get 5)
+        (i32.const 160))
+      (i32.const 0)
+      (i32.const 160))
+    (memory.fill
+      (i32.add
+        (local.get 5)
+        (i32.const 320))
+      (i32.const 0)
+      (i32.const 160))
+    (memory.fill
+      (i32.add
+        (local.get 5)
+        (i32.const 480))
+      (i32.const 0)
+      (i32.const 80))
+    (local.set 8
+      (i32.add
+        (local.tee 6
+          (i32.load offset=1052672
             (i32.shl
               (local.get 4)
               (i32.const 2))))
@@ -11852,29 +11885,28 @@
             (i32.const -1)))))
     (local.set 10
       (i32.sub
-        (local.tee 11
-          (select
-            (local.tee 10
-              (i32.div_s
+        (local.tee 9
+          (i32.and
+            (i32.div_s
+              (i32.extend16_s
                 (i32.add
                   (local.get 3)
-                  (i32.const -3))
-                (i32.const 24)))
-            (i32.const 0)
-            (i32.gt_s
-              (local.get 10)
-              (i32.const 0))))
+                  (i32.const -3)))
+              (i32.const 24))
+            (i32.const 65535)))
         (local.get 7)))
-    (local.set 1
+    (local.set 11
       (i32.add
         (i32.sub
           (i32.shl
-            (local.get 11)
+            (local.get 9)
             (i32.const 2))
           (i32.shl
             (local.get 1)
             (i32.const 2)))
-        (i32.const 1052908)))
+        (i32.const 1052692)))
+    (local.set 1
+      (i32.const 0))
     (loop ;; label = @1
       (block ;; label = @2
         (block ;; label = @3
@@ -11888,22 +11920,22 @@
         (local.set 12
           (f64.convert_i32_s
             (i32.load
-              (local.get 1)))))
+              (local.get 11)))))
       (f64.store
         (i32.add
           (local.get 5)
           (i32.shl
-            (local.get 6)
+            (local.get 1)
             (i32.const 3)))
         (local.get 12))
       (block ;; label = @2
         (br_if 0 (;@2;)
           (i32.ge_u
-            (local.get 6)
-            (local.get 9)))
-        (local.set 1
-          (i32.add
             (local.get 1)
+            (local.get 8)))
+        (local.set 11
+          (i32.add
+            (local.get 11)
             (i32.const 4)))
         (local.set 10
           (i32.add
@@ -11911,23 +11943,23 @@
             (i32.const 1)))
         (br_if 1 (;@1;)
           (i32.le_u
-            (local.tee 6
+            (local.tee 1
               (i32.add
-                (local.get 6)
+                (local.get 1)
                 (i32.lt_u
-                  (local.get 6)
-                  (local.get 9))))
-            (local.get 9)))))
+                  (local.get 1)
+                  (local.get 8))))
+            (local.get 8)))))
     (local.set 10
       (i32.const 0))
     (loop ;; label = @1
-      (local.set 9
+      (local.set 8
         (i32.add
           (local.get 10)
           (local.get 7)))
       (local.set 12
         (f64.const 0x0p+0 (;=0;)))
-      (local.set 6
+      (local.set 1
         (i32.const 0))
       (block ;; label = @2
         (loop ;; label = @3
@@ -11939,27 +11971,27 @@
                   (i32.add
                     (local.get 0)
                     (i32.shl
-                      (local.get 6)
+                      (local.get 1)
                       (i32.const 3))))
                 (f64.load
                   (i32.add
                     (local.get 5)
                     (i32.shl
                       (i32.sub
-                        (local.get 9)
-                        (local.get 6))
+                        (local.get 8)
+                        (local.get 1))
                       (i32.const 3)))))))
           (br_if 1 (;@2;)
             (i32.ge_u
-              (local.get 6)
+              (local.get 1)
               (local.get 7)))
           (br_if 0 (;@3;)
             (i32.le_u
-              (local.tee 6
+              (local.tee 1
                 (i32.add
-                  (local.get 6)
+                  (local.get 1)
                   (i32.lt_u
-                    (local.get 6)
+                    (local.get 1)
                     (local.get 7))))
               (local.get 7)))))
       (f64.store
@@ -11975,7 +12007,7 @@
         (br_if 0 (;@2;)
           (i32.ge_u
             (local.get 10)
-            (local.get 8)))
+            (local.get 6)))
         (br_if 1 (;@1;)
           (i32.le_u
             (local.tee 10
@@ -11983,53 +12015,48 @@
                 (local.get 10)
                 (i32.lt_u
                   (local.get 10)
-                  (local.get 8))))
-            (local.get 8)))))
-    (local.set 14
+                  (local.get 6))))
+            (local.get 6)))))
+    (local.set 13
       (i32.add
-        (local.tee 13
+        (i32.add
+          (i32.shl
+            (local.get 6)
+            (i32.const 2))
           (i32.add
-            (i32.add
-              (local.get 5)
-              (i32.const 480))
-            (i32.const -4)))
-        (i32.shl
-          (local.get 8)
-          (i32.const 2))))
-    (local.set 16
+            (local.get 5)
+            (i32.const 480)))
+        (i32.const -4)))
+    (local.set 15
       (i32.and
         (i32.sub
           (i32.const 47)
-          (local.tee 15
+          (local.tee 14
             (i32.add
               (local.get 3)
               (i32.mul
-                (local.get 11)
+                (local.get 9)
                 (i32.const -24)))))
         (i32.const 31)))
-    (local.set 17
+    (local.set 16
       (i32.and
         (i32.sub
           (i32.const 48)
-          (local.get 15))
+          (local.get 14))
         (i32.const 31)))
-    (local.set 3
-      (i32.add
-        (local.get 5)
-        (i32.const 312)))
-    (local.set 19
+    (local.set 18
       (i32.gt_s
-        (local.tee 18
+        (local.tee 17
           (i32.add
-            (local.get 15)
+            (local.get 14)
             (i32.const -24)))
         (i32.const 0)))
-    (local.set 20
+    (local.set 19
       (i32.add
-        (local.get 18)
+        (local.get 17)
         (i32.const -1)))
-    (local.set 1
-      (local.get 8))
+    (local.set 11
+      (local.get 6))
     (block ;; label = @1
       (loop ;; label = @2
         (local.set 12
@@ -12039,27 +12066,27 @@
                 (local.get 5)
                 (i32.const 320))
               (i32.shl
-                (local.tee 21
-                  (local.get 1))
+                (local.tee 3
+                  (local.get 11))
                 (i32.const 3)))))
         (block ;; label = @3
           (br_if 0 (;@3;)
             (i32.eqz
-              (local.get 21)))
-          (local.set 9
+              (local.get 3)))
+          (local.set 8
             (i32.add
               (local.get 5)
               (i32.const 480)))
-          (local.set 6
-            (local.get 21))
+          (local.set 1
+            (local.get 3))
           (loop ;; label = @4
             (i32.store
-              (local.get 9)
+              (local.get 8)
               (i32.trunc_sat_f64_s
                 (f64.add
                   (local.get 12)
                   (f64.mul
-                    (local.tee 22
+                    (local.tee 20
                       (f64.convert_i32_s
                         (i32.trunc_sat_f64_s
                           (f64.mul
@@ -12070,44 +12097,48 @@
               (f64.add
                 (f64.load
                   (i32.add
-                    (local.get 3)
-                    (i32.shl
-                      (local.get 6)
-                      (i32.const 3))))
-                (local.get 22)))
+                    (i32.add
+                      (i32.add
+                        (local.get 5)
+                        (i32.const 320))
+                      (i32.shl
+                        (local.get 1)
+                        (i32.const 3)))
+                    (i32.const -8)))
+                (local.get 20)))
             (br_if 1 (;@3;)
               (local.tee 10
                 (i32.eq
-                  (local.get 6)
+                  (local.get 1)
                   (i32.const 1))))
-            (local.set 9
+            (local.set 8
               (i32.add
-                (local.get 9)
+                (local.get 8)
                 (i32.const 4)))
             (br_if 0 (;@4;)
-              (local.tee 6
+              (local.tee 1
                 (select
                   (i32.const 1)
                   (i32.add
-                    (local.get 6)
+                    (local.get 1)
                     (i32.const -1))
                   (local.get 10))))))
         (block ;; label = @3
           (block ;; label = @4
             (br_if 0 (;@4;)
               (i32.gt_u
-                (local.tee 6
+                (local.tee 1
                   (i32.and
                     (i32.wrap_i64
                       (i64.shr_u
-                        (local.tee 24
+                        (local.tee 22
                           (i64.reinterpret_f64
-                            (local.tee 23
+                            (local.tee 21
                               (f64.mul
-                                (local.tee 22
-                                  (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
+                                (local.tee 20
+                                  (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn6scalbn
                                     (local.get 12)
-                                    (local.get 18)))
+                                    (local.get 17)))
                                 (f64.const 0x1p-3 (;=0.125;))))))
                         (i64.const 52)))
                     (i32.const 2047)))
@@ -12115,62 +12146,62 @@
             (block ;; label = @5
               (br_if 0 (;@5;)
                 (i32.gt_u
-                  (local.get 6)
+                  (local.get 1)
                   (i32.const 1022)))
               (local.set 12
                 (f64.const 0x0p+0 (;=0;)))
               (br_if 2 (;@3;)
                 (i64.gt_s
-                  (local.get 24)
+                  (local.get 22)
                   (i64.const -1)))
               (local.set 12
                 (select
-                  (local.get 23)
+                  (local.get 21)
                   (f64.const -0x1p+0 (;=-1;))
                   (f64.eq
-                    (local.get 23)
+                    (local.get 21)
                     (f64.const 0x0p+0 (;=0;)))))
               (br 2 (;@3;)))
             (local.set 12
-              (local.get 23))
+              (local.get 21))
             (br_if 1 (;@3;)
               (i64.eqz
                 (i64.and
-                  (local.tee 26
+                  (local.tee 24
                     (i64.shr_u
                       (i64.const 4503599627370495)
-                      (local.tee 25
+                      (local.tee 23
                         (i64.extend_i32_u
                           (i32.add
-                            (local.get 6)
+                            (local.get 1)
                             (i32.const -1023))))))
-                  (local.get 24))))
+                  (local.get 22))))
             (local.set 12
               (f64.reinterpret_i64
                 (i64.and
                   (i64.add
                     (i64.and
                       (i64.shr_s
-                        (local.get 24)
+                        (local.get 22)
                         (i64.const 63))
-                      (local.get 26))
-                    (local.get 24))
+                      (local.get 24))
+                    (local.get 22))
                   (i64.shr_s
                     (i64.const -4503599627370496)
-                    (local.get 25)))))
+                    (local.get 23)))))
             (br 1 (;@3;)))
           (local.set 12
-            (local.get 23)))
+            (local.get 21)))
         (local.set 12
           (f64.sub
             (local.tee 12
               (f64.add
-                (local.get 22)
+                (local.get 20)
                 (f64.mul
                   (local.get 12)
                   (f64.const -0x1p+3 (;=-8;)))))
             (f64.convert_i32_s
-              (local.tee 27
+              (local.tee 25
                 (i32.trunc_sat_f64_s
                   (local.get 12))))))
         (block ;; label = @3
@@ -12179,23 +12210,27 @@
               (block ;; label = @6
                 (block ;; label = @7
                   (br_if 0 (;@7;)
-                    (local.get 19))
+                    (local.get 18))
                   (block ;; label = @8
                     (br_if 0 (;@8;)
-                      (local.get 18))
-                    (local.set 28
+                      (local.get 17))
+                    (local.set 26
                       (i32.shr_s
                         (i32.load
                           (i32.add
-                            (local.get 13)
-                            (i32.shl
-                              (local.get 21)
-                              (i32.const 2))))
+                            (i32.add
+                              (i32.add
+                                (local.get 5)
+                                (i32.const 480))
+                              (i32.shl
+                                (local.get 3)
+                                (i32.const 2)))
+                            (i32.const -4)))
                         (i32.const 23)))
                     (br 2 (;@6;)))
-                  (local.set 28
+                  (local.set 26
                     (i32.const 2))
-                  (local.set 29
+                  (local.set 27
                     (i32.const 0))
                   (br_if 4 (;@3;)
                     (i32.eqz
@@ -12204,53 +12239,57 @@
                         (f64.const 0x1p-1 (;=0.5;)))))
                   (br 2 (;@5;)))
                 (i32.store
-                  (local.tee 6
+                  (local.tee 1
                     (i32.add
-                      (local.get 13)
-                      (i32.shl
-                        (local.get 21)
-                        (i32.const 2))))
-                  (local.tee 9
+                      (i32.add
+                        (i32.add
+                          (local.get 5)
+                          (i32.const 480))
+                        (i32.shl
+                          (local.get 3)
+                          (i32.const 2)))
+                      (i32.const -4)))
+                  (local.tee 8
                     (i32.sub
-                      (local.tee 6
+                      (local.tee 1
                         (i32.load
-                          (local.get 6)))
+                          (local.get 1)))
                       (i32.shl
-                        (local.tee 6
+                        (local.tee 1
                           (i32.shr_s
-                            (local.get 6)
-                            (local.get 17)))
-                        (local.get 17)))))
-                (local.set 28
+                            (local.get 1)
+                            (local.get 16)))
+                        (local.get 16)))))
+                (local.set 26
                   (i32.shr_s
-                    (local.get 9)
-                    (local.get 16)))
-                (local.set 27
+                    (local.get 8)
+                    (local.get 15)))
+                (local.set 25
                   (i32.add
-                    (local.get 6)
-                    (local.get 27))))
+                    (local.get 1)
+                    (local.get 25))))
               (br_if 1 (;@4;)
                 (i32.lt_s
-                  (local.get 28)
+                  (local.get 26)
                   (i32.const 1))))
-            (local.set 9
+            (local.set 8
               (i32.const 1))
             (block ;; label = @5
               (br_if 0 (;@5;)
                 (i32.eqz
-                  (local.get 21)))
+                  (local.get 3)))
               (local.set 10
                 (i32.const 0))
-              (local.set 6
+              (local.set 1
                 (i32.add
                   (local.get 5)
                   (i32.const 480)))
-              (local.set 1
-                (local.get 21))
+              (local.set 11
+                (local.get 3))
               (loop ;; label = @6
-                (local.set 9
+                (local.set 8
                   (i32.load
-                    (local.get 6)))
+                    (local.get 1)))
                 (block ;; label = @7
                   (block ;; label = @8
                     (block ;; label = @9
@@ -12263,81 +12302,85 @@
                         (br 1 (;@9;)))
                       (br_if 1 (;@8;)
                         (i32.eqz
-                          (local.get 9)))
+                          (local.get 8)))
                       (local.set 10
                         (i32.const 16777216)))
                     (i32.store
-                      (local.get 6)
+                      (local.get 1)
                       (i32.sub
                         (local.get 10)
-                        (local.get 9)))
+                        (local.get 8)))
                     (local.set 10
                       (i32.const 1))
-                    (local.set 9
+                    (local.set 8
                       (i32.const 0))
                     (br 1 (;@7;)))
                   (local.set 10
                     (i32.const 0))
-                  (local.set 9
+                  (local.set 8
                     (i32.const 1)))
-                (local.set 6
+                (local.set 1
                   (i32.add
-                    (local.get 6)
+                    (local.get 1)
                     (i32.const 4)))
                 (br_if 0 (;@6;)
-                  (local.tee 1
+                  (local.tee 11
                     (i32.add
-                      (local.get 1)
+                      (local.get 11)
                       (i32.const -1))))))
             (block ;; label = @5
               (br_if 0 (;@5;)
                 (i32.lt_s
-                  (local.get 18)
+                  (local.get 17)
                   (i32.const 1)))
-              (local.set 6
+              (local.set 1
                 (i32.const 8388607))
               (block ;; label = @6
                 (block ;; label = @7
                   (br_table 1 (;@6;) 0 (;@7;) 2 (;@5;)
-                    (local.get 20)))
-                (local.set 6
+                    (local.get 19)))
+                (local.set 1
                   (i32.const 4194303)))
               (i32.store
                 (local.tee 10
                   (i32.add
-                    (local.get 13)
-                    (i32.shl
-                      (local.get 21)
-                      (i32.const 2))))
+                    (i32.add
+                      (i32.add
+                        (local.get 5)
+                        (i32.const 480))
+                      (i32.shl
+                        (local.get 3)
+                        (i32.const 2)))
+                    (i32.const -4)))
                 (i32.and
                   (i32.load
                     (local.get 10))
-                  (local.get 6))))
-            (local.set 27
+                  (local.get 1))))
+            (local.set 25
               (i32.add
-                (local.get 27)
+                (local.get 25)
                 (i32.const 1)))
-            (local.set 29
+            (local.set 27
               (i32.const 2))
             (br_if 1 (;@3;)
               (i32.ne
-                (local.get 28)
+                (local.get 26)
                 (i32.const 2)))
             (local.set 12
               (f64.sub
                 (f64.const 0x1p+0 (;=1;))
                 (local.get 12)))
             (br_if 1 (;@3;)
-              (local.get 9))
+              (local.get 8))
             (local.set 12
               (f64.sub
                 (local.get 12)
-                (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn6scalbn
                   (f64.const 0x1p+0 (;=1;))
-                  (local.get 18))))
+                  (local.get 17))))
             (br 1 (;@3;)))
-          (local.set 29
-            (local.get 28)))
+          (local.set 27
+            (local.get 26)))
         (block ;; label = @3
           (br_if 0 (;@3;)
             (f64.ne
@@ -12346,16 +12389,16 @@
           (block ;; label = @4
             (br_if 0 (;@4;)
               (i32.gt_u
-                (local.get 8)
-                (local.tee 6
+                (local.get 6)
+                (local.tee 1
                   (i32.add
-                    (local.get 21)
+                    (local.get 3)
                     (i32.const -1)))))
-            (local.set 9
+            (local.set 8
               (i32.const 0))
             (block ;; label = @5
               (loop ;; label = @6
-                (local.set 9
+                (local.set 8
                   (i32.or
                     (i32.load
                       (i32.add
@@ -12363,103 +12406,103 @@
                           (local.get 5)
                           (i32.const 480))
                         (i32.shl
-                          (local.get 6)
+                          (local.get 1)
                           (i32.const 2))))
-                    (local.get 9)))
+                    (local.get 8)))
                 (br_if 1 (;@5;)
                   (i32.ge_u
-                    (local.get 8)
-                    (local.get 6)))
+                    (local.get 6)
+                    (local.get 1)))
                 (br_if 0 (;@6;)
                   (i32.le_u
-                    (local.get 8)
-                    (local.tee 6
+                    (local.get 6)
+                    (local.tee 1
                       (i32.sub
-                        (local.get 6)
+                        (local.get 1)
                         (i32.lt_u
-                          (local.get 8)
-                          (local.get 6))))))))
+                          (local.get 6)
+                          (local.get 1))))))))
             (br_if 0 (;@4;)
               (i32.eqz
-                (local.get 9)))
-            (local.set 6
+                (local.get 8)))
+            (local.set 1
               (i32.add
                 (i32.add
                   (i32.add
                     (local.get 5)
                     (i32.const 480))
                   (i32.shl
-                    (local.get 21)
+                    (local.get 3)
                     (i32.const 2)))
                 (i32.const -4)))
             (loop ;; label = @5
-              (local.set 21
+              (local.set 3
                 (i32.add
-                  (local.get 21)
+                  (local.get 3)
                   (i32.const -1)))
-              (local.set 18
+              (local.set 17
                 (i32.add
-                  (local.get 18)
+                  (local.get 17)
                   (i32.const -24)))
               (local.set 7
                 (i32.load
-                  (local.get 6)))
-              (local.set 6
+                  (local.get 1)))
+              (local.set 1
                 (i32.add
-                  (local.get 6)
+                  (local.get 1)
                   (i32.const -4)))
               (br_if 0 (;@5;)
                 (i32.eqz
                   (local.get 7)))
               (br 4 (;@1;))))
-          (local.set 9
+          (local.set 8
             (i32.const 0))
-          (local.set 6
-            (local.get 14))
+          (local.set 1
+            (local.get 13))
           (loop ;; label = @4
-            (local.set 9
+            (local.set 8
               (i32.add
-                (local.get 9)
+                (local.get 8)
                 (i32.const 1)))
             (local.set 10
               (i32.load
-                (local.get 6)))
-            (local.set 6
+                (local.get 1)))
+            (local.set 1
               (i32.add
-                (local.get 6)
+                (local.get 1)
                 (i32.const -4)))
             (br_if 0 (;@4;)
               (i32.eqz
                 (local.get 10))))
           (br_if 1 (;@2;)
             (i32.ge_u
-              (local.get 21)
-              (local.tee 1
+              (local.get 3)
+              (local.tee 11
                 (i32.add
-                  (local.get 9)
-                  (local.get 21)))))
+                  (local.get 8)
+                  (local.get 3)))))
           (local.set 10
             (i32.add
-              (local.get 21)
+              (local.get 3)
               (i32.const 1)))
           (loop ;; label = @4
             (f64.store
               (i32.add
                 (local.get 5)
                 (i32.shl
-                  (local.tee 9
+                  (local.tee 8
                     (i32.add
                       (local.get 10)
                       (local.get 7)))
                   (i32.const 3)))
               (f64.convert_i32_s
-                (i32.load offset=1052904
+                (i32.load offset=1052688
                   (i32.shl
                     (i32.add
                       (local.get 10)
-                      (local.get 11))
+                      (local.get 9))
                     (i32.const 2)))))
-            (local.set 6
+            (local.set 1
               (i32.const 0))
             (local.set 12
               (f64.const 0x0p+0 (;=0;)))
@@ -12473,27 +12516,27 @@
                         (i32.add
                           (local.get 0)
                           (i32.shl
-                            (local.get 6)
+                            (local.get 1)
                             (i32.const 3))))
                       (f64.load
                         (i32.add
                           (local.get 5)
                           (i32.shl
                             (i32.sub
-                              (local.get 9)
-                              (local.get 6))
+                              (local.get 8)
+                              (local.get 1))
                             (i32.const 3)))))))
                 (br_if 1 (;@5;)
                   (i32.ge_u
-                    (local.get 6)
+                    (local.get 1)
                     (local.get 7)))
                 (br_if 0 (;@6;)
                   (i32.le_u
-                    (local.tee 6
+                    (local.tee 1
                       (i32.add
-                        (local.get 6)
+                        (local.get 1)
                         (i32.lt_u
-                          (local.get 6)
+                          (local.get 1)
                           (local.get 7))))
                     (local.get 7)))))
             (f64.store
@@ -12505,35 +12548,35 @@
                   (local.get 10)
                   (i32.const 3)))
               (local.get 12))
-            (local.set 6
+            (local.set 1
               (i32.add
                 (local.get 10)
                 (i32.lt_u
                   (local.get 10)
-                  (local.get 1))))
+                  (local.get 11))))
             (br_if 2 (;@2;)
               (i32.ge_u
                 (local.get 10)
-                (local.get 1)))
+                (local.get 11)))
             (local.set 10
-              (local.get 6))
+              (local.get 1))
             (br_if 0 (;@4;)
               (i32.le_u
-                (local.get 6)
-                (local.get 1)))
+                (local.get 1)
+                (local.get 11)))
             (br 2 (;@2;)))))
       (block ;; label = @2
         (block ;; label = @3
           (br_if 0 (;@3;)
             (f64.ge
               (local.tee 12
-                (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
+                (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn6scalbn
                   (local.get 12)
                   (i32.sub
                     (i32.const 0)
-                    (local.get 18))))
+                    (local.get 17))))
               (f64.const 0x1p+24 (;=16777216;))))
-          (local.set 22
+          (local.set 20
             (local.get 12))
           (br 1 (;@2;)))
         (i32.store
@@ -12542,42 +12585,42 @@
               (local.get 5)
               (i32.const 480))
             (i32.shl
-              (local.get 21)
+              (local.get 3)
               (i32.const 2)))
           (i32.trunc_sat_f64_s
             (f64.add
               (local.get 12)
               (f64.mul
-                (local.tee 22
+                (local.tee 20
                   (f64.convert_i32_s
                     (i32.trunc_sat_f64_s
                       (f64.mul
                         (local.get 12)
                         (f64.const 0x1p-24 (;=0.00000005960464477539063;))))))
                 (f64.const -0x1p+24 (;=-16777216;))))))
-        (local.set 21
+        (local.set 3
           (i32.add
-            (local.get 21)
+            (local.get 3)
             (i32.const 1)))
-        (local.set 18
-          (local.get 15)))
+        (local.set 17
+          (local.get 14)))
       (i32.store
         (i32.add
           (i32.add
             (local.get 5)
             (i32.const 480))
           (i32.shl
-            (local.get 21)
+            (local.get 3)
             (i32.const 2)))
         (i32.trunc_sat_f64_s
-          (local.get 22))))
-    (local.set 6
+          (local.get 20))))
+    (local.set 1
       (i32.add
         (i32.add
           (local.get 5)
           (i32.const 320))
         (i32.shl
-          (local.get 21)
+          (local.get 3)
           (i32.const 3))))
     (local.set 7
       (i32.add
@@ -12585,25 +12628,25 @@
           (local.get 5)
           (i32.const 480))
         (i32.shl
-          (local.get 21)
+          (local.get 3)
           (i32.const 2))))
     (local.set 12
-      (call $_ZN4libm4math6scalbn6scalbn17hd5ee51b98c77623bE
+      (call $_RNvNtNtCskrL9OOIMpwY_4libm4math6scalbn6scalbn
         (f64.const 0x1p+0 (;=1;))
-        (local.get 18)))
+        (local.get 17)))
     (local.set 0
-      (local.get 21))
+      (local.get 3))
     (loop ;; label = @1
       (f64.store
-        (local.get 6)
+        (local.get 1)
         (f64.mul
           (local.get 12)
           (f64.convert_i32_s
             (i32.load
               (local.get 7)))))
-      (local.set 6
+      (local.set 1
         (i32.add
-          (local.get 6)
+          (local.get 1)
           (i32.const -8)))
       (local.set 7
         (i32.add
@@ -12626,27 +12669,27 @@
           (local.get 5)
           (i32.const 320))
         (i32.shl
-          (local.get 21)
+          (local.get 3)
           (i32.const 3))))
-    (local.set 6
-      (local.get 21))
+    (local.set 1
+      (local.get 3))
     (loop ;; label = @1
-      (local.set 9
+      (local.set 8
         (i32.add
           (select
-            (local.get 8)
-            (local.tee 1
+            (local.get 6)
+            (local.tee 11
               (i32.sub
-                (local.get 21)
+                (local.get 3)
                 (local.tee 10
-                  (local.get 6))))
+                  (local.get 1))))
             (i32.lt_u
-              (local.get 8)
-              (local.get 1)))
+              (local.get 6)
+              (local.get 11)))
           (i32.const 1)))
       (local.set 12
         (f64.const 0x0p+0 (;=0;)))
-      (local.set 6
+      (local.set 1
         (i32.const 0))
       (local.set 7
         (i32.const 0))
@@ -12657,19 +12700,19 @@
             (f64.mul
               (f64.load
                 (i32.add
-                  (local.get 6)
-                  (i32.const 1053168)))
+                  (local.get 1)
+                  (i32.const 1052952)))
               (f64.load
                 (i32.add
                   (local.get 0)
-                  (local.get 6))))))
-        (local.set 6
+                  (local.get 1))))))
+        (local.set 1
           (i32.add
-            (local.get 6)
+            (local.get 1)
             (i32.const 8)))
         (br_if 0 (;@2;)
           (i32.ne
-            (local.get 9)
+            (local.get 8)
             (local.tee 7
               (i32.add
                 (local.get 7)
@@ -12680,14 +12723,14 @@
             (local.get 5)
             (i32.const 160))
           (i32.shl
-            (local.get 1)
+            (local.get 11)
             (i32.const 3)))
         (local.get 12))
       (local.set 0
         (i32.add
           (local.get 0)
           (i32.const -8)))
-      (local.set 6
+      (local.set 1
         (i32.add
           (local.get 10)
           (i32.const -1)))
@@ -12698,27 +12741,27 @@
         (br_if 0 (;@2;)
           (i32.eqz
             (local.get 4)))
-        (local.set 6
+        (local.set 1
           (i32.add
             (i32.add
               (local.get 5)
               (i32.const 160))
             (i32.shl
-              (local.get 21)
+              (local.get 3)
               (i32.const 3))))
         (local.set 12
           (f64.const 0x0p+0 (;=0;)))
         (local.set 7
-          (local.get 21))
+          (local.get 3))
         (loop ;; label = @3
           (local.set 12
             (f64.add
               (local.get 12)
               (f64.load
-                (local.get 6))))
-          (local.set 6
+                (local.get 1))))
+          (local.set 1
             (i32.add
-              (local.get 6)
+              (local.get 1)
               (i32.const -8)))
           (br_if 0 (;@3;)
             (i32.ne
@@ -12733,7 +12776,7 @@
             (f64.neg
               (local.get 12))
             (local.get 12)
-            (local.get 29)))
+            (local.get 27)))
         (local.set 12
           (f64.sub
             (f64.load offset=160
@@ -12742,8 +12785,8 @@
         (block ;; label = @3
           (br_if 0 (;@3;)
             (i32.eqz
-              (local.get 21)))
-          (local.set 6
+              (local.get 3)))
+          (local.set 1
             (i32.const 1))
           (loop ;; label = @4
             (local.set 12
@@ -12755,36 +12798,36 @@
                       (local.get 5)
                       (i32.const 160))
                     (i32.shl
-                      (local.get 6)
+                      (local.get 1)
                       (i32.const 3))))))
             (br_if 1 (;@3;)
               (i32.ge_u
-                (local.get 6)
-                (local.get 21)))
+                (local.get 1)
+                (local.get 3)))
             (br_if 0 (;@4;)
               (i32.le_u
-                (local.tee 6
+                (local.tee 1
                   (i32.add
-                    (local.get 6)
+                    (local.get 1)
                     (i32.lt_u
-                      (local.get 6)
-                      (local.get 21))))
-                (local.get 21)))))
+                      (local.get 1)
+                      (local.get 3))))
+                (local.get 3)))))
         (f64.store offset=8
           (local.get 2)
           (select
             (f64.neg
               (local.get 12))
             (local.get 12)
-            (local.get 29)))
+            (local.get 27)))
         (br 1 (;@1;)))
-      (local.set 6
+      (local.set 1
         (i32.add
           (i32.add
             (local.get 5)
             (i32.const 160))
           (i32.shl
-            (local.get 21)
+            (local.get 3)
             (i32.const 3))))
       (local.set 12
         (f64.const 0x0p+0 (;=0;)))
@@ -12793,16 +12836,16 @@
           (f64.add
             (local.get 12)
             (f64.load
-              (local.get 6))))
-        (local.set 6
+              (local.get 1))))
+        (local.set 1
           (i32.add
-            (local.get 6)
+            (local.get 1)
             (i32.const -8)))
         (br_if 0 (;@2;)
           (i32.ne
-            (local.tee 21
+            (local.tee 3
               (i32.add
-                (local.get 21)
+                (local.get 3)
                 (i32.const -1)))
             (i32.const -1))))
       (f64.store
@@ -12811,16 +12854,16 @@
           (f64.neg
             (local.get 12))
           (local.get 12)
-          (local.get 29))))
+          (local.get 27))))
     (global.set $__stack_pointer
       (i32.add
         (local.get 5)
         (i32.const 560)))
     (i32.and
-      (local.get 27)
+      (local.get 25)
       (i32.const 7))
   )
-  (func $_ZN4libm4math8rem_pio28rem_pio26medium17h661801483d1aa963E (;71;) (type 13) (param i32 f64 i32)
+  (func $_RNvNvNtNtCskrL9OOIMpwY_4libm4math8rem_pio28rem_pio26medium (;73;) (type 14) (param i32 f64 i32)
     (local f64 f64 f64 f64)
     (block ;; label = @1
       (br_if 0 (;@1;)
@@ -12924,56 +12967,7 @@
           (local.get 5))
         (local.get 4)))
   )
-  (func $__ashlti3 (;72;) (type 14) (param i32 i64 i64 i32)
-    (local i64)
-    (block ;; label = @1
-      (block ;; label = @2
-        (br_if 0 (;@2;)
-          (i32.and
-            (local.get 3)
-            (i32.const 64)))
-        (br_if 1 (;@1;)
-          (i32.eqz
-            (local.get 3)))
-        (local.set 2
-          (i64.or
-            (i64.shl
-              (local.get 2)
-              (local.tee 4
-                (i64.extend_i32_u
-                  (i32.and
-                    (local.get 3)
-                    (i32.const 63)))))
-            (i64.shr_u
-              (local.get 1)
-              (i64.extend_i32_u
-                (i32.and
-                  (i32.sub
-                    (i32.const 0)
-                    (local.get 3))
-                  (i32.const 63))))))
-        (local.set 1
-          (i64.shl
-            (local.get 1)
-            (local.get 4)))
-        (br 1 (;@1;)))
-      (local.set 2
-        (i64.shl
-          (local.get 1)
-          (i64.extend_i32_u
-            (i32.and
-              (local.get 3)
-              (i32.const 63)))))
-      (local.set 1
-        (i64.const 0)))
-    (i64.store
-      (local.get 0)
-      (local.get 1))
-    (i64.store offset=8
-      (local.get 0)
-      (local.get 2))
-  )
-  (func $__multi3 (;73;) (type 15) (param i32 i64 i64 i64 i64)
+  (func $__multi3 (;74;) (type 15) (param i32 i64 i64 i64 i64)
     (local i64 i64 i64 i64 i64 i64)
     (i64.store
       (local.get 0)
@@ -13036,7 +13030,7 @@
             (local.get 3)
             (local.get 2)))))
   )
-  (func $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17h8d9ba2662c058edeE (;74;) (type 15) (param i32 i64 i64 i64 i64)
+  (func $_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem12u128_div_rem (;75;) (type 15) (param i32 i64 i64 i64 i64)
     (local i32 i64 i32 i32 i32 i64 i64 i64 i64)
     (global.set $__stack_pointer
       (local.tee 5
@@ -13049,364 +13043,71 @@
       (block ;; label = @2
         (block ;; label = @3
           (block ;; label = @4
-            (br_if 0 (;@4;)
-              (i32.le_u
-                (local.tee 7
-                  (i32.wrap_i64
-                    (select
-                      (i64.clz
-                        (local.get 4))
-                      (i64.add
-                        (i64.clz
-                          (local.get 3))
-                        (i64.const 64))
-                      (i64.ne
-                        (local.get 4)
-                        (i64.const 0)))))
-                (local.tee 8
-                  (i32.wrap_i64
-                    (select
-                      (i64.clz
-                        (local.get 2))
-                      (i64.add
-                        (i64.clz
-                          (local.get 1))
-                        (i64.const 64))
-                      (i64.ne
-                        (local.get 2)
-                        (i64.const 0)))))))
-            (br_if 1 (;@3;)
-              (i32.gt_u
-                (local.get 8)
-                (i32.const 63)))
-            (br_if 2 (;@2;)
-              (i32.gt_u
-                (local.get 7)
-                (i32.const 95)))
             (block ;; label = @5
               (block ;; label = @6
                 (block ;; label = @7
-                  (br_if 0 (;@7;)
-                    (i32.lt_u
-                      (i32.sub
-                        (local.get 7)
-                        (local.get 8))
-                      (i32.const 32)))
-                  (call $__lshrti3
-                    (i32.add
-                      (local.get 5)
-                      (i32.const 160))
-                    (local.get 3)
-                    (local.get 4)
-                    (local.tee 9
-                      (i32.sub
-                        (i32.const 96)
-                        (local.get 7))))
-                  (local.set 10
-                    (i64.add
-                      (i64.load32_u offset=160
-                        (local.get 5))
-                      (i64.const 1)))
-                  (local.set 11
-                    (i64.const 0))
-                  (local.set 6
-                    (i64.const 0))
-                  (br 1 (;@6;)))
-                (call $__lshrti3
-                  (i32.add
-                    (local.get 5)
-                    (i32.const 48))
-                  (local.get 1)
-                  (local.get 2)
-                  (local.tee 8
-                    (i32.sub
-                      (i32.const 64)
-                      (local.get 8))))
-                (call $__lshrti3
-                  (i32.add
-                    (local.get 5)
-                    (i32.const 32))
-                  (local.get 3)
-                  (local.get 4)
-                  (local.get 8))
-                (local.set 6
-                  (i64.const 0))
-                (call $__multi3
-                  (local.get 5)
-                  (local.get 3)
-                  (i64.const 0)
-                  (local.tee 12
-                    (i64.div_u
-                      (i64.load offset=48
-                        (local.get 5))
-                      (i64.load offset=32
-                        (local.get 5))))
-                  (i64.const 0))
-                (call $__multi3
-                  (i32.add
-                    (local.get 5)
-                    (i32.const 16))
-                  (local.get 4)
-                  (i64.const 0)
-                  (local.get 12)
-                  (i64.const 0))
-                (local.set 10
-                  (i64.load
-                    (local.get 5)))
-                (block ;; label = @7
-                  (br_if 0 (;@7;)
-                    (i64.ne
-                      (i64.add
-                        (i64.load offset=24
-                          (local.get 5))
-                        (i64.extend_i32_u
-                          (i64.lt_u
-                            (local.tee 11
+                  (block ;; label = @8
+                    (br_if 0 (;@8;)
+                      (i32.le_u
+                        (local.tee 7
+                          (i32.wrap_i64
+                            (select
+                              (i64.clz
+                                (local.get 4))
                               (i64.add
-                                (local.tee 13
-                                  (i64.load offset=8
-                                    (local.get 5)))
-                                (i64.load offset=16
-                                  (local.get 5))))
-                            (local.get 13))))
-                      (i64.const 0)))
-                  (br_if 2 (;@5;)
-                    (i32.eqz
-                      (select
+                                (i64.clz
+                                  (local.get 3))
+                                (i64.const 64))
+                              (i64.ne
+                                (local.get 4)
+                                (i64.const 0)))))
                         (local.tee 8
-                          (i64.lt_u
-                            (local.get 1)
-                            (local.get 10)))
-                        (i64.lt_u
-                          (local.get 2)
-                          (local.get 11))
-                        (i64.eq
-                          (local.get 2)
-                          (local.get 11))))))
-                (local.set 2
-                  (i64.sub
-                    (i64.sub
-                      (i64.add
-                        (i64.add
-                          (local.get 4)
-                          (local.get 2))
-                        (i64.extend_i32_u
-                          (i64.lt_u
-                            (local.tee 1
+                          (i32.wrap_i64
+                            (select
+                              (i64.clz
+                                (local.get 2))
                               (i64.add
-                                (local.get 3)
-                                (local.get 1)))
-                            (local.get 3))))
-                      (local.get 11))
-                    (i64.extend_i32_u
-                      (i64.lt_u
-                        (local.get 1)
-                        (local.get 10)))))
-                (local.set 12
-                  (i64.add
-                    (local.get 12)
-                    (i64.const -1)))
-                (local.set 1
-                  (i64.sub
-                    (local.get 1)
-                    (local.get 10)))
-                (br 5 (;@1;)))
-              (block ;; label = @6
-                (block ;; label = @7
-                  (loop ;; label = @8
+                                (i64.clz
+                                  (local.get 1))
+                                (i64.const 64))
+                              (i64.ne
+                                (local.get 2)
+                                (i64.const 0)))))))
+                    (br_if 1 (;@7;)
+                      (i32.gt_u
+                        (local.get 8)
+                        (i32.const 63)))
+                    (br_if 2 (;@6;)
+                      (i32.gt_u
+                        (local.get 7)
+                        (i32.const 95)))
+                    (br_if 3 (;@5;)
+                      (i32.lt_u
+                        (i32.sub
+                          (local.get 7)
+                          (local.get 8))
+                        (i32.const 32)))
                     (call $__lshrti3
                       (i32.add
                         (local.get 5)
-                        (i32.const 144))
-                      (local.get 1)
-                      (local.get 2)
-                      (local.tee 8
-                        (i32.sub
-                          (i32.const 64)
-                          (local.get 8))))
-                    (local.set 12
-                      (i64.load offset=144
-                        (local.get 5)))
-                    (block ;; label = @9
-                      (br_if 0 (;@9;)
-                        (i32.ge_u
-                          (local.get 8)
-                          (local.get 9)))
-                      (call $__lshrti3
-                        (i32.add
-                          (local.get 5)
-                          (i32.const 80))
-                        (local.get 3)
-                        (local.get 4)
-                        (local.get 8))
-                      (call $__multi3
-                        (i32.add
-                          (local.get 5)
-                          (i32.const 64))
-                        (local.get 3)
-                        (local.get 4)
-                        (local.tee 13
-                          (i64.div_u
-                            (local.get 12)
-                            (i64.load offset=80
-                              (local.get 5))))
-                        (i64.const 0))
-                      (block ;; label = @10
-                        (br_if 0 (;@10;)
-                          (select
-                            (local.tee 8
-                              (i64.lt_u
-                                (local.get 1)
-                                (local.tee 10
-                                  (i64.load offset=64
-                                    (local.get 5)))))
-                            (i64.lt_u
-                              (local.get 2)
-                              (local.tee 12
-                                (i64.load offset=72
-                                  (local.get 5))))
-                            (i64.eq
-                              (local.get 2)
-                              (local.get 12))))
-                        (local.set 2
-                          (i64.sub
-                            (i64.sub
-                              (local.get 2)
-                              (local.get 12))
-                            (i64.extend_i32_u
-                              (local.get 8))))
-                        (local.set 1
-                          (i64.sub
-                            (local.get 1)
-                            (local.get 10)))
-                        (local.set 6
-                          (i64.add
-                            (local.get 6)
-                            (i64.extend_i32_u
-                              (i64.lt_u
-                                (local.tee 12
-                                  (i64.add
-                                    (local.get 11)
-                                    (local.get 13)))
-                                (local.get 11)))))
-                        (br 9 (;@1;)))
-                      (local.set 2
-                        (i64.sub
-                          (i64.sub
-                            (i64.add
-                              (i64.add
-                                (local.get 2)
-                                (local.get 4))
-                              (i64.extend_i32_u
-                                (i64.lt_u
-                                  (local.tee 4
-                                    (i64.add
-                                      (local.get 1)
-                                      (local.get 3)))
-                                  (local.get 1))))
-                            (local.get 12))
-                          (i64.extend_i32_u
-                            (i64.lt_u
-                              (local.get 4)
-                              (local.get 10)))))
-                      (local.set 1
-                        (i64.sub
-                          (local.get 4)
-                          (local.get 10)))
-                      (local.set 6
-                        (i64.add
-                          (local.get 6)
-                          (i64.extend_i32_u
-                            (i64.lt_u
-                              (local.tee 12
-                                (i64.add
-                                  (i64.add
-                                    (local.get 13)
-                                    (local.get 11))
-                                  (i64.const -1)))
-                              (local.get 11)))))
-                      (br 8 (;@1;)))
-                    (call $__ashlti3
-                      (i32.add
-                        (local.get 5)
-                        (i32.const 128))
-                      (local.tee 12
-                        (i64.div_u
-                          (local.get 12)
-                          (local.get 10)))
-                      (i64.const 0)
-                      (local.tee 8
-                        (i32.sub
-                          (local.get 8)
-                          (local.get 9))))
-                    (call $__multi3
-                      (i32.add
-                        (local.get 5)
-                        (i32.const 112))
+                        (i32.const 160))
                       (local.get 3)
                       (local.get 4)
-                      (local.get 12)
-                      (i64.const 0))
-                    (call $__ashlti3
-                      (i32.add
-                        (local.get 5)
-                        (i32.const 96))
-                      (i64.load offset=112
-                        (local.get 5))
-                      (i64.load offset=120
-                        (local.get 5))
-                      (local.get 8))
-                    (local.set 6
+                      (local.tee 9
+                        (i32.sub
+                          (i32.const 96)
+                          (local.get 7))))
+                    (local.set 10
                       (i64.add
-                        (i64.add
-                          (i64.load offset=136
-                            (local.get 5))
-                          (local.get 6))
-                        (i64.extend_i32_u
-                          (i64.lt_u
-                            (local.tee 11
-                              (i64.add
-                                (local.tee 6
-                                  (i64.load offset=128
-                                    (local.get 5)))
-                                (local.get 11)))
-                            (local.get 6)))))
-                    (block ;; label = @9
-                      (br_if 0 (;@9;)
-                        (i32.le_u
-                          (local.get 7)
-                          (local.tee 8
-                            (i32.wrap_i64
-                              (select
-                                (i64.clz
-                                  (local.tee 2
-                                    (i64.sub
-                                      (i64.sub
-                                        (local.get 2)
-                                        (i64.load offset=104
-                                          (local.get 5)))
-                                      (i64.extend_i32_u
-                                        (i64.lt_u
-                                          (local.get 1)
-                                          (local.tee 12
-                                            (i64.load offset=96
-                                              (local.get 5))))))))
-                                (i64.add
-                                  (i64.clz
-                                    (local.tee 1
-                                      (i64.sub
-                                        (local.get 1)
-                                        (local.get 12))))
-                                  (i64.const 64))
-                                (i64.ne
-                                  (local.get 2)
-                                  (i64.const 0)))))))
-                      (br_if 2 (;@7;)
-                        (i32.gt_u
-                          (local.get 8)
-                          (i32.const 63)))
-                      (br 1 (;@8;))))
-                  (br_if 1 (;@6;)
+                        (i64.load32_u offset=160
+                          (local.get 5))
+                        (i64.const 1)))
+                    (local.set 11
+                      (i64.const 0))
+                    (local.set 6
+                      (i64.const 0))
+                    (br 4 (;@4;)))
+                  (br_if 5 (;@2;)
                     (i32.eqz
                       (select
                         (local.tee 8
@@ -13420,167 +13121,457 @@
                           (local.get 2)
                           (local.get 4)))))
                   (local.set 12
-                    (local.get 11))
+                    (i64.const 0))
                   (br 6 (;@1;)))
                 (local.set 1
                   (i64.sub
                     (local.get 1)
                     (i64.mul
-                      (local.tee 2
+                      (local.tee 12
                         (i64.div_u
                           (local.get 1)
                           (local.get 3)))
                       (local.get 3))))
                 (local.set 6
-                  (i64.add
-                    (local.get 6)
-                    (i64.extend_i32_u
-                      (i64.lt_u
-                        (local.tee 12
-                          (i64.add
-                            (local.get 11)
-                            (local.get 2)))
-                        (local.get 11)))))
+                  (i64.const 0))
                 (local.set 2
                   (i64.const 0))
                 (br 5 (;@1;)))
-              (local.set 2
-                (i64.sub
-                  (i64.sub
-                    (local.get 2)
-                    (local.get 4))
-                  (i64.extend_i32_u
-                    (local.get 8))))
+              (local.set 12
+                (i64.or
+                  (i64.shl
+                    (local.tee 2
+                      (i64.div_u
+                        (i64.or
+                          (i64.shl
+                            (i64.sub
+                              (local.get 2)
+                              (i64.mul
+                                (local.tee 6
+                                  (i64.div_u
+                                    (local.get 2)
+                                    (local.tee 4
+                                      (i64.and
+                                        (local.get 3)
+                                        (i64.const 4294967295)))))
+                                (local.get 3)))
+                            (i64.const 32))
+                          (local.tee 12
+                            (i64.shr_u
+                              (local.get 1)
+                              (i64.const 32))))
+                        (local.get 4)))
+                    (i64.const 32))
+                  (local.tee 3
+                    (i64.div_u
+                      (local.tee 1
+                        (i64.or
+                          (i64.shl
+                            (i64.sub
+                              (local.get 12)
+                              (i64.mul
+                                (local.get 2)
+                                (local.get 3)))
+                            (i64.const 32))
+                          (i64.and
+                            (local.get 1)
+                            (i64.const 4294967295))))
+                      (local.get 4)))))
               (local.set 1
                 (i64.sub
                   (local.get 1)
-                  (local.get 3)))
+                  (i64.mul
+                    (local.get 3)
+                    (local.get 4))))
               (local.set 6
-                (i64.add
-                  (local.get 6)
-                  (i64.extend_i32_u
-                    (i64.eqz
-                      (local.tee 12
-                        (i64.add
-                          (local.get 11)
-                          (i64.const 1)))))))
+                (i64.or
+                  (i64.shr_u
+                    (local.get 2)
+                    (i64.const 32))
+                  (local.get 6)))
+              (local.set 2
+                (i64.const 0))
               (br 4 (;@1;)))
+            (call $__lshrti3
+              (i32.add
+                (local.get 5)
+                (i32.const 48))
+              (local.get 1)
+              (local.get 2)
+              (local.tee 8
+                (i32.sub
+                  (i32.const 64)
+                  (local.get 8))))
+            (call $__lshrti3
+              (i32.add
+                (local.get 5)
+                (i32.const 32))
+              (local.get 3)
+              (local.get 4)
+              (local.get 8))
+            (local.set 6
+              (i64.const 0))
+            (call $__multi3
+              (local.get 5)
+              (local.get 3)
+              (i64.const 0)
+              (local.tee 12
+                (i64.div_u
+                  (i64.load offset=48
+                    (local.get 5))
+                  (i64.load offset=32
+                    (local.get 5))))
+              (i64.const 0))
+            (call $__multi3
+              (i32.add
+                (local.get 5)
+                (i32.const 16))
+              (local.get 4)
+              (i64.const 0)
+              (local.get 12)
+              (i64.const 0))
+            (local.set 10
+              (i64.load
+                (local.get 5)))
+            (block ;; label = @5
+              (br_if 0 (;@5;)
+                (i64.ne
+                  (i64.add
+                    (i64.load offset=24
+                      (local.get 5))
+                    (i64.extend_i32_u
+                      (i64.lt_u
+                        (local.tee 11
+                          (i64.add
+                            (local.tee 13
+                              (i64.load offset=8
+                                (local.get 5)))
+                            (i64.load offset=16
+                              (local.get 5))))
+                        (local.get 13))))
+                  (i64.const 0)))
+              (br_if 2 (;@3;)
+                (i32.eqz
+                  (select
+                    (local.tee 8
+                      (i64.lt_u
+                        (local.get 1)
+                        (local.get 10)))
+                    (i64.lt_u
+                      (local.get 2)
+                      (local.get 11))
+                    (i64.eq
+                      (local.get 2)
+                      (local.get 11))))))
             (local.set 2
               (i64.sub
                 (i64.sub
-                  (local.get 2)
+                  (i64.add
+                    (i64.add
+                      (local.get 4)
+                      (local.get 2))
+                    (i64.extend_i32_u
+                      (i64.lt_u
+                        (local.tee 1
+                          (i64.add
+                            (local.get 3)
+                            (local.get 1)))
+                        (local.get 3))))
                   (local.get 11))
                 (i64.extend_i32_u
-                  (local.get 8))))
+                  (i64.lt_u
+                    (local.get 1)
+                    (local.get 10)))))
+            (local.set 12
+              (i64.add
+                (local.get 12)
+                (i64.const -1)))
             (local.set 1
               (i64.sub
                 (local.get 1)
                 (local.get 10)))
+            (br 3 (;@1;)))
+          (block ;; label = @4
+            (block ;; label = @5
+              (loop ;; label = @6
+                (call $__lshrti3
+                  (i32.add
+                    (local.get 5)
+                    (i32.const 144))
+                  (local.get 1)
+                  (local.get 2)
+                  (local.tee 8
+                    (i32.sub
+                      (i32.const 64)
+                      (local.get 8))))
+                (local.set 12
+                  (i64.load offset=144
+                    (local.get 5)))
+                (block ;; label = @7
+                  (br_if 0 (;@7;)
+                    (i32.ge_u
+                      (local.get 8)
+                      (local.get 9)))
+                  (call $__lshrti3
+                    (i32.add
+                      (local.get 5)
+                      (i32.const 80))
+                    (local.get 3)
+                    (local.get 4)
+                    (local.get 8))
+                  (call $__multi3
+                    (i32.add
+                      (local.get 5)
+                      (i32.const 64))
+                    (local.get 3)
+                    (local.get 4)
+                    (local.tee 13
+                      (i64.div_u
+                        (local.get 12)
+                        (i64.load offset=80
+                          (local.get 5))))
+                    (i64.const 0))
+                  (block ;; label = @8
+                    (br_if 0 (;@8;)
+                      (select
+                        (local.tee 8
+                          (i64.lt_u
+                            (local.get 1)
+                            (local.tee 10
+                              (i64.load offset=64
+                                (local.get 5)))))
+                        (i64.lt_u
+                          (local.get 2)
+                          (local.tee 12
+                            (i64.load offset=72
+                              (local.get 5))))
+                        (i64.eq
+                          (local.get 2)
+                          (local.get 12))))
+                    (local.set 2
+                      (i64.sub
+                        (i64.sub
+                          (local.get 2)
+                          (local.get 12))
+                        (i64.extend_i32_u
+                          (local.get 8))))
+                    (local.set 1
+                      (i64.sub
+                        (local.get 1)
+                        (local.get 10)))
+                    (local.set 6
+                      (i64.add
+                        (local.get 6)
+                        (i64.extend_i32_u
+                          (i64.lt_u
+                            (local.tee 12
+                              (i64.add
+                                (local.get 11)
+                                (local.get 13)))
+                            (local.get 11)))))
+                    (br 7 (;@1;)))
+                  (local.set 2
+                    (i64.sub
+                      (i64.sub
+                        (i64.add
+                          (i64.add
+                            (local.get 2)
+                            (local.get 4))
+                          (i64.extend_i32_u
+                            (i64.lt_u
+                              (local.tee 4
+                                (i64.add
+                                  (local.get 1)
+                                  (local.get 3)))
+                              (local.get 1))))
+                        (local.get 12))
+                      (i64.extend_i32_u
+                        (i64.lt_u
+                          (local.get 4)
+                          (local.get 10)))))
+                  (local.set 1
+                    (i64.sub
+                      (local.get 4)
+                      (local.get 10)))
+                  (local.set 6
+                    (i64.add
+                      (local.get 6)
+                      (i64.extend_i32_u
+                        (i64.lt_u
+                          (local.tee 12
+                            (i64.add
+                              (i64.add
+                                (local.get 13)
+                                (local.get 11))
+                              (i64.const -1)))
+                          (local.get 11)))))
+                  (br 6 (;@1;)))
+                (call $__ashlti3
+                  (i32.add
+                    (local.get 5)
+                    (i32.const 128))
+                  (local.tee 12
+                    (i64.div_u
+                      (local.get 12)
+                      (local.get 10)))
+                  (i64.const 0)
+                  (local.tee 8
+                    (i32.sub
+                      (local.get 8)
+                      (local.get 9))))
+                (call $__multi3
+                  (i32.add
+                    (local.get 5)
+                    (i32.const 112))
+                  (local.get 3)
+                  (local.get 4)
+                  (local.get 12)
+                  (i64.const 0))
+                (call $__ashlti3
+                  (i32.add
+                    (local.get 5)
+                    (i32.const 96))
+                  (i64.load offset=112
+                    (local.get 5))
+                  (i64.load offset=120
+                    (local.get 5))
+                  (local.get 8))
+                (local.set 6
+                  (i64.add
+                    (i64.add
+                      (i64.load offset=136
+                        (local.get 5))
+                      (local.get 6))
+                    (i64.extend_i32_u
+                      (i64.lt_u
+                        (local.tee 11
+                          (i64.add
+                            (local.tee 6
+                              (i64.load offset=128
+                                (local.get 5)))
+                            (local.get 11)))
+                        (local.get 6)))))
+                (block ;; label = @7
+                  (br_if 0 (;@7;)
+                    (i32.le_u
+                      (local.get 7)
+                      (local.tee 8
+                        (i32.wrap_i64
+                          (select
+                            (i64.clz
+                              (local.tee 2
+                                (i64.sub
+                                  (i64.sub
+                                    (local.get 2)
+                                    (i64.load offset=104
+                                      (local.get 5)))
+                                  (i64.extend_i32_u
+                                    (i64.lt_u
+                                      (local.get 1)
+                                      (local.tee 12
+                                        (i64.load offset=96
+                                          (local.get 5))))))))
+                            (i64.add
+                              (i64.clz
+                                (local.tee 1
+                                  (i64.sub
+                                    (local.get 1)
+                                    (local.get 12))))
+                              (i64.const 64))
+                            (i64.ne
+                              (local.get 2)
+                              (i64.const 0)))))))
+                  (br_if 2 (;@5;)
+                    (i32.gt_u
+                      (local.get 8)
+                      (i32.const 63)))
+                  (br 1 (;@6;))))
+              (br_if 1 (;@4;)
+                (i32.eqz
+                  (select
+                    (local.tee 8
+                      (i64.lt_u
+                        (local.get 1)
+                        (local.get 3)))
+                    (i64.lt_u
+                      (local.get 2)
+                      (local.get 4))
+                    (i64.eq
+                      (local.get 2)
+                      (local.get 4)))))
+              (local.set 12
+                (local.get 11))
+              (br 4 (;@1;)))
+            (local.set 1
+              (i64.sub
+                (local.get 1)
+                (i64.mul
+                  (local.tee 2
+                    (i64.div_u
+                      (local.get 1)
+                      (local.get 3)))
+                  (local.get 3))))
             (local.set 6
+              (i64.add
+                (local.get 6)
+                (i64.extend_i32_u
+                  (i64.lt_u
+                    (local.tee 12
+                      (i64.add
+                        (local.get 11)
+                        (local.get 2)))
+                    (local.get 11)))))
+            (local.set 2
               (i64.const 0))
             (br 3 (;@1;)))
           (local.set 2
             (i64.sub
               (i64.sub
                 (local.get 2)
-                (select
-                  (local.get 4)
-                  (i64.const 0)
-                  (local.tee 8
-                    (select
-                      (i64.ge_u
-                        (local.get 1)
-                        (local.get 3))
-                      (i64.ge_u
-                        (local.get 2)
-                        (local.get 4))
-                      (i64.eq
-                        (local.get 2)
-                        (local.get 4))))))
+                (local.get 4))
               (i64.extend_i32_u
-                (i64.lt_u
-                  (local.get 1)
-                  (local.tee 4
-                    (select
-                      (local.get 3)
-                      (i64.const 0)
-                      (local.get 8)))))))
+                (local.get 8))))
           (local.set 1
             (i64.sub
               (local.get 1)
-              (local.get 4)))
-          (local.set 12
-            (i64.extend_i32_u
-              (local.get 8)))
+              (local.get 3)))
+          (local.set 6
+            (i64.add
+              (local.get 6)
+              (i64.extend_i32_u
+                (i64.eqz
+                  (local.tee 12
+                    (i64.add
+                      (local.get 11)
+                      (i64.const 1)))))))
           (br 2 (;@1;)))
+        (local.set 2
+          (i64.sub
+            (i64.sub
+              (local.get 2)
+              (local.get 11))
+            (i64.extend_i32_u
+              (local.get 8))))
         (local.set 1
           (i64.sub
             (local.get 1)
-            (i64.mul
-              (local.tee 12
-                (i64.div_u
-                  (local.get 1)
-                  (local.get 3)))
-              (local.get 3))))
+            (local.get 10)))
         (local.set 6
           (i64.const 0))
-        (local.set 2
-          (i64.const 0))
         (br 1 (;@1;)))
-      (local.set 12
-        (i64.or
-          (i64.shl
-            (local.tee 2
-              (i64.div_u
-                (i64.or
-                  (i64.shl
-                    (i64.sub
-                      (local.get 2)
-                      (i64.mul
-                        (local.tee 6
-                          (i64.div_u
-                            (local.get 2)
-                            (local.tee 4
-                              (i64.and
-                                (local.get 3)
-                                (i64.const 4294967295)))))
-                        (local.get 3)))
-                    (i64.const 32))
-                  (local.tee 12
-                    (i64.shr_u
-                      (local.get 1)
-                      (i64.const 32))))
-                (local.get 4)))
-            (i64.const 32))
-          (local.tee 3
-            (i64.div_u
-              (local.tee 1
-                (i64.or
-                  (i64.shl
-                    (i64.sub
-                      (local.get 12)
-                      (i64.mul
-                        (local.get 2)
-                        (local.get 3)))
-                    (i64.const 32))
-                  (i64.and
-                    (local.get 1)
-                    (i64.const 4294967295))))
-              (local.get 4)))))
+      (local.set 2
+        (i64.sub
+          (i64.sub
+            (local.get 2)
+            (local.get 4))
+          (i64.extend_i32_u
+            (local.get 8))))
       (local.set 1
         (i64.sub
           (local.get 1)
-          (i64.mul
-            (local.get 3)
-            (local.get 4))))
-      (local.set 6
-        (i64.or
-          (i64.shr_u
-            (local.get 2)
-            (i64.const 32))
-          (local.get 6)))
-      (local.set 2
-        (i64.const 0)))
+          (local.get 3)))
+      (local.set 12
+        (i64.const 1)))
     (i64.store offset=16
       (local.get 0)
       (local.get 1))
@@ -13598,14 +13589,14 @@
         (local.get 5)
         (i32.const 176)))
   )
-  (func $__udivti3 (;75;) (type 15) (param i32 i64 i64 i64 i64)
+  (func $__udivti3 (;76;) (type 15) (param i32 i64 i64 i64 i64)
     (local i32)
     (global.set $__stack_pointer
       (local.tee 5
         (i32.sub
           (global.get $__stack_pointer)
           (i32.const 32))))
-    (call $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17h8d9ba2662c058edeE
+    (call $_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem12u128_div_rem
       (local.get 5)
       (local.get 1)
       (local.get 2)
@@ -13626,7 +13617,7 @@
         (local.get 5)
         (i32.const 32)))
   )
-  (func $__lshrti3 (;76;) (type 14) (param i32 i64 i64 i32)
+  (func $__ashlti3 (;77;) (type 16) (param i32 i64 i64 i32)
     (local i64)
     (block ;; label = @1
       (block ;; label = @2
@@ -13637,36 +13628,30 @@
         (br_if 1 (;@1;)
           (i32.eqz
             (local.get 3)))
-        (local.set 1
+        (local.set 2
           (i64.or
             (i64.shl
               (local.get 2)
-              (i64.extend_i32_u
-                (i32.and
-                  (i32.sub
-                    (i32.const 0)
-                    (local.get 3))
-                  (i32.const 63))))
-            (i64.shr_u
-              (local.get 1)
               (local.tee 4
                 (i64.extend_i32_u
-                  (i32.and
-                    (local.get 3)
-                    (i32.const 63)))))))
-        (local.set 2
-          (i64.shr_u
-            (local.get 2)
+                  (local.get 3))))
+            (i64.shr_u
+              (local.get 1)
+              (i64.extend_i32_u
+                (i32.sub
+                  (i32.const 0)
+                  (local.get 3))))))
+        (local.set 1
+          (i64.shl
+            (local.get 1)
             (local.get 4)))
         (br 1 (;@1;)))
-      (local.set 1
-        (i64.shr_u
-          (local.get 2)
-          (i64.extend_i32_u
-            (i32.and
-              (local.get 3)
-              (i32.const 63)))))
       (local.set 2
+        (i64.shl
+          (local.get 1)
+          (i64.extend_i32_u
+            (local.get 3))))
+      (local.set 1
         (i64.const 0)))
     (i64.store
       (local.get 0)
@@ -13675,14 +13660,14 @@
       (local.get 0)
       (local.get 2))
   )
-  (func $__umodti3 (;77;) (type 15) (param i32 i64 i64 i64 i64)
+  (func $__umodti3 (;78;) (type 15) (param i32 i64 i64 i64 i64)
     (local i32)
     (global.set $__stack_pointer
       (local.tee 5
         (i32.sub
           (global.get $__stack_pointer)
           (i32.const 32))))
-    (call $_ZN17compiler_builtins3int19specialized_div_rem12u128_div_rem17h8d9ba2662c058edeE
+    (call $_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem12u128_div_rem
       (local.get 5)
       (local.get 1)
       (local.get 2)
@@ -13703,10 +13688,58 @@
         (local.get 5)
         (i32.const 32)))
   )
-  (data $.rodata (;0;) (i32.const 1048576) "\00\00\80?\00\00\c0?\00\00\00\00\dc\cf\d15\00\00\00\00\00\c0\15?8c\ed>\da\0fI?^\98{?\da\0f\c9?i7\ac1h!\223\b4\0f\143h!\a23]=\7ff\9e\a0\e6?\00\00\00\00\00\889=D\17u\faR\b0\e6?\00\00\00\00\00\00\d8<\fe\d9\0bu\12\c0\e6?\00\00\00\00\00x(\bd\bfv\d4\dd\dc\cf\e6?\00\00\00\00\00\c0\1e=)\1ae<\b2\df\e6?\00\00\00\00\00\00\d8\bc\e3:Y\98\92\ef\e6?\00\00\00\00\00\00\bc\bc\86\93Q\f9}\ff\e6?\00\00\00\00\00\d8/\bd\a3-\f4ft\0f\e7?\00\00\00\00\00\88,\bd\c3_\ec\e8u\1f\e7?\00\00\00\00\00\c0\13=\05\cf\ea\86\82/\e7?\00\00\00\00\0008\bdR\81\a5H\9a?\e7?\00\00\00\00\00\c0\00\bd\fc\cc\d75\bdO\e7?\00\00\00\00\00\88/=\f1gBV\eb_\e7?\00\00\00\00\00\e0\03=Hm\ab\b1$p\e7?\00\00\00\00\00\d0'\bd8]\deOi\80\e7?\00\00\00\00\00\00\dd\bc\00\1d\ac8\b9\90\e7?\00\00\00\00\00\00\e3<x\01\ebs\14\a1\e7?\00\00\00\00\00\00\ed\bc`\d0v\09{\b1\e7?\00\00\00\00\00@ =3\c10\01\ed\c1\e7?\00\00\00\00\00\00\a0<6\86\ffbj\d2\e7?\00\00\00\00\00\90&\bd;N\cf6\f3\e2\e7?\00\00\00\00\00\e0\02\bd\e8\c3\91\84\87\f3\e7?\00\00\00\00\00X$\bdN\1b>T'\04\e8?\00\00\00\00\00\003=\1a\07\d1\ad\d2\14\e8?\00\00\00\00\00\00\0f=~\cdL\99\89%\e8?\00\00\00\00\00\c0!\bd\d0B\b9\1eL6\e8?\00\00\00\00\00\d0)=\b5\ca#F\1aG\e8?\00\00\00\00\00\10G=\bc[\9f\17\f4W\e8?\00\00\00\00\00`\22=\af\91D\9b\d9h\e8?\00\00\00\00\00\c42\bd\95\a31\d9\cay\e8?\00\00\00\00\00\00#\bd\b8e\8a\d9\c7\8a\e8?\00\00\00\00\00\80*\bd\00Xx\a4\d0\9b\e8?\00\00\00\00\00\00\ed\bc#\a2*B\e5\ac\e8?\00\00\00\00\00(3=\fa\19\d6\ba\05\be\e8?\00\00\00\00\00\b4B=\83C\b5\162\cf\e8?\00\00\00\00\00\d0.\bdLf\08^j\e0\e8?\00\00\00\00\00P \bd\07x\15\99\ae\f1\e8?\00\00\00\00\00((=\0e,(\d0\fe\02\e9?\00\00\00\00\00\b0\1c\bd\96\ff\91\0b[\14\e9?\00\00\00\00\00\e0\05\bd\f9/\aaS\c3%\e9?\00\00\00\00\00@\f5<J\c6\cd\b077\e9?\00\00\00\00\00 \17=\ae\98_+\b8H\e9?\00\00\00\00\00\00\09\bd\cbR\c8\cbDZ\e9?\00\00\00\00\00h%=!ov\9a\ddk\e9?\00\00\00\00\00\d06\bd*N\de\9f\82}\e9?\00\00\00\00\00\00\01\bd\a3#z\e43\8f\e9?\00\00\00\00\00\00-=\04\06\cap\f1\a0\e9?\00\00\00\00\00\a48\bd\89\ffSM\bb\b2\e9?\00\00\00\00\00\5c5=[\f1\a3\82\91\c4\e9?\00\00\00\00\00\b8&=\c5\b8K\19t\d6\e9?\00\00\00\00\00\00\ec\bc\8e#\e3\19c\e8\e9?\00\00\00\00\00\d0\17=\02\f3\07\8d^\fa\e9?\00\00\00\00\00@\16=M\e5]{f\0c\ea?\00\00\00\00\00\00\f5\bc\f6\b8\8e\edz\1e\ea?\00\00\00\00\00\e0\09='.J\ec\9b0\ea?\00\00\00\00\00\d8*=]\0aF\80\c9B\ea?\00\00\00\00\00\f0\1a\bd\9b%>\b2\03U\ea?\00\00\00\00\00`\0b=\13b\f4\8aJg\ea?\00\00\00\00\00\888=\a7\b30\13\9ey\ea?\00\00\00\00\00 \11=\8d.\c1S\fe\8b\ea?\00\00\00\00\00\c0\06=\d2\fcyUk\9e\ea?\00\00\00\00\00\b8)\bd\b8o5!\e5\b0\ea?\00\00\00\00\00p+=\81\f3\d3\bfk\c3\ea?\00\00\00\00\00\00\d9<\80'<:\ff\d5\ea?\00\00\00\00\00\00\e4<\a3\d2Z\99\9f\e8\ea?\00\00\00\00\00\90,\bdg\f3\22\e6L\fb\ea?\00\00\00\00\00P\16=\90\b7\8d)\07\0e\eb?\00\00\00\00\00\d4/=\a9\89\9al\ce \eb?\00\00\00\00\00p\12=K\1aO\b8\a23\eb?\00\00\00\00\00GM=\e7G\b7\15\84F\eb?\00\00\00\00\0088\bd:Y\e5\8drY\eb?\00\00\00\00\00\00\98<j\c5\f1)nl\eb?\00\00\00\00\00\d0\0a=P^\fb\f2v\7f\eb?\00\00\00\00\00\80\de<\b2I'\f2\8c\92\eb?\00\00\00\00\00\c0\04\bd\03\06\a10\b0\a5\eb?\00\00\00\00\00p\0d\bdfo\9a\b7\e0\b8\eb?\00\00\00\00\00\90\0d=\ff\c1K\90\1e\cc\eb?\00\00\00\00\00\a0\02=o\a1\f3\c3i\df\eb?\00\00\00\00\00x\1f\bd\b8\1d\d7[\c2\f2\eb?\00\00\00\00\00\a0\10\bd\e9\b2Aa(\06\ec?\00\00\00\00\00@\11\bd\e0R\85\dd\9b\19\ec?\00\00\00\00\00\e0\0b=\eed\fa\d9\1c-\ec?\00\00\00\00\00@\09\bd/\d0\ff_\ab@\ec?\00\00\00\00\00\d0\0e\bd\15\fd\faxGT\ec?\00\00\00\00\00f9=\cb\d0W.\f1g\ec?\00\00\00\00\00\10\1a\bd\b6\c1\88\89\a8{\ec?\00\00\00\00\80EX\bd3\e7\06\94m\8f\ec?\00\00\00\00\00H\1a\bd\df\c4QW@\a3\ec?\00\00\00\00\00\00\cb<\94\90\ef\dc \b7\ec?\00\00\00\00\00@\01=\89\16m.\0f\cb\ec?\00\00\00\00\00 \f0<\12\c4]U\0b\df\ec?\00\00\00\00\00`\f3<;\ab[[\15\f3\ec?\00\00\00\00\00\90\06\bd\bc\89\07J-\07\ed?\00\00\00\00\00\a0\09=\fa\c8\08+S\1b\ed?\00\00\00\00\00\e0\15\bd\85\8a\0d\08\87/\ed?\00\00\00\00\00(\1d=\03\a2\ca\ea\c8C\ed?\00\00\00\00\00\a0\01=\91\a4\fb\dc\18X\ed?\00\00\00\00\00\00\df<\a1\e6b\e8vl\ed?\00\00\00\00\00\a0\03\bdN\83\c9\16\e3\80\ed?\00\00\00\00\00\d8\0c\bd\90`\ffq]\95\ed?\00\00\00\00\00\c0\f4<\ae2\db\03\e6\a9\ed?\00\00\00\00\00\90\ff<%\83:\d6|\be\ed?\00\00\00\00\00\80\e9<E\b4\01\f3!\d3\ed?\00\00\00\00\00 \f5\bc\bf\05\1cd\d5\e7\ed?\00\00\00\00\00p\1d\bd\ec\9a{3\97\fc\ed?\00\00\00\00\00\14\16\bd^}\19kg\11\ee?\00\00\00\00\00H\0b=\e7\a3\f5\14F&\ee?\00\00\00\00\00\ce@=\5c\ee\16;3;\ee?\00\00\00\00\00h\0c=\b4?\8b\e7.P\ee?\00\00\00\00\000\09\bdhmg$9e\ee?\00\00\00\00\00\00\e5\bcDL\c7\fbQz\ee?\00\00\00\00\00\f8\07\bd&\b7\cdwy\8f\ee?\00\00\00\00\00p\f3\bc\e8\90\a4\a2\af\a4\ee?\00\00\00\00\00\d0\e5<\e4\ca|\86\f4\b9\ee?\00\00\00\00\00\1a\16=\0dh\8e-H\cf\ee?\00\00\00\00\00P\f5<\14\85\18\a2\aa\e4\ee?\00\00\00\00\00@\c6<\13Za\ee\1b\fa\ee?\00\00\00\00\00\80\ee\bc\06A\b6\1c\9c\0f\ef?\00\00\00\00\00\88\fa\bcc\b9k7+%\ef?\00\00\00\00\00\90,\bdur\ddH\c9:\ef?\00\00\00\00\00\00\aa<$En[vP\ef?\00\00\00\00\00\f0\f4\bc\fdD\88y2f\ef?\00\00\00\00\00\80\ca<8\be\9c\ad\fd{\ef?\00\00\00\00\00\bc\fa<\82<$\02\d8\91\ef?\00\00\00\00\00`\d4\bc\8e\90\9e\81\c1\a7\ef?\00\00\00\00\00\0c\0b\bd\11\d5\926\ba\bd\ef?\00\00\00\00\00\e0\c0\bc\94q\8f+\c2\d3\ef?\00\00\00\00\80\de\10\bd\ee#*k\d9\e9\ef?\00\00\00\00\00C\ee<\00\00\00\00\00\00\f0?\00\00\00\00\00\00\00\00\be\bcZ\fa\1a\0b\f0?\00\00\00\00\00@\b3\bc\033\fb\a9=\16\f0?\00\00\00\00\00\17\12\bd\82\02;\14h!\f0?\00\00\00\00\00@\ba<l\80w>\9a,\f0?\00\00\00\00\00\98\ef<\ca\bb\11.\d47\f0?\00\00\00\00\00@\c7\bc\89\7fn\e8\15C\f0?\00\00\00\00\000\d8<gT\f6r_N\f0?\00\00\00\00\00?\1a\bdZ\85\15\d3\b0Y\f0?\00\00\00\00\00\84\02\bd\95\1f<\0e\0ae\f0?\00\00\00\00\00`\f1<\1a\f7\dd)kp\f0?\00\00\00\00\00$\15=-\a8r+\d4{\f0?\00\00\00\00\00\a0\e9\bc\d0\9bu\18E\87\f0?\00\00\00\00\00@\e6<\c8\07f\f6\bd\92\f0?\00\00\00\00\00x\00\bd\83\f3\c6\ca>\9e\f0?\00\00\00\00\00\00\98\bc09\1f\9b\c7\a9\f0?\00\00\00\00\00\a0\ff<\fc\88\f9lX\b5\f0?\00\00\00\00\00\c8\fa\bc\8al\e4E\f1\c0\f0?\00\00\00\00\00\c0\d9<\16Hr+\92\cc\f0?\00\00\00\00\00 \05=\d8]9#;\d8\f0?\00\00\00\00\00\d0\fa\bc\f3\d1\d32\ec\e3\f0?\00\00\00\00\00\ac\1b=\a6\a9\df_\a5\ef\f0?\00\00\00\00\00\e8\04\bd\f0\d2\fe\aff\fb\f0?\00\00\00\00\000\0d\bdK#\d7(0\07\f1?\00\00\00\00\00P\f1<[[\12\d0\01\13\f1?\00\00\00\00\00\00\ec<\f9*^\ab\db\1e\f1?\00\00\00\00\00\bc\16=\d51l\c0\bd*\f1?\00\00\00\00\00@\e8<}\04\f2\14\a86\f1?\00\00\00\00\00\d0\0e\bd\e9-\a9\ae\9aB\f1?\00\00\00\00\00\e0\e8<81O\93\95N\f1?\00\00\00\00\00@\eb<q\8e\a5\c8\98Z\f1?\00\00\00\00\000\05=\df\c3qT\a4f\f1?\00\00\00\00\008\03=\11R}<\b8r\f1?\00\00\00\00\00\d4(=\9f\bb\95\86\d4~\f1?\00\00\00\00\00\d0\05\bd\93\8d\8c8\f9\8a\f1?\00\00\00\00\00\88\1c\bdf]7X&\97\f1?\00\00\00\00\00\f0\11=\a7\cbo\eb[\a3\f1?\00\00\00\00\00H\10=\e3\87\13\f8\99\af\f1?\00\00\00\00\009G\bdT]\04\84\e0\bb\f1?\00\00\00\00\00\e4$=C\1c(\95/\c8\f1?\00\00\00\00\00 \0a\bd\b2\b9h1\87\d4\f1?\00\00\00\00\00\80\e3<1@\b4^\e7\e0\f1?\00\00\00\00\00\c0\ea<8\d9\fc\22P\ed\f1?\00\00\00\00\00\90\01=\f7\cd8\84\c1\f9\f1?\00\00\00\00\00x\1b\bd\8f\8db\88;\06\f2?\00\00\00\00\00\94-=\1e\a8x5\be\12\f2?\00\00\00\00\00\00\d8<A\dd}\91I\1f\f2?\00\00\00\00\004+=#\13y\a2\dd+\f2?\00\00\00\00\00\f8\19=\e7aunz8\f2?\00\00\00\00\00\c8\19\bd'\14\82\fb\1fE\f2?\00\00\00\00\000\02=\02\a6\b2O\ceQ\f2?\00\00\00\00\00H\13\bd\b0\ce\1eq\85^\f2?\00\00\00\00\00p\12=\16}\e2eEk\f2?\00\00\00\00\00\d0\11=\0f\e0\1d4\0ex\f2?\00\00\00\00\00\ee1=>c\f5\e1\df\84\f2?\00\00\00\00\00\c0\14\bd0\bb\91u\ba\91\f2?\00\00\00\00\00\d8\13\bd\09\df\1f\f5\9d\9e\f2?\00\00\00\00\00\b0\08=\9b\0e\d1f\8a\ab\f2?\00\00\00\00\00|\22\bd:\da\da\d0\7f\b8\f2?\00\00\00\00\004*=\f9\1aw9~\c5\f2?\00\00\00\00\00\80\10\bd\d9\02\e4\a6\85\d2\f2?\00\00\00\00\00\d0\0e\bdy\15d\1f\96\df\f2?\00\00\00\00\00 \f4\bc\cf.>\a9\af\ec\f2?\00\00\00\00\00\98$\bd\22\88\bdJ\d2\f9\f2?\00\00\00\00\000\16\bd%\b61\0a\fe\06\f3?\00\00\00\00\0062\bd\0b\a5\ee\ed2\14\f3?\00\00\00\00\80\dfp\bd\b8\d7L\fcp!\f3?\00\00\00\00\00H\22\bd\a2\e9\a8;\b8.\f3?\00\00\00\00\00\98%\bdf\17d\b2\08<\f3?\00\00\00\00\00\d0\1e='\fa\e3fbI\f3?\00\00\00\00\00\00\dc\bc\0f\9f\92_\c5V\f3?\00\00\00\00\00\d80\bd\b9\88\de\a21d\f3?\00\00\00\00\00\c8\22=9\aa:7\a7q\f3?\00\00\00\00\00` =\fet\1e#&\7f\f3?\00\00\00\00\00`\16\bd8\d8\05m\ae\8c\f3?\00\00\00\00\00\e0\0a\bd\c3>q\1b@\9a\f3?\00\00\00\00\00rD\bd \a0\e54\db\a7\f3?\00\00\00\00\00 \08=\95n\ec\bf\7f\b5\f3?\00\00\00\00\00\80>=\f2\a8\13\c3-\c3\f3?\00\00\00\00\00\80\ef<\22\e1\edD\e5\d0\f3?\00\00\00\00\00\a0\17\bd\bb4\12L\a6\de\f3?\00\00\00\00\000&=\ccN\1c\dfp\ec\f3?\00\00\00\00\00\a6H\bd\8c~\ac\04E\fa\f3?\00\00\00\00\00\dc<\bd\bb\a0g\c3\22\08\f4?\00\00\00\00\00\b8%=\95.\f7!\0a\16\f4?\00\00\00\00\00\c0\1e=FF\09'\fb#\f4?\00\00\00\00\00`\13\bd \a9P\d9\f51\f4?\00\00\00\00\00\98#=\eb\b9\84?\fa?\f4?\00\00\00\00\00\00\fa<\19\89a`\08N\f4?\00\00\00\00\00\c0\f6\bc\01\d2\a7B \5c\f4?\00\00\00\00\00\c0\0b\bd\16\00\1d\edAj\f4?\00\00\00\00\00\80\12\bd&3\8bfmx\f4?\00\00\00\00\00\e00=\00<\c1\b5\a2\86\f4?\00\00\00\00\00@-\bd\04\af\92\e1\e1\94\f4?\00\00\00\00\00 \0c=r\d3\d7\f0*\a3\f4?\00\00\00\00\00P\1e\bd\01\b8m\ea}\b1\f4?\00\00\00\00\00\80\07=\e1)6\d5\da\bf\f4?\00\00\00\00\00\80\13\bd2\c1\17\b8A\ce\f4?\00\00\00\00\00\80\00=\db\dd\fd\99\b2\dc\f4?\00\00\00\00\00p,=\96\ab\d8\81-\eb\f4?\00\00\00\00\00\e0\1c\bd\02-\9dv\b2\f9\f4?\00\00\00\00\00 \19=\c11E\7fA\08\f5?\00\00\00\00\00\c0\08\bd*f\cf\a2\da\16\f5?\00\00\00\00\00\00\fa\bc\eaQ?\e8}%\f5?\00\00\00\00\00\08J=\daN\9dV+4\f5?\00\00\00\00\00\d8&\bd\1a\ac\f6\f4\e2B\f5?\00\00\00\00\00D2\bd\db\94]\ca\a4Q\f5?\00\00\00\00\00<H=k\11\e9\ddp`\f5?\00\00\00\00\00\b0$=\de)\b56Go\f5?\00\00\00\00\00ZA=\0e\c4\e2\db'~\f5?\00\00\00\00\00\e0)\bdo\c7\97\d4\12\8d\f5?\00\00\00\00\00\08#\bdL\0b\ff'\08\9c\f5?\00\00\00\00\00\ecM='TH\dd\07\ab\f5?\00\00\00\00\00\00\c4\bc\f4z\a8\fb\11\ba\f5?\00\00\00\00\00\080=\0bFY\8a&\c9\f5?\00\00\00\00\00\c8&\bd?\8e\99\90E\d8\f5?\00\00\00\00\00\9aF=\e1 \ad\15o\e7\f5?\00\00\00\00\00@\1b\bd\ca\eb\dc \a3\f6\f5?\00\00\00\00\00p\17=\b8\dcv\b9\e1\05\f6?\00\00\00\00\00\f8&=\15\f7\cd\e6*\15\f6?\00\00\00\00\00\00\01=1U:\b0~$\f6?\00\00\00\00\00\d0\15\bd\b5)\19\1d\dd3\f6?\00\00\00\00\00\d0\12\bd\13\c3\cc4FC\f6?\00\00\00\00\00\80\ea\bc\fa\8e\bc\fe\b9R\f6?\00\00\00\00\00`(\bd\973U\828b\f6?\00\00\00\00\00\feq=\8e2\08\c7\c1q\f6?\00\00\00\00\00 7\bd~\a9L\d4U\81\f6?\00\00\00\00\00\80\e6<q\94\9e\b1\f4\90\f6?\00\00\00\00\00x)\bd\00\00\00?\00\00\00\bf\cd;\7ff\9e\a0\e6?\87\01\ebs\14\a1\e7?\db\a0*B\e5\ac\e8?\90\f0\a3\82\91\c4\e9?\ad\d3Z\99\9f\e8\ea?\9cR\85\dd\9b\19\ec?\87\a4\fb\dc\18X\ed?\da\90\a4\a2\af\a4\ee?\00\00\00\00\00\00\f0?\0f\89\f9lX\b5\f0?{Q}<\b8r\f1?8bunz8\f2?\15\b71\0a\fe\06\f3?\224\12L\a6\de\f3?'*6\d5\da\bf\f4?)TH\dd\07\ab\f5?\00\00\00\00\00\00\f0?\8br\8d\f9\a2(\f4?=n=\a5\fee\f9?\03\00\00\00\04\00\00\00\04\00\00\00\06\00\00\00\83\f9\a2\00DNn\00\fc)\15\00\d1W'\00\dd4\f5\00b\db\c0\00<\99\95\00A\90C\00cQ\fe\00\bb\de\ab\00\b7a\c5\00:n$\00\d2MB\00I\06\e0\00\09\ea.\00\1c\92\d1\00\eb\1d\fe\00)\b1\1c\00\e8>\a7\00\f55\82\00D\bb.\00\9c\e9\84\00\b4&p\00A~_\00\d6\919\00S\839\00\9c\f49\00\8b_\84\00(\f9\bd\00\f8\1f;\00\de\ff\97\00\0f\98\05\00\11/\ef\00\0aZ\8b\00m\1fm\00\cf~6\00\09\cb'\00FO\b7\00\9ef?\00-\ea_\00\ba'u\00\e5\eb\c7\00={\f1\00\f79\07\00\92R\8a\00\fbk\ea\00\1f\b1_\00\08]\8d\000\03V\00{\fcF\00\f0\abk\00 \bc\cf\006\f4\9a\00\e3\a9\1d\00^a\91\00\08\1b\e6\00\85\99e\00\a0\14_\00\8d@h\00\80\d8\ff\00'sM\00\06\061\00\caV\15\00\c9\a8s\00{\e2`\00k\8c\c0\00\00\00\00@\fb!\f9?\00\00\00\00-Dt>\00\00\00\80\98F\f8<\00\00\00`Q\ccx;\00\00\00\80\83\1b\f09\00\00\00@ %z8\00\00\00\80\22\82\e36\00\00\00\00\1d\f3i5Q\b4\f0\b2\96\b1D\b0\f9\ae\b6\ady\acC\ab\14\aa\eb\a8\c8\a7\aa\a6\92\a5\80\a4s\a3k\a2h\a1j\a0p\9f{\9e\8a\9d\9d\9c\b5\9b\d1\9a\f0\99\13\99:\98e\97\93\96\c4\95\f8\940\94k\93\a9\92\ea\91.\91u\90\be\8f\0a\8fY\8e\aa\8d\fe\8cT\8c\ac\8b\07\8bd\8a\c4\89%\89\89\88\ee\87V\87\c0\86+\86\99\85\08\85y\84\ec\83a\83\d8\82P\82\c9\81E\81\c2\80@\80\02\ff\0e\fd%\fbG\f9s\f7\aa\f5\ea\f34\f2\87\f0\e3\eeG\ed\b3\eb'\ea\a3\e8'\e7\b2\e5C\e4\dc\e2z\e1 \e0\cb\de}\dd4\dc\f1\da\b3\d9{\d8H\d7\1a\d6\f1\d4\cd\d3\ad\d2\92\d1{\d0i\cf[\ceQ\cdJ\ccH\cbJ\caO\c9X\c8d\c7t\c6\87\c5\9d\c4\b7\c3\d4\c2\f4\c1\16\c1<\c0e\bf\90\be\be\bd\ef\bc#\bcY\bb\91\ba\cc\b9\0a\b9J\b8\8c\b7\d0\b6\17\b6`\b5\00\00\00\00\00\00\f0?\00\00\00\00\00\00\f8?\00\00\00\00\00\00\00\00\06\d0\cfC\eb\fdL>\00\00\00\00\00\00\00\00\00\00\00@\03\b8\e2?O\bba\05g\ac\dd?\18-DT\fb!\e9?\9b\f6\81\d2\0bs\ef?\18-DT\fb!\f9?\e2e/\22\7f+z<\07\5c\143&\a6\81<\bd\cb\f0z\88\07p<\07\5c\143&\a6\91<\00\00\00\00\00\00\e0?\00\00\00\00\00\00\e0\bf\18-DT\fb!\e9?\18-DT\fb!\e9\bf\d2!3\7f|\d9\02@\d2!3\7f|\d9\02\c0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\80\18-DT\fb!\09@\18-DT\fb!\09\c0\db\0fI?\db\0fI\bf\e4\cb\16@\e4\cb\16\c0\00\00\00\00\00\00\00\80\db\0fI@\db\0fI\c0")
+  (func $__lshrti3 (;79;) (type 16) (param i32 i64 i64 i32)
+    (local i64)
+    (block ;; label = @1
+      (block ;; label = @2
+        (br_if 0 (;@2;)
+          (i32.and
+            (local.get 3)
+            (i32.const 64)))
+        (br_if 1 (;@1;)
+          (i32.eqz
+            (local.get 3)))
+        (local.set 1
+          (i64.or
+            (i64.shl
+              (local.get 2)
+              (i64.extend_i32_u
+                (i32.sub
+                  (i32.const 0)
+                  (local.get 3))))
+            (i64.shr_u
+              (local.get 1)
+              (local.tee 4
+                (i64.extend_i32_u
+                  (local.get 3))))))
+        (local.set 2
+          (i64.shr_u
+            (local.get 2)
+            (local.get 4)))
+        (br 1 (;@1;)))
+      (local.set 1
+        (i64.shr_u
+          (local.get 2)
+          (i64.extend_i32_u
+            (local.get 3))))
+      (local.set 2
+        (i64.const 0)))
+    (i64.store
+      (local.get 0)
+      (local.get 1))
+    (i64.store offset=8
+      (local.get 0)
+      (local.get 2))
+  )
+  (data $.rodata (;0;) (i32.const 1052672) "\03\00\00\00\04\00\00\00\04\00\00\00\06\00\00\00\83\f9\a2\00DNn\00\fc)\15\00\d1W'\00\dd4\f5\00b\db\c0\00<\99\95\00A\90C\00cQ\fe\00\bb\de\ab\00\b7a\c5\00:n$\00\d2MB\00I\06\e0\00\09\ea.\00\1c\92\d1\00\eb\1d\fe\00)\b1\1c\00\e8>\a7\00\f55\82\00D\bb.\00\9c\e9\84\00\b4&p\00A~_\00\d6\919\00S\839\00\9c\f49\00\8b_\84\00(\f9\bd\00\f8\1f;\00\de\ff\97\00\0f\98\05\00\11/\ef\00\0aZ\8b\00m\1fm\00\cf~6\00\09\cb'\00FO\b7\00\9ef?\00-\ea_\00\ba'u\00\e5\eb\c7\00={\f1\00\f79\07\00\92R\8a\00\fbk\ea\00\1f\b1_\00\08]\8d\000\03V\00{\fcF\00\f0\abk\00 \bc\cf\006\f4\9a\00\e3\a9\1d\00^a\91\00\08\1b\e6\00\85\99e\00\a0\14_\00\8d@h\00\80\d8\ff\00'sM\00\06\061\00\caV\15\00\c9\a8s\00{\e2`\00k\8c\c0\00\00\00\00@\fb!\f9?\00\00\00\00-Dt>\00\00\00\80\98F\f8<\00\00\00`Q\ccx;\00\00\00\80\83\1b\f09\00\00\00@ %z8\00\00\00\80\22\82\e36\00\00\00\00\1d\f3i5\00\00\00\00\00\00\e0?\00\00\00\00\00\00\e0\bf\00\00\00\00\00\00\f0?\00\00\00\00\00\00\f8?\00\00\00\00\00\00\00\00\06\d0\cfC\eb\fdL>\00\00\00\00\00\00\00\00\00\00\00@\03\b8\e2?O\bba\05g\ac\dd?\18-DT\fb!\e9?\9b\f6\81\d2\0bs\ef?\18-DT\fb!\f9?\e2e/\22\7f+z<\07\5c\143&\a6\81<\bd\cb\f0z\88\07p<\07\5c\143&\a6\91<\00\00\00\00\00\00\f0?\8br\8d\f9\a2(\f4?=n=\a5\fee\f9?]=\7ff\9e\a0\e6?\00\00\00\00\00\889=D\17u\faR\b0\e6?\00\00\00\00\00\00\d8<\fe\d9\0bu\12\c0\e6?\00\00\00\00\00x(\bd\bfv\d4\dd\dc\cf\e6?\00\00\00\00\00\c0\1e=)\1ae<\b2\df\e6?\00\00\00\00\00\00\d8\bc\e3:Y\98\92\ef\e6?\00\00\00\00\00\00\bc\bc\86\93Q\f9}\ff\e6?\00\00\00\00\00\d8/\bd\a3-\f4ft\0f\e7?\00\00\00\00\00\88,\bd\c3_\ec\e8u\1f\e7?\00\00\00\00\00\c0\13=\05\cf\ea\86\82/\e7?\00\00\00\00\0008\bdR\81\a5H\9a?\e7?\00\00\00\00\00\c0\00\bd\fc\cc\d75\bdO\e7?\00\00\00\00\00\88/=\f1gBV\eb_\e7?\00\00\00\00\00\e0\03=Hm\ab\b1$p\e7?\00\00\00\00\00\d0'\bd8]\deOi\80\e7?\00\00\00\00\00\00\dd\bc\00\1d\ac8\b9\90\e7?\00\00\00\00\00\00\e3<x\01\ebs\14\a1\e7?\00\00\00\00\00\00\ed\bc`\d0v\09{\b1\e7?\00\00\00\00\00@ =3\c10\01\ed\c1\e7?\00\00\00\00\00\00\a0<6\86\ffbj\d2\e7?\00\00\00\00\00\90&\bd;N\cf6\f3\e2\e7?\00\00\00\00\00\e0\02\bd\e8\c3\91\84\87\f3\e7?\00\00\00\00\00X$\bdN\1b>T'\04\e8?\00\00\00\00\00\003=\1a\07\d1\ad\d2\14\e8?\00\00\00\00\00\00\0f=~\cdL\99\89%\e8?\00\00\00\00\00\c0!\bd\d0B\b9\1eL6\e8?\00\00\00\00\00\d0)=\b5\ca#F\1aG\e8?\00\00\00\00\00\10G=\bc[\9f\17\f4W\e8?\00\00\00\00\00`\22=\af\91D\9b\d9h\e8?\00\00\00\00\00\c42\bd\95\a31\d9\cay\e8?\00\00\00\00\00\00#\bd\b8e\8a\d9\c7\8a\e8?\00\00\00\00\00\80*\bd\00Xx\a4\d0\9b\e8?\00\00\00\00\00\00\ed\bc#\a2*B\e5\ac\e8?\00\00\00\00\00(3=\fa\19\d6\ba\05\be\e8?\00\00\00\00\00\b4B=\83C\b5\162\cf\e8?\00\00\00\00\00\d0.\bdLf\08^j\e0\e8?\00\00\00\00\00P \bd\07x\15\99\ae\f1\e8?\00\00\00\00\00((=\0e,(\d0\fe\02\e9?\00\00\00\00\00\b0\1c\bd\96\ff\91\0b[\14\e9?\00\00\00\00\00\e0\05\bd\f9/\aaS\c3%\e9?\00\00\00\00\00@\f5<J\c6\cd\b077\e9?\00\00\00\00\00 \17=\ae\98_+\b8H\e9?\00\00\00\00\00\00\09\bd\cbR\c8\cbDZ\e9?\00\00\00\00\00h%=!ov\9a\ddk\e9?\00\00\00\00\00\d06\bd*N\de\9f\82}\e9?\00\00\00\00\00\00\01\bd\a3#z\e43\8f\e9?\00\00\00\00\00\00-=\04\06\cap\f1\a0\e9?\00\00\00\00\00\a48\bd\89\ffSM\bb\b2\e9?\00\00\00\00\00\5c5=[\f1\a3\82\91\c4\e9?\00\00\00\00\00\b8&=\c5\b8K\19t\d6\e9?\00\00\00\00\00\00\ec\bc\8e#\e3\19c\e8\e9?\00\00\00\00\00\d0\17=\02\f3\07\8d^\fa\e9?\00\00\00\00\00@\16=M\e5]{f\0c\ea?\00\00\00\00\00\00\f5\bc\f6\b8\8e\edz\1e\ea?\00\00\00\00\00\e0\09='.J\ec\9b0\ea?\00\00\00\00\00\d8*=]\0aF\80\c9B\ea?\00\00\00\00\00\f0\1a\bd\9b%>\b2\03U\ea?\00\00\00\00\00`\0b=\13b\f4\8aJg\ea?\00\00\00\00\00\888=\a7\b30\13\9ey\ea?\00\00\00\00\00 \11=\8d.\c1S\fe\8b\ea?\00\00\00\00\00\c0\06=\d2\fcyUk\9e\ea?\00\00\00\00\00\b8)\bd\b8o5!\e5\b0\ea?\00\00\00\00\00p+=\81\f3\d3\bfk\c3\ea?\00\00\00\00\00\00\d9<\80'<:\ff\d5\ea?\00\00\00\00\00\00\e4<\a3\d2Z\99\9f\e8\ea?\00\00\00\00\00\90,\bdg\f3\22\e6L\fb\ea?\00\00\00\00\00P\16=\90\b7\8d)\07\0e\eb?\00\00\00\00\00\d4/=\a9\89\9al\ce \eb?\00\00\00\00\00p\12=K\1aO\b8\a23\eb?\00\00\00\00\00GM=\e7G\b7\15\84F\eb?\00\00\00\00\0088\bd:Y\e5\8drY\eb?\00\00\00\00\00\00\98<j\c5\f1)nl\eb?\00\00\00\00\00\d0\0a=P^\fb\f2v\7f\eb?\00\00\00\00\00\80\de<\b2I'\f2\8c\92\eb?\00\00\00\00\00\c0\04\bd\03\06\a10\b0\a5\eb?\00\00\00\00\00p\0d\bdfo\9a\b7\e0\b8\eb?\00\00\00\00\00\90\0d=\ff\c1K\90\1e\cc\eb?\00\00\00\00\00\a0\02=o\a1\f3\c3i\df\eb?\00\00\00\00\00x\1f\bd\b8\1d\d7[\c2\f2\eb?\00\00\00\00\00\a0\10\bd\e9\b2Aa(\06\ec?\00\00\00\00\00@\11\bd\e0R\85\dd\9b\19\ec?\00\00\00\00\00\e0\0b=\eed\fa\d9\1c-\ec?\00\00\00\00\00@\09\bd/\d0\ff_\ab@\ec?\00\00\00\00\00\d0\0e\bd\15\fd\faxGT\ec?\00\00\00\00\00f9=\cb\d0W.\f1g\ec?\00\00\00\00\00\10\1a\bd\b6\c1\88\89\a8{\ec?\00\00\00\00\80EX\bd3\e7\06\94m\8f\ec?\00\00\00\00\00H\1a\bd\df\c4QW@\a3\ec?\00\00\00\00\00\00\cb<\94\90\ef\dc \b7\ec?\00\00\00\00\00@\01=\89\16m.\0f\cb\ec?\00\00\00\00\00 \f0<\12\c4]U\0b\df\ec?\00\00\00\00\00`\f3<;\ab[[\15\f3\ec?\00\00\00\00\00\90\06\bd\bc\89\07J-\07\ed?\00\00\00\00\00\a0\09=\fa\c8\08+S\1b\ed?\00\00\00\00\00\e0\15\bd\85\8a\0d\08\87/\ed?\00\00\00\00\00(\1d=\03\a2\ca\ea\c8C\ed?\00\00\00\00\00\a0\01=\91\a4\fb\dc\18X\ed?\00\00\00\00\00\00\df<\a1\e6b\e8vl\ed?\00\00\00\00\00\a0\03\bdN\83\c9\16\e3\80\ed?\00\00\00\00\00\d8\0c\bd\90`\ffq]\95\ed?\00\00\00\00\00\c0\f4<\ae2\db\03\e6\a9\ed?\00\00\00\00\00\90\ff<%\83:\d6|\be\ed?\00\00\00\00\00\80\e9<E\b4\01\f3!\d3\ed?\00\00\00\00\00 \f5\bc\bf\05\1cd\d5\e7\ed?\00\00\00\00\00p\1d\bd\ec\9a{3\97\fc\ed?\00\00\00\00\00\14\16\bd^}\19kg\11\ee?\00\00\00\00\00H\0b=\e7\a3\f5\14F&\ee?\00\00\00\00\00\ce@=\5c\ee\16;3;\ee?\00\00\00\00\00h\0c=\b4?\8b\e7.P\ee?\00\00\00\00\000\09\bdhmg$9e\ee?\00\00\00\00\00\00\e5\bcDL\c7\fbQz\ee?\00\00\00\00\00\f8\07\bd&\b7\cdwy\8f\ee?\00\00\00\00\00p\f3\bc\e8\90\a4\a2\af\a4\ee?\00\00\00\00\00\d0\e5<\e4\ca|\86\f4\b9\ee?\00\00\00\00\00\1a\16=\0dh\8e-H\cf\ee?\00\00\00\00\00P\f5<\14\85\18\a2\aa\e4\ee?\00\00\00\00\00@\c6<\13Za\ee\1b\fa\ee?\00\00\00\00\00\80\ee\bc\06A\b6\1c\9c\0f\ef?\00\00\00\00\00\88\fa\bcc\b9k7+%\ef?\00\00\00\00\00\90,\bdur\ddH\c9:\ef?\00\00\00\00\00\00\aa<$En[vP\ef?\00\00\00\00\00\f0\f4\bc\fdD\88y2f\ef?\00\00\00\00\00\80\ca<8\be\9c\ad\fd{\ef?\00\00\00\00\00\bc\fa<\82<$\02\d8\91\ef?\00\00\00\00\00`\d4\bc\8e\90\9e\81\c1\a7\ef?\00\00\00\00\00\0c\0b\bd\11\d5\926\ba\bd\ef?\00\00\00\00\00\e0\c0\bc\94q\8f+\c2\d3\ef?\00\00\00\00\80\de\10\bd\ee#*k\d9\e9\ef?\00\00\00\00\00C\ee<\00\00\00\00\00\00\f0?\00\00\00\00\00\00\00\00\be\bcZ\fa\1a\0b\f0?\00\00\00\00\00@\b3\bc\033\fb\a9=\16\f0?\00\00\00\00\00\17\12\bd\82\02;\14h!\f0?\00\00\00\00\00@\ba<l\80w>\9a,\f0?\00\00\00\00\00\98\ef<\ca\bb\11.\d47\f0?\00\00\00\00\00@\c7\bc\89\7fn\e8\15C\f0?\00\00\00\00\000\d8<gT\f6r_N\f0?\00\00\00\00\00?\1a\bdZ\85\15\d3\b0Y\f0?\00\00\00\00\00\84\02\bd\95\1f<\0e\0ae\f0?\00\00\00\00\00`\f1<\1a\f7\dd)kp\f0?\00\00\00\00\00$\15=-\a8r+\d4{\f0?\00\00\00\00\00\a0\e9\bc\d0\9bu\18E\87\f0?\00\00\00\00\00@\e6<\c8\07f\f6\bd\92\f0?\00\00\00\00\00x\00\bd\83\f3\c6\ca>\9e\f0?\00\00\00\00\00\00\98\bc09\1f\9b\c7\a9\f0?\00\00\00\00\00\a0\ff<\fc\88\f9lX\b5\f0?\00\00\00\00\00\c8\fa\bc\8al\e4E\f1\c0\f0?\00\00\00\00\00\c0\d9<\16Hr+\92\cc\f0?\00\00\00\00\00 \05=\d8]9#;\d8\f0?\00\00\00\00\00\d0\fa\bc\f3\d1\d32\ec\e3\f0?\00\00\00\00\00\ac\1b=\a6\a9\df_\a5\ef\f0?\00\00\00\00\00\e8\04\bd\f0\d2\fe\aff\fb\f0?\00\00\00\00\000\0d\bdK#\d7(0\07\f1?\00\00\00\00\00P\f1<[[\12\d0\01\13\f1?\00\00\00\00\00\00\ec<\f9*^\ab\db\1e\f1?\00\00\00\00\00\bc\16=\d51l\c0\bd*\f1?\00\00\00\00\00@\e8<}\04\f2\14\a86\f1?\00\00\00\00\00\d0\0e\bd\e9-\a9\ae\9aB\f1?\00\00\00\00\00\e0\e8<81O\93\95N\f1?\00\00\00\00\00@\eb<q\8e\a5\c8\98Z\f1?\00\00\00\00\000\05=\df\c3qT\a4f\f1?\00\00\00\00\008\03=\11R}<\b8r\f1?\00\00\00\00\00\d4(=\9f\bb\95\86\d4~\f1?\00\00\00\00\00\d0\05\bd\93\8d\8c8\f9\8a\f1?\00\00\00\00\00\88\1c\bdf]7X&\97\f1?\00\00\00\00\00\f0\11=\a7\cbo\eb[\a3\f1?\00\00\00\00\00H\10=\e3\87\13\f8\99\af\f1?\00\00\00\00\009G\bdT]\04\84\e0\bb\f1?\00\00\00\00\00\e4$=C\1c(\95/\c8\f1?\00\00\00\00\00 \0a\bd\b2\b9h1\87\d4\f1?\00\00\00\00\00\80\e3<1@\b4^\e7\e0\f1?\00\00\00\00\00\c0\ea<8\d9\fc\22P\ed\f1?\00\00\00\00\00\90\01=\f7\cd8\84\c1\f9\f1?\00\00\00\00\00x\1b\bd\8f\8db\88;\06\f2?\00\00\00\00\00\94-=\1e\a8x5\be\12\f2?\00\00\00\00\00\00\d8<A\dd}\91I\1f\f2?\00\00\00\00\004+=#\13y\a2\dd+\f2?\00\00\00\00\00\f8\19=\e7aunz8\f2?\00\00\00\00\00\c8\19\bd'\14\82\fb\1fE\f2?\00\00\00\00\000\02=\02\a6\b2O\ceQ\f2?\00\00\00\00\00H\13\bd\b0\ce\1eq\85^\f2?\00\00\00\00\00p\12=\16}\e2eEk\f2?\00\00\00\00\00\d0\11=\0f\e0\1d4\0ex\f2?\00\00\00\00\00\ee1=>c\f5\e1\df\84\f2?\00\00\00\00\00\c0\14\bd0\bb\91u\ba\91\f2?\00\00\00\00\00\d8\13\bd\09\df\1f\f5\9d\9e\f2?\00\00\00\00\00\b0\08=\9b\0e\d1f\8a\ab\f2?\00\00\00\00\00|\22\bd:\da\da\d0\7f\b8\f2?\00\00\00\00\004*=\f9\1aw9~\c5\f2?\00\00\00\00\00\80\10\bd\d9\02\e4\a6\85\d2\f2?\00\00\00\00\00\d0\0e\bdy\15d\1f\96\df\f2?\00\00\00\00\00 \f4\bc\cf.>\a9\af\ec\f2?\00\00\00\00\00\98$\bd\22\88\bdJ\d2\f9\f2?\00\00\00\00\000\16\bd%\b61\0a\fe\06\f3?\00\00\00\00\0062\bd\0b\a5\ee\ed2\14\f3?\00\00\00\00\80\dfp\bd\b8\d7L\fcp!\f3?\00\00\00\00\00H\22\bd\a2\e9\a8;\b8.\f3?\00\00\00\00\00\98%\bdf\17d\b2\08<\f3?\00\00\00\00\00\d0\1e='\fa\e3fbI\f3?\00\00\00\00\00\00\dc\bc\0f\9f\92_\c5V\f3?\00\00\00\00\00\d80\bd\b9\88\de\a21d\f3?\00\00\00\00\00\c8\22=9\aa:7\a7q\f3?\00\00\00\00\00` =\fet\1e#&\7f\f3?\00\00\00\00\00`\16\bd8\d8\05m\ae\8c\f3?\00\00\00\00\00\e0\0a\bd\c3>q\1b@\9a\f3?\00\00\00\00\00rD\bd \a0\e54\db\a7\f3?\00\00\00\00\00 \08=\95n\ec\bf\7f\b5\f3?\00\00\00\00\00\80>=\f2\a8\13\c3-\c3\f3?\00\00\00\00\00\80\ef<\22\e1\edD\e5\d0\f3?\00\00\00\00\00\a0\17\bd\bb4\12L\a6\de\f3?\00\00\00\00\000&=\ccN\1c\dfp\ec\f3?\00\00\00\00\00\a6H\bd\8c~\ac\04E\fa\f3?\00\00\00\00\00\dc<\bd\bb\a0g\c3\22\08\f4?\00\00\00\00\00\b8%=\95.\f7!\0a\16\f4?\00\00\00\00\00\c0\1e=FF\09'\fb#\f4?\00\00\00\00\00`\13\bd \a9P\d9\f51\f4?\00\00\00\00\00\98#=\eb\b9\84?\fa?\f4?\00\00\00\00\00\00\fa<\19\89a`\08N\f4?\00\00\00\00\00\c0\f6\bc\01\d2\a7B \5c\f4?\00\00\00\00\00\c0\0b\bd\16\00\1d\edAj\f4?\00\00\00\00\00\80\12\bd&3\8bfmx\f4?\00\00\00\00\00\e00=\00<\c1\b5\a2\86\f4?\00\00\00\00\00@-\bd\04\af\92\e1\e1\94\f4?\00\00\00\00\00 \0c=r\d3\d7\f0*\a3\f4?\00\00\00\00\00P\1e\bd\01\b8m\ea}\b1\f4?\00\00\00\00\00\80\07=\e1)6\d5\da\bf\f4?\00\00\00\00\00\80\13\bd2\c1\17\b8A\ce\f4?\00\00\00\00\00\80\00=\db\dd\fd\99\b2\dc\f4?\00\00\00\00\00p,=\96\ab\d8\81-\eb\f4?\00\00\00\00\00\e0\1c\bd\02-\9dv\b2\f9\f4?\00\00\00\00\00 \19=\c11E\7fA\08\f5?\00\00\00\00\00\c0\08\bd*f\cf\a2\da\16\f5?\00\00\00\00\00\00\fa\bc\eaQ?\e8}%\f5?\00\00\00\00\00\08J=\daN\9dV+4\f5?\00\00\00\00\00\d8&\bd\1a\ac\f6\f4\e2B\f5?\00\00\00\00\00D2\bd\db\94]\ca\a4Q\f5?\00\00\00\00\00<H=k\11\e9\ddp`\f5?\00\00\00\00\00\b0$=\de)\b56Go\f5?\00\00\00\00\00ZA=\0e\c4\e2\db'~\f5?\00\00\00\00\00\e0)\bdo\c7\97\d4\12\8d\f5?\00\00\00\00\00\08#\bdL\0b\ff'\08\9c\f5?\00\00\00\00\00\ecM='TH\dd\07\ab\f5?\00\00\00\00\00\00\c4\bc\f4z\a8\fb\11\ba\f5?\00\00\00\00\00\080=\0bFY\8a&\c9\f5?\00\00\00\00\00\c8&\bd?\8e\99\90E\d8\f5?\00\00\00\00\00\9aF=\e1 \ad\15o\e7\f5?\00\00\00\00\00@\1b\bd\ca\eb\dc \a3\f6\f5?\00\00\00\00\00p\17=\b8\dcv\b9\e1\05\f6?\00\00\00\00\00\f8&=\15\f7\cd\e6*\15\f6?\00\00\00\00\00\00\01=1U:\b0~$\f6?\00\00\00\00\00\d0\15\bd\b5)\19\1d\dd3\f6?\00\00\00\00\00\d0\12\bd\13\c3\cc4FC\f6?\00\00\00\00\00\80\ea\bc\fa\8e\bc\fe\b9R\f6?\00\00\00\00\00`(\bd\973U\828b\f6?\00\00\00\00\00\feq=\8e2\08\c7\c1q\f6?\00\00\00\00\00 7\bd~\a9L\d4U\81\f6?\00\00\00\00\00\80\e6<q\94\9e\b1\f4\90\f6?\00\00\00\00\00x)\bd\00\00\00?\00\00\00\bf\00\00\80?\00\00\c0?\00\00\00\00\dc\cf\d15\00\00\00\00\00\c0\15?8c\ed>\da\0fI?^\98{?\da\0f\c9?i7\ac1h!\223\b4\0f\143h!\a23\cd;\7ff\9e\a0\e6?\87\01\ebs\14\a1\e7?\db\a0*B\e5\ac\e8?\90\f0\a3\82\91\c4\e9?\ad\d3Z\99\9f\e8\ea?\9cR\85\dd\9b\19\ec?\87\a4\fb\dc\18X\ed?\da\90\a4\a2\af\a4\ee?\00\00\00\00\00\00\f0?\0f\89\f9lX\b5\f0?{Q}<\b8r\f1?8bunz8\f2?\15\b71\0a\fe\06\f3?\224\12L\a6\de\f3?'*6\d5\da\bf\f4?)TH\dd\07\ab\f5?Q\b4\f0\b2\96\b1D\b0\f9\ae\b6\ady\acC\ab\14\aa\eb\a8\c8\a7\aa\a6\92\a5\80\a4s\a3k\a2h\a1j\a0p\9f{\9e\8a\9d\9d\9c\b5\9b\d1\9a\f0\99\13\99:\98e\97\93\96\c4\95\f8\940\94k\93\a9\92\ea\91.\91u\90\be\8f\0a\8fY\8e\aa\8d\fe\8cT\8c\ac\8b\07\8bd\8a\c4\89%\89\89\88\ee\87V\87\c0\86+\86\99\85\08\85y\84\ec\83a\83\d8\82P\82\c9\81E\81\c2\80@\80\02\ff\0e\fd%\fbG\f9s\f7\aa\f5\ea\f34\f2\87\f0\e3\eeG\ed\b3\eb'\ea\a3\e8'\e7\b2\e5C\e4\dc\e2z\e1 \e0\cb\de}\dd4\dc\f1\da\b3\d9{\d8H\d7\1a\d6\f1\d4\cd\d3\ad\d2\92\d1{\d0i\cf[\ceQ\cdJ\ccH\cbJ\caO\c9X\c8d\c7t\c6\87\c5\9d\c4\b7\c3\d4\c2\f4\c1\16\c1<\c0e\bf\90\be\be\bd\ef\bc#\bcY\bb\91\ba\cc\b9\0a\b9J\b8\8c\b7\d0\b6\17\b6`\b5\18-DT\fb!\e9?\18-DT\fb!\e9\bf\d2!3\7f|\d9\02@\d2!3\7f|\d9\02\c0\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\80\18-DT\fb!\09@\18-DT\fb!\09\c0\db\0fI?\db\0fI\bf\e4\cb\16@\e4\cb\16\c0\00\00\00\00\00\00\00\80\db\0fI@\db\0fI\c0")
+  (@custom ".debug_abbrev" (after data) "\01\11\01%\0e\13\05\03\0e\10\17\1b\0e\11\01U\17\00\00\029\01\03\0e\00\00\03.\00\11\01\12\06@\18n\0e\03\0e:\0b;\0b6\0b?\19\87\01\19\00\00\00\01\11\01%\0e\13\05\03\0e\10\17\1b\0e\11\01\12\06\00\00\029\01\03\0e\00\00\03.\01\11\01\12\06@\18\03\0e:\0b;\05?\19\00\00\04\1d\011\10\11\01\12\06X\0bY\05W\0b\00\00\05\1d\011\10\11\01\12\06X\0bY\0bW\0b\00\00\06\1d\001\10\11\01\12\06X\0bY\05W\0b\00\00\07\1d\001\10\11\01\12\06X\0bY\0bW\0b\00\00\08\1d\011\10U\17X\0bY\0bW\0b\00\00\09\1d\001\10U\17X\0bY\0bW\0b\00\00\0a\1d\001\10U\17X\0bY\05W\0b\00\00\0b\11\01%\0e\13\05\03\0e\10\17\1b\0e\00\00\0c.\00n\0e\03\0e:\0b;\05 \0b\00\00\0d.\00n\0e\03\0e:\0b;\0b \0b\00\00\0e.\00n\0e\03\0e:\0b;\05?\19 \0b\00\00\00\01\11\01%\0e\13\05\03\0e\10\17\1b\0e\11\01U\17\00\00\029\01\03\0e\00\00\03.\00n\0e\03\0e:\0b;\0b \0b\00\00\04.\00n\0e\03\0e:\0b;\05 \0b\00\00\05.\01\11\01\12\06@\18n\0e\03\0e:\0b;\0b\00\00\06\1d\011\13\11\01\12\06X\0bY\0bW\0b\00\00\07\1d\001\13\11\01\12\06X\0bY\0bW\0b\b6B\0b\00\00\08\1d\001\13\11\01\12\06X\0bY\0bW\0b\00\00\09\1d\011\13\11\01\12\06X\0bY\0b\00\00\0a\1d\011\13U\17X\0bY\0bW\0b\00\00\0b\1d\001\13\11\01\12\06X\0bY\05W\0b\00\00\0c\1d\011\13\11\01\12\06X\0bY\05W\0b\00\00\0d\1d\001\13U\17X\0bY\05W\0b\00\00\0e\1d\001\13U\17X\0bY\0bW\0b\00\00\00\01\11\01%\0e\13\05\03\0e\10\17\1b\0e\11\01\12\06\00\00\029\01\03\0e\00\00\03.\01\11\01\12\06@\18\03\0e:\0b;\05?\19\00\00\04\1d\001\10\11\01\12\06X\0bY\05W\0b\00\00\05\11\01%\0e\13\05\03\0e\10\17\1b\0e\00\00\06.\00n\0e\03\0e:\0b;\05?\19 \0b\00\00\00\01\11\01%\0e\13\05\03\0e\10\17\1b\0e\11\01\12\06\00\00\029\01\03\0e\00\00\03.\01\11\01\12\06@\18\03\0e:\0b;\05?\19\00\00\04\1d\011\10\11\01\12\06X\0bY\05W\0b\00\00\05\1d\011\10\11\01\12\06X\0bY\0bW\0b\00\00\06\1d\011\10U\17X\0bY\0bW\0b\00\00\07\1d\001\10U\17X\0bY\05W\0b\00\00\08\1d\001\10\11\01\12\06X\0bY\05W\0b\00\00\09\1d\001\10\11\01\12\06X\0bY\0bW\0b\00\00\0a\11\01%\0e\13\05\03\0e\10\17\1b\0e\00\00\0b.\00n\0e\03\0e:\0b;\0b \0b\00\00\0c.\00n\0e\03\0e:\0b;\05?\19 \0b\00\00\0d.\00n\0e\03\0e:\0b;\05 \0b\00\00\00\01\11\01%\0e\13\05\03\0e\10\17\1b\0e\11\01\12\06\00\00\029\01\03\0e\00\00\03.\01\11\01\12\06@\18\03\0e:\0b;\05?\19\00\00\04\1d\001\10\11\01\12\06X\0bY\05W\0b\00\00\05\11\01%\0e\13\05\03\0e\10\17\1b\0e\00\00\06.\00n\0e\03\0e:\0b;\05?\19 \0b\00\00\00\01\11\01%\0e\13\05\03\0e\10\17\1b\0e\11\01\12\06\00\00\029\01\03\0e\00\00\03.\01\11\01\12\06@\18\03\0e:\0b;\05?\19\00\00\04\1d\011\10\11\01\12\06X\0bY\05W\0b\00\00\05\1d\011\10\11\01\12\06X\0bY\0bW\0b\00\00\06\1d\001\10\11\01\12\06X\0bY\0bW\0b\00\00\07\1d\001\10\11\01\12\06X\0bY\05W\0b\00\00\08\11\01%\0e\13\05\03\0e\10\17\1b\0e\00\00\09.\00n\0e\03\0e:\0b;\0b \0b\00\00\0a.\00n\0e\03\0e:\0b;\05?\19 \0b\00\00\0b.\00n\0e\03\0e:\0b;\05 \0b\00\00\00")
+  (@custom ".debug_info" (after data) "\89\00\00\00\04\00\00\00\00\00\04\01\b1\13\00\00\1c\00K\13\00\00\00\00\00\00_\11\00\00\00\00\00\00\00\00\00\00\02\c2\08\00\00\02\b8\08\00\00\03\bdq\00\00\03\00\00\00\07\ed\03\00\00\00\00\9f\f6\00\00\00\1a\01\00\00\01<\03\03\17F\00\00\09\00\00\00\07\ed\03\00\00\00\00\9f\fb\09\00\00\1f\0a\00\00\01\8a\03\02\d9\00\00\00\03\0dF\00\00\09\00\00\00\07\ed\03\00\00\00\00\9fS\03\00\00\87\03\00\00\01\ad\03\00\00\00\00\cf\01\00\00\04\005\00\00\00\04\01\b1\13\00\00\1c\00\a3\0f\00\00x\00\00\00_\11\00\00\12{\00\00n\00\00\00\02\f7\01\00\00\02\ed\00\00\00\02n\07\00\00\02\1d\0f\00\00\03\12{\00\00n\00\00\00\07\ed\03\00\00\00\00\9f\1d\0f\00\00\01\de\01\04\0e\03\00\00\1f{\00\00`\00\00\00\01\e0\01)\05\01\03\00\00\1f{\00\00`\00\00\00\05\a1\0b\05\a9\02\00\00\1f{\00\00\15\00\00\00\05\10!\06\9c\02\00\00\1f{\00\00\0b\00\00\00\02~\018\06\9c\02\00\00*{\00\00\01\00\00\00\02~\01\1a\06-\03\00\00+{\00\00\09\00\00\00\02~\01'\00\07\bc\02\00\004{\00\00\01\00\00\00\05\117\05\a9\02\00\005{\00\00\0d\00\00\00\05\11!\06-\03\00\005{\00\00\0d\00\00\00\02~\01'\00\07\bc\02\00\00B{\00\00\01\00\00\00\05\12\1c\05\a9\02\00\00C{\00\00\03\00\00\00\05\12!\06-\03\00\00C{\00\00\03\00\00\00\02~\01'\00\08\cf\02\00\00 \00\00\00\05\17\0e\09M\03\00\00 \00\00\00\02\8f\0d\00\08\bf\03\00\008\00\00\00\05\15\13\0a\90\03\00\008\00\00\00\02D\01\09\00\08\cf\02\00\00P\00\00\00\05\1a\0e\09M\03\00\00P\00\00\00\02\8f\0d\00\05\e1\02\00\00p{\00\00\05\00\00\00\05\19!\07:\03\00\00p{\00\00\05\00\00\00\02\93\0d\00\05\e1\02\00\00u{\00\00\05\00\00\00\05\1a%\07:\03\00\00u{\00\00\05\00\00\00\02\93\0d\00\05\a9\02\00\00R{\00\00\07\00\00\00\05\13!\06-\03\00\00R{\00\00\07\00\00\00\02~\01'\00\00\00\00\00\00\00\00\00\fa\00\00\00\04\005\00\00\00\04\0b\b1\13\00\00\1c\00\1d\0c\00\00:\02\00\00_\11\00\00\02\f7\01\00\00\02\b3\08\00\00\02\ae\08\00\00\02\e5\00\00\00\02\84\01\00\00\02\00\00\00\00\0c\9f\03\00\00\00\04\00\00\01z\01\01\0c\d2\05\00\003\06\00\00\01}\01\01\00\02V\00\00\00\0cK\08\00\00\ab\08\00\00\01i\01\01\00\020\00\00\00\0d,\09\00\00\ee\09\00\00\01\8e\01\00\02`\00\00\00\0d\d4\06\00\00e\07\00\00\01\92\01\00\00\00\00\00\02\ed\00\00\00\02n\07\00\00\02r\07\00\00\0df\0b\00\00\02\0c\00\00\02\07\01\00\0e\ea\0e\00\00\1d\0f\00\00\03\d5\01\01\00\00\00\02\c2\08\00\00\02\0b\04\00\00\02C\00\00\00\0c\a3\06\00\00e\07\00\00\04\bd\08\01\0c\a3\06\00\00e\07\00\00\04\bd\08\01\00\02:\00\00\00\0c\ca\09\00\00\ee\09\00\00\04u\08\01\00\00\00\00q\00\00\00\04\005\00\00\00\04\0b\b1\13\00\00\1c\00\b1\0c\00\00^\03\00\00_\11\00\00\02\c2\08\00\00\02\8f\01\00\00\02$\01\00\00\02L\00\00\00\0cD\02\00\00y\02\00\00\01\1a\01\01\00\00\00\00\02\f7\01\00\00\02\b3\08\00\00\02\ae\08\00\00\02\e5\00\00\00\02\84\01\00\00\02\f1\00\00\00\0c\b8\0a\00\00\0c\0c\00\00\02C\01\01\00\00\00\00\00\00\00)\05\00\00\04\00\12\01\00\00\04\01\b1\13\00\00\1c\00\b7\12\00\00\00\04\00\00_\11\00\00\00\00\00\00\d0\01\00\00\02\c2\08\00\00\02\0b\04\00\00\02\1d\00\00\00\03\c5\01\00\00\e9\01\00\00\02\99\01\04\a9\00\00\00\cd\00\00\00\02a\05\01\04\a2\05\00\00\c6\05\00\00\02(\06\01\00\02\0a\00\00\00\04%\0a\00\00\ab\0a\00\00\02<\0a\01\04y\00\00\00\cd\00\00\00\02a\05\01\04r\05\00\00\c6\05\00\00\02(\06\01\00\02j\00\00\00\03\93\01\00\00\e9\01\00\00\02\99\01\04A\07\00\00e\07\00\00\02c\0a\01\04\99\09\00\00\ee\09\00\00\02\17\0a\01\04V\0a\00\00\ab\0a\00\00\02<\0a\01\00\00\00\02\f7\01\00\00\02\ed\00\00\00\02\0f\04\00\00\03(\01\00\00l\01\00\00\031\01\03\1b\05\00\00_\05\00\00\05\e4\01\05\ff\ff\ff\ff\89\02\00\00\07\ed\03\00\00\00\00\9f\cb\04\00\00\0f\05\00\00\01\14\06\d3\00\00\00\ff\ff\ff\ff\05\00\00\00\01\a5\1f\075\00\00\00\ff\ff\ff\ff\01\00\00\00\03@\1c\02\075\00\00\00\ff\ff\ff\ff\03\00\00\00\03@2\02\00\08a\00\00\00\ff\ff\ff\ff\0f\00\00\00\01\ab'\09\df\00\00\00\ff\ff\ff\ff\17\00\00\00\01\00\08A\00\00\00\ff\ff\ff\ff\07\00\00\00\05\e5\1c\08N\00\00\00\ff\ff\ff\ff\10\00\00\00\05\e6 \00\0a\df\00\00\00h\00\00\00\01n2\08A\00\00\00\ff\ff\ff\ff\03\00\00\00\05\e5\1c\08N\00\00\00\ff\ff\ff\ff\0a\00\00\00\05\e6 \00\0a\df\00\00\00\80\00\00\00\01q2\08A\00\00\00\ff\ff\ff\ff\05\00\00\00\05\e5\1c\08N\00\00\00\ff\ff\ff\ff\08\00\00\00\05\e6 \00\08a\00\00\00\ff\ff\ff\ff\0f\00\00\00\01\8b+\0a\df\00\00\00\98\00\00\00\01\93/\08A\00\00\00\ff\ff\ff\ff\05\00\00\00\05\e5\1c\08N\00\00\00\ff\ff\ff\ff\08\00\00\00\05\e6 \00\06\d3\00\00\00\ff\ff\ff\ff\08\00\00\00\018*\085\00\00\00\ff\ff\ff\ff\03\00\00\00\03@2\085\00\00\00\ff\ff\ff\ff\05\00\00\00\03@\1c\00\08a\00\00\00\ff\ff\ff\ff\0f\00\00\00\01R+\0a\df\00\00\00\b0\00\00\00\01Z/\08A\00\00\00\ff\ff\ff\ff\05\00\00\00\05\e5\1c\08N\00\00\00\ff\ff\ff\ff\08\00\00\00\05\e6 \00\0a\df\00\00\00\c8\00\00\00\01*\1f\08A\00\00\00\ff\ff\ff\ff\05\00\00\00\05\e5\1c\08N\00\00\00\ff\ff\ff\ff\08\00\00\00\05\e6 \00\0a\df\00\00\00\e0\00\00\00\01c#\08A\00\00\00\ff\ff\ff\ff\05\00\00\00\05\e5\1c\08N\00\00\00\ff\ff\ff\ff\08\00\00\00\05\e6 \00\00\03t\04\00\00\b8\04\00\00\05\7f\01\02g\04\00\00\03B\06\00\00\96\06\00\00\06\19\01\03\c7\08\00\00\1b\09\00\00\06\1d\01\00\05\82{\00\00:\04\00\00\04\ed\00\05\9f#\04\00\00g\04\00\00\06\12\08\8e\00\00\00\a1{\00\00!\00\00\00\060\1e\08\8e\00\00\00\c2{\00\00\13\00\00\00\061\22\0b\a7\00\00\00!~\00\00\11\00\00\00\06f\01!\0b\b4\00\00\002~\00\00\13\00\00\00\06f\013\0c\d9\02\00\00\d1}\00\00\05\00\00\00\06Y\01$\08n\00\00\00\d1}\00\00\05\00\00\00\05\80\1c\00\0d\9a\00\00\00\f8\00\00\00\06S\01!\0c\d9\02\00\00a~\00\00\09\00\00\00\06L\01$\08n\00\00\00a~\00\00\09\00\00\00\05\80\1c\00\0d\8e\00\00\00\10\01\00\00\06m\01\1e\0c\d9\02\00\00\1a\7f\00\00\0f\00\00\00\06|\01\1f\08n\00\00\00\1a\7f\00\00\07\00\00\00\05\80\1c\08{\00\00\00!\7f\00\00\08\00\00\00\05\81 \00\06\d9\02\00\00\f6|\00\00\05\00\00\00\06\d4\1b\08n\00\00\00\f6|\00\00\05\00\00\00\05\80\1c\00\0a\ea\02\00\00(\01\00\00\06\da'\0e\9a\00\00\00(\01\00\00\06\1a(\00\0a\f6\02\00\00H\01\00\00\06\db*\0e\9a\00\00\00h\01\00\00\06\1f\16\08\a7\00\00\00.}\00\00\0a\00\00\00\06 \16\00\08\a7\00\00\00Q}\00\00\11\00\00\00\06\e2\1d\0e\b4\00\00\00\88\01\00\00\06\e2/\06\d9\02\00\00=|\00\00\17\00\00\00\06I\22\08n\00\00\00=|\00\00\07\00\00\00\05\80\1c\08{\00\00\00D|\00\00\10\00\00\00\05\81 \00\06\d9\02\00\00d|\00\00\0b\00\00\00\06\5c'\08n\00\00\00d|\00\00\03\00\00\00\05\80\1c\08{\00\00\00g|\00\00\08\00\00\00\05\81 \00\0a\d9\02\00\00\a0\01\00\00\06_&\08n\00\00\00x|\00\00\07\00\00\00\05\80\1c\08{\00\00\00\80|\00\00\0a\00\00\00\05\81 \00\0a\d9\02\00\00\b8\01\00\00\06b&\08n\00\00\00\95|\00\00\05\00\00\00\05\80\1c\08{\00\00\00\9f|\00\00\0e\00\00\00\05\81 \00\00\00\00\00\00b\00\00\00\04\00\f2\01\00\00\04\01\b1\13\00\00\1c\00#\12\00\00-\0a\00\00_\11\00\00\bd\7f\00\00H\00\00\00\02\f7\01\00\00\02\ed\00\00\00\02t\00\00\00\02\a1\0e\00\00\03\bd\7f\00\00H\00\00\00\04\ed\00\05\9f\a1\0e\00\00\01\de\01\04\93\09\00\00\d1\7f\00\00(\00\00\00\01\e0\01)\00\00\00\00\00\00:\00\00\00\04\00\f2\01\00\00\04\05\b1\13\00\00\1c\00\8f\11\00\00\eb\0a\00\00_\11\00\00\02\f7\01\00\00\02\ed\00\00\00\02t\00\00\00\06m\0e\00\00\a1\0e\00\00\01\d5\01\01\00\00\00\00W\01\00\00\04\00Q\02\00\00\04\01\b1\13\00\00\1c\007\10\00\00F\0b\00\00_\11\00\00\06\80\00\00N\00\00\00\02\f7\01\00\00\02\ed\00\00\00\02~\01\00\00\02[\0f\00\00\03\06\80\00\00N\00\00\00\07\ed\03\00\00\00\00\9f[\0f\00\00\01\de\01\04>\0b\00\00\12\80\00\00A\00\00\00\01\e0\01)\051\0b\00\00\12\80\00\00A\00\00\00\02T\0b\06f\0b\00\00\e8\01\00\00\02\0e\1b\06\a0\0b\00\00\e8\01\00\00\05\9b\0d\07\93\0b\00\00\e8\01\00\00\03\14\0b\16\00\00\05f\0b\00\00\1f\80\00\00\07\00\00\00\02\0fJ\05\a0\0b\00\00\1f\80\00\00\07\00\00\00\05\9b\0d\08\93\0b\00\00\1f\80\00\00\07\00\00\00\03\14\0b\16\00\00\09\cd\0b\00\00&\80\00\00\03\00\00\00\02\0f+\05r\0b\00\00)\80\00\00\02\00\00\00\02\0f\1b\05\ba\0b\00\00)\80\00\00\02\00\00\00\05{1\08\ad\0b\00\00)\80\00\00\02\00\00\00\03@\0b\16\00\00\09\eb\0b\00\00+\80\00\00\03\00\00\00\02\0f\11\05f\0b\00\008\80\00\00\0c\00\00\00\02\09\17\05\a0\0b\00\008\80\00\00\0c\00\00\00\05\9b\0d\08\93\0b\00\008\80\00\00\0c\00\00\00\03\14\0b\16\00\00\00\00\00\00\00\00\00\00\fa\00\00\00\04\00Q\02\00\00\04\0a\b1\13\00\00\1c\00\d9\0d\00\00\e7\0c\00\00_\11\00\00\02\f7\01\00\00\02\ed\00\00\00\02~\01\00\00\02F\08\00\00\0b\a7\0b\00\00\f7\0b\00\00\01\05\01\00\0c&\0f\00\00[\0f\00\00\02\d5\01\01\00\00\02\b3\08\00\00\02\ae\08\00\00\02\e5\00\00\00\02\84\01\00\00\02\13\00\00\00\0b\a7\07\00\00\07\08\00\00\04\9a\01\0b\7f\02\00\00\df\02\00\00\04z\01\00\00\00\00\00\00\02\c2\08\00\00\02\0b\04\00\00\02\0a\00\00\00\0d\14\08\00\008\08\00\00\03\f0\07\01\0dv\07\00\00\07\08\00\00\03\10\0b\01\0d\1c\03\00\00@\03\00\00\03\a9\08\01\0d\eb\02\00\00\0f\03\00\00\03<\0b\01\00\02\1d\00\00\00\0d\87\0a\00\00\ab\0a\00\00\03<\0a\01\00\00\02\8f\01\00\00\02$\01\00\00\02&\00\00\00\0d\09\02\00\00y\02\00\00\05\1a\01\01\00\00\00\00\00b\00\00\00\04\00\1f\03\00\00\04\01\b1\13\00\00\1c\00E\0d\00\00-\0e\00\00_\11\00\00U\80\00\00H\00\00\00\02\f7\01\00\00\02\ed\00\00\00\02t\00\00\00\02\99\0f\00\00\03U\80\00\00H\00\00\00\04\ed\00\05\9f\99\0f\00\00\01\de\01\04\90\0c\00\00i\80\00\00(\00\00\00\01\e0\01)\00\00\00\00\00\00:\00\00\00\04\00\1f\03\00\00\04\05\b1\13\00\00\1c\00\8f\11\00\00\eb\0e\00\00_\11\00\00\02\f7\01\00\00\02\ed\00\00\00\02t\00\00\00\06e\0f\00\00\99\0f\00\00\01\d5\01\01\00\00\00\00c\01\00\00\04\00~\03\00\00\04\01\b1\13\00\00\1c\00\cb\10\00\00F\0f\00\00_\11\00\00\9e\80\00\00N\00\00\00\02\f7\01\00\00\02\ed\00\00\00\02~\01\00\00\02\e0\0e\00\00\03\9e\80\00\00N\00\00\00\07\ed\03\00\00\00\00\9f\e0\0e\00\00\01\de\01\04G\0e\00\00\aa\80\00\00A\00\00\00\01\e0\01)\05:\0e\00\00\aa\80\00\00A\00\00\00\02r\0b\06\9c\0e\00\00\b6\80\00\00\03\00\00\00\02<I\05o\0e\00\00\b9\80\00\00\02\00\00\00\02<8\05\bc\0e\00\00\b9\80\00\00\02\00\00\00\05\9b\0d\07\af\0e\00\00\b9\80\00\00\02\00\00\00\03\14\0b\16\00\00\05{\0e\00\00\bb\80\00\00\08\00\00\00\02<\1b\05\d6\0e\00\00\bb\80\00\00\08\00\00\00\05{1\07\c9\0e\00\00\bb\80\00\00\08\00\00\00\03@\0b\16\00\00\06\f4\0e\00\00\c3\80\00\00\03\00\00\00\02<\11\05{\0e\00\00\c6\80\00\00\09\00\00\00\02=\1b\05\d6\0e\00\00\c6\80\00\00\09\00\00\00\05{1\07\c9\0e\00\00\c6\80\00\00\09\00\00\00\03@\0b\16\00\00\05{\0e\00\00\d0\80\00\00\0c\00\00\00\027\17\05\d6\0e\00\00\d0\80\00\00\0c\00\00\00\05{1\07\c9\0e\00\00\d0\80\00\00\0c\00\00\00\03@\0b\16\00\00\00\00\00\00\00\00\00\00\fa\00\00\00\04\00~\03\00\00\04\08\b1\13\00\00\1c\00\d9\0d\00\00\e7\10\00\00_\11\00\00\02\f7\01\00\00\02\ed\00\00\00\02~\01\00\00\02N\03\00\00\09!\0b\00\00\ec\0b\00\00\014\01\00\0a\ab\0e\00\00\e0\0e\00\00\02\d5\01\01\00\00\02\b3\08\00\00\02\ae\08\00\00\02\e5\00\00\00\02\84\01\00\00\02\13\00\00\00\09\a7\07\00\00\07\08\00\00\04\9a\01\09\7f\02\00\00\df\02\00\00\04z\01\00\00\00\00\00\00\02\c2\08\00\00\02\0b\04\00\00\02\1d\00\00\00\0b\87\0a\00\00\ab\0a\00\00\03<\0a\01\00\02\0a\00\00\00\0b\14\08\00\008\08\00\00\03\f0\07\01\0bv\07\00\00\07\08\00\00\03\10\0b\01\0b\1c\03\00\00@\03\00\00\03\a9\08\01\0b\eb\02\00\00\0f\03\00\00\03<\0b\01\00\00\02\8f\01\00\00\02$\01\00\00\02&\00\00\00\0b\09\02\00\00y\02\00\00\05\1a\01\01\00\00\00\00\00")
+  (@custom ".debug_ranges" (after data) "\bdq\00\00\c0q\00\00\17F\00\00 F\00\00\0dF\00\00\16F\00\00\00\00\00\00\00\00\00\004\00\00\00:\00\00\00G\00\00\00V\00\00\00\00\00\00\00\00\00\00\00:\00\00\00;\00\00\00V\00\00\00^\00\00\00\00\00\00\00\00\00\00\00;\00\00\00@\00\00\00h\00\00\00m\00\00\00\00\00\00\00\00\00\00\00\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\00\00\00\00\00\00\00\00\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\00\00\00\00\00\00\00\00\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\00\00\00\00\00\00\00\00\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\00\00\00\00\00\00\00\00\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\00\00\00\00\00\00\00\00\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\fe\ff\ff\ff\00\00\00\00\00\00\00\00w~\00\00\8b~\00\00\91~\00\00\9b~\00\00\00\00\00\00\00\00\00\00\d8~\00\00\db~\00\00\e0~\00\00\ee~\00\00\00\00\00\00\00\00\00\00\fb|\00\00\01}\00\00\14}\00\00\1b}\00\00\22}\00\00'}\00\00\00\00\00\00\00\00\00\00\01}\00\00\14}\00\00\1b}\00\00\22}\00\00'}\00\008}\00\00\00\00\00\00\00\00\00\00\01}\00\00\14}\00\00\1b}\00\00\22}\00\00'}\00\00.}\00\00\00\00\00\00\00\00\00\00b}\00\00r}\00\00u}\00\00|}\00\00\00\00\00\00\00\00\00\00x|\00\00\7f|\00\00\80|\00\00\8a|\00\00\00\00\00\00\00\00\00\00\95|\00\00\9a|\00\00\9f|\00\00\ad|\00\00\00\00\00\00\00\00\00\00\fe\ff\ff\ff\fe\ff\ff\ff\82{\00\00\bc\7f\00\00\00\00\00\00\00\00\00\00\14\00\00\00\19\00\00\00(\00\00\001\00\00\00\00\00\00\00\00\00\00\00")
+  (@custom ".debug_str" (after data) "{impl#39}\00{impl#9}\00{impl#18}\00{impl#8}\00{impl#84}\00{impl#24}\00{impl#4}\00{impl#3}\00{impl#91}\00{impl#31}\00{impl#20}\00{impl#10}\00udiv\00_RNvMs7_NtCsdkdt1aaAg1T_4core3numy11checked_div\00_RNvMs6_NtCsdkdt1aaAg1T_4core3numm11checked_div\00panic_const\00support\00int\00DInt\00_RNvNtCsdkdt1aaAg1T_4core9panicking9panic_fmt\00bit\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem23u32_normalization_shift\00int_traits\00ops\00_RNvMs8_NtCsdkdt1aaAg1T_4core3numo13leading_zeros\00_RNvMs6_NtCsdkdt1aaAg1T_4core3numm13leading_zeros\00compiler_builtins\00_RNvXs1k_NtNtCsdkdt1aaAg1T_4core3ops3bityNtB6_5BitOr5bitor\00_RNvXs1r_NtNtCsdkdt1aaAg1T_4core3ops3bitnNtB6_5BitOr5bitor\00_RNvXsg_NtNtNtNtCs6RiiD5tsSf6_17compiler_builtins4math9libm_math7support10int_traitsyNtB5_3Int11logical_shr\00_RNvMs7_NtCsdkdt1aaAg1T_4core3numy12wrapping_shr\00_RNvMs7_NtCsdkdt1aaAg1T_4core3numy13unchecked_shr\00Lshr\00_RNvNtNtCsdkdt1aaAg1T_4core9panicking11panic_const23panic_const_rem_by_zero\00_RNvXsB_NtNtNtNtCs6RiiD5tsSf6_17compiler_builtins4math9libm_math7support10int_traitslNtB5_4HInt10zero_widen\00num\00specialized_div_rem\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem12u128_div_rem\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem18u64_by_u64_div_rem\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem11u64_div_rem\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem18u32_by_u32_div_rem\00_RNvMs7_NtCsdkdt1aaAg1T_4core3numy11checked_rem\00_RNvMs6_NtCsdkdt1aaAg1T_4core3numm11checked_rem\00_RNvXsB_NtNtNtNtCs6RiiD5tsSf6_17compiler_builtins4math9libm_math7support10int_traitslNtB5_4HInt14zero_widen_mul\00_RNvNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem12u128_div_rem12carrying_mul\00_RNvMs1_NtCsdkdt1aaAg1T_4core3numx12wrapping_mul\00_RNvXsi_NtNtNtNtCs6RiiD5tsSf6_17compiler_builtins4math9libm_math7support10int_traitsxNtB5_3Int12wrapping_mul\00_RNvMs8_NtCsdkdt1aaAg1T_4core3numo12wrapping_mul\00Mul\00_RNvMs7_NtCsdkdt1aaAg1T_4core3numy12wrapping_shl\00_RNvXsg_NtNtNtNtCs6RiiD5tsSf6_17compiler_builtins4math9libm_math7support10int_traitsyNtB5_3Int12wrapping_shl\00_RNvMs7_NtCsdkdt1aaAg1T_4core3numy13unchecked_shl\00Ashl\00_RNvXst_NtNtNtNtCs6RiiD5tsSf6_17compiler_builtins4math9libm_math7support10int_traitsxNtB5_4DInt2hi\00libm_math\00panicking\00core\00_RNvNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int19specialized_div_rem12u128_div_rem16carrying_mul_add\00_RNvXsm_NtNtNtNtCs6RiiD5tsSf6_17compiler_builtins4math9libm_math7support10int_traitsnNtB5_3Int12wrapping_add\00_RNvMs8_NtCsdkdt1aaAg1T_4core3numo12wrapping_add\00_RNvMs2_NtCsdkdt1aaAg1T_4core3numn12wrapping_add\00_RNvNtCsdkdt1aaAg1T_4core9panicking5panic\00_RNvMs7_NtCsdkdt1aaAg1T_4core3numy12wrapping_sub\00_RNvMs8_NtCsdkdt1aaAg1T_4core3numo12wrapping_sub\00_RNvMs6_NtCsdkdt1aaAg1T_4core3numm12wrapping_sub\00_RNvYnNtNtNtNtNtCs6RiiD5tsSf6_17compiler_builtins4math9libm_math7support10int_traits4DInt10from_lo_hiBd_\00_RNvYoNtNtNtCs6RiiD5tsSf6_17compiler_builtins3int5shift4Lshr4lshrB9_\00_RNvYnNtNtNtCs6RiiD5tsSf6_17compiler_builtins3int3mul3Mul3mulB9_\00_RNvYoNtNtNtCs6RiiD5tsSf6_17compiler_builtins3int5shift4Ashl4ashlB9_\00lshr<u128>\00ashl<u128>\00mul<i128>\00from_lo_hi<i128>\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.019\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.026\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.345\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.024\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int4udiv9___udivti3\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int5shift9___lshrti3\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int3mul8___multi3\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int5shift9___ashlti3\00_RNvNtNtCs6RiiD5tsSf6_17compiler_builtins3int4udiv9___umodti3\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.193\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.343\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.362\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.052\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.250\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/compiler-builtins/compiler-builtins/src/lib.rs/@/compiler_builtins.4fe5e33483b78f92-cgu.020\00/rustc/8bab26f4f68e0e26f0bb7960be334d5b520ea452/library/core/src/lib.rs/@/core.9b3796e30d99ddb7-cgu.0\00clang LLVM (rustc version 1.97.1 (8bab26f4f 2026-07-14))\00")
+  (@custom ".debug_line" (after data) "t\00\00\00\04\005\00\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/core/src\00\00panicking.rs\00\01\00\00\00\05\0e\0a\00\05\02\beq\00\00\03\cf\00\01\02\02\00\01\01\05\05\0a\00\05\02\18F\00\00\03\95\01\01\02\08\00\01\01\05\11\0a\00\05\02\0eF\00\00\03\ae\01\01\02\08\00\01\01\be\01\00\00\04\009\01\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src\00library/compiler-builtins/compiler-builtins/src/math/../../../libm/src/math/support\00library/core/src/num\00library/core/src/ops\00library/compiler-builtins/compiler-builtins/src/int\00\00macros.rs\00\01\00\00int_traits.rs\00\02\00\00int_macros.rs\00\03\00\00bit.rs\00\04\00\00mul.rs\00\05\00\00\00\00\05\02\12{\00\00\03\dd\03\01\04\02\05\15\0a\03\9d\7f\c8\06\ac\04\03\05\0d\06\03\c3\0e \04\02\05\15\03\acq\90\04\03\05\0d\03\d4\0e \04\02\05\15\03\acq\c8\04\03\05\0d\03\d4\0e \03\b8\7f<\04\04\05-\03\a4qf\04\03\05\0d\03\dc\0e \03\c8\00X\03\b8\7ft\04\04\05-\03\a4q\e4\04\03\05\0d\03\a4\0f\82\06X\06\03\b8\7fX\04\01\05\0e\03\ebrX\02\01\00\01\01 \01\00\00\04\00\1a\01\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src/math/../../../libm/src/math/support\00library/compiler-builtins/compiler-builtins/src/int\00library/compiler-builtins/compiler-builtins/src\00library/core/src/num\00\00int_traits.rs\00\01\00\00mul.rs\00\02\00\00macros.rs\00\03\00\00int_macros.rs\00\04\00\00\00\9e\00\00\00\04\00\98\00\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/core/src/ops\00library/compiler-builtins/compiler-builtins/src/math/../../../libm/src/math/support\00\00bit.rs\00\01\00\00int_traits.rs\00\02\00\00\00)\06\00\00\04\00\f6\00\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src/int/specialized_div_rem\00library/core/src/num\00library/compiler-builtins/compiler-builtins/src\00\00delegate.rs\00\01\00\00uint_macros.rs\00\02\00\00norm_shift.rs\00\01\00\00lib.rs\00\03\00\00mod.rs\00\01\00\00trifecta.rs\00\01\00\00\00\00\05\02\ff\ff\ff\ff\03\13\01\05\1a\0a\03\0c\c8rg\05\0d\93\06\03^\9e\05.\03\22X\05\0dX\03^<\03\22J\03^.\03\22 \03^\90\03\22J\03^.\04\02\05\14\06\03\9a\01f\06 \04\03\05\17\06\03\a6\7f<\04\01\05+\03\e8\00 \05(W\04\02\05\0d\03\96\13\ba\04\01\05\1c\03\efl\e4\05\1d>\05 u\06\03\d1~t\05\19\06\03\b4\01\90s\05\15\03w<\05 3\05)/\06\03\d0~t\05.\06\03\22f\05\0d\06\90\05\18\06\03\0c.\05\1f\033\90\04\02\03\86\0at\03\c7\01t\04\01\05\1c\03\bat\f2\06\03\98\7f<\05+\06\03\ed\00J\04\02\05\1f\03\fa\09\90\04\01\053\03\8dv<\05\15\03\a7\7fX\05N\03\d9\00 \05M\06X\05! \04\02\05\1f\06\03\ba\0b \04\01\05\15\03\eds\9e\05*\03\d5\00t\04\02\05\1f\03\f7\09.\04\01\05!\03\8dvX\04\02\05\1f\03\ba\0bf\04\01\05!\03\c7t\82\04\04\05\00\06\03\8b\7f<\04\01\05:\06\03\ff\00<\059\06X\05'\90\05\1c\060\06\03\ff~t\05,\06\03\87\01J\04\02\05\0d\03\b6\13\e4\04\01\05 \03\cfl\e4\05!>\05$\e6\06\03\f0~<\05\1d\06\03\9b\01\90s\05\19\03p<\05$4\05M3\05L\06X\05>\06\1e\04\02\05\1f\03\d4\09<\04\01\054\03\aevX\04\02\05\1f\03\99\0b\90\04\01\05)\03\e8t\82\04\04\05\00\06\03\ea~<\04\02\05\14\06\03\9a\01t\06<\04\01\05&\06\03\9f\7fX\05/\03\15\ba\05,W\04\02\05\0d\03\f0\13\ba\04\01\05 \03\96l\e4\05!>\05$\e6\06\03\a9\7f<\05\1d\06\03\df\00\90s\05\19\03s<\05$4\05>1\04\02\05\1f\03\8d\0a<\04\01\05-\03\f4uX\04\02\05\1f\03\d3\0b\82\04\01\05F\03\adt\82\04\04\05\00\06\03\a5\7f<\04\02\05\1f\06\03\e7\0a<\04\01\05\1d\03\c4uX\04\02\05\1f\03\83\0cX\04\01\05+\03\fds\82\04\04\05\00\06\03U<\04\02\05\1f\06\03\e7\0a<\04\01\05,\03\fduX\05!\06\90\04\02\05\1f\06\03\ca\0b<\04\01\05<\03\b6t\82\04\04\05\00\06\03\9c\7f<\04\01\05%\06\03\82\01<\06\03\fe~\82\05\0a\06\03\b8\01\e4\02\01\00\01\01\04\06\00\05\02\82{\00\00\03\11\01\04\02\05\14\0a\03\88\01\08\d6\06\08\f2\04\06\05\10\06\03\9e\7f\08.\06\03HX\06\03\c6\00J\06\03\ba\7f<\06\03\d0\00X\05\1b\03\1b<\05'\03\b0\7ft\05\1f\03\9f\02<\05\1d\c5\05\1f?\05$\f5\05\0d\b0\06\03\bf}.\05\14\06\03; \06\03E\08J\03;J\03E.\04\02\05\1f\06\03\e7\0a \03\c7\01t\04\04\05\00\06\03\d2s\f2\04\06\05$\06\03\db\00\e4\04\02\05\1f\03\8c\0a \03\c7\01<\04\06\03\b0t\82\04\02\03\89\0a\90\04\06\05'\03\b4ut\04\02\05\1f\03\93\0c \04\06\05'\03\eds\9e\05\1e\03\c6\00\90\04\02\05\1f\03\86\0a.\04\06\05\15\03\feuX\04\02\05\1f\03\c9\0bX\04\06\05'\03\eds\d6\05\15\03\ca\00 \04\04\05\00\06\03\9b\7f\90\04\06\05!\06\03\d2\01<\05\1d\b9\05!=\83\08\9dY\04\02\05\1f\03\94\09X\05\0d\03\fd\09X\06f\08.ttX\06\03\b4\7ft\04\06\05\14\03\c5m\9e\06\03\a3~\08t\04\02\05\0d\06\03\98\14 \03%\08\12\04\06\05\19\03\a2m\f2\04\02\05\0d\03\de\12<\04\06\05\15\03\a1mt\06\03\a2~.\05!\06\03\c6\02 \08+?\05\14\f6\05%\03\0e\90\051\03\09\08 \05%\03wf\04\02\05\1f\03\8f\08\ac\04\06\051\03\fawX\05\18\e6\051:\05\18\92\05:\b2\05!\06\08 \05\19\f2\03\97}.\04\02\05\0d\06\03\98\14 \03%\08\12\04\06\05$\03\a8n\08.\05\1d\06\90\05\19\06\9d\06\03\9c}.\05\1c\06\03\d0\02 \04\02\05\1f\03\97\08f\04\06\05%\03\e6w\90\05\1c[\04\02\05\0d\03\94\12\82\04\06\05\1c\03\efm\08<\04\02\05\0d\03\91\12f\04\06\05\1c\03\efm\9e\7f\05\15\06f\05\1c<\05\15f\05\1c\06\d9\05\15\06\ac\05\1c \05\15t\04\02\05\14\06\03\c7~X\04\06\05\15\03\b9\01<\04\02\05\14\03\c7~X\04\06\03\d5\01\d6\06\03\91}X\06\03\fa\02J\06\03\86}X\06\03\ef\02 \05\18\22\06\03\8f}\08J\03\f1\02J\03\8f}.\04\02\05\1f\06\03\e7\0a \03\c7\01t\04\06\05\1d\03\cfv\82\04\04\05\00\06\03\83}\08<\04\06\05*\06\03\f2\02<\05!\06\08t\05\19\82\03\8e}.\05)\06\03\e5\01 \06\03\9b~\08t\05 \06\03< \06\03D\08X\05\0a\06\03\80\03\08\ba\02\0d\00\01\01\ba\00\00\00\04\00\90\00\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src\00library/compiler-builtins/compiler-builtins/src/int\00\00macros.rs\00\01\00\00udiv.rs\00\02\00\00\00\00\05\02\bd\7f\00\00\03\dd\03\01\04\02\05\0d\0a\03\c4}\08<\04\01\05\0e\03\bf\02\02(\01\02\0c\00\01\01W\00\00\00\04\00Q\00\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src\00\00macros.rs\00\01\00\00\00\9d\01\00\00\04\00<\01\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src\00library/compiler-builtins/compiler-builtins/src/int\00library/core/src/num\00library/core/src/ops\00library/compiler-builtins/compiler-builtins/src/math/../../../libm/src/math/support\00\00macros.rs\00\01\00\00shift.rs\00\02\00\00uint_macros.rs\00\03\00\00bit.rs\00\04\00\00int_traits.rs\00\05\00\00\00\00\05\02\06\80\00\00\03\dd\03\01\04\02\05\0c\0a\03\a9|\ba\05\13?\04\03\05\11\03\f1\0fX\06X\05\0d\06\03\c2\04t\05\11\03\f7|<\04\04\05-\03\e6p.\04\03\05\11\03\e1\0d<\06\03\85p\90\06\03\fb\0f \06\03\85p\ba\04\01\05\0e\06\03\e1\03\e4\02\01\00\01\01B\01\00\00\04\00<\01\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src/int\00library/compiler-builtins/compiler-builtins/src\00library/core/src/num\00library/compiler-builtins/compiler-builtins/src/math/../../../libm/src/math/support\00library/core/src/ops\00\00shift.rs\00\01\00\00macros.rs\00\02\00\00uint_macros.rs\00\03\00\00int_traits.rs\00\04\00\00bit.rs\00\05\00\00\00\ba\00\00\00\04\00\90\00\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src\00library/compiler-builtins/compiler-builtins/src/int\00\00macros.rs\00\01\00\00udiv.rs\00\02\00\00\00\00\05\02U\80\00\00\03\dd\03\01\04\02\05\0d\0a\03\ce}\08<\04\01\05\0e\03\b5\02\02(\01\02\0c\00\01\01W\00\00\00\04\00Q\00\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src\00\00macros.rs\00\01\00\00\00\9d\01\00\00\04\00<\01\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src\00library/compiler-builtins/compiler-builtins/src/int\00library/core/src/num\00library/core/src/ops\00library/compiler-builtins/compiler-builtins/src/math/../../../libm/src/math/support\00\00macros.rs\00\01\00\00shift.rs\00\02\00\00uint_macros.rs\00\03\00\00bit.rs\00\04\00\00int_traits.rs\00\05\00\00\00\00\05\02\9e\80\00\00\03\dd\03\01\04\02\05\0c\0a\03\d8|\ba\05\13>\06\03HX\04\03\05\0d\06\03\bd\14J\05\11\03\be{<\03\b9\01.\04\04\05-\03\e6p\82\04\03\05\11\03\9a\0f<\06\03\ccn\90\06\03\b4\11 \06\03\ccn\ba\04\01\05\0e\06\03\e1\03\e4\02\01\00\01\01B\01\00\00\04\00<\01\00\00\01\01\01\fb\0e\0d\00\01\01\01\01\00\00\00\01\00\00\01library/compiler-builtins/compiler-builtins/src/int\00library/compiler-builtins/compiler-builtins/src\00library/core/src/num\00library/compiler-builtins/compiler-builtins/src/math/../../../libm/src/math/support\00library/core/src/ops\00\00shift.rs\00\01\00\00macros.rs\00\02\00\00uint_macros.rs\00\03\00\00int_traits.rs\00\04\00\00bit.rs\00\05\00\00\00")
   (@producers
     (language "Rust" "")
-    (processed-by "rustc" "1.94.1 (e408947bf 2026-03-25)")
+    (processed-by "rustc" "1.97.1 (8bab26f4f 2026-07-14)")
   )
   (@custom "target_features" (after data) "\08+\0bbulk-memory+\0fbulk-memory-opt+\16call-indirect-overlong+\0amultivalue+\0fmutable-globals+\13nontrapping-fptoint+\0freference-types+\08sign-ext")
 )

--- a/wado-compiler/lib/core/prelude/primitive.wado
+++ b/wado-compiler/lib/core/prelude/primitive.wado
@@ -1401,7 +1401,10 @@ impl f32 {
         return f32_fmod(x, y);
     }
 
-    /// x * y + z, rounded once instead of twice
+    /// x * y + z, rounded once instead of twice.
+    ///
+    /// Wasm has no scalar FMA instruction, so this runs a software
+    /// implementation — accurate, but slower than `x * y + z`.
     pub fn mul_add(x: f32, y: f32, z: f32) -> f32 {
         return f32_mul_add(x, y, z);
     }
@@ -1771,7 +1774,10 @@ impl f64 {
         return f64_fmod(x, y);
     }
 
-    /// x * y + z, rounded once instead of twice
+    /// x * y + z, rounded once instead of twice.
+    ///
+    /// Wasm has no scalar FMA instruction, so this runs a software
+    /// implementation — accurate, but slower than `x * y + z`.
     pub fn mul_add(x: f64, y: f64, z: f64) -> f64 {
         return f64_mul_add(x, y, z);
     }

--- a/wado-compiler/lib/core/prelude/primitive.wado
+++ b/wado-compiler/lib/core/prelude/primitive.wado
@@ -1401,7 +1401,7 @@ impl f32 {
         return f32_fmod(x, y);
     }
 
-    /// x * y + z, rounded once instead of twice.
+    /// `x * y + z`, rounded once instead of twice.
     ///
     /// Wasm has no scalar FMA instruction, so this is a software
     /// implementation — slower than `x * y + z`.
@@ -1774,7 +1774,7 @@ impl f64 {
         return f64_fmod(x, y);
     }
 
-    /// x * y + z, rounded once instead of twice.
+    /// `x * y + z`, rounded once instead of twice.
     ///
     /// Wasm has no scalar FMA instruction, so this is a software
     /// implementation — slower than `x * y + z`.

--- a/wado-compiler/lib/core/prelude/primitive.wado
+++ b/wado-compiler/lib/core/prelude/primitive.wado
@@ -87,6 +87,7 @@ use {
     libm_cbrt as f64_cbrt,
     libm_hypot as f64_hypot,
     libm_fmod as f64_fmod,
+    libm_fma as f64_mul_add,
     libm_sinf as f32_sin,
     libm_cosf as f32_cos,
     libm_tanf as f32_tan,
@@ -111,6 +112,7 @@ use {
     libm_cbrtf as f32_cbrt,
     libm_hypotf as f32_hypot,
     libm_fmodf as f32_fmod,
+    libm_fmaf as f32_mul_add,
 } from "../libm.wat" with { type: "wat" };
 
 use {
@@ -1399,6 +1401,11 @@ impl f32 {
         return f32_fmod(x, y);
     }
 
+    /// x * y + z, rounded once instead of twice
+    pub fn mul_add(x: f32, y: f32, z: f32) -> f32 {
+        return f32_mul_add(x, y, z);
+    }
+
     pub fn is_nan(&self) -> bool {
         return *self != *self;
     }
@@ -1762,6 +1769,11 @@ impl f64 {
     /// Floating-point remainder of x/y
     pub fn fmod(x: f64, y: f64) -> f64 {
         return f64_fmod(x, y);
+    }
+
+    /// x * y + z, rounded once instead of twice
+    pub fn mul_add(x: f64, y: f64, z: f64) -> f64 {
+        return f64_mul_add(x, y, z);
     }
 
     pub fn is_nan(&self) -> bool {

--- a/wado-compiler/lib/core/prelude/primitive.wado
+++ b/wado-compiler/lib/core/prelude/primitive.wado
@@ -1403,8 +1403,8 @@ impl f32 {
 
     /// x * y + z, rounded once instead of twice.
     ///
-    /// Wasm has no scalar FMA instruction, so this runs a software
-    /// implementation — accurate, but slower than `x * y + z`.
+    /// Wasm has no scalar FMA instruction, so this is a software
+    /// implementation — slower than `x * y + z`.
     pub fn mul_add(x: f32, y: f32, z: f32) -> f32 {
         return f32_mul_add(x, y, z);
     }
@@ -1776,8 +1776,8 @@ impl f64 {
 
     /// x * y + z, rounded once instead of twice.
     ///
-    /// Wasm has no scalar FMA instruction, so this runs a software
-    /// implementation — accurate, but slower than `x * y + z`.
+    /// Wasm has no scalar FMA instruction, so this is a software
+    /// implementation — slower than `x * y + z`.
     pub fn mul_add(x: f64, y: f64, z: f64) -> f64 {
         return f64_mul_add(x, y, z);
     }

--- a/wado-compiler/lib/core/prelude/primitive_test.wado
+++ b/wado-compiler/lib/core/prelude/primitive_test.wado
@@ -249,6 +249,24 @@ test "f64 power functions" {
     assert f64::fmod(7.0, 3.0) == 1.0;
 }
 
+test "f64 mul_add" {
+    assert f64::mul_add(2.0, 3.0, 4.0) == 10.0;
+    assert f64::mul_add(-2.0, 3.0, 4.0) == -2.0;
+    assert f64::mul_add(0.0, 0.0, 1.5) == 1.5;
+
+    // A single rounding of x * y + z, unlike the two roundings of `x * y + z`.
+    assert f64::mul_add(0.1, 0.1, -0.01) == 9.020562075079397e-19;
+    assert 0.1 * 0.1 - 0.01 == 1.734723475976807e-18;
+
+    // The naive form cancels to zero; the fused form keeps the product's tail.
+    let x = 1234567890.123;
+    let y = 1.0000000001;
+    assert f64::mul_add(x, y, -(x * y)) == 8.268968492995062e-8;
+
+    assert f64::mul_add(f64::NAN, 1.0, 1.0).is_nan();
+    assert f64::mul_add(f64::INFINITY, 2.0, 1.0) == f64::INFINITY;
+}
+
 test "f32 wasm instruction math" {
     assert f32::abs(-3.5) == 3.5;
     assert f32::abs(2.0) == 2.0;
@@ -300,6 +318,20 @@ test "f32 power functions" {
     assert f32::cbrt(27.0) == 3.0;
     assert f32::hypot(3.0, 4.0) == 5.0;
     assert f32::fmod(7.0, 3.0) == 1.0;
+}
+
+test "f32 mul_add" {
+    assert f32::mul_add(2.0, 3.0, 4.0) == 10.0;
+    assert f32::mul_add(-2.0, 3.0, 4.0) == -2.0;
+
+    // A single rounding of x * y + z, unlike the two roundings of `x * y + z`.
+    assert f32::mul_add(0.1, 0.1, -0.01) == 5.2154064e-10;
+    let tenth: f32 = 0.1;
+    let hundredth: f32 = 0.01;
+    assert tenth * tenth - hundredth == 9.313226e-10;
+
+    assert f32::mul_add(f32::NAN, 1.0, 1.0).is_nan();
+    assert f32::mul_add(f32::INFINITY, 2.0, 1.0) == f32::INFINITY;
 }
 
 test "f64 constants" {

--- a/wado-compiler/lib/core/prelude/primitive_test.wado
+++ b/wado-compiler/lib/core/prelude/primitive_test.wado
@@ -254,7 +254,7 @@ test "f64 mul_add" {
     assert f64::mul_add(-2.0, 3.0, 4.0) == -2.0;
     assert f64::mul_add(0.0, 0.0, 1.5) == 1.5;
 
-    // A single rounding of x * y + z, unlike the two roundings of `x * y + z`.
+    // One rounding, not two: the naive form lands elsewhere.
     assert f64::mul_add(0.1, 0.1, -0.01) == 9.020562075079397e-19;
     assert 0.1 * 0.1 - 0.01 == 1.734723475976807e-18;
 
@@ -324,7 +324,7 @@ test "f32 mul_add" {
     assert f32::mul_add(2.0, 3.0, 4.0) == 10.0;
     assert f32::mul_add(-2.0, 3.0, 4.0) == -2.0;
 
-    // A single rounding of x * y + z, unlike the two roundings of `x * y + z`.
+    // One rounding, not two: the naive form lands elsewhere.
     assert f32::mul_add(0.1, 0.1, -0.01) == 5.2154064e-10;
     let tenth: f32 = 0.1;
     let hundredth: f32 = 0.01;

--- a/wado-compiler/tests/generated/format.fixtures/mess.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/mess.lower.wado
@@ -3186,6 +3186,10 @@ pub fn libm_expm1(arg0: f64) -> f64;
 
 pub fn libm_expm1f(arg0: f32) -> f32;
 
+pub fn libm_fma(arg0: f64, arg1: f64, arg2: f64) -> f64;
+
+pub fn libm_fmaf(arg0: f32, arg1: f32, arg2: f32) -> f32;
+
 pub fn libm_fmod(arg0: f64, arg1: f64) -> f64;
 
 pub fn libm_fmodf(arg0: f32, arg1: f32) -> f32;
@@ -7775,6 +7779,10 @@ pub fn f32::fmod(x: f32, y: f32) -> f32 {
     return "core:libm.wat::libm_fmodf"(x, y);
 }
 
+pub fn f32::mul_add(x: f32, y: f32, z: f32) -> f32 {
+    return "core:libm.wat::libm_fmaf"(x, y, z);
+}
+
 pub fn f32::is_nan(self: Box<f32>) -> bool {
     return (self.value != self.value);
 }
@@ -8124,6 +8132,10 @@ pub fn f64::hypot(x: f64, y: f64) -> f64 {
 
 pub fn f64::fmod(x: f64, y: f64) -> f64 {
     return "core:libm.wat::libm_fmod"(x, y);
+}
+
+pub fn f64::mul_add(x: f64, y: f64, z: f64) -> f64 {
+    return "core:libm.wat::libm_fma"(x, y, z);
 }
 
 pub fn f64::is_nan(self: Box<f64>) -> bool {

--- a/wado-compiler/tests/generated/format.fixtures/ops.all.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/ops.all.lower.wado
@@ -2781,6 +2781,10 @@ pub fn libm_expm1(arg0: f64) -> f64;
 
 pub fn libm_expm1f(arg0: f32) -> f32;
 
+pub fn libm_fma(arg0: f64, arg1: f64, arg2: f64) -> f64;
+
+pub fn libm_fmaf(arg0: f32, arg1: f32, arg2: f32) -> f32;
+
 pub fn libm_fmod(arg0: f64, arg1: f64) -> f64;
 
 pub fn libm_fmodf(arg0: f32, arg1: f32) -> f32;
@@ -7338,6 +7342,10 @@ pub fn f32::fmod(x: f32, y: f32) -> f32 {
     return "core:libm.wat::libm_fmodf"(x, y);
 }
 
+pub fn f32::mul_add(x: f32, y: f32, z: f32) -> f32 {
+    return "core:libm.wat::libm_fmaf"(x, y, z);
+}
+
 pub fn f32::is_nan(self: Box<f32>) -> bool {
     return (self.value != self.value);
 }
@@ -7687,6 +7695,10 @@ pub fn f64::hypot(x: f64, y: f64) -> f64 {
 
 pub fn f64::fmod(x: f64, y: f64) -> f64 {
     return "core:libm.wat::libm_fmod"(x, y);
+}
+
+pub fn f64::mul_add(x: f64, y: f64, z: f64) -> f64 {
+    return "core:libm.wat::libm_fma"(x, y, z);
 }
 
 pub fn f64::is_nan(self: Box<f64>) -> bool {

--- a/wado-compiler/tests/generated/format.fixtures/ops.mess.lower.wado
+++ b/wado-compiler/tests/generated/format.fixtures/ops.mess.lower.wado
@@ -2781,6 +2781,10 @@ pub fn libm_expm1(arg0: f64) -> f64;
 
 pub fn libm_expm1f(arg0: f32) -> f32;
 
+pub fn libm_fma(arg0: f64, arg1: f64, arg2: f64) -> f64;
+
+pub fn libm_fmaf(arg0: f32, arg1: f32, arg2: f32) -> f32;
+
 pub fn libm_fmod(arg0: f64, arg1: f64) -> f64;
 
 pub fn libm_fmodf(arg0: f32, arg1: f32) -> f32;
@@ -7338,6 +7342,10 @@ pub fn f32::fmod(x: f32, y: f32) -> f32 {
     return "core:libm.wat::libm_fmodf"(x, y);
 }
 
+pub fn f32::mul_add(x: f32, y: f32, z: f32) -> f32 {
+    return "core:libm.wat::libm_fmaf"(x, y, z);
+}
+
 pub fn f32::is_nan(self: Box<f32>) -> bool {
     return (self.value != self.value);
 }
@@ -7687,6 +7695,10 @@ pub fn f64::hypot(x: f64, y: f64) -> f64 {
 
 pub fn f64::fmod(x: f64, y: f64) -> f64 {
     return "core:libm.wat::libm_fmod"(x, y);
+}
+
+pub fn f64::mul_add(x: f64, y: f64, z: f64) -> f64 {
+    return "core:libm.wat::libm_fma"(x, y, z);
 }
 
 pub fn f64::is_nan(self: Box<f64>) -> bool {


### PR DESCRIPTION
`f32::mul_add(x, y, z)` and `f64::mul_add(x, y, z)` compute `x * y + z` with a
single rounding, matching Rust's naming for the operation.

Core Wasm has no scalar FMA instruction, so both bind libm's software
implementation through the bundled `core:libm.wat` asset, alongside the other
deterministic math functions. The result is correctly rounded and identical
across hosts, unlike the relaxed-SIMD `f32x4`/`f64x2.relaxed_madd`, whose
precision is implementation-defined. The doc comment says so at the call site,
since the accuracy costs a call into software arithmetic rather than a single
instruction.

The tests pin the property that distinguishes the operation from a naive
`x * y + z`: `f64::mul_add(0.1, 0.1, -0.01)` is `9.020562075079397e-19` while
`0.1 * 0.1 - 0.01` is `1.734723475976807e-18`, and a cancellation case where
the naive form collapses to `0.0` keeps the product's tail.

`mise run update-bundled` writes the regenerated wat to
`wado-compiler/lib/core/libm.wat`, the path the compiler embeds, and passes
`CARGO_PROFILE_RELEASE_STRIP=none` so the module keeps its name section. Running
the task reproduces the checked-in file byte for byte.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2Dw2vBjeDEm2zdoyGBNSu)_