### PR TITLE
docs: reorganize AGENTS.md around a wado-cli skill, and fix `wado lsp --help`

### DIFF
--- a/.claude/skills/wado-cli/SKILL.md
+++ b/.claude/skills/wado-cli/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: wado-cli
-description: How to drive the `wado` command — the subcommand list, and the behaviour its `--help` does not state (directory grants, reading a test run, symbol notation, inspecting invalid Wasm). Read before invoking the `wado` binary.
+description: How to drive the `wado` command — compile, run, test, serve, format, and publish a Wado program, target a Wasm world, pick an allocator, grant directories, and inspect the compiler with dump and query. Read before invoking the `wado` binary.
 ---
 
 # The `wado` CLI
 
-`wado <command> --help` is the source of truth for flags, and it is thorough —
-it states the allocator modes and their defaults per world, the optimization
-levels, every `dump` phase, every `query` kind, and how `publish` authenticates.
-Run it rather than guessing. This file carries the command list and the things
-that help text does not say.
+`wado <command> --help` is the source of truth for flags and is thorough — it
+states the allocator modes and their per-world defaults, the optimization
+levels, every `dump` phase, and every `query` kind. Run it rather than guessing.
 
 Inside the wado repository, `wado` means `cargo run --bin wado --`.
 
@@ -46,54 +44,174 @@ Global options:
 `build` works from a `wado.toml` and writes `build/<world>.wasm`; `compile`,
 `run`, `serve`, and `dump` take a single source file.
 
-## What `--help` does not say
+## Target World
 
-### Directory grants
+A Wado program targets a Wasm _world_: the CLI command (`wasi:cli/command`, the
+default), the HTTP service (`wasi:http/service`, run via `wado serve`), or the
+synthetic test world (selected with `--world test`, used by E2E tests). Several
+defaults — including the allocator — depend on the target world.
 
-A program reaches only the directories granted to it — the current one by
-default, or exactly the `--dir` grants once any is given. Paths open relative to
-a grant, so **an absolute path never opens**. Reach a file outside the tree by
-granting its directory and naming the file relative to that:
+`--world <name>` overrides it. `--world test` exports the entry module's `test`
+blocks and drops everything else. `compile` and `check` accept it; `serve` and
+`test` pick their world automatically.
+
+```sh
+wado compile --world test file.wado  # compile against the test world
+wado check --world test file.wado    # type-check against the test world
+```
+
+## Allocators
+
+Three allocators are available via `--allocator <mode>`:
+
+- `bump` (default for CLI): bump pointer; never frees. Fast, minimal code.
+- `freelist` (default for the HTTP world): reclaims freed memory via a free list. For long-running processes.
+- `debug` (default for the test world): never reuses freed memory; poisons freed memory with `0xFF`. For use-after-free detection.
+
+```sh
+wado compile --allocator bump file.wado      # bump allocator
+wado compile --allocator freelist file.wado  # free-list allocator
+wado compile --allocator debug file.wado     # debug allocator
+```
+
+`wado compile` selects the `debug` allocator automatically when targeting the
+test world; E2E tests rely on this.
+
+## Compile
+
+```sh
+wado compile -o file.wasm file.wado    # generate Wasm
+wado compile -o file.wat file.wado     # generate WAT
+wado compile --wat-to-stdout file.wado # output WAT to stdout
+```
+
+Optimization levels: `-O0` (none), `-O1` (development), `-O2` (production,
+default), `-O3` (aggressive), `-Os` (`-O2` + strip symbols).
+
+To inspect invalid Wasm when debugging codegen bugs, skip validation:
+
+```sh
+# Output raw Wasm bytes even if invalid
+wado compile --no-validate --wat-to-stdout file.wado
+```
+
+`wado check` verifies a source file — and re-runs its Kiln generators, comparing
+the output against the committed source — without emitting Wasm.
+
+## Run
+
+```sh
+wado run file.wado  # run a CLI program with wasmtime
+```
+
+A program reaches only the directories granted to it: the current one, or
+exactly the `--dir` grants once any is given. Paths open relative to a grant, so
+an absolute path never opens — reach a file outside the tree by granting its
+directory and naming it relative to that.
 
 ```sh
 wado run --dir /tmp/scratch prog.wado Foo.g4  # Foo.g4 resolves inside /tmp/scratch
 ```
 
-### Reading a test run
+## Test
 
-A failure or a resolved `#[TODO]` prints its own one-line notice immediately.
-Otherwise `wado test` prints a digest every 5s —
-`N/Total files · tests, failed, todo, skip · ETA` — and ends with a
-`compile:`/`load:`/`skip:`/`test:` summary. Reading the last line or two is
-enough to know where a long run stands.
-
-### Inspecting invalid Wasm
-
-When codegen emits a module the validator rejects, combine the two flags to see
-the WAT anyway:
+`wado test` discovers and runs `test` blocks (compiled against the `test` world,
+see Target World above).
 
 ```sh
-wado compile --no-validate --wat-to-stdout file.wado
+wado test                           # discover and run every .wado test in the project
+wado test file.wado                 # run tests in one file
+wado test --filter '**/json*.wado'  # run tests in files matching a wildcard
 ```
 
-### Symbol notation
+A failure or resolved `#[TODO]` prints its own one-line notice immediately,
+otherwise a digest (`N/Total files · tests, failed, todo, skip · ETA`) prints
+every 5s, ending in a `compile:`/`load:`/`skip:`/`test:` summary. `tail`ing the
+last line or two is enough to read the current state of a long run.
 
-`--symbol` takes `MODULE#SYMBOL`, which `--help` only illustrates:
+## Serve
 
