### PR TITLE
chore(ci): publish the shared build cache, and test Wado at -O2

### DIFF
--- a/.github/workflows/cargo-cache.yml
+++ b/.github/workflows/cargo-cache.yml
@@ -1,13 +1,13 @@
-# Publishes the shared cargo caches every other environment restores from.
+# Publishes the shared cargo caches every other build restores from:
 #
-#   cargo/registry/linux-x86_64.tar.gz  registry index, .crate files, unpacked sources (GCS)
-#   cargo/sccache/linux-x86_64.tar.gz   sccache content-addressed compile cache (GCS)
-#   v0-rust-ci-Linux-x64-*              ci.yml's target/ and registry (Actions cache)
+#   cargo/registry/linux-x86_64.tar.gz  registry index, .crate files, unpacked sources
+#   cargo/sccache/linux-x86_64.tar.gz   sccache content-addressed compile cache
+#   v0-rust-ci-Linux-x64-*              ci.yml's target/ and registry
 #
-# The GCS objects serve non-GitHub environments (e.g. the Claude Code web
-# container); the Actions cache serves ci.yml, which restores `shared-key: ci`
-# with `save-if: false`. It must be written from main: an Actions cache written
-# on a PR branch is invisible to main and to every other branch.
+# The first two go to GCS, for non-GitHub environments (e.g. the Claude Code web
+# container). The third is an Actions cache that ci.yml restores read-only; only
+# a main-branch run can write it, because a cache saved on a PR branch is
+# invisible to main and to sibling branches.
 #
 # The registry cache saves the download and the unpack; the sccache cache saves
 # compiling every dependency. See .claude/hooks/cargo-cache-restore.mts
@@ -23,7 +23,7 @@
 # (Ubuntu 24.04 `apt` sccache) so the on-disk cache format matches.
 #
 # CARGO_* ENV PARITY IS ALSO LOAD-BEARING. sccache hashes every CARGO_* env var
-# into the Rust cache key, so this job's CARGO_* set (CARGO_HOME,
+# into the Rust cache key, so the `upload` job's CARGO_* set (CARGO_HOME,
 # CARGO_TARGET_DIR, CARGO_INCREMENTAL) must match the container's warm-cache
 # build (mise.toml) exactly.
 #
@@ -31,12 +31,12 @@
 #   vars.GCP_WIF_PROVIDER    workload identity provider resource name
 #   vars.GCP_CACHE_WRITER_SA writer service-account email (roles/storage.objectAdmin on the bucket)
 #   vars.GCP_CACHE_BUCKET    GCS bucket name (e.g. wado-lang-cache)
-name: Cargo caches (registry + sccache)
+name: Cargo caches
 
 on:
   push:
     branches: [main]
-    # All of these feed the sccache cache key. Without a republish the
+    # All of these feed both cache keys. Without a republish the
     # container silently falls back to a cold build; `warm-cache` reports the
     # hit rate so that stays visible.
     paths:
@@ -140,9 +140,8 @@ jobs:
           destination: ${{ vars.GCP_CACHE_BUCKET }}/cargo/sccache
           parent: false
 
-  # ENV PARITY IS LOAD-BEARING HERE TOO. rust-cache hashes the CARGO_*/RUST* env
-  # set into the cache key, so this job's env must be exactly ci.yml's, with none
-  # of the sccache vars above, or ci.yml computes a different key and never hits.
+  # ENV PARITY AGAIN: rust-cache hashes the CARGO_*/RUST* env set into the cache
+  # key, so this job's env must be exactly ci.yml's — none of the sccache vars.
   actions-cache:
     name: Warm ci.yml's Actions cache
     runs-on: ubuntu-latest
@@ -166,6 +165,5 @@ jobs:
         with:
           shared-key: ci
 
-      # `--all-targets` also covers the dev-dependencies only ci.yml's test
-      # binaries pull in.
+      # `--all-targets` for the dev-dependencies only ci.yml's test binaries need.
       - run: cargo build --workspace --locked --all-targets

