### PR TITLE
fix(kiln): output reconciliation spares a staging temp

### DIFF
--- a/wado-cli/src/cache.rs
+++ b/wado-cli/src/cache.rs
@@ -145,15 +145,13 @@ pub fn staging_file_name(file_name: &str) -> String {
     )
 }
 
-/// Whether `file_name` names a [`write_atomic`] staging file.
 pub fn is_staging_file(file_name: &str) -> bool {
     file_name.contains(STAGING_INFIX)
 }
 
-/// Write `bytes` to `path` atomically: create the parent dir, write a sibling
-/// temp file, then rename into place. A crash or a concurrent writer can only
-/// leave a stray temp file, never a half-written `component.wasm` that the
-/// `is_file()` cache check would then trust forever.
+/// Write `bytes` to `path` atomically. A crash or a concurrent writer can only
+/// leave a stray staging file, never a half-written one the `is_file()` cache
+/// check would then trust forever.
 pub fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
@@ -177,10 +175,6 @@ mod tests {
 
     #[test]
     fn write_atomic_is_concurrency_safe_for_the_same_path() {
-        // A parallel compile fetches the same registry component from several
-        // files at once, so `write_atomic` runs concurrently on one path. Every
-        // writer must succeed and leave the full bytes — no writer may rename
-        // another's temp file out from under it.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ghcr.io/ns/pkg/0.1.0/component.wasm");
         let bytes: Vec<u8> = (0..4096).map(|i| (i % 251) as u8).collect();

--- a/wado-cli/src/cache.rs
+++ b/wado-cli/src/cache.rs
@@ -130,25 +130,36 @@ fn relative_under_root(
     Ok(root()?.join(relative))
 }
 
+const STAGING_INFIX: &str = ".tmp-wado-";
+
+/// The sibling [`write_atomic`] stages `file_name` in, unique per process and
+/// per thread so two writers never rename away each other's temp.
+pub fn staging_file_name(file_name: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    format!(
+        "{file_name}{STAGING_INFIX}{}-{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// Whether `file_name` names a [`write_atomic`] staging file.
+pub fn is_staging_file(file_name: &str) -> bool {
+    file_name.contains(STAGING_INFIX)
+}
+
 /// Write `bytes` to `path` atomically: create the parent dir, write a sibling
 /// temp file, then rename into place. A crash or a concurrent writer can only
 /// leave a stray temp file, never a half-written `component.wasm` that the
 /// `is_file()` cache check would then trust forever.
 pub fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
     }
-    // A per-write temp sibling, unique across processes (pid) and across threads
-    // within one process (the counter): a parallel compile fetches the same
-    // component from several files at once, so two writers must never share — and
-    // rename away — each other's temp file. The rename is the atomic publish step.
-    let tmp = path.with_extension(format!(
-        "tmp-{}-{}",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed)
+    let tmp = path.with_file_name(staging_file_name(
+        &path.file_name().unwrap_or_default().to_string_lossy(),
     ));
     std::fs::write(&tmp, bytes)?;
     match std::fs::rename(&tmp, path) {

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -40,6 +40,7 @@ use wado_compiler::kiln::{
 use wado_compiler::{Code, Diagnostic, Severity};
 use wado_manifest::Manifest;
 
+use crate::cache::{is_staging_file, write_atomic};
 use crate::kiln_metadata::{
     self, FileHash as MetaFileHash, METADATA_VERSION, Metadata, OutputEntry as MetaOutputEntry,
 };
@@ -294,11 +295,9 @@ pub async fn execute_with_mode<H: CompilerHost>(
                 // be written by several files' compiles at once during a parallel
                 // `wado test` sweep, and a plain `fs::write` lets a concurrent
                 // reader observe a torn, half-written module.
-                crate::cache::write_atomic(&full_path, &bytes).map_err(|source| {
-                    ExecuteError::Io {
-                        path: full_path.clone(),
-                        source,
-                    }
+                write_atomic(&full_path, &bytes).map_err(|source| ExecuteError::Io {
+                    path: full_path.clone(),
+                    source,
                 })?;
             }
             ExecuteMode::DryRun => {
@@ -595,6 +594,9 @@ fn walk_and_delete(
             continue;
         }
         if !ft.is_file() {
+            continue;
+        }
+        if is_staging_file(&entry.file_name().to_string_lossy()) {
             continue;
         }
         let Ok(content) = std::fs::read_to_string(&path) else {
@@ -1679,6 +1681,7 @@ mod tests {
 
     mod cache_tests {
         use super::*;
+        use crate::cache::staging_file_name;
         use indexmap::IndexMap;
         use std::sync::Mutex;
         use wado_compiler::compiler_host::{
@@ -1962,6 +1965,23 @@ mod tests {
             assert!(kept_path.exists());
             assert!(!orphan_path.exists());
             assert!(hand_written_path.exists());
+        }
+
+        /// A concurrent `write_atomic` stages the output's full bytes — header
+        /// included — in a sibling temp before renaming it into place. Deleting
+        /// one fails that publish with `ENOENT` against the final path.
+        #[test]
+        fn reconcile_outputs_spares_a_concurrent_writers_staging_temp() {
+            let tmp = tempfile::tempdir().unwrap();
+            let out_dir = tmp.path().join("build/kiln/proto");
+            std::fs::create_dir_all(&out_dir).unwrap();
+            let staging = out_dir.join(staging_file_name("gen.wado"));
+            std::fs::write(&staging, "#![generated(by = \"gen\", sources = [])]\n").unwrap();
+
+            let deleted = reconcile_outputs(tmp.path(), &out_dir, &[]).unwrap();
+
+            assert!(deleted.is_empty(), "a staging temp is not an orphan");
+            assert!(staging.exists());
         }
 
         #[test]

--- a/wado-cli/src/kiln_driver.rs
+++ b/wado-cli/src/kiln_driver.rs
@@ -291,10 +291,6 @@ pub async fn execute_with_mode<H: CompilerHost>(
                         normalized.as_str(),
                     );
                 }
-                // Atomic publish (temp + rename): the same generated output can
-                // be written by several files' compiles at once during a parallel
-                // `wado test` sweep, and a plain `fs::write` lets a concurrent
-                // reader observe a torn, half-written module.
                 write_atomic(&full_path, &bytes).map_err(|source| ExecuteError::Io {
                     path: full_path.clone(),
                     source,
@@ -1967,9 +1963,6 @@ mod tests {
             assert!(hand_written_path.exists());
         }
 
-        /// A concurrent `write_atomic` stages the output's full bytes — header
-        /// included — in a sibling temp before renaming it into place. Deleting
-        /// one fails that publish with `ENOENT` against the final path.
         #[test]
         fn reconcile_outputs_spares_a_concurrent_writers_staging_temp() {
             let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
`cache::write_atomic` publishes a file by staging its full bytes in a sibling
temp and renaming that into place. For a Kiln output those bytes are the
finished file, `#[generated]` header and all, so a staging temp is
indistinguishable by content from the output it will become.

`kiln_driver::reconcile_outputs` sweeps an invocation's `output_dir` and deletes
every file carrying that header whose project-relative path is not among the
invocation's outputs — a staging temp's path never is. `walk_and_delete` skips a
staging file before it reads any header, so a reconcile is safe to run while
another compile is mid-publish in the same directory.

That matters under a parallel `wado test` sweep, where two concurrent compiles
of one source reconcile a shared output directory. The unguarded window is
narrow — between the temp's write and its rename — and a reconcile landing
inside it removes the temp, failing the publish with the final path's name:

```
kiln: I/O error at package-gale/build/kiln/kiln-<hash>/between.wado:
      No such file or directory (os error 2)
```

The name in that message is the output's, not the temp's, because the write site
reports the path it was asked to publish.

`cache::staging_file_name` and `cache::is_staging_file` hold the naming rule, so
the writer and the pruner share one definition. The infix sits in the file name
(`gen.wado.tmp-wado-<pid>-<seq>`), leaving a staging file recognizable whatever
the target is named.