-- `MODULE` is the import specifier, quoted as in `use` — droppable for a scheme or bare name (`core:json`), required for a path or URL (`"./utils.wado"`).
-- `SYMBOL` uses Wado's own operators: bare `name` (free function/type/global), `Type::name` (associated const/fn), `Type.name` (method), `Type^Trait::name` (trait-impl member).
+Use `wado serve` to run a Wado HTTP service (wasi:http/service world):
 
 ```sh
-wado query hover --symbol core:json#from_string
+wado serve file.wado                        # serve on 0.0.0.0:8080 (default)
+wado serve --addr 127.0.0.1:3000 file.wado  # serve on a custom address
+```
+
+## Dump
+
+Use `wado dump` to inspect compiler internal state for debugging.
+See `wado dump --help` for the full help.
+
+```sh
+wado dump file.wado                  # show final WIR (default)
+wado dump --nir file.wado            # show final NIR (after optimization)
+wado dump --nir -O0 file.wado        # show NIR without optimization
+wado dump --ast file.wado            # show parsed AST
+wado dump --modules file.wado        # show loaded modules
+wado dump --symbols file.wado        # show symbol table
+wado dump --types file.wado          # show type table
+wado dump --tir-resolved file.wado       # show TIR after type resolution
+wado dump --tir-monomorphized file.wado  # show TIR after monomorphization
+wado dump --nir-lowered file.wado        # show NIR right after lowering (before optimize)
+```
+
+## Query
+
+`wado query` answers compiler questions about a symbol, for tooling and docs. A
+symbol is addressed either by position (`--line`/`--column` in a file) or by
+_symbol notation_ `MODULE#SYMBOL`:
+
+- `MODULE` is the import specifier; quote it as in `use` — droppable for a scheme or bare name (`core:json`), required for a path or URL (`"./utils.wado"`).
+- `SYMBOL` uses Wado's operators: bare `name` (free function/type/global), `Type::name` (associated const/fn), `Type.name` (method), `Type^Trait::name` (trait-impl member).
+
+```sh
+wado query hover --symbol core:json#from_string                   # signature / type
+wado query hover --symbol ./hello.wado#run --base example          # local module
 wado query definition --symbol core:cbor#CborDeserializer.peek_byte
-wado query references --symbol core:cli#println --base example
+wado query references --symbol core:cli#println --base example     # all uses (workspace)
+wado query hover --line 5 --column 10 file.wado                   # position-based
+wado query diagnostics file.wado                                  # errors/warnings
 ```
 
-`references` loads every `.wado` under `--base`, so it spans the workspace
-rather than one file. For a type, `hover` also lists its `impl` blocks. The
-notation spec is `docs/wep-2026-06-14-symbol-notation.md`.
+Common options:
 
-### Formatting in this repository
+- `--symbol <notation>` — locate by name instead of `--line`/`--column`.
+- `--base <dir>` — anchor relative modules (default: cwd; `core:` / `wasi:` are location-independent).
+- `--all` — include private members; the default is the public-API view (matches `wado doc`).
+- `--json` — machine-readable output.
 
-`mise run format-wado` formats every fixture the compiler tests use — including
-uncommitted ones, which it may not leave intact.
+For a type, `hover` also lists its `impl` blocks. `references` loads every
+`.wado` under `--base`, so it spans the workspace. See
+`docs/wep-2026-06-14-symbol-notation.md` for the notation spec.
+
+## Format
+
+The `wado format` command formats Wado source code.
+
+```sh
+wado format -w file.wado  # rewrite in place
+```
+
+In the wado repository, `mise run format-wado` formats all the fixtures used by
+compiler tests.
+
+**Caution:** `mise run format-wado` may break uncommitted test fixtures. When the
+syntax is updated, make sure to add tests to `wado-compiler/tests/format.rs`.
+
+## Publish
+
+`wado publish` builds the package and uploads it through `wkg`. Credentials
+belong to `wkg`, not Wado — authenticate to the registry first (`docker login`,
+or `WKG_OCI_USERNAME` / `WKG_OCI_PASSWORD`; for GHCR the password is a token with
+the `write:packages` scope). `--dry-run` runs every readiness check without
+uploading.
+
+## Compilation Log and Timing
+
+The compiler emits timestamped diagnostics to stderr. Use `--log-level` to
+control verbosity.
+
+```sh
+wado compile --log-level debug file.wado
+```

--- a/.claude/skills/wado-cli/SKILL.md
+++ b/.claude/skills/wado-cli/SKILL.md
@@ -25,7 +25,7 @@ Commands:
   clean [options]                     Evict derived cache state (git worktrees)
   build [options]                     Build the project's worlds from wado.toml
   compile [options] <file.wado>       Compile a single Wado source file
-  check [options] [file.wado]         Verify Kiln generators match committed source (CI)
+  check [options] [file.wado]         Verify a source file and its Kiln generators
   run [options] [file.wado]           Compile and run a Wado CLI program
   serve [options] [file.wado]         Compile and serve a Wado HTTP service
   test [options] [files or dirs...]   Run tests in Wado source files

--- a/.claude/skills/wado-cli/SKILL.md
+++ b/.claude/skills/wado-cli/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: wado-cli
+description: How to drive the `wado` command — the subcommand list, and the behaviour its `--help` does not state (directory grants, reading a test run, symbol notation, inspecting invalid Wasm). Read before invoking the `wado` binary.
+---
+
+# The `wado` CLI
+
+`wado <command> --help` is the source of truth for flags, and it is thorough —
+it states the allocator modes and their defaults per world, the optimization
+levels, every `dump` phase, every `query` kind, and how `publish` authenticates.
+Run it rather than guessing. This file carries the command list and the things
+that help text does not say.
+
+Inside the wado repository, `wado` means `cargo run --bin wado --`.
+
+## Commands
+
+```
+Usage: wado <command> [options]
+
+Commands:
+  init [options]                      Create a new wado.toml manifest
+  update [options]                    Resolve dependencies and write wado.lock
+  fetch [options]                     Download the project's registry dependencies
+  clean [options]                     Evict derived cache state (git worktrees)
+  build [options]                     Build the project's worlds from wado.toml
+  compile [options] <file.wado>       Compile a single Wado source file
+  check [options] [file.wado]         Verify Kiln generators match committed source (CI)
+  run [options] [file.wado]           Compile and run a Wado CLI program
+  serve [options] [file.wado]         Compile and serve a Wado HTTP service
+  test [options] [files or dirs...]   Run tests in Wado source files
+  format [options] <file.wado>...     Format a Wado source file
+  doc [options] <file.wado>...        Generate documentation from source files
+  dump [options] <file.wado>...       Dump compiler internal state
+  wit [options] [file.wado | dir]     Emit the WIT contract for a Wado program
+  syntax [options]                    Generate syntax definition files
+  lsp [options]                       Start the language server (LSP over stdio)
+  query <kind> [options] <file.wado>  Query language service information
+  publish [options]                   Check whether the package can be published
+
+Global options:
+  --help     Show this help message
+  --version  Show version information
+```
+
+`build` works from a `wado.toml` and writes `build/<world>.wasm`; `compile`,
+`run`, `serve`, and `dump` take a single source file.
+
+## What `--help` does not say
+
+### Directory grants
+
+A program reaches only the directories granted to it — the current one by
+default, or exactly the `--dir` grants once any is given. Paths open relative to
+a grant, so **an absolute path never opens**. Reach a file outside the tree by
+granting its directory and naming the file relative to that:
+
+```sh
+wado run --dir /tmp/scratch prog.wado Foo.g4  # Foo.g4 resolves inside /tmp/scratch
+```
+
+### Reading a test run
+
+A failure or a resolved `#[TODO]` prints its own one-line notice immediately.
+Otherwise `wado test` prints a digest every 5s —
+`N/Total files · tests, failed, todo, skip · ETA` — and ends with a
+`compile:`/`load:`/`skip:`/`test:` summary. Reading the last line or two is
+enough to know where a long run stands.
+
+### Inspecting invalid Wasm
+
+When codegen emits a module the validator rejects, combine the two flags to see
+the WAT anyway:
+
+```sh
+wado compile --no-validate --wat-to-stdout file.wado
+```
+
+### Symbol notation
+
+`--symbol` takes `MODULE#SYMBOL`, which `--help` only illustrates:
+
+- `MODULE` is the import specifier, quoted as in `use` — droppable for a scheme or bare name (`core:json`), required for a path or URL (`"./utils.wado"`).
+- `SYMBOL` uses Wado's own operators: bare `name` (free function/type/global), `Type::name` (associated const/fn), `Type.name` (method), `Type^Trait::name` (trait-impl member).
+
+```sh
+wado query hover --symbol core:json#from_string
+wado query definition --symbol core:cbor#CborDeserializer.peek_byte
+wado query references --symbol core:cli#println --base example
+```
+
+`references` loads every `.wado` under `--base`, so it spans the workspace
+rather than one file. For a type, `hover` also lists its `impl` blocks. The
+notation spec is `docs/wep-2026-06-14-symbol-notation.md`.
+
+### Formatting in this repository
+
+`mise run format-wado` formats every fixture the compiler tests use — including
+uncommitted ones, which it may not leave intact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,198 +102,43 @@ Wado-specific features:
 - `assert` statements with power-assert-like diagnostics. Assertions cannot be disabled, so they are always reliable.
 - Literal spread `..base`: JS-leaning (anonymous composition, key-value merge, last-wins); a named struct allows only a single leading `..base`.
 
