### PR TITLE
docs(stdlib): keep the test layout out of the module docs

### DIFF
--- a/docs/stdlib-core-zlib.md
+++ b/docs/stdlib-core-zlib.md
@@ -15,11 +15,7 @@ streams with FDICT set return `ZlibError::PresetDictionaryNotSupported`.
 
 The decoder is annotated against the format specifications, whose text is
 kept under `wado-compiler/ref/` (RFC 1950, RFC 1951, RFC 1952). Section
-references in the comments below point at those documents. The RFCs define
-only the bitstream formats, not encoder heuristics, and they ship no
-conformance vectors, so `zlib_test.wado` pairs hand-built, spec-anchored
-decode vectors (verified against a reference zlib) with cross-validation in
-`tests/zlib_interop.rs`.
+references in the comments below point at those documents.
 
 Features:
 

--- a/wado-compiler/lib/core/allocator.wado
+++ b/wado-compiler/lib/core/allocator.wado
@@ -116,9 +116,6 @@ export fn debug_realloc(oldptr: i32, oldsize: i32, align: i32, newsize: i32) -> 
 /// is congruent to 8 mod 16). Wasm memory is zero-initialised, so every
 /// bin head starts empty.
 ///
-/// The algorithm is exercised end-to-end by the `allocator_freelist_*`
-/// fixtures in `tests/fixtures/`.
-///
 /// Selected by `--allocator freelist` (default for HTTP service world).
 
 /// Block size encoded in a boundary tag (clears the low 3 bits).

--- a/wado-compiler/lib/core/zlib.wado
+++ b/wado-compiler/lib/core/zlib.wado
@@ -11,11 +11,7 @@
 //!
 //! The decoder is annotated against the format specifications, whose text is
 //! kept under `wado-compiler/ref/` (RFC 1950, RFC 1951, RFC 1952). Section
-//! references in the comments below point at those documents. The RFCs define
-//! only the bitstream formats, not encoder heuristics, and they ship no
-//! conformance vectors, so `zlib_test.wado` pairs hand-built, spec-anchored
-//! decode vectors (verified against a reference zlib) with cross-validation in
-//! `tests/zlib_interop.rs`.
+//! references in the comments below point at those documents.
 //!
 //! Features:
 //!


### PR DESCRIPTION
The `core:zlib` and `core:allocator` docs describe the API and the
specifications it implements. Where the tests for a module live, and how their
vectors are built, is not part of that: a caller of the module cannot act on
it, and a file name written into prose goes stale the moment a test moves.

`docs/stdlib-core-zlib.md` is generated from the `//!` header of
`wado-compiler/lib/core/zlib.wado`, so the two carry the same text and
`mise run doc-stdlib` leaves the file unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3GycuCsegemWdeibPy5vH)_