--- a/.github/workflows/cargo-cache.yml
+++ b/.github/workflows/cargo-cache.yml
@@ -45,6 +45,8 @@ on:
       - "*/Cargo.toml"
       - rust-toolchain.toml
       - .github/workflows/cargo-cache.yml
+      # ci.yml's env is hashed into the Actions cache key (see the job below).
+      - .github/workflows/ci.yml
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cargo-cache.yml
+++ b/.github/workflows/cargo-cache.yml
@@ -1,8 +1,13 @@
-# Publishes shared cargo caches to GCS so non-GitHub environments (e.g. the
-# Claude Code web container) can restore them. Two objects are produced:
+# Publishes the shared cargo caches every other environment restores from.
 #
-#   cargo/registry/linux-x86_64.tar.gz  registry index, .crate files, unpacked sources
-#   cargo/sccache/linux-x86_64.tar.gz   sccache content-addressed compile cache
+#   cargo/registry/linux-x86_64.tar.gz  registry index, .crate files, unpacked sources (GCS)
+#   cargo/sccache/linux-x86_64.tar.gz   sccache content-addressed compile cache (GCS)
+#   v0-rust-ci-Linux-x64-*              ci.yml's target/ and registry (Actions cache)
+#
+# The GCS objects serve non-GitHub environments (e.g. the Claude Code web
+# container); the Actions cache serves ci.yml, which restores `shared-key: ci`
+# with `save-if: false`. It must be written from main: an Actions cache written
+# on a PR branch is invisible to main and to every other branch.
 #
 # The registry cache saves the download and the unpack; the sccache cache saves
 # compiling every dependency. See .claude/hooks/cargo-cache-restore.mts
@@ -50,24 +55,23 @@ permissions:
   contents: read
   id-token: write
 
-env:
-  # Mirror the container's absolute paths (see the parity note above).
-  CONTAINER_REPO: /home/user/wado
-  CARGO_HOME: /root/.cargo
-  SCCACHE_DIR: /root/.cargo/sccache
-  CARGO_TARGET_DIR: /home/user/wado/target
-  RUSTC_WRAPPER: sccache
-  CARGO_INCREMENTAL: "0"
-  # Keep a cache that outgrows sccache's 10 GiB default from being LRU-trimmed
-  # into one with holes.
-  SCCACHE_CACHE_SIZE: 30G
-  # RUSTFLAGS is a sccache cache-key input; keep it identical to the container's
-  # mise [env] (both unset).
-
 jobs:
   upload:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    env:
+      # Mirror the container's absolute paths (see the parity note above).
+      CONTAINER_REPO: /home/user/wado
+      CARGO_HOME: /root/.cargo
+      SCCACHE_DIR: /root/.cargo/sccache
+      CARGO_TARGET_DIR: /home/user/wado/target
+      RUSTC_WRAPPER: sccache
+      CARGO_INCREMENTAL: "0"
+      # Keep a cache that outgrows sccache's 10 GiB default from being LRU-trimmed
+      # into one with holes.
+      SCCACHE_CACHE_SIZE: 30G
+      # RUSTFLAGS is a sccache cache-key input; keep it identical to the container's
+      # mise [env] (both unset).
     steps:
       - uses: actions/checkout@v7
         with:
@@ -135,3 +139,33 @@ jobs:
           path: out/sccache/linux-x86_64.tar.gz
           destination: ${{ vars.GCP_CACHE_BUCKET }}/cargo/sccache
           parent: false
+
+  # ENV PARITY IS LOAD-BEARING HERE TOO. rust-cache hashes the CARGO_*/RUST* env
+  # set into the cache key, so this job's env must be exactly ci.yml's, with none
+  # of the sccache vars above, or ci.yml computes a different key and never hits.
+  actions-cache:
+    name: Warm ci.yml's Actions cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: 0
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          df -h /
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci
+
+      # `--all-targets` also covers the dev-dependencies only ci.yml's test
+      # binaries pull in.
+      - run: cargo build --workspace --locked --all-targets

--- a/.github/workflows/cargo-cache.yml
+++ b/.github/workflows/cargo-cache.yml
@@ -1,13 +1,8 @@
 # Publishes the shared cargo caches every other build restores from:
 #