-## The Compiler
+## Repository Map
 
-The compiler is implemented in `wado-compiler/`.
-
-See also:
-
-- `docs/compiler.md` for the compiler internals.
-- `docs/optimizer.md` for the optimization passes.
-
-### Bundled Library
-
-The compiler bundles Wasm modules for language features:
-
-- `wado-bundled-libm/` — deterministic math functions using the `libm` crate.
+- `wado-compiler/` — the compiler: frontend, IR pipeline, optimizer, codegen. The Wado standard library (`core:*`, `wasi:*`) lives in `wado-compiler/lib/`. Internals: `docs/compiler.md`, `docs/optimizer.md`.
+- `wado-cli/` — the `wado` binary (see below).
+- `wado-lsp/` — the language service engine, also compiled to Wasm for the browser.
+- `wado-vscode/` — the VS Code extension.
+- `wado-from-idl/` — generates the `wasi:*` and `core:kiln` stdlib modules from WIT.
+- `wado-manifest/` — `wado.toml` / `wado.lock` parsing, validation, and dependency resolution.
+- `wado-bundled-libm/` — deterministic math, bundled into the compiler as a Wasm module. (`wado-bundled-icu/` is a not-yet-wired spike.)
+- `docs/` — the language spec (`docs/spec.md`), stdlib docs, and the Wado Evolution Proposals (`docs/wep-*.md`) recording significant language and architecture decisions.
+- `benchmark/`, `wasm-size/` — performance and code-size measurement.
+- `package-*/` — packages written in Wado; `package-gale/` is the ANTLR4 port.
+- `vendor/` — reference specs and runtimes, as git submodules (see References).
 
 ## The CLI
 
-The CLI is implemented in `wado-cli/` as a subcommand-style CLI. The sections below describe each subcommand.
+The `wado` binary is implemented in `wado-cli/`. Below, `wado` is shorthand for `cargo run --bin wado --`. `wado --help` lists every subcommand and `wado <command> --help` its flags.
 
-In the examples below, `wado` is shorthand for `cargo run --bin wado --`.
+The ones you reach for while developing the toolchain:
 
-A Wado program targets a Wasm _world_: the CLI command (`wasi:cli/command`, the default), the HTTP service (`wasi:http/service`, run via `wado serve`), or the synthetic test world (selected with `--world test`, used by E2E tests). Several defaults — including the allocator — depend on the target world.
+- `compile` — compile one source file to Wasm or WAT. `-O0` (none) … `-O3` (aggressive), `-Os` (`-O2` + strip symbols); default `-O2`.
+- `check` — verify a source file (and its Kiln generators) without emitting Wasm.
+- `run` — compile and run a CLI program with wasmtime.
+- `test` — run the `test` blocks in Wado source files.
+- `serve` — compile and serve an HTTP service.
+- `dump` — dump compiler internal state at every stage: AST, modules, symbols, types, TIR, NIR, WIR.
+- `query` — ask the language service for hover / definition / references / diagnostics, by position or by `MODULE#SYMBOL` notation.
+- `format` — format Wado source code.
 
-### Compile Command
+The rest (`init`, `update`, `fetch`, `build`, `publish`, `doc`, `wit`, `syntax`, `lsp`, `clean`) serve packaging, registry, and editor integration.
 
-```sh
-wado compile -o file.wasm file.wado    # generate Wasm
-wado compile -o file.wat file.wado     # generate WAT
-wado compile --wat-to-stdout file.wado # output WAT to stdout
-```
+Behaviour that no `--help` will remind you of:
 
