### PR TITLE
chore(ci): skip Tidy on tagpr release branches

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -35,12 +35,19 @@ jobs:
 
       # Skip the heavy steps when the latest commit is tidy's own output, so we
       # don't re-tidy idempotent output or spin up a push loop.
-      - name: Precheck — short-circuit on a tidy bot commit
+      #
+      # Skip tagpr release branches too: tagpr replays every non-tagpr commit
+      # onto the branch it recreates, so a pushed `chore: tidy` never leaves it.
+      - name: Precheck — short-circuit on a tidy bot commit or a tagpr branch
         id: precheck
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           msg=$(git log -1 --pretty=%s)
           email=$(git log -1 --pretty=%ae)
           if [ "$msg" = "chore: tidy" ] && [[ "$email" == *"[bot]"* ]]; then
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$HEAD_REF" == tagpr-from-* ]]; then
             echo "should-run=false" >> "$GITHUB_OUTPUT"
           else
             echo "should-run=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The Tidy workflow short-circuits on `tagpr-from-*` head branches, alongside its existing short-circuit on tidy's own bot commits.

tagpr recreates its release branch on top of main on every push and replays every non-tagpr commit onto it unconditionally, keeping the replay even when the resulting tree is unchanged. A `chore: tidy` commit pushed onto that branch therefore survives every recreation, and turns into an empty commit once its content reaches main. Release PR #1677 carries five such commits.

The release commits touch only the version files and CHANGELOG, so there is nothing on that branch for Tidy to regenerate that main has not already tidied.

The branch name reaches the script through `env` rather than a `${{ }}` expansion in `run:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)