-#   cargo/registry/linux-x86_64.tar.gz  registry index, .crate files, unpacked sources
-#   cargo/sccache/linux-x86_64.tar.gz   sccache content-addressed compile cache
-#   v0-rust-ci-Linux-x64-*              ci.yml's target/ and registry
-#
-# The first two go to GCS, for non-GitHub environments (e.g. the Claude Code web
-# container). The third is an Actions cache that ci.yml restores read-only; only
-# a main-branch run can write it, because a cache saved on a PR branch is
-# invisible to main and to sibling branches.
+#   cargo/registry/linux-x86_64.tar.gz  registry index, .crate files, unpacked sources (GCS)
+#   cargo/sccache/linux-x86_64.tar.gz   sccache content-addressed compile cache (GCS)
+#   v0-rust-ci-Linux-x64-*              ci.yml's target/ and registry (Actions cache)
 #
 # The registry cache saves the download and the unpack; the sccache cache saves
 # compiling every dependency. See .claude/hooks/cargo-cache-restore.mts
@@ -45,7 +40,6 @@ on:
       - "*/Cargo.toml"
       - rust-toolchain.toml
       - .github/workflows/cargo-cache.yml
-      # ci.yml's env is hashed into the Actions cache key (see the job below).
       - .github/workflows/ci.yml
   workflow_dispatch:
 
@@ -142,8 +136,6 @@ jobs:
           destination: ${{ vars.GCP_CACHE_BUCKET }}/cargo/sccache
           parent: false
 
-  # ENV PARITY AGAIN: rust-cache hashes the CARGO_*/RUST* env set into the cache
-  # key, so this job's env must be exactly ci.yml's — none of the sccache vars.
   actions-cache:
     name: Warm ci.yml's Actions cache
     runs-on: ubuntu-latest
@@ -167,5 +159,4 @@ jobs:
         with:
           shared-key: ci
 
-      # `--all-targets` for the dev-dependencies only ci.yml's test binaries need.
       - run: cargo build --workspace --locked --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
       # component) without pushing, so no wkg or credentials are needed.
       - run: cargo run --locked -p wado-cli -- publish --dry-run
 
-  test-gale-o1:
-    name: Test (Gale O1)
+  test-gale:
+    name: Test (Gale)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -209,53 +209,7 @@ jobs:
         env:
           MISE_VERBOSE: ${{ runner.debug }}
 
-      - run: mise run test-gale-o1
-
-  test-gale-o2:
-    name: Test (Gale O2)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-      - uses: jdx/mise-action@v4.2.3
-        with:
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          MISE_VERBOSE: ${{ runner.debug }}
-
-      - run: mise run test-gale-o2
-
-  test-gale-o3:
-    name: Test (Gale O3)
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci
-          save-if: false
-      - uses: jdx/mise-action@v4.2.3
-        with:
-          cache: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          MISE_VERBOSE: ${{ runner.debug }}
-
-      - run: mise run test-gale-o3
+      - run: mise run test-gale
 
   # Build-light static gates folded into one sub-minute job. Neither needs the
   # shared `ci` build cache: `check-deps` is a pure `cargo tree -d` resolution,
@@ -299,9 +253,7 @@ jobs:
         changes,
         test-core,
         test-wado,
-        test-gale-o1,
-        test-gale-o2,
-        test-gale-o3,
+        test-gale,
         test-e2e-o0,
         test-e2e-o1,
         test-e2e-o2,
@@ -326,7 +278,7 @@ jobs:
             echo "Docs-only change: test jobs skipped, reporting success."
             exit 0
           fi
-          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o1.result }} ${{ needs.test-gale-o2.result }} ${{ needs.test-gale-o3.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o2.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check.result }}"
+          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o2.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check.result }}"
           for result in $results; do
             if [ "$result" != "success" ]; then
               echo "One or more jobs failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,8 @@ jobs:
       # component) without pushing, so no wkg or credentials are needed.
       - run: cargo run --locked -p wado-cli -- publish --dry-run
 