-To inspect invalid Wasm when debugging codegen bugs, use `--no-validate`:
-
-```sh
-# Skip validation and output raw Wasm bytes even if invalid
-wado compile --no-validate --wat-to-stdout file.wado
-```
-
-Optimization levels: `-O0` (none), `-O1` (development), `-O2` (production, default), `-O3` (aggressive), `-Os` (`-O2` + strip symbols).
-
-#### Target World
-
-`--world <name>` overrides the target world (default: `wasi:cli/command`). `--world test` selects the test world, exporting the entry module's `test` blocks and dropping everything else. `compile` and `check` accept it; `serve` and `test` pick their world automatically.
-
-```sh
-wado compile --world test file.wado  # compile against the test world
-wado check --world test file.wado    # type-check against the test world
-```
-
-#### Allocators
-
-Three allocators are available via `--allocator <mode>`:
-
-- `bump` (default for CLI): Bump pointer; never frees. Fast, minimal code.
-- `freelist` (default for HTTP world): Reclaims freed memory via a free list. For long-running processes.
-- `debug` (default for test world): Never reuses freed memory; poisons freed memory with `0xFF`. For use-after-free detection.
-
-```sh
-wado compile --allocator bump file.wado      # bump allocator
-wado compile --allocator freelist file.wado  # free-list allocator
-wado compile --allocator debug file.wado     # debug allocator
-```
-
-`wado compile` selects the `debug` allocator automatically when targeting the test world; E2E tests rely on this.
-
-### Run Command
-
-```sh
-wado run file.wado  # run a CLI program with wasmtime
-```
-
-A program reaches only the directories granted to it: the current one, or exactly the `--dir` grants once any is given. Paths open relative to a grant, so an absolute path never opens — reach a file outside the tree by granting its directory and naming it relative to that.
-
-```sh
-wado run --dir /tmp/scratch prog.wado Foo.g4  # Foo.g4 resolves inside /tmp/scratch
-```
-
-### Test Command
-
-`wado test` discovers and runs `test` blocks (compiled against the `test` world, see Target World above).
-
-```sh
-wado test                    # discover and run every .wado test in the project
-wado test file.wado          # run tests in one file
-wado test --filter '**/json*.wado'  # run tests in files matching a wildcard
-```
-
-A failure or resolved `#[TODO]` prints its own one-line notice immediately, otherwise a digest (`N/Total files · tests, failed, todo, skip · ETA`) prints every 5s, ending in a `compile:`/`load:`/`skip:`/`test:` summary. `tail`ing the last line or two is enough to read the current state of a long run.
-
-### Serve Command
-
-Use `wado serve` to run a Wado HTTP service (wasi:http/service world):
-
-```sh
-wado serve file.wado                        # serve on 0.0.0.0:8080 (default)
-wado serve --addr 127.0.0.1:3000 file.wado  # serve on a custom address
-```
-
-### Dump Command
-
-Use `wado dump` to inspect compiler internal state for debugging.
-See `wado dump --help` for the full help.
-
-```sh
-wado dump file.wado                  # show final WIR (default)
-wado dump --nir file.wado            # show final NIR (after optimization)
-wado dump --nir -O0 file.wado        # show NIR without optimization
-wado dump --ast file.wado            # show parsed AST
-wado dump --modules file.wado        # show loaded modules
-wado dump --symbols file.wado        # show symbol table
-wado dump --types file.wado          # show type table
-wado dump --tir-resolved file.wado       # show TIR after type resolution
-wado dump --tir-monomorphized file.wado  # show TIR after monomorphization
-wado dump --nir-lowered file.wado        # show NIR right after lowering (before optimize)
-```
-
-### Query Command
-
-`wado query` answers compiler questions about a symbol, for tooling and docs. A symbol is addressed either by position (`--line`/`--column` in a file) or by _symbol notation_ `MODULE#SYMBOL`:
-
-- `MODULE` is the import specifier; quote it as in `use` — droppable for a scheme or bare name (`core:json`), required for a path or URL (`"./utils.wado"`).
-- `SYMBOL` uses Wado's operators: bare `name` (free function/type/global), `Type::name` (associated const/fn), `Type.name` (method), `Type^Trait::name` (trait-impl member).
-
-```sh
-wado query hover --symbol core:json#from_string                   # signature / type
-wado query hover --symbol ./hello.wado#run --base example          # local module
-wado query definition --symbol core:cbor#CborDeserializer.peek_byte
-wado query references --symbol core:cli#println --base example     # all uses (workspace)
-wado query hover --line 5 --column 10 file.wado                   # position-based
-wado query diagnostics file.wado                                  # errors/warnings
-```
-
-Common options:
-
-- `--symbol <notation>` — locate by name instead of `--line`/`--column`.
-- `--base <dir>` — anchor relative modules (default: cwd; `core:` / `wasi:` are location-independent).
-- `--all` — include private members; the default is the public-API view (matches `wado doc`).
-- `--json` — machine-readable output.
-
-For a type, `hover` also lists its `impl` blocks. `references` loads every `.wado` under `--base`, so it spans the workspace. See `docs/wep-2026-06-14-symbol-notation.md` for the notation spec.
-
-### The Formatter
-
-The `wado format` command formats Wado source code.
-
-`mise run format-wado` formats all the fixtures used by compiler tests.
-
-**Caution:** `mise run format-wado` may break uncommitted test fixtures. When the syntax is updated, make sure to add tests to `wado-compiler/tests/format.rs`.
-
-### Compilation Log and Timing
-
-The compiler emits timestamped diagnostics to stderr. Use `--log-level` to control verbosity.
-
-```sh
-wado compile --log-level debug file.wado
-```
-
-## The Standard Library
-
-`wasi:*` modules are part of the Wado standard library.
-
-These modules are generated from WIT files by the `wado-from-idl` tool. To update any `wasi/*.wado` file, edit `wado-from-idl` and run:
-
-```sh
-mise run update-stdlib-wasi
-```
-
-This requires the `vendor/wasmtime` git submodule to be initialized.
-
-## Package Manifest
-
-`wado-manifest/` handles `wado.toml` parsing, validation, and `wado.lock` lock file management.
-
-This crate must compile for `wasm32-unknown-unknown`. CI enforces this.
-
-## Language Server Protocol
-
-The LSP engine is implemented in `wado-lsp/`.
-
-## VS Code Extension
-
-The VS Code extension is implemented in `wado-vscode/`.
-
-The syntax files are generated from `wado-compiler/src/syntax.rs` by:
-
-```sh
-mise run update-wado-vscode-grammar
-```
-
-Whenever the syntax changes, regenerate the grammar and update the formatter fixtures in `wado-compiler/tests/format.fixtures/`.
-
-See `wado-vscode/README.md` for more details.
+- A program targets a Wasm _world_: `wasi:cli/command` (default), `wasi:http/service`, or the synthetic `test` world. `--world test` exports the entry module's `test` blocks and drops everything else; `serve` and `test` pick their world automatically.
+- The world selects the allocator: `bump` for CLI (never frees), `freelist` for HTTP (long-running), `debug` for the test world (never reuses freed memory, poisons it with `0xFF`). E2E tests rely on the test world picking `debug`.
+- `wado run` reaches only the directories granted to it: the current one, or exactly the `--dir` grants once any is given. Paths open relative to a grant, so an absolute path never opens.
+- `mise run format-wado` formats every compiler test fixture and may break uncommitted ones. When the syntax changes, add tests to `wado-compiler/tests/format.rs`.
 
 ## Dependencies
 
@@ -329,7 +174,3 @@ To initialize:
 ```sh
 git submodule update --init --recommend-shallow
 ```
-
-### Wado Evolution Proposals (WEP)
-
-Wado uses Wado Evolution Proposals (WEPs) to document significant language features and architecture decisions. See `docs/` for existing WEPs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Wado-specific features:
 
 ## The CLI
 
-The `wado` binary is implemented in `wado-cli/`. Below, `wado` is shorthand for `cargo run --bin wado --`. `wado --help` lists every subcommand and `wado <command> --help` its flags.
+The `wado` binary is implemented in `wado-cli/`. Below, `wado` is shorthand for `cargo run --bin wado --`. `wado --help` lists every subcommand and `wado <command> --help` its flags; the `wado-cli` skill covers the workflows.
 
 The ones you reach for while developing the toolchain:
 

--- a/wado-cli/AGENTS.md
+++ b/wado-cli/AGENTS.md
@@ -1,163 +1,35 @@
 # wado-cli
 
-The `wado` binary: a subcommand-style CLI over `wado-compiler` and `wado-lsp`.
+The `wado` binary. It drives `wado-compiler` and `wado-lsp`, hosts the wasmtime
+runtime for `run` / `serve` / `test`, and owns the Kiln and dependency backends.
 
-In the examples below, `wado` is shorthand for `cargo run --bin wado --`.
-`wado --help` lists every subcommand; the sections below cover the ones with
-workflows worth writing down.
+How to _use_ the CLI is the `wado-cli` skill, not this file.
 
-## Target World
+## Rules
 
-A Wado program targets a Wasm _world_: the CLI command (`wasi:cli/command`, the
-default), the HTTP service (`wasi:http/service`, run via `wado serve`), or the
-synthetic test world (selected with `--world test`, used by E2E tests). Several
-defaults — including the allocator — depend on the target world.
+- Argument parsing is hand-rolled on `lexopt`. Do not introduce clap or another
+  parser framework. Each subcommand parses its own options and owns its usage
+  and help text in its own module.
+- `process::exit` belongs to `main()` alone. A subcommand returns `CliExit`
+  (`args.rs`) from both its parse and its run, so there is exactly one exit
+  path. Use `CliExit::silent_failure` when the subcommand has already printed
+  its own diagnostics.
+- Adding a subcommand means adding a `Cmd` variant in `main.rs` — it must appear
+  in `ALL` and gain a `name`, `args`, and `desc` arm — plus its module.
+- The binary sets mimalloc as the global allocator: `wado serve` is
+  allocation-heavy per request and the system allocator contends across threads.
 
-`--world <name>` overrides it. `--world test` exports the entry module's `test`
-blocks and drops everything else. `compile` and `check` accept it; `serve` and
-`test` pick their world automatically.
+## Module Map
 
-```sh
-wado compile --world test file.wado  # compile against the test world
-wado check --world test file.wado    # type-check against the test world
-```
+- `compile.rs`, `check.rs`, `run.rs`, `serve.rs`, `test.rs`, `format.rs`, `doc.rs`, `dump.rs`, `wit.rs`, `query.rs` — one subcommand each.
+- `runtime.rs`, `http_hooks.rs`, `timezone_host.rs`, `tls_trust.rs` — the wasmtime host: instantiation, WASI wiring, and the hooks `serve` needs.
+- `kiln_driver.rs`, `kiln_provider.rs`, `kiln_runtime.rs`, `kiln_wit.rs`, `kiln_metadata.rs` — Kiln generators. `check` re-runs them and byte-compares against the committed source.
+- `manifest.rs`, `build.rs`, `build_dep.rs`, `dep_component.rs`, `fetch.rs`, `git.rs`, `oci.rs`, `registry.rs`, `publish.rs` — `wado.toml` handling and the dependency backends behind `wado-manifest`'s `DependencyProvider` seam.
+- `query_adapter.rs`, `lsp.rs` — bridge to `wado-lsp`, for the `query` subcommand and the stdio server.
+- `discover.rs`, `test_report.rs` — test file discovery and the progress digest.
 
-## Allocators
+## Tests
 
-Three allocators are available via `--allocator <mode>`:
-
-- `bump` (default for CLI): Bump pointer; never frees. Fast, minimal code.
-- `freelist` (default for HTTP world): Reclaims freed memory via a free list. For long-running processes.
-- `debug` (default for test world): Never reuses freed memory; poisons freed memory with `0xFF`. For use-after-free detection.
-
-```sh
-wado compile --allocator bump file.wado      # bump allocator
-wado compile --allocator freelist file.wado  # free-list allocator
-wado compile --allocator debug file.wado     # debug allocator
-```
-
-`wado compile` selects the `debug` allocator automatically when targeting the
-test world; E2E tests rely on this.
-
-## Compile Command
-
-```sh
-wado compile -o file.wasm file.wado    # generate Wasm
-wado compile -o file.wat file.wado     # generate WAT
-wado compile --wat-to-stdout file.wado # output WAT to stdout
-```
-
-To inspect invalid Wasm when debugging codegen bugs, use `--no-validate`:
-
-```sh
-# Skip validation and output raw Wasm bytes even if invalid
-wado compile --no-validate --wat-to-stdout file.wado
-```
-
-Optimization levels: `-O0` (none), `-O1` (development), `-O2` (production,
-default), `-O3` (aggressive), `-Os` (`-O2` + strip symbols).
-
-## Run Command
-
-```sh
-wado run file.wado  # run a CLI program with wasmtime
-```
-
-A program reaches only the directories granted to it: the current one, or
-exactly the `--dir` grants once any is given. Paths open relative to a grant, so
-an absolute path never opens — reach a file outside the tree by granting its
-directory and naming it relative to that.
-
-```sh
-wado run --dir /tmp/scratch prog.wado Foo.g4  # Foo.g4 resolves inside /tmp/scratch
-```
-
-## Test Command
-
-`wado test` discovers and runs `test` blocks (compiled against the `test` world,
-see Target World above).
-
-```sh
-wado test                    # discover and run every .wado test in the project
-wado test file.wado          # run tests in one file
-wado test --filter '**/json*.wado'  # run tests in files matching a wildcard
-```
-
-A failure or resolved `#[TODO]` prints its own one-line notice immediately,
-otherwise a digest (`N/Total files · tests, failed, todo, skip · ETA`) prints
-every 5s, ending in a `compile:`/`load:`/`skip:`/`test:` summary. `tail`ing the
-last line or two is enough to read the current state of a long run.
-
-## Serve Command
-
-Use `wado serve` to run a Wado HTTP service (wasi:http/service world):
-
-```sh
-wado serve file.wado                        # serve on 0.0.0.0:8080 (default)
-wado serve --addr 127.0.0.1:3000 file.wado  # serve on a custom address
-```
-
-## Dump Command
-
-Use `wado dump` to inspect compiler internal state for debugging.
-See `wado dump --help` for the full help.
-
-```sh
-wado dump file.wado                  # show final WIR (default)
-wado dump --nir file.wado            # show final NIR (after optimization)
-wado dump --nir -O0 file.wado        # show NIR without optimization
-wado dump --ast file.wado            # show parsed AST
-wado dump --modules file.wado        # show loaded modules
-wado dump --symbols file.wado        # show symbol table
-wado dump --types file.wado          # show type table
-wado dump --tir-resolved file.wado       # show TIR after type resolution
-wado dump --tir-monomorphized file.wado  # show TIR after monomorphization
-wado dump --nir-lowered file.wado        # show NIR right after lowering (before optimize)
-```
-
-## Query Command
-
-`wado query` answers compiler questions about a symbol, for tooling and docs. A
-symbol is addressed either by position (`--line`/`--column` in a file) or by
-_symbol notation_ `MODULE#SYMBOL`:
-
-- `MODULE` is the import specifier; quote it as in `use` — droppable for a scheme or bare name (`core:json`), required for a path or URL (`"./utils.wado"`).
-- `SYMBOL` uses Wado's operators: bare `name` (free function/type/global), `Type::name` (associated const/fn), `Type.name` (method), `Type^Trait::name` (trait-impl member).
-
-```sh
-wado query hover --symbol core:json#from_string                   # signature / type
-wado query hover --symbol ./hello.wado#run --base example          # local module
-wado query definition --symbol core:cbor#CborDeserializer.peek_byte
-wado query references --symbol core:cli#println --base example     # all uses (workspace)
-wado query hover --line 5 --column 10 file.wado                   # position-based
-wado query diagnostics file.wado                                  # errors/warnings
-```
-
-Common options:
-
-- `--symbol <notation>` — locate by name instead of `--line`/`--column`.
-- `--base <dir>` — anchor relative modules (default: cwd; `core:` / `wasi:` are location-independent).
-- `--all` — include private members; the default is the public-API view (matches `wado doc`).
-- `--json` — machine-readable output.
-
-For a type, `hover` also lists its `impl` blocks. `references` loads every
-`.wado` under `--base`, so it spans the workspace. See
-`docs/wep-2026-06-14-symbol-notation.md` for the notation spec.
-
-## Format Command
-
-The `wado format` command formats Wado source code.
-
-`mise run format-wado` formats all the fixtures used by compiler tests.
-
-**Caution:** `mise run format-wado` may break uncommitted test fixtures. When the
-syntax is updated, make sure to add tests to `wado-compiler/tests/format.rs`.
-
-## Compilation Log and Timing
-
-The compiler emits timestamped diagnostics to stderr. Use `--log-level` to
-control verbosity.
-
-```sh
-wado compile --log-level debug file.wado
-```
+`tests/cli_parse.rs` covers argument parsing without running a compile; the
+rest (`cli.rs`, `serve.rs`, `lsp.rs`, `kiln_*.rs`, `dependency_resolution.rs`,
+`git_dependency.rs`, `run_inprocess.rs`) drive the subcommands end to end.