-  test-gale:
-    name: Test (Gale)
+  test-gale-o3:
+    name: Test (Gale O3)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -209,7 +209,7 @@ jobs:
         env:
           MISE_VERBOSE: ${{ runner.debug }}
 
-      - run: mise run test-gale
+      - run: mise run test-gale-o3
 
   # Build-light static gates folded into one sub-minute job. Neither needs the
   # shared `ci` build cache: `check-deps` is a pure `cargo tree -d` resolution,
@@ -253,7 +253,7 @@ jobs:
         changes,
         test-core,
         test-wado,
-        test-gale,
+        test-gale-o3,
         test-e2e-o0,
         test-e2e-o1,
         test-e2e-o2,
@@ -278,7 +278,7 @@ jobs:
             echo "Docs-only change: test jobs skipped, reporting success."
             exit 0
           fi
-          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o2.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check.result }}"
+          results="${{ needs.test-core.result }} ${{ needs.test-wado.result }} ${{ needs.test-gale-o3.result }} ${{ needs.test-e2e-o0.result }} ${{ needs.test-e2e-o1.result }} ${{ needs.test-e2e-o2.result }} ${{ needs.test-e2e-o3.result }} ${{ needs.test-e2e-os.result }} ${{ needs.check.result }}"
           for result in $results; do
             if [ "$result" != "success" ]; then
               echo "One or more jobs failed"

--- a/mise.toml
+++ b/mise.toml
@@ -277,7 +277,7 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 # `wado test` walks the repo-root wado.toml and recurses into every
-# nested package. In CI, package-gale runs in its own job (test-gale),
+# nested package. In CI, package-gale runs in its own job (test-gale-o3),
 # so we exclude it here to keep this job fast.
 # Locally we include everything so a single `mise run test-wado` covers
 # it all. CI also switches to `--format tap` for its machine-readable
@@ -293,8 +293,8 @@ fi
 cargo run -p wado-cli -- test "${extra_args[@]}"
 """
 
-[tasks.test-gale]
-description = "Run package-gale tests"
+[tasks.test-gale-o3]
+description = "Run package-gale tests with -O3"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
@@ -302,7 +302,7 @@ extra_args=()
 if [ -n "${CI:-}" ]; then
     extra_args+=(--format tap)
 fi
-cargo run -p wado-cli -- test package-gale "${extra_args[@]}"
+cargo run -p wado-cli -- test -O3 package-gale "${extra_args[@]}"
 """
 
 [tasks.test-cov]

--- a/mise.toml
+++ b/mise.toml
@@ -277,8 +277,8 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 # `wado test` walks the repo-root wado.toml and recurses into every
-# nested package. In CI, package-gale runs in its own per-optlevel jobs
-# (test-gale-o1/o2/o3), so we exclude it here to keep this job fast.
+# nested package. In CI, package-gale runs in its own job (test-gale),
+# so we exclude it here to keep this job fast.
 # Locally we include everything so a single `mise run test-wado` covers
 # it all. CI also switches to `--format tap` for its machine-readable
 # per-test output; the default `heartbeat` format is for local/agent use.
@@ -293,8 +293,8 @@ fi
 cargo run -p wado-cli -- test "${extra_args[@]}"
 """
 
-[tasks.test-gale-o1]
-description = "Run package-gale tests with -O1"
+[tasks.test-gale]
+description = "Run package-gale tests"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
@@ -302,31 +302,7 @@ extra_args=()
 if [ -n "${CI:-}" ]; then
     extra_args+=(--format tap)
 fi
-cargo run -p wado-cli -- test -O1 package-gale "${extra_args[@]}"
-"""
-
-[tasks.test-gale-o2]
-description = "Run package-gale tests with -O2"
-run = """
-#!/usr/bin/env bash
-set -xe -o pipefail
-extra_args=()
-if [ -n "${CI:-}" ]; then
-    extra_args+=(--format tap)
-fi
-cargo run -p wado-cli -- test -O2 package-gale "${extra_args[@]}"
-"""
-
-[tasks.test-gale-o3]
-description = "Run package-gale tests with -O3"
-run = """
-#!/usr/bin/env bash
-set -xe -o pipefail
-extra_args=()
-if [ -n "${CI:-}" ]; then
-    extra_args+=(--format tap)
-fi
-cargo run -p wado-cli -- test -O3 package-gale "${extra_args[@]}"
+cargo run -p wado-cli -- test package-gale "${extra_args[@]}"
 """
 
 [tasks.test-cov]