--- a/wado-cli/AGENTS.md
+++ b/wado-cli/AGENTS.md
@@ -1,0 +1,163 @@
+# wado-cli
+
+The `wado` binary: a subcommand-style CLI over `wado-compiler` and `wado-lsp`.
+
+In the examples below, `wado` is shorthand for `cargo run --bin wado --`.
+`wado --help` lists every subcommand; the sections below cover the ones with
+workflows worth writing down.
+
+## Target World
+
+A Wado program targets a Wasm _world_: the CLI command (`wasi:cli/command`, the
+default), the HTTP service (`wasi:http/service`, run via `wado serve`), or the
+synthetic test world (selected with `--world test`, used by E2E tests). Several
+defaults — including the allocator — depend on the target world.
+
+`--world <name>` overrides it. `--world test` exports the entry module's `test`
+blocks and drops everything else. `compile` and `check` accept it; `serve` and
+`test` pick their world automatically.
+
+```sh
+wado compile --world test file.wado  # compile against the test world
+wado check --world test file.wado    # type-check against the test world
+```
+
+## Allocators
+
+Three allocators are available via `--allocator <mode>`:
+
+- `bump` (default for CLI): Bump pointer; never frees. Fast, minimal code.
+- `freelist` (default for HTTP world): Reclaims freed memory via a free list. For long-running processes.
+- `debug` (default for test world): Never reuses freed memory; poisons freed memory with `0xFF`. For use-after-free detection.
+
+```sh
+wado compile --allocator bump file.wado      # bump allocator
+wado compile --allocator freelist file.wado  # free-list allocator
+wado compile --allocator debug file.wado     # debug allocator
+```
+
+`wado compile` selects the `debug` allocator automatically when targeting the
+test world; E2E tests rely on this.
+
+## Compile Command
+
+```sh
+wado compile -o file.wasm file.wado    # generate Wasm
+wado compile -o file.wat file.wado     # generate WAT
+wado compile --wat-to-stdout file.wado # output WAT to stdout
+```
+
+To inspect invalid Wasm when debugging codegen bugs, use `--no-validate`:
+
+```sh
+# Skip validation and output raw Wasm bytes even if invalid
+wado compile --no-validate --wat-to-stdout file.wado
+```
+
+Optimization levels: `-O0` (none), `-O1` (development), `-O2` (production,
+default), `-O3` (aggressive), `-Os` (`-O2` + strip symbols).
+
+## Run Command
+
+```sh
+wado run file.wado  # run a CLI program with wasmtime
+```
+
+A program reaches only the directories granted to it: the current one, or
+exactly the `--dir` grants once any is given. Paths open relative to a grant, so
+an absolute path never opens — reach a file outside the tree by granting its
+directory and naming it relative to that.
+
+```sh
+wado run --dir /tmp/scratch prog.wado Foo.g4  # Foo.g4 resolves inside /tmp/scratch
+```
+
+## Test Command
+
+`wado test` discovers and runs `test` blocks (compiled against the `test` world,
+see Target World above).
+
+```sh
+wado test                    # discover and run every .wado test in the project
+wado test file.wado          # run tests in one file
+wado test --filter '**/json*.wado'  # run tests in files matching a wildcard
+```
+
+A failure or resolved `#[TODO]` prints its own one-line notice immediately,
+otherwise a digest (`N/Total files · tests, failed, todo, skip · ETA`) prints
+every 5s, ending in a `compile:`/`load:`/`skip:`/`test:` summary. `tail`ing the
+last line or two is enough to read the current state of a long run.
+
+## Serve Command
+
+Use `wado serve` to run a Wado HTTP service (wasi:http/service world):
+
+```sh
+wado serve file.wado                        # serve on 0.0.0.0:8080 (default)
+wado serve --addr 127.0.0.1:3000 file.wado  # serve on a custom address
+```
+
+## Dump Command
+
+Use `wado dump` to inspect compiler internal state for debugging.
+See `wado dump --help` for the full help.
+
+```sh
+wado dump file.wado                  # show final WIR (default)
+wado dump --nir file.wado            # show final NIR (after optimization)
+wado dump --nir -O0 file.wado        # show NIR without optimization
+wado dump --ast file.wado            # show parsed AST
+wado dump --modules file.wado        # show loaded modules
+wado dump --symbols file.wado        # show symbol table
+wado dump --types file.wado          # show type table
+wado dump --tir-resolved file.wado       # show TIR after type resolution
+wado dump --tir-monomorphized file.wado  # show TIR after monomorphization
+wado dump --nir-lowered file.wado        # show NIR right after lowering (before optimize)
+```
+
+## Query Command
+
+`wado query` answers compiler questions about a symbol, for tooling and docs. A
+symbol is addressed either by position (`--line`/`--column` in a file) or by
+_symbol notation_ `MODULE#SYMBOL`:
+
+- `MODULE` is the import specifier; quote it as in `use` — droppable for a scheme or bare name (`core:json`), required for a path or URL (`"./utils.wado"`).
+- `SYMBOL` uses Wado's operators: bare `name` (free function/type/global), `Type::name` (associated const/fn), `Type.name` (method), `Type^Trait::name` (trait-impl member).
+
+```sh
+wado query hover --symbol core:json#from_string                   # signature / type
+wado query hover --symbol ./hello.wado#run --base example          # local module
+wado query definition --symbol core:cbor#CborDeserializer.peek_byte
+wado query references --symbol core:cli#println --base example     # all uses (workspace)
+wado query hover --line 5 --column 10 file.wado                   # position-based
+wado query diagnostics file.wado                                  # errors/warnings
+```
+
+Common options:
+
+- `--symbol <notation>` — locate by name instead of `--line`/`--column`.
+- `--base <dir>` — anchor relative modules (default: cwd; `core:` / `wasi:` are location-independent).
+- `--all` — include private members; the default is the public-API view (matches `wado doc`).
+- `--json` — machine-readable output.
+
+For a type, `hover` also lists its `impl` blocks. `references` loads every
+`.wado` under `--base`, so it spans the workspace. See
+`docs/wep-2026-06-14-symbol-notation.md` for the notation spec.
+
+## Format Command
+
+The `wado format` command formats Wado source code.
+
+`mise run format-wado` formats all the fixtures used by compiler tests.
+
+**Caution:** `mise run format-wado` may break uncommitted test fixtures. When the
+syntax is updated, make sure to add tests to `wado-compiler/tests/format.rs`.
+
+## Compilation Log and Timing
+
+The compiler emits timestamped diagnostics to stderr. Use `--log-level` to
+control verbosity.
+
+```sh
+wado compile --log-level debug file.wado
+```

--- a/wado-cli/CLAUDE.md
+++ b/wado-cli/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -1,8 +1,39 @@
 //! `wado lsp` subcommand — delegates to the stdio LSP server in `wado-lsp`.
 
-use crate::args::CliExit;
+use std::fmt::Write as _;
 
-pub async fn run() -> Result<(), CliExit> {
+use crate::args::{self, CliExit};
+
+#[derive(Debug)]
+pub struct LspOptions {}
+
+fn format_usage() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "Usage: wado lsp [options]").unwrap();
+    writeln!(buf).unwrap();
+    writeln!(
+        buf,
+        "Start the Wado language server, speaking LSP over stdio."
+    )
+    .unwrap();
+    writeln!(buf).unwrap();
+    writeln!(buf, "Options:").unwrap();
+    writeln!(buf, "  -h, --help  Show this help message").unwrap();
+    buf
+}
+
+pub fn parse_args(mut parser: lexopt::Parser) -> Result<LspOptions, CliExit> {
+    let usage = format_usage();
+    if let Some(arg) = args::next_arg(&mut parser)? {
+        return match arg {
+            lexopt::Arg::Long("help") | lexopt::Arg::Short('h') => Err(CliExit::help(usage)),
+            other => Err(args::unexpected_arg(other, &usage)),
+        };
+    }
+    Ok(LspOptions {})
+}
+
+pub async fn run(_opts: LspOptions) -> Result<(), CliExit> {
     wado_lsp::server::run_stdio().await;
     Ok(())
 }