--- a/mise.toml
+++ b/mise.toml
@@ -3,15 +3,11 @@
 # Schema: https://mise.jdx.dev/schema/mise.json
 
 [tools]
-# Rust toolchain - mise respects rust-toolchain.toml automatically
-
-# Markdown formatting is provided by `wado-dev-tools format-md`, which
-# embeds the dprint markdown plugin as a Cargo dependency. No external
-# dprint CLI is required.
-
-# Node.js - required for VS Code extension development and the jco runtime.
+# Rust is absent because mise reads rust-toolchain.toml; dprint because
+# `wado-dev-tools format-md` embeds the markdown plugin as a Cargo dependency.
+#
 # Node 26 (V8 14.6) ships stable JSPI, so `WebAssembly.Suspending` works without
-# `--experimental-wasm-jspi` (which Node 26 no longer accepts).
+# `--experimental-wasm-jspi`, which Node 26 no longer accepts.
 node = "26"
 
 [settings]
@@ -35,14 +31,12 @@ mise run warm-cache
 description = "Reconstruct target/ from the restored sccache cache"
 run = """
 #!/usr/bin/env bash
-# Turns the restored sccache cache (see .claude/hooks/cargo-cache-restore.mts)
-# into a warm target/. sccache is used ONLY here, because its cache key depends
-# on the CARGO_* set normalized below — a plain `cargo build` in this container
-# has a different set and would only add misses.
+# Turns the restored sccache cache (.claude/hooks/cargo-cache-restore.mts) into
+# a warm target/. sccache is used ONLY here: its key depends on the CARGO_* set
+# normalized below, which a plain `cargo build` here does not reproduce.
 set -e -o pipefail
 export SCCACHE_DIR="${SCCACHE_DIR:-$HOME/.cargo/sccache}"
-# Match the ceiling cargo-cache.yml publishes under, so a cache that outgrows
-# sccache's 10 GiB default is not LRU-trimmed after we restore it.
+# cargo-cache.yml's ceiling; the 10 GiB default would LRU-trim what we restored.
 export SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-30G}"
 if ! command -v sccache >/dev/null 2>&1; then
   echo "sccache not installed; skipping warm-cache (normal cold build applies)"
@@ -79,24 +73,19 @@ if [ ! -d "$SCCACHE_DIR" ] || [ -z "$(ls -A "$SCCACHE_DIR" 2>/dev/null)" ]; then
   echo "no sccache cache at $SCCACHE_DIR; skipping warm-cache (already warmed, or none published)"
   exit 0
 fi
-# Reconstruct dependency artifacts from the content-addressed cache. sccache
-# hashes every CARGO_* env var into the Rust cache key, so expose exactly the
-# CARGO_* set the cargo-cache.yml runner used — this container otherwise leaks
-# CARGO_HTTP_CAINFO and drops the runner's three.
+# sccache hashes every CARGO_* env var into the key, so expose exactly the set
+# cargo-cache.yml used — this container otherwise leaks CARGO_HTTP_CAINFO.
 unset $(compgen -e | grep '^CARGO_' || true)
 warm() {
   env CARGO_HOME="$HOME/.cargo" CARGO_TARGET_DIR="$PWD/target" CARGO_INCREMENTAL=0 \
     RUSTC_WRAPPER=sccache "$@"
 }
-# Disjoint artifact sets that cargo derives neither from the other: `check`
-# emits .rmeta, `build` .rlib and the linked binaries. Keep in step with
-# cargo-cache.yml, which publishes entries for both.
+# Disjoint artifact sets, neither derived from the other: `check` emits .rmeta,
+# `build` .rlib and the binaries. cargo-cache.yml publishes entries for both.
 warm cargo check --workspace --locked
 warm cargo build --workspace --locked --all-targets
-# The dev loop also runs with CARGO_INCREMENTAL=0 (see AGENTS.md), so a later
-# plain `cargo build` reuses these directly.
 
-# Every cache-key input is pinned in two places at once, so drift is otherwise
+# Cache-key inputs are pinned in two places at once, so drift is otherwise
 # invisible: warm-cache still exits 0 and just quietly costs a cold build.
 stats=$(sccache --show-stats 2>/dev/null || true)
 echo "${stats}"
@@ -116,9 +105,9 @@ if [ "${total}" -gt 0 ]; then
 fi
 
 # Nothing reads the cache once target/ is warm, so reclaim its gigabytes — but
-# only in the container, where it is a disposable download. Elsewhere
-# $SCCACHE_DIR is the developer's and may back every other project.
-# A later `cargo clean` in the container therefore costs a full cold build.
+# only in the container, where it is a disposable download and a later
+# `cargo clean` is understood to cost a cold build. Elsewhere $SCCACHE_DIR is
+# the developer's and may back every other project.
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
   sccache --stop-server >/dev/null 2>&1 || true
   rm -rf "${SCCACHE_DIR}"
@@ -159,18 +148,11 @@ run = """
 #!/usr/bin/env bash
 set -e -o pipefail
 