--- a/wado-cli/src/main.rs
+++ b/wado-cli/src/main.rs
@@ -103,7 +103,7 @@ impl Cmd {
             Self::Clean => "Evict derived cache state (git worktrees)",
             Self::Build => "Build the project's worlds from wado.toml",
             Self::Compile => "Compile a single Wado source file",
-            Self::Check => "Verify Kiln generators match committed source (CI)",
+            Self::Check => "Verify a source file and its Kiln generators",
             Self::Run => "Compile and run a Wado CLI program",
             Self::Serve => "Compile and serve a Wado HTTP service",
             Self::Test => "Run tests in Wado source files",
@@ -278,7 +278,10 @@ async fn dispatch() -> Result<(), CliExit> {
                     let opts = wado_cli::syntax::parse_args(parser)?;
                     wado_cli::syntax::run(opts)
                 }
-                Cmd::Lsp => Box::pin(wado_cli::lsp::run()).await,
+                Cmd::Lsp => {
+                    let opts = wado_cli::lsp::parse_args(parser)?;
+                    Box::pin(wado_cli::lsp::run(opts)).await
+                }
                 Cmd::Query => {
                     let opts = wado_cli::query::parse_args(parser)?;
                     Box::pin(wado_cli::query::run(opts)).await

--- a/wado-cli/tests/cli.rs
+++ b/wado-cli/tests/cli.rs
@@ -346,6 +346,29 @@ fn test_help() {
         .stderr(predicate::str::contains("run"));
 }
 
+/// The one-line summary in the command list must describe the whole
+/// subcommand, matching `wado check --help`.
+#[test]
+fn test_help_summarizes_check_as_verifying_a_source_file() {
+    wado()
+        .arg("--help")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "check [options] [file.wado]         Verify a source file and its Kiln generators",
+        ));
+}
+
+/// `--help` must print usage rather than start the language server on stdio.
+#[test]
+fn test_lsp_help_does_not_start_the_server() {
+    wado()
+        .args(["lsp", "--help"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Usage: wado lsp"));
+}
+
 #[test]
 fn test_run_propagates_a_guest_exit_code() {
     // `wasi:cli/exit` reaches wasmtime as `Err(I32Exit)`, indistinguishable

--- a/wado-cli/tests/cli_parse.rs
+++ b/wado-cli/tests/cli_parse.rs
@@ -9,6 +9,7 @@ use wado_cli::args::CliExit;
 use wado_cli::build;
 use wado_cli::check;
 use wado_cli::compile::{self, OptLevel, OutputFormat};
+use wado_cli::lsp;
 
 /// Assert that a `Result<T, CliExit>` is an error with exit code 1
 /// and the message contains the given substring.
@@ -957,4 +958,30 @@ fn parse_log_level_valid() {
     );
     assert_eq!(parse_log_level("off"), Some(wado_compiler::LogLevel::Off));
     assert_eq!(parse_log_level("invalid"), None);
+}
+
+// ---- lsp ----
+
+#[test]
+fn lsp_help() {
+    let parser = Parser::from_args(&["--help"]);
+    assert_help(lsp::parse_args(parser), "Usage: wado lsp");
+}
+
+#[test]
+fn lsp_short_help() {
+    let parser = Parser::from_args(&["-h"]);
+    assert_help(lsp::parse_args(parser), "Usage: wado lsp");
+}
+
+#[test]
+fn lsp_unknown_option() {
+    let parser = Parser::from_args(&["--unknown"]);
+    assert_err(lsp::parse_args(parser), "invalid option");
+}
+
+#[test]
+fn lsp_no_args() {
+    let parser = Parser::from_args(&[] as &[&str]);
+    lsp::parse_args(parser).unwrap();
 }

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -67,6 +67,10 @@ For other important files:
 - `lib/core/builtin.wado` for compiler intrinsics.
 - `lib/core/rt.wado` for runtime support helpers (panic, assert, CM ABI glue)
 
+`lib/wasi/` and `lib/core/kiln/` are generated from WIT — see `wado-from-idl/AGENTS.md` before editing them.
+
+The crate also bundles prebuilt Wasm modules for language features: `wado-bundled-libm/` provides deterministic math via the `libm` crate. Rebuild it with `mise run update-bundled`.
+
 ## E2E Test Specification (Compiler Tests)
 
 E2E tests verify language features and compiler behaviors (codegen, error messages, optimization). They are `.wado` files in `tests/fixtures/` with a `__DATA__` section containing test specification in JSON.

--- a/wado-from-idl/AGENTS.md
+++ b/wado-from-idl/AGENTS.md
@@ -1,0 +1,14 @@
+# wado-from-idl
+
+Generates Wado stdlib modules from WIT files.
+
+## Generated Modules
+
+- `wasi:*` — the WASI P3 bindings in `wado-compiler/lib/wasi/`, generated from
+  wasmtime's WIT. Regenerate with `mise run update-stdlib-wasi`; it requires the
+  `vendor/wasmtime` submodule.
+- `core:kiln` — the submodules under `wado-compiler/lib/core/kiln/`. Regenerate
+  with `mise run update-stdlib-kiln`. The facade `lib/core/kiln.wado` is
+  hand-written and must be preserved.
+
+Never edit a generated `.wado` file. Change this crate and regenerate.

--- a/wado-from-idl/CLAUDE.md
+++ b/wado-from-idl/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/wado-manifest/AGENTS.md
+++ b/wado-manifest/AGENTS.md
@@ -1,0 +1,12 @@
+# wado-manifest
+
+`wado.toml` parsing and validation, `wado.lock` management, and dependency
+resolution. See `README.md` for the crate's scope and status, and
+[WEP: Package Manifest](../docs/wep-2026-02-14-package-manifest.md) for the
+specification.
+
+## Rules
+
+- This crate must compile for `wasm32-unknown-unknown`. CI enforces it.
+- It performs no I/O. Network, git, and filesystem fetching are injected by
+  `wado-cli` through the `DependencyProvider` seam — keep that boundary.

--- a/wado-manifest/CLAUDE.md
+++ b/wado-manifest/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/wado-vscode/AGENTS.md
+++ b/wado-vscode/AGENTS.md
@@ -1,0 +1,11 @@
+# wado-vscode
+
+The VS Code extension, hosting `wado-lsp` as a bundled Wasm module. `README.md`
+covers the setup, inner loop, tests, and settings.
+
+## Rules
+
+- The TextMate grammar and `language-configuration.json` are generated from
+  `wado-compiler/src/syntax.rs`. Never edit them by hand.
+- Whenever the syntax changes, run `mise run update-wado-vscode-grammar` and
+  update the formatter fixtures in `wado-compiler/tests/format.fixtures/`.

--- a/wado-vscode/CLAUDE.md
+++ b/wado-vscode/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/wasm-size/CLAUDE.md
+++ b/wasm-size/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## The root `AGENTS.md`

It is loaded into every session, so it holds only what is always true and cannot be discovered from the repository:

- the project rules and the tooling discipline,
- the tour of the Wado language,
- a map of the tree,
- the CLI behaviour no `--help` states — how the target world selects the allocator, what `wado run` grants through `--dir`, and that `mise run format-wado` rewrites uncommitted fixtures.

Everything else lives where it belongs.

## Per-directory guidance

Each directory documents itself, and the harness loads that file when work touches the directory:

- `wado-cli/AGENTS.md` — the crate's development doc: the `lexopt` parsing convention, the single `process::exit` path through `CliExit`, what adding a subcommand touches, the module map, and the test layout.
- `wado-from-idl/AGENTS.md` — how the `wasi:*` and `core:kiln` stdlib modules are generated, and that the generated `.wado` files are not to be edited.
- `wado-manifest/AGENTS.md` — the `wasm32-unknown-unknown` and no-I/O constraints.
- `wado-vscode/AGENTS.md` — grammar regeneration and the formatter fixtures it implies.
- `wado-compiler/AGENTS.md` — which parts of `lib/` are generated, and the bundled `wado-bundled-libm` module.

`wasm-size/` gains the `CLAUDE.md` symlink that every other `AGENTS.md` directory carries.

## The `wado-cli` skill

Using the CLI is a separate concern from developing it, and it serves Wado users, not only people working on the toolchain. The skill is the usage doc: the command list as the binary prints it, then how to invoke each subcommand — compiling to Wasm and WAT, selecting a world and an allocator, running with a directory grant, the three ways to invoke `wado test`, serving on a custom address, each `dump` phase, the `query` kinds and the symbol notation behind `--symbol`, formatting in place, publishing through `wkg`, and raising the log level.

`wado <command> --help` stays the source of truth for flags, and it is thorough — allocator modes and their per-world defaults, optimization levels, every `dump` phase, every `query` kind. The skill adds what a flag list cannot: worked invocations, and the behaviour the help text leaves out, such as paths opening relative to a `--dir` grant so an absolute path never opens, and how to read a `wado test` digest.

## `wado lsp --help`

It prints usage. The subcommand parses its arguments like every other one, so `--help` reaches a `CliExit::help` instead of falling through to `run_stdio`, where it started the language server and exited on the immediate stdin EOF without printing anything.

The command list also summarizes `check` as verifying a source file and its Kiln generators, matching `wado check --help`: the subcommand type-checks the source as well as re-running the generators.

Covered by `tests/cli_parse.rs` (help, short help, unknown option, no args) and `tests/cli.rs` (both help texts as the binary prints them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)