-# wado pins the wasm-tools family (wasmparser/wasm-encoder/wasmprinter/wit-parser/
-# wat) to the same generation wasmtime depends on, so cargo dedupes instead of
-# compiling parallel 0.x trees. See [workspace.dependencies] in Cargo.toml. This
-# guard fails when a new duplicate sneaks in (e.g. a dep bumped back to a
-# different generation, or `wat` floating up past its tilde pin).
-#
-# A few duplicates are irreducible: they come from transitive deps we do not pin
-# directly. List their exact versions in `allow` so the guard ignores them:
+# The wasm-tools family is pinned to wasmtime's generation in
+# [workspace.dependencies], so cargo dedupes instead of compiling parallel 0.x
+# trees. `allow` holds the duplicates from transitive deps we cannot pin:
 #   wasmparser / wasm-encoder 0.245.1  <- walrus 0.26
 #   wast 35.0.2                        <- witx <- wasmtime-wasi (wiggle)
-# (wit-bindgen's 0.244 generation is pulled by the target-gated `wasip3` guest
-#  crate, never reaches the host tree, and so never shows up in `cargo tree -d`.)
 family='wasm-encoder|wasmparser|wasmprinter|wasm-metadata|wat|wast|wit-parser|wit-component'
 allow='wasmparser v0.245.1|wasm-encoder v0.245.1|wast v35.0.2'
 
@@ -244,9 +226,8 @@ description = "Build the wasmtime CLI from vendor/wasmtime (matches the embedded
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# vendor/wasmtime is a separate workspace tracking upstream dev; its source is
-# not warning-clean, so build it with an empty RUSTFLAGS to ignore any
-# deny-warnings flags inherited from the environment.
+# vendor/wasmtime tracks upstream dev and is not warning-clean, so drop any
+# deny-warnings RUSTFLAGS inherited from the environment.
 RUSTFLAGS= cargo build --release -p wasmtime-cli --manifest-path vendor/wasmtime/Cargo.toml
 """
 
@@ -261,12 +242,8 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 touch wado-compiler/tests/e2e.rs
-# Run the harness with nproc-1 (floor 1) threads. Each e2e test compiles a
-# Wado program and runs it under wasmtime; wasmtime spawns its own worker
-# threads (codegen, epoch ticker, async I/O), so leaving one core free for
-# them avoids contention. The previous fixed cap of 2 was a workaround for
-# SIGSEGV from resource exhaustion on a constrained sandbox; reinstate that
-# cap if it recurs.
+# Leave a core for the threads wasmtime spawns per e2e test (codegen, epoch
+# ticker, async I/O). Drop back to a fixed 2 if a constrained sandbox SIGSEGVs.
 n=$(nproc); threads=$(( n > 1 ? n - 1 : 1 ))
 cargo test -- --test-threads="$threads"
 """
@@ -276,16 +253,9 @@ description = "Run Wado module tests"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# `wado test` walks the repo-root wado.toml and recurses into every
-# nested package. In CI, package-gale runs in its own job (test-gale-o3),
-# so we exclude it here to keep this job fast.
-# Locally we include everything so a single `mise run test-wado` covers
-# it all. CI also switches to `--format tap` for its machine-readable
-# per-test output; the default `heartbeat` format is for local/agent use.
-#
-# benchmark/* test blocks use only inline data — the `Preopens`-driven
-# file reads sit in `export fn run()`, which the test world does not
-# invoke — so they need no `--dir` setup of their own.
+# package-gale is excluded in CI only, where test-gale-o3 covers it; locally
+# one run walks every nested package. benchmark/* test blocks need no `--dir`:
+# their file reads sit in `export fn run()`, which the test world never calls.
 extra_args=()
 if [ -n "${CI:-}" ]; then
     extra_args+=(--exclude 'package-gale/**' --format tap)
@@ -344,10 +314,8 @@ description = "Format all Wado source files"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# Format the whole workspace. Each package's wado.toml [format] section
-# controls its own exclusions (e.g. wado-compiler excludes `tests/**`);
-# generated/ and build/ directories, vendor submodules, and gitignored paths
-# are skipped automatically.
+# Exclusions come from each package's wado.toml [format] (wado-compiler excludes
+# `tests/**`); generated/, build/, submodules and gitignored paths are automatic.
 cargo run --bin wado -- format -w .
 """
 
@@ -369,14 +337,9 @@ depends = ["build-golden-tools"]
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# golden-dump overwrites each golden file in place and, only after every file
-# has been regenerated, prunes the stale ones (no matching fixture). There is
-# no point at which the golden files are all deleted, so `git status` never
-# shows a scary mass deletion mid-run.
 mkdir -p wado-compiler/tests/generated/fixtures
-# A fixture with no __DATA__ section defaults to the test world (matching the
-# e2e harness), so `--default-world test` keeps golden-dump and the harness in
-# agreement.
+# `--default-world test` matches the e2e harness, which reads a fixture with no
+# __DATA__ section as the test world.
 ./target/debug/wado-dev-tools golden-dump \
     --in 'wado-compiler/tests/fixtures/{name}.wado' \
     --emit wir:'wado-compiler/tests/generated/fixtures/{name}.wir.wado' \
@@ -445,12 +408,8 @@ description = "Build the wado-lsp wasm32-wasip1 binary (-Os) into wado-vscode/ou
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# @vscode/wasm-wasi-lsp hosts wasm32-wasip1 modules only; the p2 component
-# target is not yet consumable by the VS Code Wasm host. See
-# docs/wep-2026-04-18-lsp-architecture.md (fallback noted in Prerequisites).
-# Build for size (-Os + LTO, mirroring wado-bundled-libm and the browser
-# playground): the bundled server ships in the VSIX and gains nothing from
-# speed-oriented codegen.
+# @vscode/wasm-wasi-lsp hosts wasm32-wasip1 modules only, not p2 components; see
+# docs/wep-2026-04-18-lsp-architecture.md. Size over speed: it ships in the VSIX.
 CARGO_PROFILE_RELEASE_OPT_LEVEL=s CARGO_PROFILE_RELEASE_LTO=true \
   cargo build -p wado-lsp --bin wado-lsp --target wasm32-wasip1 --release
 mkdir -p wado-vscode/out
@@ -464,8 +423,7 @@ run = """
 set -xe -o pipefail
 mise run build-wado-lsp-wasm-rust
 
-# Compile the extension TS so wado-vscode/out/extension.js stays in sync —
-# otherwise a Reload Window picks up stale JS that doesn't match the wasm.
+# Without this, a Reload Window picks up JS that no longer matches the wasm.
 ( cd wado-vscode && [ -d node_modules ] || npm install )
 ( cd wado-vscode && npm run compile )
 """
@@ -476,22 +434,16 @@ run = """
 #!/usr/bin/env bash
 set -e -o pipefail
 
-# Make sure node_modules exists before launching tsc -watch.
 ( cd wado-vscode && [ -d node_modules ] || npm install )
 
-# tsc -watch rebuilds wado-vscode/out/extension.js on every TS edit. VS Code
-# does not auto-reload extension code, so you still need
-# "Developer: Reload Window" after a TS change — but extension.js is always
-# in sync once tsc has rebuilt it.
+# A TS change still needs "Developer: Reload Window"; VS Code does not reload
+# extension code on its own.
 ( cd wado-vscode && exec npm run watch ) &
 TSC_PID=$!
 trap 'kill -TERM $TSC_PID 2>/dev/null || true; wait $TSC_PID 2>/dev/null || true' EXIT INT TERM
 
-# cargo watch rebuilds the wasm on every Rust change. The extension's
-# FileSystemWatcher picks the new wasm up and restarts the LSP server,
-# so Rust-only changes do not require a Reload Window. Use the rust-only
-# build task so we don't kick off a redundant `npm run compile` on every
-# Rust edit (the tsc watcher above already keeps extension.js fresh).
+# A Rust change does not: the extension's FileSystemWatcher restarts the server
+# on the new wasm. Rust-only build task, since tsc above already covers the TS.
 cargo watch \\
     -w wado-lsp \\
     -w wado-compiler \\
@@ -549,8 +501,7 @@ description = "Regenerate core:kiln stdlib submodules from WIT file (facade is h
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# Clean the auto-generated submodules; the facade `lib/core/kiln.wado`
-# is hand-written and must be preserved.
+# Submodules only — the facade `lib/core/kiln.wado` is hand-written.
 rm -f wado-compiler/lib/core/kiln/*.wado
 cargo run -p wado-from-idl -- \
     --wit-dir wado-compiler/lib/core/kiln \
@@ -649,8 +600,7 @@ run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
 cd vendor/jco
-# Apply the Wado patches on top of the pinned upstream checkout (idempotent:
-# skip if they are already applied to the working tree).
+# Idempotent: skip if the patches are already in the working tree.
 if git apply --reverse --check ../../vendor/jco.patch 2>/dev/null; then
   echo "jco.patch already applied"
 else

--- a/mise.toml
+++ b/mise.toml
@@ -290,7 +290,7 @@ extra_args=()
 if [ -n "${CI:-}" ]; then
     extra_args+=(--exclude 'package-gale/**' --format tap)
 fi
-cargo run -p wado-cli -- test "${extra_args[@]}"
+cargo run -p wado-cli -- test -O2 "${extra_args[@]}"
 """
 
 [tasks.test-gale-o3]


### PR DESCRIPTION
## Build cache

`cargo-cache.yml` publishes three caches from `main`: the two GCS objects that non-GitHub environments restore, and the GitHub Actions cache every `ci.yml` job reads under `shared-key: ci`. An Actions cache is visible only to the branch that wrote it, that branch's descendants, and the default branch, so a main-branch writer is what makes those read-only restores hit. Without a hit each job compiles the full dependency graph from scratch.

Two constraints hold the setup together:

- rust-cache hashes the `CARGO_*`/`RUST*` env set into the cache key, so `actions-cache`'s env is exactly `ci.yml`'s. The sccache variables live on the `upload` job rather than at workflow scope to keep them off it.
- `.github/workflows/ci.yml` is in `on.push.paths`, so editing that env republishes the cache under the new key.

`--all-targets` covers the dev-dependencies only `ci.yml`'s test binaries pull in. rust-cache drops the workspace crates' own artifacts before saving, so what ships is the dependency graph plus the registry.

## Optimization coverage

Every Wado test runs through the optimizer: `test-wado` compiles at `-O2` and `test-gale-o3` at `-O3`. `wado test` selects O0 when given no level, unlike `compile` and `build`, so both tasks name one explicitly.

package-gale runs at O3 alone. Coverage of the remaining levels comes from the `Test (E2E *)` jobs, which span -O0 through -Os over `wado-compiler/tests/fixtures/`.

## mise comments

Task comments carry what the command below them cannot show: why a flag is set, why a step is absent, and what degrades silently when an invariant breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSwrw5FDs2zW6yf2kCJ4JE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSwrw5FDs2zW6yf2kCJ4JE)_