### PR TITLE
fix(niri): refuse folds that outlive the write they depend on

### DIFF
--- a/docs/wep-2026-04-27-nir-interpreter.md
+++ b/docs/wep-2026-04-27-nir-interpreter.md
@@ -2,24 +2,21 @@
 
 ## Context
 
-The Wado optimizer needs to reduce expressions the source made constant —
-literal arithmetic, a branch whose condition is known, a pure call with
-constant arguments — to the value they denote. `niri` ("NIR Interpreter") is
-the engine that answers what a NIR expression evaluates to at compile time.
-Constant folding is its primary consumer; branch pruning, constant
-propagation, and compile-time function evaluation reuse it.
+The optimizer needs to reduce what the source made constant — literal
+arithmetic, a branch whose condition is known, a pure call with constant
+arguments — to the value it denotes. `niri` is the engine that answers what a
+NIR expression evaluates to at compile time. Constant folding is its primary
+consumer; branch pruning, constant propagation and compile-time function
+evaluation reuse it.
 
-This WEP records the trajectory so contributors don't re-litigate the design
-each time we want to fold a richer expression. It states capabilities, not
-mechanisms: what `niri` can and cannot evaluate. How it does so is the code's
-business.
+This WEP states capabilities, not mechanisms: what `niri` can and cannot
+evaluate. How it does so is the code's business.
 
 ## Decision
 
-`niri` is a **partial evaluator** for NIR: it reduces what it can and leaves
-a residual otherwise. Beyond the in-process engine, a complementary
-**wasm-CTFE backend** runs full pure calls through a real Wasm runtime, using
-Wado's effect system as a type-checked purity gate.
+`niri` is a partial evaluator: it reduces what it can and leaves a residual
+otherwise. A complementary wasm-CTFE backend runs whole pure calls through a
+real Wasm runtime, using Wado's effect system as a type-checked purity gate.
 
 ### Why two backends
 
@@ -30,465 +27,268 @@ Wado's effect system as a type-checked purity gate.
 | Partial eval | Yes (residuals)                                    | No (whole-call)                                         |
 | Coverage     | Whatever we hand-write                             | All of Wado, for free                                   |
 
-These are complementary, not alternatives. `niri` stays cheap and
-fine-grained; wasm execution covers anything `niri` balks at.
+`niri` stays cheap and fine-grained; wasm execution covers anything it balks at.
 
 ### Scope boundary against the ValueGraph
 
-`niri` evaluates **pure values**: given an expression and what is known about
-its inputs, what does it denote. The engine's `ValueGraph` owns everything
-**flow-sensitive**: reaching definitions, branch merges, loop and heap-write
-invalidation, field store-to-load seeding.
-
-The boundary is load-bearing. `niri` once carried its own per-local map of
-known fields, with branch-merge and loop-invalidation logic; it was built and
-then retired once the `ValueGraph` covered the same ground. Anything that
-needs to know _which_ definition reaches a use belongs to the `ValueGraph`,
-and a proposal to teach `niri` about control flow between statements should be
-read as a sign the fact belongs on the other side of this line.
+`niri` evaluates pure values: what an expression denotes, given what is known
+about its inputs. Everything flow-sensitive — reaching definitions, branch
+merges, loop and heap-write invalidation, field store-to-load seeding — belongs
+to the `ValueGraph`. The boundary is load-bearing: `niri` once carried its own
+per-local field map and it was retired once the `ValueGraph` covered the same
+ground. A proposal to teach `niri` about control flow between statements is a
+sign the fact belongs on the other side of the line.
 
 What the line does not forbid is a store over the values the engine itself
-constructed. Inside a frame `niri` already executes statements in order, so a
-value built there — and reachable from nothing the frame did not build — can be
-written through and read back without asking which definition reaches a use.
-The program's heap stays the `ValueGraph`'s; the engine's own is the engine's.
+built. Inside a frame `niri` executes statements in order, so a value built
+there — reachable from nothing the frame did not build — can be written through
+and read back. The program's heap stays the `ValueGraph`'s; the engine's own is
+the engine's.
 
 ### Effects are the purity gate
 
-CTFE soundness rests on effect inference: a function admitted for
-compile-time evaluation is one the effect system called pure. A bug there
-lets an impure function be evaluated at compile time. This is the same trust
+A function admitted for compile-time evaluation is one the effect system called
+pure. A bug there lets an impure function run at compile time — the same trust
 already placed in effect checking elsewhere.
 
 ## Done
 
 Value model:
 
-- Integer, float, bool and char scalars, with the arithmetic, comparison,
-  bitwise and unary operators over them, and casts between them.
-- Structs and tuples whose every field is constant, and field reads
-  projecting back out of them — out of a literal, a local, an immutable
-  global, or a compile-time call result. An aggregate leaves the engine only
-  where it has a literal shape to be written as; otherwise what reaches the IR
-  is the scalars projected out of it.
-- An enum value, which is its discriminant, and a variant value, which is its
-  case plus the payload the case carries. Both construction forms fold and both
-  pattern kinds decide, so an `Option` / `Result` accessor exposed by inlining
-  collapses instead of leaving a residual match, and a policy enum passed to a
-  library helper — serde's `CaseStyle` — is a constant at the call it reaches. An
-  enum constant enters the pool under the enum's own type, which is an `i32` no
-  primitive names, so reading one back out is its own case; a variant has no
-  literal shape and stays inside the engine.
-- A three-state lattice — unevaluated, constant, non-constant — with a join,
-  so an unreachable branch contributes nothing to the result and a trapping
-  arm does not contaminate a fold.
+- Integer, float, bool and char scalars, with their arithmetic, comparison,
+  bitwise and unary operators and the casts between them.
+- Structs and tuples whose every field is constant, and the field reads
+  projecting back out of a literal, a local, an immutable global or a
+  compile-time call result.
+- Enums, whose discriminant is the whole value, and variants, which carry a case
+  and its payload. Both construction forms fold and both pattern kinds decide.
+- An aggregate leaves the engine only where it has a literal shape to be written
+  as. Otherwise what reaches the IR is the scalars projected out of it.
+- A three-state lattice — unevaluated, constant, non-constant — so an
+  unreachable branch contributes nothing and a trapping arm does not contaminate
+  a fold.
 
 Bindings:
 
-- Immutable locals whose initializer is constant read back as that constant.
-  Mutable and assigned locals are non-constant.
-- Immutable globals whose initializer is constant fold at every read, as do
-  the known constant fields of a global (a sequence global's length).
-- A global whose value is not in its slot but in the assignment that fills it —
-  what an extracted initializer and body globalization both leave behind —
-  reads back from that assignment. A global assigned anything that does not
-  reduce, or two disagreeing constants, stays non-constant. Reads inside module
-  initialization need no exception: initializers are ordered by dependency, so
-  a read there already follows the assignment it would fold from.
-- Nothing is read off a global something writes through. `global` without `mut`
-  forbids reassignment, not in-place mutation, so a `&mut self` method, a
-  mutable borrow, or a store to a projection of one makes both its value and
-  its known fields stale — the same discipline a local carrying an aggregate is
-  held to.
-- An aggregate constant binds to a local only when every mention of that local
-  merely reads it. `niri` models whole values, not the heap, so a local
-  another handle can write through would go stale.
-- A borrow denotes what it points at rather than operating on it, so a local
-  bound to `&CONST` carries the referent and reads project out of it. Which
+- Immutable locals and globals whose initializer is constant, plus a global's
+  separately known fields, such as a sequence global's length.
+- A global whose value is not in its slot but in the assignment that fills it,
+  which is what an extracted initializer and body globalization leave behind.
+  Two disagreeing assignments make it non-constant.
+- Nothing is read off a local or global something writes through: `global`
+  without `mut` forbids reassignment, not in-place mutation. An aggregate binds
+  to a local only when every mention of that local merely reads it.
+- A borrow denotes its referent, so a local bound to `&CONST` carries it. Which
   locals those are is decided once per body over the whole arena, so a read
   folds through a binding an in-place rewrite displaced — and an index more than
-  one binder names therefore carries nothing, since such a scan cannot say which
-  binding governs a read.
+  one binder names carries nothing, since such a scan cannot say which binding
+  governs a read.
 
 Control flow:
 
-- `if`, expression and statement form: a constant condition collapses to the
-  chosen arm; a side-effect-free condition whose arms denote the same constant
-  collapses to that constant.
-- `match`: a constant scrutinee selects the first arm that provably matches;
-  a provably exhaustive match whose every arm denotes the same constant
-  collapses to it. The exhaustiveness requirement is what keeps the implicit
-  no-match trap alive.
+- `if`: a constant condition collapses to the chosen arm, and a side-effect-free
+  condition whose arms denote the same constant collapses to it.
+- `match`: a constant scrutinee selects the first arm that provably matches, and
+  a provably exhaustive match whose arms all denote one constant collapses to
+  it. Exhaustiveness is what keeps the implicit no-match trap alive.
 - Patterns decided: wildcard, binding, integer / bool / char literal, range,
-  or-patterns, a constant-valued pattern, struct patterns, and exact-arity
-  tuple patterns. A definite field mismatch rules an arm out even when a
-  sibling field binds.
-- An arm's guard and body are evaluated with that arm's bindings in scope.
-- `match X { Enum::Case => true, _ => false }` — the shape
-  `X matches { Case }` desugars to — collapses to a discriminator comparison
-  before the match ever reaches pattern lowering.
+  or-patterns, constant-valued, struct, and exact-arity tuple. An arm's guard and
+  body are evaluated with that arm's bindings in scope.
+- `X matches { Case }` collapses to a discriminator comparison before the match
+  reaches pattern lowering.
 
 Calls:
 
-- A free call whose arguments are all constant and whose callee is pure,
-  non-async, monomorphic, and returning something runs at compile time. A call
-  that yields nothing has no value to substitute, and handing one back would
-  leave a value where the program expects none. The body executes statement
-  by statement, so a `let` sequence, assignment to a local, an `if` whose
-  condition decides, an early `return`, a labeled block completed by its
-  `break`, and a loop all reach a value. Recursion and total work are bounded.
-  A body that does not produce a constant leaves the call in place, so a
-  runtime trap inside it stays observable.
-- A call whose result may carry the caller's storage runs for its writes but
-  yields no value: it would stand as a snapshot the next write to that storage
-  leaves stale. Two parameter kinds reach there — a `&mut` one, whose referent
-  the result may embed (`Formatter::new(&mut buf)`), and one `stores[p]` declares
-  the callee keeps, whose alias leaves inside an ordinary aggregate that neither
-  the return type nor the write targets name. A scalar embeds nothing.
+- A free call runs at compile time when its arguments are all constant and its
+  callee is pure, non-async and monomorphic. The body executes statement by
+  statement, so `let` sequences, assignments, decided branches, early returns,
+  labeled blocks and loops all reach a value.
 - A statement counts as executed only when everything it evaluates lands on a
-  constant. Reducing an expression is not performing it: an unfolded call, a
-  global write, or an operation that would trap all leave work undone, and
-  stepping past them would drop it.
-- A loop needs no constant trip count. The work budget bounds it, so one that
-  does not finish in time abandons the evaluation rather than guessing, and
-  what an iteration derived does not survive into the next. The budget is per
-  function, so what one spends cannot decide whether the next one folds.
+  constant. An unfolded call, a global write or a would-be trap leaves work
+  undone, and stepping past it would drop it.
+- A loop needs no constant trip count: the work budget bounds it, and the budget
+  is per function. Recursion is bounded too, and a body that does not produce a
+  constant leaves the call in place, so a runtime trap inside it stays
+  observable.
+- A result that may carry the caller's storage is withheld, though the writes
+  still land. Two parameter kinds reach that storage: a `&mut` one, whose
+  referent the result may embed (`Formatter::new(&mut buf)`), and one `stores[p]`
+  declares the callee keeps, whose alias leaves inside an ordinary aggregate that
+  neither the return type nor the write targets name. Either result would stand
+  as a snapshot the next write leaves stale. A scalar embeds nothing.
 - A local the frame cannot track — one a mutable borrow, a mutable argument, a
-  method receiver, a store through a projection, or an assignment buried inside
-  a larger expression can write — carries no value, so a stale constant cannot
-  outlive the write. A shared borrow is not one of those channels.
-- A string literal's `len()` folds, as a consequence of the generic
-  struct-field projection rather than any string-specific rule.
+  receiver or an assignment buried in a larger expression can write — carries no
+  value. A shared borrow is not one of those channels.
 
 Sequences:
 
 - The array backing a `String` or a `List` is a value, built from a byte-string
-  literal or a fully-constant array literal, bounded by a maximum length past
-  which building one would cost more than any fold it enables. `String` and
-  `List` need no case of their own: each is an aggregate whose backing field is
-  a sequence and whose length field is an integer — and an array literal
-  denotes that whole container, since that is what it lowers to.
-- Whether a local may carry an aggregate is decided from the reachable body. A
-  node an earlier rewrite orphaned cannot run, so it must not disqualify one:
-  inlining `t.len()` leaves the original method call behind, and counting its
-  receiver would refuse every list the caller then reads.
-- An element or length read folds through the array builtins the read lowers
-  to, not through an index node. Both the generic builtin and the `u8`
-  specialization are recognized. A read past the end is left alone, since it
-  traps at run time.
-- A shared borrow reads as the constant it points at, which is what makes a
-  backing array reachable at all — it reaches the builtin as `&arr`. Only a
-  shared one: a write goes through a mutable borrow, which stays unmodelled.
-- A constant list's length folds, so a constant-index bounds check on it does
-  too, and so does the element that check guards — out of a local literal, and
-  out of a global, whose container the engine recovers from the assignment that
-  fills its slot. Only a scalar element reaches the IR; an aggregate one stays
-  inside the engine, as every aggregate does.
-- A prefix clone folds: `array_clone_prefix(&src, len)` — what a value copy of a
-  sequence container lowers to — is the source's first `len` elements. Without
-  it, passing a constant `String` by value hands the callee a value the engine
-  cannot see, which is where a derivation's own field reads end up.
-- An element write lands. `array_set` through a `&mut` reaching a place the
-  frame owns — a local it bound to a constant, plus the field path into it —
-  updates that local's value, so a later read sees what was written. The write
-  is performed, not folded: it only counts at statement position, where the
-  executor runs it. A place rooted anywhere else — a parameter, a global,
-  anything the frame did not build — has no current value to update and
-  abandons the evaluation rather than being stepped past.
-- A shared borrow never makes its root stale: nothing writes through one, which
-  is the same reading the aggregate-binding scan gives the node, where `&x`
-  counts as a read of `x`. A frame that refused it could not run a body whose
-  own parameter is borrowed — which every `&self` method's is, and which is what
-  a derivation walking member handles does at every step. A mutable borrow still
-  does, except where the executor performs the write itself (a sequence
-  builtin).
-- A byte-sequence container the engine knows the contents of is written back as
-  the literal the lower phase emits for a source string — a struct over a packed
-  byte array and its length. The bytes are the container's first `used`, since
-  a grown container's capacity outruns what it holds and capacity is not
-  observable. A container the frame never filled stays as the source wrote it:
-  an empty one is a reservation rather than a result, and a literal cannot
-  carry the capacity it asked for.
-- Written back wherever the write buys something, which is everywhere but two
-  shapes already holding the answer. One is the literal the rewrite itself
-  produces: refusing what was already written is what keeps the worklist
-  settling. The other is a read of a globalized constant, whose value is in a
-  shared slot precisely so it is built once — a literal in its place is that
-  constant copied back to every site. Anything else is written, including the
-  field read and the borrow operand a derived wire name would otherwise cost on
-  every call.
+  literal or a fully-constant array literal, up to a maximum length past which
+  building one costs more than any fold it enables.
+- Element and length reads fold through the array builtins they lower to, not
+  through an index node. A read past the end is left alone to trap at run time.
+- An element write lands, and a prefix clone folds — the latter being what a
+  value copy of a sequence container lowers to.
+- A write goes into the value where it lies rather than rebuilding the container
+  around it, so filling a sequence is not quadratic in its length. The backing is
+  shared until something writes it, so a value copied out beforehand keeps what
+  it was given.
+- A byte-sequence container the engine filled is written back as the literal the
+  lower phase emits for a source string, over its first `used` bytes. One the
+  frame never filled stays as the source wrote it: an empty container is a
+  reservation rather than a result.
 
 Regions:
 
-- A self-contained block runs as a frame the engine starts from scratch: one
-  that builds its value in locals of its own, reads and writes only those, and
-  yields the result is as self-contained as a call body — the difference is
-  that the caller wrote it inline. This is what folds a fully-constant string
-  template to the literal the source could have written.
-- Self-containment is decided before the run rather than during it: every
-  local the block mentions must be one it declares, and every call one a frame
-  could run. A region's frame starts empty, so a read of an outer local yields
-  nothing and an unrunnable call has no body to execute — the run abandons on
-  either. Deciding first is what keeps the attempt cheap, since the run copies
-  the whole enclosing body while the checks only walk the block. What they give
-  up is a mention on a statically dead path, which no scan can tell from a live
-  one.
-- A block yielding nothing denotes nothing, whatever its last statement
-  computed. An inlined statement call leaves the callee's result there while
-  the block stands where the program expects no value, and a constant put in
-  that position is one the surrounding type cannot hold.
-- The copy a run makes is charged to the step budget, because it is the work.
-  Uncharged, a function full of templates pays a whole-body copy per template
-  per pass and const folding turns quadratic in function size. A very large
-  function may find the budget spent before its later regions, which is the
-  trade every budgeted evaluation makes.
-- A write inside a frame goes into the value where it lies rather than
-  rebuilding the container around it. Rebuilding copies the whole backing per
-  write, which makes filling a sequence quadratic in its length. The backing is
-  shared until something writes it, so a value copied out beforehand — Wado's
-  value semantics say `let d = c` is a copy — forks at that first write and
-  keeps what it was given.
-- A `let` binding a borrow of a local place resolves to an alias inside a
-  frame rather than to a value, and so does rebinding a local that already
-  carries one: copying a reference copies the reference, so both handles name
-  the same storage. That is what carries the desugared template's
-  `let self = &mut __r` through the appends that follow.
-- An alias is resolved by a projection — a field read, an element read, a
-  deref — and by nothing else. The engine has no reference values, so handing
-  the referent back where the reference itself is read would turn a capture
-  into a copy, and a later write through the reference would land in that copy
-  while the referent kept a value it no longer holds. `Formatter { buf: &mut
-  __r }` is refused on that ground rather than by accident. An ordinary walk
-  performs nothing, so outside a frame such a binding still clobbers its
-  referent.
-- A reference is recognized by shape, not by spelling. The boxing pass redefines
-  a `&T` into `Box<T>`, so every refusal above — a reference-typed node, a
-  reference-returning callee, a reference-typed binding, region or free read —
-  asks both, and one that asked only the borrow spelling would snapshot an alias
-  a later write invalidates.
-- A cast between the same reference shape denotes its operand;
-  monomorphization leaves one over every buffer the formatting path builds. A
-  converting cast still folds only through the primitive-cast evaluator. Place
-  naming and the trackability mentions read through casts alike, so a borrow
-  reaching a builtin wrapped in one still names — and keeps trackable — the
-  local it writes.
+- A self-contained block — one that builds its value in locals of its own, reads
+  and writes only those, and yields the result — runs as a frame the engine
+  starts from scratch. This is what folds a fully-constant string template to
+  the literal the source could have written.
+- Self-containment is decided before the run, since the run copies the enclosing
+  body while the checks only walk the block. What that gives up is a mention on
+  a statically dead path, which no scan can tell from a live one.
+- A block yielding nothing denotes nothing, whatever its last statement computed.
+- An outer local the region only reads is seeded from the walker's environment
+  when it is constant there. A write position — an `Assign` target, a `&mut`
+  borrow root, or an argument the callee's signature takes by `&mut` — or a
+  reference-typed mention refuses the region instead.
+- Inside a frame, a `let` binding a borrow of a local place resolves to an alias,
+  and so does rebinding a local that already carries one: copying a reference
+  copies the reference. An alias is resolved by a projection and by nothing else,
+  so a capture never turns into a copy.
+- A reference is recognized by shape rather than by spelling, since the boxing
+  pass redefines `&T` into `Box<T>`. A cast between the same reference shape
+  denotes its operand.
 
 ## TODO
 
-### Values the engine cannot represent
+Values the engine cannot represent:
 
-- A place-valued field, so an aggregate can carry a reference. Today such an
-  aggregate is simply not a constant, since a field holding the referent's
-  value would take a write meant for the referent. What the field needs to
-  hold is the place the frame already names elsewhere, which would make the
-  alias machinery reach through a struct as well as through a local.
-  `Formatter { buf: &mut __r }` is the shape waiting on this, and so is every
-  result a `stores` callee hands back.
+- [ ] A place-valued field, so an aggregate can carry a reference. Today such an
+      aggregate is not a constant, since a field holding the referent's value
+      would take a write meant for the referent; what it needs to hold is the
+      place the frame already names elsewhere. `Formatter { buf: &mut __r }`
+      waits on this, and so does every result a `stores` callee hands back — and
+      that refusal is whole-value, so a scalar field naming no storage is refused
+      with the rest, which is why `Array::slice`'s computed bounds stop folding.
+- [ ] An aggregate that is not a byte sequence has no way back into the IR. A
+      `List<T>` of scalars wants the `ArrayLiteral` shape and a plain struct a
+      `StructLiteral`, each needing its own answer to "is this already the
+      literal the rewrite writes" so the worklist still settles.
+- [ ] Comparing two literal strings, which reaches the engine as a guard and
+      means running a method call over references.
 
-  The refusal is whole-value, so it costs more than the alias it protects: a
-  scalar field names no storage yet is refused with the rest. `Array::slice`
-  shows it — the two bounds it computes stop folding because the backing it was
-  handed shares their aggregate.
-- An aggregate that is not a byte sequence has no way back into the IR. A
-  `List<T>` of scalars would want the `ArrayLiteral` shape, and a plain struct
-  a `StructLiteral` over its materialized fields; both are exits to add beside
-  the byte-sequence one, each needing its own answer to "is this already the
-  literal the rewrite writes" so the worklist still settles.
-- Comparing two literal strings. A string pattern reaches the engine as a
-  guard, and deciding it means running the comparison — which is a method call
-  taking references, so it waits on the two entries below rather than on the
-  value model.
+Calls:
 
-### Calls
+- [ ] A destructuring `let`; a body containing one is abandoned.
+- [ ] Method calls, excluded because a `&mut self` receiver mutates through the
+      call. Unnecessary for a receiver the frame owns, which the store can update.
+- [ ] A call that returns nothing but whose every write lands in a place the
+      frame owns, which is what lets a builder-style helper run.
+- [ ] Closure calls: an indirect call whose closure is known is never resolved
+      to a direct call, so neither inlining nor CTFE reaches through it.
+- [ ] Recursion beyond a base case. The wasm-CTFE backend is the intended answer.
 
-- A destructuring `let`, which binds a pattern rather than a name; a body
-  containing one is abandoned.
-- Method calls, excluded because a `&mut self` receiver mutates through the
-  call. Worth revisiting now that mod-ref and alias analysis can prove a
-  receiver is not written — and unnecessary for a receiver the frame owns, which
-  the store below can simply update.
-- A call that returns nothing. Eligibility asks for a value to substitute, which
-  is the right question for replacing a call and the wrong one for running it:
-  a call whose every write lands in a place the frame owns is executable as a
-  statement whatever it returns. Splitting the two — value-CTFE and
-  frame-executable — is what lets a builder-style helper run.
-- Closure calls: an indirect call whose closure is known at the call site is
-  never resolved to a direct call, so neither inlining nor CTFE can reach
-  through it.
-- Recursion beyond a base case. The wasm-CTFE backend below is the intended
-  answer.
+Control flow:
 
-### Control flow
+- [ ] A `switch` with a constant scrutinee. A switch is formed before inlining,
+      so a scrutinee inlining makes constant survives untouched.
+- [ ] Unrolling a loop in the caller — a code-size trade needing a cost model,
+      not an evaluation capability.
+- [ ] Guards decided when the engine is only asked what an expression denotes.
 
-- A `switch` with a constant scrutinee is not folded, although `if` and
-  `match` are. Since a switch is formed before inlining, a scrutinee that
-  inlining makes constant survives to the end untouched.
-- Unrolling a loop in place in the caller. Distinct from running one during a
-  compile-time call, which is done: this is a code-size trade needing a cost
-  model, not an evaluation capability.
-- Guards decided when the engine is only asked what an expression denotes;
-  today an arm's bindings are only in scope on the rewriting path.
+Sequences:
 
-### Sequences
-
-- The rest of the spine. Element and field writes land, an allocation denotes a
-  zero-filled sequence and a copy a spliced one; what remains is a `&mut`
-  argument writing back into the caller frame's place on return. Without it a
-  buffer that grows — which is what `String` does the moment it outruns its
-  capacity — still abandons the evaluation, because `grow` reshapes the
-  caller's container from a frame of its own. What will not fit even then — a
-  table past the length cap, a fill loop past the step budget — stays the
-  wasm-CTFE backend's case.
-
-### Regions
-
-- A region's frame is seeded from the walker's environment: an outer local
-  the region only reads, constant at the region's flow point, is bound in the
-  frame as a value snapshot. The write test is what keeps that sound —
-  `region_free_reads` rejects an outer local in a write position (an `Assign`
-  target, a `&mut` borrow root, or any argument the callee's signature takes
-  by `&mut` — the signature, because boxing can erase the borrow node at the
-  call site — refusing outright when a write's place no local roots), and a
-  reference-typed mention is refused, since reading a `&mut T` value hands a
-  callee the same write capability. A
-  reference-typed region result is refused for its own reason: the fold would
-  materialize a fresh value where the program yields an alias, and `ref.eq`
-  tells the two apart. A constant outer local therefore folds during the
-  loop, before globalization would hoist it — which also keeps globalization
-  from planting the hoist's `GlobalVarSet` inside the region, a write that
-  would disqualify it for good.
+- [ ] A `&mut` argument writing back into the caller frame's place on return.
+      Without it a buffer that grows still abandons the evaluation, because
+      `grow` reshapes the caller's container from a frame of its own. What will
+      not fit even then stays the wasm-CTFE backend's case.
 
 ### Compile-time string formatting
 
 A template whose interpolations are all constant still formats at run time.
 `` `n=${42}` `` reaches the end of the optimizer as a buffer allocation, two
-byte pushes, a `Formatter` literal, and a call to `i32::fmt_decimal`, paying a
-digit-count loop and a division loop per evaluation — and keeping the
-formatting code alive in the binary — for four bytes decided at compile time.
-The same string written `"n=42"` folds to a deduplicated constant global.
-Every `${}` over constants, every `to_string()` on a literal, every constant
-`assert` message, and every constant `${x:?}` pays this.
+byte pushes, a `Formatter` literal and a call to `i32::fmt_decimal` — a
+digit-count loop and a division loop per evaluation, plus the formatting code
+kept alive in the binary, for four bytes decided at compile time. Every `${}`
+over constants, every `to_string()` on a literal and every constant `assert`
+message pays it.
 
-Nothing here waits on trait dispatch: `Display::fmt` is monomorphized and
-devirtualized to a free call before the optimizer runs. The aggregate exit, the
-store, the frame-executable call, and region recognition together fold the
-region to the literal the source could have written, after which
-constant-object globalization deduplicates it and DCE drops the formatting
-functions no live call reaches. What the remaining coverage waits on is the
-value model: an interpolation that keeps its `Formatter` literal needs an enum
-value for the alignment field and a place-naming value for the `&mut` buffer
-field, so a callee's write through `f.buf` lands in the region's buffer rather
-than in a copy inside the `Formatter` aggregate.
+Nothing waits on trait dispatch: `Display::fmt` is devirtualized to a free call
+before the optimizer runs. The aggregate exit, the store, the frame-executable
+call and region recognition together fold the region to a literal, after which
+globalization deduplicates it and DCE drops the unreached formatting functions.
+What the remaining coverage waits on is the value model above: an interpolation
+keeping its `Formatter` literal needs an enum value for the alignment field and
+a place-naming value for the `&mut` buffer field.
 
 Fold the region, not the call. A region constructs its own buffer, so every
-value inside it is concrete and nothing is assumed about it.
+value inside it is concrete. The call-level fold — rewriting one `fmt` over a
+constant into `push_str(<literal>)`, which a template mixing constant and
+runtime interpolations needs — claims more than one concrete evaluation shows:
+that the callee appends the same bytes to every buffer. `#[compiler_item]` is
+where that claim comes from, as it already does for `push_str`.
 
-The call-level fold — rewriting one `fmt` over a constant into
-`push_str(<literal>)`, which is what a template mixing constant and runtime
-interpolations needs — claims more than one concrete evaluation shows: that the
-callee appends the same bytes to every buffer, not just to the one it ran
-against. `#[compiler_item]` is where that comes from, as it already does for
-`push_str` — the rewrite expanding `buf.push_str("abc")` into per-byte `push`
-is licensed by the marker, not by an analysis of either body.
-
-Mark `Formatter`'s write primitives, not `Display::fmt`. Marking the trait
-would extend the trust across every user-written impl, where nothing is
-checkable; a primitive is one small stdlib function a reader can confirm, the
-same obligation `push_str` already carries.
-
-What a marked primitive declares is a region append: everything it does to the
-buffer happens at or above the length the buffer had on entry, and what lies
-below is neither read nor moved. That is the stdlib's formatting idiom as
-written — `prepare_int_write` reserves a region the digit writers fill
-backwards, `mark` / `apply_padding` appends content and then shifts it to make
-room for alignment, and `fpfmt`'s writers reserve and slide a fractional tail
-to insert the point. A strictly-append contract, where bytes land on the end
-and are never revisited, is not the design: a padded float cannot learn its
-length before appending, so reaching it would mean formatting through an
-intermediate buffer, which costs more at run time than the contract is worth.
-Region append covers all three idioms unchanged and is still one sentence.
-
-What any particular `fmt` body does is then derived rather than declared: run it
-against a buffer the engine constructed, and admit the result when every buffer
-access either went through a marked primitive or landed inside a region one of
-them just returned. A body that reads the buffer's prior length for its own
-purposes, or reaches `f.buf` outside that, is refused — a condition the engine
-checks rather than an invariant it hopes for.
-
-The markers also keep the buffer plumbing out of the interpreter: a marked
-`push_str` is applied by its declared meaning, so `grow`'s undecidable capacity
-test and `realloc_to`'s prefix copy are never interpreted. The reserved region a
-primitive hands back is the same place the frame store hands out, so the two
-capabilities want the same representation.
-
-What is left, each red/green with the fixture first:
+Mark `Formatter`'s write primitives, not `Display::fmt`: marking the trait would
+extend the trust to every user-written impl, where nothing is checkable. What a
+marked primitive declares is a region append — everything it does to the buffer
+happens at or above the length the buffer had on entry, and what lies below is
+neither read nor moved. That covers the stdlib's three formatting idioms
+(`prepare_int_write`, `mark` / `apply_padding`, `fpfmt`'s reserving writers)
+unchanged, where a strictly-append contract would not. What a particular `fmt`
+body does is then derived: run it against a buffer the engine built, and admit
+the result when every buffer access went through a marked primitive or landed
+inside a region one just returned.
 
 - [ ] Coverage, in order of engine cost: `bool` / `char` / `String`, then
-      integers, then width / zero-pad / radix specs, then `Inspect`, then
-      floats. A `String` literal interpolation folds already — its `fmt`
-      inlines down to reserve-and-write, so no `Formatter` value survives —
-      and every other type keeps a `Formatter` literal, which waits on the
-      enum and `&mut`-field values above. Each step measures what it spends
-      against the step budget: integer formatting is two short loops and fits,
-      and `fpfmt` is the candidate for overrunning it — if it does, floats are
-      the wasm-CTFE backend's case rather than a reason to raise the budget.
-- [ ] A remark for a region that nearly folded — one runtime interpolation, or
-      an exhausted budget — so a missed fold is visible instead of silent, plus
-      a `wasm-size` and `benchmark` run to record what the whole thing bought.
-
-A template with any runtime interpolation keeps today's imperative form,
-including the loop-buffer reuse `tmpl_hoist` gives it.
+      integers, then width / zero-pad / radix specs, then `Inspect`, then floats.
+      A `String` interpolation folds already. Each step measures what it spends
+      against the step budget; if `fpfmt` overruns it, floats are the wasm-CTFE
+      backend's case rather than a reason to raise the budget.
+- [ ] A remark for a region that nearly folded — one runtime interpolation, or an
+      exhausted budget — plus a `wasm-size` and `benchmark` run to record what
+      the whole thing bought.
 
 ### wasm-CTFE backend
 
-- `wado-compiler` must compile to `wasm32-unknown-unknown`, so it cannot link
-  a Wasm runtime. Compile-time evaluation of a whole call therefore routes
-  through the compiler host, as generator execution already does. Hosts with
-  a runtime implement it; the LSP and browser hosts decline and `niri` stays
-  in-process.
-- Triggered when in-process reduction gives up on a callee that is still
-  pure by its effects; the result is used as if the in-process engine had
-  produced it.
-- Enables `compute_lookup_table(256)` and similar workloads at compile time
-  without re-implementing every NIR construct in the interpreter.
+- [ ] `wado-compiler` must compile to `wasm32-unknown-unknown`, so it cannot link
+      a Wasm runtime. Whole-call evaluation therefore routes through the compiler
+      host, as generator execution already does; hosts without a runtime decline
+      and `niri` stays in-process.
+- [ ] Triggered when in-process reduction gives up on a callee still pure by its
+      effects, with the result used as if the in-process engine produced it.
 
 ## Complexity
 
-Reduction is monotone — expressions only move toward literal form — and
-idempotent, and the optimizer's fixed-point loop is the only fixed point:
-`niri` does not iterate internally. Each extension should keep the engine's
-work bounded in the size of what it is asked about; a rule whose cost is
-quadratic in body size, or that rebuilds a large value per query, is the
-failure mode to watch for. Everything else about speed is a profiling
-question, not a design-time one.
+Reduction is monotone and idempotent, and the optimizer's fixed-point loop is
+the only fixed point: `niri` does not iterate internally. Each extension should
+keep the engine's work bounded in the size of what it is asked about; a rule
+whose cost is quadratic in body size, or that rebuilds a large value per query,
+is the failure mode to watch for.
 
 ## Determinism
 
 - Float NaN bits are nondeterministic in Wasm, so NaN-producing arithmetic is
-  never folded. This holds for both backends.
-- `v128` and relaxed-SIMD have implementation-defined corner cases; SIMD CTFE
-  is deferred to a later WEP.
-- Integer wrapping and signed `MIN / -1` semantics match Wasm. Division by
-  zero and signed `MIN / -1` are left unfolded so the runtime trap survives.
-- Float zero carries no sign distinction through a fold: `-0.0` and `+0.0`
-  are equal, so `if cond { -0.0 } else { 0.0 }` collapses to one of the two
-  and an operation that observes the sign of zero sees the chosen
-  representative. This matches IEEE 754 equality. A caller needing
-  bit-precise zeros should get a per-operation equality predicate rather than
-  a globally weakened fold.
+  never folded, on either backend.
+- `v128` and relaxed-SIMD have implementation-defined corner cases; SIMD CTFE is
+  deferred to a later WEP.
+- Integer wrapping and signed `MIN / -1` match Wasm. Division by zero and signed
+  `MIN / -1` are left unfolded so the runtime trap survives.
+- Float zero carries no sign through a fold: `-0.0` and `+0.0` are equal, so
+  `if cond { -0.0 } else { 0.0 }` collapses to one of the two. A caller needing
+  bit-precise zeros should get a per-operation equality predicate rather than a
+  globally weakened fold.
 
 ## Out of scope
 
-- User-facing CTFE syntax (`#[const_eval]`, `const fn`). Decide once real
-  demand shows up.
+- User-facing CTFE syntax (`#[const_eval]`, `const fn`). Decide once real demand
+  shows up.
 - Salsa-style demand-driven reanalysis across compiler runs.
 
 ## Open questions
 
 - Where does the wasm-CTFE module cache live — per `compile` invocation or per
-  process? Per-invocation is simpler; per-process speeds up watch-mode
-  workflows but needs eviction.
+  process? Per-invocation is simpler; per-process speeds up watch mode but needs
+  eviction.
 - Which primitives make the marked set. Every buffer touch in the formatting
-  path has to reach one, so the set is whatever `write_str`, `write_char`,
-  `pad`, `mark` / `apply_padding`, `prepare_int_write`, and `fpfmt`'s reserving
-  writers turn out to factor into.
+  path has to reach one.

--- a/docs/wep-2026-04-27-nir-interpreter.md
+++ b/docs/wep-2026-04-27-nir-interpreter.md
@@ -104,7 +104,13 @@ Bindings:
   merely reads it. `niri` models whole values, not the heap, so a local
   another handle can write through would go stale.
 - A borrow denotes what it points at rather than operating on it, so a local
-  bound to `&CONST` carries the referent and reads project out of it.
+  bound to `&CONST` carries the referent and reads project out of it. Which
+  locals those are is decided once per body and flow-insensitively, which is
+  what lets a read still fold through a binding an in-place rewrite has since
+  displaced. An index more than one binder names therefore carries nothing: a
+  scan that cannot order two bindings cannot say which one a read is governed
+  by, and an orphaned `let x = &GLOBAL` would otherwise speak for the live
+  binding that replaced it.
 
 Control flow:
 
@@ -135,6 +141,14 @@ Calls:
   `break`, and a loop all reach a value. Recursion and total work are bounded.
   A body that does not produce a constant leaves the call in place, so a
   runtime trap inside it stays observable.
+- A call whose result may carry the caller's own storage runs for its writes but
+  yields no value. Two parameter kinds reach that storage — a `&mut` one, whose
+  referent the result may embed (`Formatter::new(&mut buf)`), and one the callee
+  declares it keeps past the call (`stores[p]`), whose alias leaves inside an
+  ordinary aggregate that neither the return type nor the write targets name.
+  The engine has no reference values, so either result would stand as a snapshot
+  the next write to that storage leaves stale. A scalar embeds nothing and is
+  handed back as usual.
 - A statement counts as executed only when everything it evaluates lands on a
   constant. Reducing an expression is not performing it: an unfolded call, a
   global write, or an operation that would trap all leave work undone, and

--- a/docs/wep-2026-04-27-nir-interpreter.md
+++ b/docs/wep-2026-04-27-nir-interpreter.md
@@ -281,12 +281,20 @@ Regions:
 
 ### Values the engine cannot represent
 
-- A place-valued field, so an aggregate can carry a `&mut`. Today such an
+- A place-valued field, so an aggregate can carry a reference. Today such an
   aggregate is simply not a constant, since a field holding the referent's
   value would take a write meant for the referent. What the field needs to
   hold is the place the frame already names elsewhere, which would make the
   alias machinery reach through a struct as well as through a local.
-  `Formatter { buf: &mut __r }` is the shape waiting on this.
+  `Formatter { buf: &mut __r }` is the shape waiting on this, and so is every
+  result a `stores` callee hands back.
+
+  The refusal is whole-value, which costs more than the alias it protects: a
+  scalar field cannot name storage, so the scalars such a result carries are
+  safe to project and are refused anyway. `Array::slice` is where that shows —
+  it returns the backing it was given alongside two bounds it computed itself,
+  and the bounds stop folding because the backing shares their aggregate.
+  Naming the place per field is what separates them.
 - An aggregate that is not a byte sequence has no way back into the IR. A
   `List<T>` of scalars would want the `ArrayLiteral` shape, and a plain struct
   a `StructLiteral` over its materialized fields; both are exits to add beside

--- a/docs/wep-2026-04-27-nir-interpreter.md
+++ b/docs/wep-2026-04-27-nir-interpreter.md
@@ -105,12 +105,10 @@ Bindings:
   another handle can write through would go stale.
 - A borrow denotes what it points at rather than operating on it, so a local
   bound to `&CONST` carries the referent and reads project out of it. Which
-  locals those are is decided once per body and flow-insensitively, which is
-  what lets a read still fold through a binding an in-place rewrite has since
-  displaced. An index more than one binder names therefore carries nothing: a
-  scan that cannot order two bindings cannot say which one a read is governed
-  by, and an orphaned `let x = &GLOBAL` would otherwise speak for the live
-  binding that replaced it.
+  locals those are is decided once per body over the whole arena, so a read
+  folds through a binding an in-place rewrite displaced — and an index more than
+  one binder names therefore carries nothing, since such a scan cannot say which
+  binding governs a read.
 
 Control flow:
 
@@ -141,14 +139,12 @@ Calls:
   `break`, and a loop all reach a value. Recursion and total work are bounded.
   A body that does not produce a constant leaves the call in place, so a
   runtime trap inside it stays observable.
-- A call whose result may carry the caller's own storage runs for its writes but
-  yields no value. Two parameter kinds reach that storage — a `&mut` one, whose
-  referent the result may embed (`Formatter::new(&mut buf)`), and one the callee
-  declares it keeps past the call (`stores[p]`), whose alias leaves inside an
-  ordinary aggregate that neither the return type nor the write targets name.
-  The engine has no reference values, so either result would stand as a snapshot
-  the next write to that storage leaves stale. A scalar embeds nothing and is
-  handed back as usual.
+- A call whose result may carry the caller's storage runs for its writes but
+  yields no value: it would stand as a snapshot the next write to that storage
+  leaves stale. Two parameter kinds reach there — a `&mut` one, whose referent
+  the result may embed (`Formatter::new(&mut buf)`), and one `stores[p]` declares
+  the callee keeps, whose alias leaves inside an ordinary aggregate that neither
+  the return type nor the write targets name. A scalar embeds nothing.
 - A statement counts as executed only when everything it evaluates lands on a
   constant. Reducing an expression is not performing it: an unfolded call, a
   global write, or an operation that would trap all leave work undone, and
@@ -289,12 +285,10 @@ Regions:
   `Formatter { buf: &mut __r }` is the shape waiting on this, and so is every
   result a `stores` callee hands back.
 
-  The refusal is whole-value, which costs more than the alias it protects: a
-  scalar field cannot name storage, so the scalars such a result carries are
-  safe to project and are refused anyway. `Array::slice` is where that shows —
-  it returns the backing it was given alongside two bounds it computed itself,
-  and the bounds stop folding because the backing shares their aggregate.
-  Naming the place per field is what separates them.
+  The refusal is whole-value, so it costs more than the alias it protects: a
+  scalar field names no storage yet is refused with the rest. `Array::slice`
+  shows it — the two bounds it computes stop folding because the backing it was
+  handed shares their aggregate.
 - An aggregate that is not a byte sequence has no way back into the IR. A
   `List<T>` of scalars would want the `ArrayLiteral` shape, and a plain struct
   a `StructLiteral` over its materialized fields; both are exits to add beside

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -199,8 +199,7 @@ interprocedural over-approximation.
 
 ### Standing invariants — do not reintroduce
 
-These are settled by measurement and re-derived at a cost; `wado-compiler/AGENTS.md`
-repeats them where a contributor will hit them.
+These are settled by measurement and re-derived at a cost.
 
 - No mid-pipeline rebuild of the value graph. Build-once is structural: nothing
   clears `Body::value_graph`. Maintain in place; never clear-and-rebuild.

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -10,89 +10,34 @@ The Wado compiler crate: frontend, IR pipeline, optimizer, and codegen.
 - Escalate the test scope as the work matures: `cargo check` while iterating,
   `mise run test` during development, `mise run test-wado` when wrapping up, and
   the `on-task-done` skill only when finishing a task.
+- This crate must compile for `wasm32-unknown-unknown` (a CI build check). Keep
+  OS-dependent `std` modules out of production code.
 
 ## NIR Optimize
 
-Design, soundness invariants, and open work:
+Design and soundness invariants:
 [`docs/wep-2026-06-05-nir-optimizer-architecture.md`](../docs/wep-2026-06-05-nir-optimizer-architecture.md).
-What a contributor trips over:
 
-- The value graph is built once per function (`Body::value_graph`) and
-  maintained in place. Never clear-and-rebuild it, and never key a cache or
-  side-table by `ExprId` — a pass needing a value reads it off the operand
-  (born-as-operands) or takes a scratch walk (`Engine::scoped_const_reads`).
-- A promoted read lives in the pool, not the skeleton, so a pass deciding a
-  local is unused must count it (`arena_query`'s `promoted_*` queries), scoped
-  to the reachable operands — the pool is append-only and still holds reads that
-  folded away.
-- Inside a session that census is `Engine::reads_promoted_local` /
-  `promoted_read_count`, memoized: recomputing it per rule application is
-  quadratic. The memo holds only because the edit API sees every operand
-  written, so write operands through `Engine` (`map_operands` included), never
-  through `engine.body`, and have a new mutating edit report itself —
-  `census_note_operand` / `census_note_node_operands` for what it writes, and
-  `census_note_structure` for what it attaches, which an edit that allocates now
-  and splices later needs just as much.
-- niri keeps the two surviving `ExprId`-keyed tables, and they are sound for
-  different reasons. `scratch_folds` records what a node denoted: the rewrite
-  that commits an aggregate consumes the node that produced it, so an enclosing
-  fold cannot re-derive the value from the tree — folding a string-building
-  region to a literal depends on it — and every niri rewrite is
-  value-preserving, so the memo survives a node whose content was replaced.
-  `region_misses` records a refusal instead, which nothing makes value-preserving:
-  it is bounded to the shapes `region_shape` admits and costs at worst a fold
-  nobody re-attempts until the next pass. Neither is a licence for a third.
+- Never clear-and-rebuild the value graph, and never key a cache by `ExprId`.
+  Key a memo by what the work consumed.
+- Write operands through `Engine`, never through `engine.body`, and have a new
+  mutating edit report itself (`census_note_*`). The promoted-read census is
+  memoized and holds only on that.
 - Do not narrow niri's trackability read-position whitelist to the reachable
-  tree: two attempts each lost the string-builder folds. See
-  `aggregate_safe_locals` and the two `still_vouches` tests in
-  `tests/integration/niri.rs`.
+  tree: two attempts each lost the string-builder folds.
 
 ## Standard Libraries
 
-`lib/core/` and `lib/wasi/`, embedded into the binary by `include_str!` in
-`src/stdlib.rs` — editing a `.wado` file there has no effect until the crate is
-rebuilt. `lib/core/builtin.wado` holds the compiler intrinsics and
-`lib/core/rt.wado` the runtime helpers (panic, assert, CM ABI glue).
-`lib/wasi/` and `lib/core/kiln/` are generated from WIT: read
-`wado-from-idl/AGENTS.md` first. `wado-bundled-libm/` is a prebuilt Wasm module
-(`mise run update-bundled` rebuilds it).
-
-Tests for stdlib logic live beside the implementation as `.wado` files with
-`test` blocks (`zlib_test.wado`, …) and run under `wado test`.
+`lib/core/` and `lib/wasi/` are embedded by `include_str!` in `src/stdlib.rs` —
+editing one has no effect until the crate is rebuilt. `lib/wasi/` and
+`lib/core/kiln/` are generated from WIT: read `wado-from-idl/AGENTS.md` first.
 
 ## E2E Tests
 
-`.wado` files in `tests/fixtures/`, one filename prefix per group, run at each
-optimization level — O0 and O2 locally, O1/O3/Os under `WADO_FULL_TEST=1`. A
-cross-module fixture puts the modules it loads in `tests/fixtures/sub`.
+`.wado` files in `tests/fixtures/`, expectations in a trailing `__DATA__` JSON
+section whose fields are the `serde` structs in `tests/e2e.rs`.
 
-A fixture's expectations live in a trailing `__DATA__` JSON section. The fields
-are the `serde` structs in `tests/e2e.rs` (`TestSpec`, `HttpServiceSpec`,
-`HttpRequestSpec`) — read them there rather than from a copy that drifts. What
-those structs do not say:
-
-- No `__DATA__` at all means the test world, so a library-shaped source can
-  double as a fixture verbatim (`cm_catalog.wado` is byte-identical to
-  `package-cm-catalog/src/lib.wado`). With a `__DATA__`, the world comes from the
-  top-level key: none → `wasi:cli/command`, `"test"` → test world,
-  `"wasi:http/service"` → HTTP service.
-- Each `preopened_dirs` entry gets a fresh temp directory, deleted afterwards,
-  so filesystem tests stay hermetic across the parallel per-level runs. Its
-  template is `""` for an empty scratch dir, or a workspace-relative path copied
-  in as a seed corpus (`tests/fixtures/testdata`).
-- An unmatched `tls_mocks` server name fails the handshake, so a test cannot
-  silently reach the real network. The default empty map allows none.
-- `wado dump [-O0|-O2] file.wado` is how you find the patterns for
-  `wir_expect:Ox` / `wir_not_expect:Ox`.
-
-`datatest_mini` resolves fixtures when the `harness!` macro in `tests/e2e.rs`
-expands, and an incremental `cargo test` will not re-expand it on its own. Run
-`touch tests/e2e.rs` after adding or removing a fixture, or after changing
-`WADO_FULL_TEST` (the level gates read it at expansion time). CI builds from
-scratch, so this is local-only; `cargo test -- --ignored` also runs the gated
-levels without it.
-
-## Wasm Compatibility
-
-This crate must compile for `wasm32-unknown-unknown`, enforced by a CI build
-check. Keep OS-dependent `std` modules out of production code.
+- Run `touch tests/e2e.rs` after adding or removing a fixture, or after changing
+  `WADO_FULL_TEST`. `datatest_mini` resolves fixtures at macro-expansion time and
+  an incremental `cargo test` will not re-expand on its own.
+- `wado dump [-O0|-O2] file.wado` is how you find `wir_expect:Ox` patterns.

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -1,6 +1,7 @@
 # wado-compiler
 
-The Wado compiler crate: frontend, IR pipeline, optimizer, and codegen.
+The Wado compiler crate: frontend, IR pipeline, optimizer, and codegen. The NIR
+optimizer has its own guide: [`docs/optimizer.md`](../docs/optimizer.md).
 
 ## Rules
 
@@ -12,19 +13,6 @@ The Wado compiler crate: frontend, IR pipeline, optimizer, and codegen.
   the `on-task-done` skill only when finishing a task.
 - This crate must compile for `wasm32-unknown-unknown` (a CI build check). Keep
   OS-dependent `std` modules out of production code.
-
-## NIR Optimize
-
-Design and soundness invariants:
-[`docs/wep-2026-06-05-nir-optimizer-architecture.md`](../docs/wep-2026-06-05-nir-optimizer-architecture.md).
-
-- Never clear-and-rebuild the value graph, and never key a cache by `ExprId`.
-  Key a memo by what the work consumed.
-- Write operands through `Engine`, never through `engine.body`, and have a new
-  mutating edit report itself (`census_note_*`). The promoted-read census is
-  memoized and holds only on that.
-- Do not narrow niri's trackability read-position whitelist to the reachable
-  tree: two attempts each lost the string-builder folds.
 
 ## Standard Libraries
 

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -33,10 +33,15 @@ What a contributor trips over:
   `census_note_operand` / `census_note_node_operands` for what it writes, and
   `census_note_structure` for what it attaches, which an edit that allocates now
   and splices later needs just as much.
-- niri's `scratch_folds` is the one surviving `ExprId` memo. The rewrite that
-  commits an aggregate consumes the node that produced it, so an enclosing fold
-  cannot re-derive the value from the tree — folding a string-building region to
-  a literal depends on it.
+- niri keeps the two surviving `ExprId`-keyed tables, and they are sound for
+  different reasons. `scratch_folds` records what a node denoted: the rewrite
+  that commits an aggregate consumes the node that produced it, so an enclosing
+  fold cannot re-derive the value from the tree — folding a string-building
+  region to a literal depends on it — and every niri rewrite is
+  value-preserving, so the memo survives a node whose content was replaced.
+  `region_misses` records a refusal instead, which nothing makes value-preserving:
+  it is bounded to the shapes `region_shape` admits and costs at worst a fold
+  nobody re-attempts until the next pass. Neither is a licence for a third.
 - Do not narrow niri's trackability read-position whitelist to the reachable
   tree: two attempts each lost the string-builder folds. See
   `aggregate_safe_locals` and the two `still_vouches` tests in

--- a/wado-compiler/src/niri.rs
+++ b/wado-compiler/src/niri.rs
@@ -25,8 +25,8 @@ use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
 use crate::nir::{NirFunction, NirUnaryOp};
 use crate::nir_arena::{
-    BlockId, BlockNode, Body, ExprId, ExprKind, ExprNode, LocalSet, Operand, PatId, PatKind, StmtId,
-    StmtKind, StmtNode,
+    BlockId, BlockNode, Body, ExprId, ExprKind, ExprNode, LocalSet, Operand, PatId, PatKind,
+    StmtId, StmtKind, StmtNode,
 };
 use crate::nir_value_graph::ValueKind;
 use crate::tir::{TypeId, TypeTable};

--- a/wado-compiler/src/niri.rs
+++ b/wado-compiler/src/niri.rs
@@ -350,7 +350,37 @@ pub struct Interpreter<'a> {
     /// terminate without consuming budget. The `RefCell` borrow guard cannot
     /// serve this role, since it permits concurrent immutable borrows.
     call_stack: Vec<CalleeKey>,
+    /// Runs this function's walk already made and abandoned: the callee, whether
+    /// the caller promised to apply write-backs, and the values its parameters
+    /// bound. A run is a function of exactly those — a frame starts empty and
+    /// everything else it reads is fixed for the pass — so a failed one stays
+    /// failed, and re-running it re-pays a whole-body copy and a trackability
+    /// walk for the same refusal. The budget only falls, so a run it cut short
+    /// stays cut short too.
+    ///
+    /// Keyed by what the run consumed rather than by the node that spelled it.
+    /// An `ExprId` names a slot whose content a rewrite replaces, and the answer
+    /// belongs to the call, not to the site: two sites naming one callee with
+    /// one argument list share it, and the same site inside a loop does not,
+    /// since each iteration binds its own values.
+    ///
+    /// The region path memoizes its misses per frame instead
+    /// ([`FrameState::region_misses`]): a region is a block of the body being
+    /// walked, so it has no callee and no arguments to be keyed by.
+    call_misses: Vec<CallMiss>,
 }
+
+/// A run the engine abandoned, as [`Interpreter::call_misses`] remembers it.
+struct CallMiss {
+    callee: CalleeKey,
+    may_write: bool,
+    args: Vec<Value>,
+}
+
+/// Ceiling on remembered misses. The list is scanned linearly, and a loop whose
+/// call binds fresh values each iteration would otherwise grow it without ever
+/// hitting it. Dropping a miss costs a re-run, never an answer.
+const MAX_CALL_MISSES: usize = 64;
 
 fn let_ref_global(body: &Body, stmt: &StmtKind) -> Option<(u32, GlobalKey)> {
     let StmtKind::Let {
@@ -400,6 +430,33 @@ impl<'a> Interpreter<'a> {
             facts: ProgramFacts::default(),
             step_budget: DEFAULT_STEP_BUDGET,
             call_stack: Vec::new(),
+            call_misses: Vec::new(),
+        }
+    }
+
+    /// What is left of the CTFE work budget. A fold the engine declined and a
+    /// budget at zero are the same refusal from the outside, so this is what
+    /// tells them apart.
+    #[must_use]
+    pub fn step_budget(&self) -> u32 {
+        self.step_budget
+    }
+
+    /// Whether this walk already ran and abandoned the same call.
+    pub(crate) fn call_missed(&self, callee: CalleeKey, may_write: bool, args: &[Value]) -> bool {
+        self.call_misses.iter().any(|miss| {
+            miss.callee == callee && miss.may_write == may_write && miss.args == args
+        })
+    }
+
+    /// Remember an abandoned run, up to [`MAX_CALL_MISSES`].
+    pub(crate) fn record_call_miss(&mut self, callee: CalleeKey, may_write: bool, args: Vec<Value>) {
+        if self.call_misses.len() < MAX_CALL_MISSES {
+            self.call_misses.push(CallMiss {
+                callee,
+                may_write,
+                args,
+            });
         }
     }
 
@@ -514,6 +571,9 @@ impl<'a> Interpreter<'a> {
     pub fn enter_function(&mut self) {
         self.step_budget = DEFAULT_STEP_BUDGET;
         self.frame = FrameState::default();
+        // A miss the budget cut short is a miss only under the budget that cut
+        // it, and the reset hands the next function a fresh one.
+        self.call_misses.clear();
         debug_assert!(
             self.call_stack.is_empty(),
             "niri call_stack leaked across function boundary",

--- a/wado-compiler/src/niri.rs
+++ b/wado-compiler/src/niri.rs
@@ -25,7 +25,7 @@ use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
 use crate::nir::{NirFunction, NirUnaryOp};
 use crate::nir_arena::{
-    BlockId, BlockNode, Body, ExprId, ExprKind, ExprNode, LocalSet, Operand, PatId, StmtId,
+    BlockId, BlockNode, Body, ExprId, ExprKind, ExprNode, LocalSet, Operand, PatId, PatKind, StmtId,
     StmtKind, StmtNode,
 };
 use crate::nir_value_graph::ValueKind;
@@ -224,9 +224,11 @@ impl EditSink for BodySink<'_> {
 /// `type_params` and `impl_type_params` empty, since CTFE runs after
 /// monomorphization.
 ///
-/// Neither `inline_hint` nor `stores` is consulted. Where a body is placed says
-/// nothing about compile-time knowability, and what a callee keeps is a
-/// snapshot that `Reached` is what holds sound.
+/// `inline_hint` is not consulted: where a body is placed says nothing about
+/// compile-time knowability. Nor is `stores`, which bears on whether the value
+/// a run produces may be substituted rather than on whether the body may run —
+/// a frame runs a storing callee for the writes it performs, and refuses only
+/// its result (see `run_call`).
 #[must_use]
 pub fn is_ctfe_runnable(func: &NirFunction) -> bool {
     func.effects.is_empty()
@@ -463,16 +465,44 @@ impl<'a> Interpreter<'a> {
             Trackability::outside_frame(body, self.facts).aggregate_locals;
     }
 
+    /// Record which locals a `let` bound to `&GLOBAL`, so a read through one
+    /// resolves against the global it borrows.
+    ///
+    /// An index more than one binder names keeps no alias, whatever the other
+    /// binders say. The scan is flow-insensitive and reads the whole arena —
+    /// which is what lets a read still fold through a binding an in-place
+    /// rewrite has since displaced — so a second binder is one it cannot order
+    /// against the first: an orphaned `let x = &GLOBAL` must not speak for the
+    /// live binding that replaced it, and a live rebinding must not inherit the
+    /// alias its predecessor left. Both directions cost a fold and neither
+    /// costs a wrong one.
+    ///
+    /// Every binder counts, not only a `let`: a destructuring `let` and a match
+    /// arm bind through a pattern, and index reuse across the two is real.
+    /// Reading them off `body.pats` catches both without a walk.
     pub fn record_ref_global_aliases(&mut self, body: &Body) {
         self.frame.ref_global_aliases.clear();
         let mut seen: IndexSet<u32> = IndexSet::default();
+        let mut rebound: IndexSet<u32> = IndexSet::default();
+        for (_, st) in &body.stmts {
+            if let StmtKind::Let { local_index, .. } = &st.kind
+                && !seen.insert(*local_index)
+            {
+                rebound.insert(*local_index);
+            }
+        }
+        for (_, pat) in &body.pats {
+            if let PatKind::Binding { local_index, .. } = &pat.kind
+                && !seen.insert(*local_index)
+            {
+                rebound.insert(*local_index);
+            }
+        }
         for (id, st) in &body.stmts {
-            if let Some((local, key)) = let_ref_global(body, &st.kind) {
-                if seen.insert(local) {
-                    self.frame.ref_global_aliases.insert(local, (id, key));
-                } else {
-                    self.frame.ref_global_aliases.swap_remove(&local);
-                }
+            if let Some((local, key)) = let_ref_global(body, &st.kind)
+                && !rebound.contains(&local)
+            {
+                self.frame.ref_global_aliases.insert(local, (id, key));
             }
         }
     }

--- a/wado-compiler/src/niri.rs
+++ b/wado-compiler/src/niri.rs
@@ -224,11 +224,9 @@ impl EditSink for BodySink<'_> {
 /// `type_params` and `impl_type_params` empty, since CTFE runs after
 /// monomorphization.
 ///
-/// `inline_hint` is not consulted: where a body is placed says nothing about
-/// compile-time knowability. Nor is `stores`, which bears on whether the value
-/// a run produces may be substituted rather than on whether the body may run —
-/// a frame runs a storing callee for the writes it performs, and refuses only
-/// its result (see `run_call`).
+/// Neither `inline_hint` nor `stores` is consulted: where a body is placed says
+/// nothing about compile-time knowability, and a storing callee still runs for
+/// the writes it performs — `run_call` refuses only its result.
 #[must_use]
 pub fn is_ctfe_runnable(func: &NirFunction) -> bool {
     func.effects.is_empty()
@@ -350,36 +348,21 @@ pub struct Interpreter<'a> {
     /// terminate without consuming budget. The `RefCell` borrow guard cannot
     /// serve this role, since it permits concurrent immutable borrows.
     call_stack: Vec<CalleeKey>,
-    /// Runs this function's walk already made and abandoned: the callee, whether
-    /// the caller promised to apply write-backs, and the values its parameters
-    /// bound. A run is a function of exactly those — a frame starts empty and
-    /// everything else it reads is fixed for the pass — so a failed one stays
-    /// failed, and re-running it re-pays a whole-body copy and a trackability
-    /// walk for the same refusal. The budget only falls, so a run it cut short
-    /// stays cut short too.
-    ///
-    /// Keyed by what the run consumed rather than by the node that spelled it.
-    /// An `ExprId` names a slot whose content a rewrite replaces, and the answer
-    /// belongs to the call, not to the site: two sites naming one callee with
-    /// one argument list share it, and the same site inside a loop does not,
-    /// since each iteration binds its own values.
-    ///
-    /// The region path memoizes its misses per frame instead
-    /// ([`FrameState::region_misses`]): a region is a block of the body being
-    /// walked, so it has no callee and no arguments to be keyed by.
+    /// Runs this walk abandoned. A run is a function of these three alone — a
+    /// frame starts empty and the rest is fixed for the pass — so a failed one
+    /// stays failed, and re-running it re-pays a whole-body copy for the same
+    /// refusal.
     call_misses: Vec<CallMiss>,
 }
 
-/// A run the engine abandoned, as [`Interpreter::call_misses`] remembers it.
 struct CallMiss {
     callee: CalleeKey,
     may_write: bool,
     args: Vec<Value>,
 }
 
-/// Ceiling on remembered misses. The list is scanned linearly, and a loop whose
-/// call binds fresh values each iteration would otherwise grow it without ever
-/// hitting it. Dropping a miss costs a re-run, never an answer.
+/// Ceiling on remembered misses; the list is scanned linearly. Dropping one
+/// costs a re-run, never an answer.
 const MAX_CALL_MISSES: usize = 64;
 
 fn let_ref_global(body: &Body, stmt: &StmtKind) -> Option<(u32, GlobalKey)> {
@@ -434,23 +417,20 @@ impl<'a> Interpreter<'a> {
         }
     }
 
-    /// What is left of the CTFE work budget. A fold the engine declined and a
-    /// budget at zero are the same refusal from the outside, so this is what
-    /// tells them apart.
+    /// What is left of the CTFE work budget: a declined fold and an exhausted
+    /// budget look alike from outside.
     #[must_use]
     pub fn step_budget(&self) -> u32 {
         self.step_budget
     }
 
-    /// Whether this walk already ran and abandoned the same call.
-    pub(crate) fn call_missed(&self, callee: CalleeKey, may_write: bool, args: &[Value]) -> bool {
-        self.call_misses.iter().any(|miss| {
-            miss.callee == callee && miss.may_write == may_write && miss.args == args
-        })
+    fn call_missed(&self, callee: CalleeKey, may_write: bool, args: &[Value]) -> bool {
+        self.call_misses
+            .iter()
+            .any(|miss| miss.callee == callee && miss.may_write == may_write && miss.args == args)
     }
 
-    /// Remember an abandoned run, up to [`MAX_CALL_MISSES`].
-    pub(crate) fn record_call_miss(&mut self, callee: CalleeKey, may_write: bool, args: Vec<Value>) {
+    fn record_call_miss(&mut self, callee: CalleeKey, may_write: bool, args: Vec<Value>) {
         if self.call_misses.len() < MAX_CALL_MISSES {
             self.call_misses.push(CallMiss {
                 callee,
@@ -522,21 +502,13 @@ impl<'a> Interpreter<'a> {
             Trackability::outside_frame(body, self.facts).aggregate_locals;
     }
 
-    /// Record which locals a `let` bound to `&GLOBAL`, so a read through one
-    /// resolves against the global it borrows.
+    /// Record which locals a `let` bound to `&GLOBAL`.
     ///
-    /// An index more than one binder names keeps no alias, whatever the other
-    /// binders say. The scan is flow-insensitive and reads the whole arena —
-    /// which is what lets a read still fold through a binding an in-place
-    /// rewrite has since displaced — so a second binder is one it cannot order
-    /// against the first: an orphaned `let x = &GLOBAL` must not speak for the
-    /// live binding that replaced it, and a live rebinding must not inherit the
-    /// alias its predecessor left. Both directions cost a fold and neither
-    /// costs a wrong one.
-    ///
-    /// Every binder counts, not only a `let`: a destructuring `let` and a match
-    /// arm bind through a pattern, and index reuse across the two is real.
-    /// Reading them off `body.pats` catches both without a walk.
+    /// An index more than one binder names keeps none: the scan reads the whole
+    /// arena — which is what lets a read fold through a binding an in-place
+    /// rewrite displaced — so it cannot order two binders against each other.
+    /// Pattern bindings count, since index reuse across a `let` and a match arm
+    /// is real.
     pub fn record_ref_global_aliases(&mut self, body: &Body) {
         self.frame.ref_global_aliases.clear();
         let mut seen: IndexSet<u32> = IndexSet::default();
@@ -571,8 +543,6 @@ impl<'a> Interpreter<'a> {
     pub fn enter_function(&mut self) {
         self.step_budget = DEFAULT_STEP_BUDGET;
         self.frame = FrameState::default();
-        // A miss the budget cut short is a miss only under the budget that cut
-        // it, and the reset hands the next function a fresh one.
         self.call_misses.clear();
         debug_assert!(
             self.call_stack.is_empty(),

--- a/wado-compiler/src/niri/frame.rs
+++ b/wado-compiler/src/niri/frame.rs
@@ -736,6 +736,13 @@ impl Interpreter<'_> {
         });
         let may_embed_caller_storage = !targets.is_empty() || stores_a_reference;
 
+        // Everything below is the expensive half — a whole-body copy and a
+        // trackability walk over it — and it answers the same way for the same
+        // callee and arguments, so a run already abandoned is not re-paid.
+        let args: Vec<Value> = bound.iter().map(|(_, value)| value.clone()).collect();
+        if self.call_missed(key, may_write, &args) {
+            return None;
+        }
         self.charge(1)?;
         self.call_stack.push(key);
         let mut scratch = callee_body.nodes_only_clone();
@@ -744,6 +751,9 @@ impl Interpreter<'_> {
         let run = self.exec_frame(&mut scratch, targets, returns_unit);
         self.swap_frame(caller);
         self.call_stack.pop();
+        if run.is_none() {
+            self.record_call_miss(key, may_write, args);
+        }
         run.map(|run| {
             let embeds_storage = may_embed_caller_storage
                 && !matches!(&run.result, Lattice::Const(v) if v.is_scalar());

--- a/wado-compiler/src/niri/frame.rs
+++ b/wado-compiler/src/niri/frame.rs
@@ -718,14 +718,23 @@ impl Interpreter<'_> {
         if aliased_write_targets(&targets, &places) {
             return None;
         }
-        // A callee that writes through a `&mut` parameter may hand the
-        // parameter's storage back inside its result — `Formatter::new(&mut
-        // buf)` returns a `Formatter` holding that borrow. The engine has no
-        // reference values, so the result would stand as a snapshot of the
-        // referent and every later write through it would land in the copy
-        // while the referent went stale. A scalar embeds nothing, so only an
-        // aggregate result is refused.
-        let may_embed_a_write_target = !targets.is_empty();
+        // A callee may hand a parameter's storage back inside its result —
+        // `Formatter::new(&mut buf)` returns a `Formatter` holding that borrow.
+        // The engine has no reference values, so the result would stand as a
+        // snapshot of the referent and every later write to that storage would
+        // land beside the copy while the referent went stale. A scalar embeds
+        // nothing, so only an aggregate result is refused.
+        //
+        // Two parameter kinds reach the caller's storage. A `&mut` one is
+        // whatever this site borrows. A stored one is the source's own
+        // declaration that the callee keeps the reference past the call, which
+        // is what `stores[p]` says and what no analysis of the caller can see —
+        // the alias leaves inside an ordinary aggregate, so neither
+        // `returns_reference` nor the write targets name it.
+        let stores_a_reference = callee.params.iter().any(|p| {
+            callee.stores.contains(&p.name) && self.type_table.is_reference_shaped(p.type_id)
+        });
+        let may_embed_caller_storage = !targets.is_empty() || stores_a_reference;
 
         self.charge(1)?;
         self.call_stack.push(key);
@@ -736,7 +745,7 @@ impl Interpreter<'_> {
         self.swap_frame(caller);
         self.call_stack.pop();
         run.map(|run| {
-            let embeds_storage = may_embed_a_write_target
+            let embeds_storage = may_embed_caller_storage
                 && !matches!(&run.result, Lattice::Const(v) if v.is_scalar());
             if returns_reference || embeds_storage {
                 CallRun {

--- a/wado-compiler/src/niri/frame.rs
+++ b/wado-compiler/src/niri/frame.rs
@@ -718,27 +718,18 @@ impl Interpreter<'_> {
         if aliased_write_targets(&targets, &places) {
             return None;
         }
-        // A callee may hand a parameter's storage back inside its result —
-        // `Formatter::new(&mut buf)` returns a `Formatter` holding that borrow.
-        // The engine has no reference values, so the result would stand as a
-        // snapshot of the referent and every later write to that storage would
-        // land beside the copy while the referent went stale. A scalar embeds
-        // nothing, so only an aggregate result is refused.
-        //
-        // Two parameter kinds reach the caller's storage. A `&mut` one is
-        // whatever this site borrows. A stored one is the source's own
-        // declaration that the callee keeps the reference past the call, which
-        // is what `stores[p]` says and what no analysis of the caller can see —
-        // the alias leaves inside an ordinary aggregate, so neither
-        // `returns_reference` nor the write targets name it.
+        // A result may embed a parameter's storage — `Formatter::new(&mut buf)`
+        // returns a `Formatter` holding that borrow, and `stores[p]` declares
+        // the same of a shared one. The engine has no reference values, so it
+        // would stand as a snapshot the next write to that storage leaves
+        // stale. A scalar embeds nothing.
         let stores_a_reference = callee.params.iter().any(|p| {
             callee.stores.contains(&p.name) && self.type_table.is_reference_shaped(p.type_id)
         });
         let may_embed_caller_storage = !targets.is_empty() || stores_a_reference;
 
-        // Everything below is the expensive half — a whole-body copy and a
-        // trackability walk over it — and it answers the same way for the same
-        // callee and arguments, so a run already abandoned is not re-paid.
+        // Below here is the expensive half: a whole-body copy and a
+        // trackability walk over it.
         let args: Vec<Value> = bound.iter().map(|(_, value)| value.clone()).collect();
         if self.call_missed(key, may_write, &args) {
             return None;

--- a/wado-compiler/src/niri/place.rs
+++ b/wado-compiler/src/niri/place.rs
@@ -12,13 +12,9 @@ use crate::nir_arena::{Body, ExprId, ExprKind, Operand};
 /// after monomorphization — so every walk asking what storage is named looks
 /// through them.
 ///
-/// This states the wrapper set only. The projection set is spelled again by
-/// [`lvalue_root_local`] and [`place_of`], each taking what its own question
-/// needs, and a third time by `optimize/arena_query.rs` (`strip_refs`,
-/// `storage_root`), which reaches through `VariantPayload` where none of these
-/// do. A place niri cannot root at is refused rather than mis-rooted — the
-/// executor finds nowhere to write and abandons the frame — so the divergence
-/// costs folds; a new transparent node kind still has to be taught to each.
+/// The wrapper set only. [`lvalue_root_local`], [`place_of`] and
+/// `optimize/arena_query.rs` each spell a projection set of their own, so a new
+/// transparent node kind has to be taught to each.
 fn wrapped_operand(body: &Body, e: ExprId) -> Option<Operand> {
     match &body.exprs[e].kind {
         ExprKind::Unary {

--- a/wado-compiler/src/niri/place.rs
+++ b/wado-compiler/src/niri/place.rs
@@ -10,9 +10,15 @@ use crate::nir_arena::{Body, ExprId, ExprKind, Operand};
 /// The operand a borrow or a cast wraps. Both name the same storage as their
 /// operand — `&mut x.repr as &mut Array<u8>` is how a borrow reaches a builtin
 /// after monomorphization — so every walk asking what storage is named looks
-/// through them. This is niri's one statement of the wrapper set; the
-/// optimizer keeps its own in `optimize/arena_query.rs` (`strip_refs`,
-/// `storage_root`), so a new transparent node kind must be taught to both.
+/// through them.
+///
+/// This states the wrapper set only. The projection set is spelled again by
+/// [`lvalue_root_local`] and [`place_of`], each taking what its own question
+/// needs, and a third time by `optimize/arena_query.rs` (`strip_refs`,
+/// `storage_root`), which reaches through `VariantPayload` where none of these
+/// do. A place niri cannot root at is refused rather than mis-rooted — the
+/// executor finds nowhere to write and abandons the frame — so the divergence
+/// costs folds; a new transparent node kind still has to be taught to each.
 fn wrapped_operand(body: &Body, e: ExprId) -> Option<Operand> {
     match &body.exprs[e].kind {
         ExprKind::Unary {

--- a/wado-compiler/tests/generated/fixtures/stream_write_raw_offset.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/stream_write_raw_offset.wir.wado
@@ -176,7 +176,7 @@ YY"), used: 12 });
     let data_mv_start: i32;
     let data_mv_end: i32;
     multivalue_bind [data_mv_repr, data_mv_start, data_mv_end] = "core:prelude/array.wado/Array<u8>::slice"(global:stream_write_raw_offset.wado::__const_obj_6, 2, 10);
-    ptr = builtin::i32_wrap_i64(local.tee packed_39("core:rt/cm_lower_list_u8"(data_mv_repr, 2, 8)));
+    ptr = builtin::i32_wrap_i64(local.tee packed_39("core:rt/cm_lower_list_u8"(data_mv_repr, data_mv_start, data_mv_end - data_mv_start)));
     raw_len = builtin::i32_wrap_i64(packed_39 >> 32_i64);
     "core:rt/cm_stream_write_drain"(tx_9, ptr, raw_len, 1);
     drop("mem/realloc"(ptr, raw_len, 1, 0));

--- a/wado-compiler/tests/integration/niri.rs
+++ b/wado-compiler/tests/integration/niri.rs
@@ -8204,3 +8204,179 @@ fn a_ref_returning_callee_does_not_fold_through_the_lost_alias() {
          folded through the alias",
     );
 }
+
+#[test]
+fn a_stored_reference_parameter_does_not_fold_into_a_snapshot() {
+    // fn keep(p: &Inner) -> Holder with stores[p] { return Holder { inner: p }; }
+    // fn scenario() -> i32 {
+    //     let mut p = Inner { x: 7 };
+    //     let h = keep(&p);
+    //     p.x = 9;
+    //     return h.inner.x;
+    // }
+    // `stores[p]` declares that the callee keeps the reference past the call,
+    // so at run time `h.inner` aliases `p` and scenario() == 9. The alias
+    // escapes inside an aggregate rather than as the return type, which is
+    // what `a_ref_returning_callee_does_not_fold_through_the_lost_alias`
+    // covers — a frame that bound the result as a value snapshot answers 7.
+    let mut table = TypeTable::new();
+    let inner_ty = table.make_struct("Inner".to_string(), ModuleSource::default());
+    let holder_ty = table.make_struct("Holder".to_string(), ModuleSource::default());
+    let ref_inner = table.make_ref(inner_ty);
+
+    let mut keep = make_pure_fn(
+        "keep",
+        vec![("p", ref_inner)],
+        holder_ty,
+        return_stmt(struct_lit(
+            holder_ty,
+            vec![(0, "inner", local_expr(0, ref_inner))],
+        )),
+    );
+    keep.stores.push("p".to_string());
+
+    let scenario = make_pure_fn_stmts(
+        "scenario",
+        vec![],
+        TypeTable::I32,
+        vec![
+            let_mut_stmt_b(
+                "p",
+                0,
+                inner_ty,
+                struct_lit(inner_ty, vec![(0, "x", int_lit(7, TypeTable::I32, "7"))]),
+            ),
+            let_stmt_b(
+                "h",
+                1,
+                holder_ty,
+                call_expr(
+                    &keep,
+                    vec![unary(NirUnaryOp::Ref, local_expr(0, inner_ty), ref_inner)],
+                ),
+            ),
+            assign_stmt_b(
+                field_access(local_expr(0, inner_ty), 0, "x", TypeTable::I32),
+                int_lit(9, TypeTable::I32, "9"),
+            ),
+            return_stmt(field_access(
+                field_access(local_expr(1, holder_ty), 0, "inner", ref_inner),
+                0,
+                "x",
+                TypeTable::I32,
+            )),
+        ],
+    );
+
+    let funcs = [keep, scenario];
+    let callees = build_callee_map_test(&funcs);
+    let mut interp = Interpreter::new(&table);
+    interp.with_callees(&callees);
+    interp.enter_function();
+    let call = call_expr(&funcs[1], vec![]);
+    assert_ne!(
+        reduce_lat(&mut interp, &call),
+        Lattice::Const(int(7)),
+        "the frame bound the stored reference as a value snapshot and folded \
+         through the alias",
+    );
+}
+
+#[test]
+fn a_ref_global_alias_rebound_by_a_later_let_does_not_vouch_for_it() {
+    // `let cfg = &CONFIG; let cfg = Cfg { width: 1 };` — one index, two
+    // bindings. The alias scan is flow-insensitive and reads the whole arena,
+    // so without noticing the second binding it answers `CONFIG` for every
+    // mention of the index, including the ones the rebinding governs.
+    let mut table = TypeTable::new();
+    let cfg_ty = table.make_struct("Cfg".to_string(), ModuleSource::default());
+    let module = ModuleSource::default();
+    let mut fields = GlobalFieldEnv::default();
+    fields.insert(
+        (module.clone(), "CONFIG".to_string()),
+        [("width".to_string(), int(7))].into_iter().collect(),
+    );
+
+    let mut body = Body::empty();
+    let stmts = [
+        let_stmt_b(
+            "cfg",
+            0,
+            cfg_ty,
+            unary(
+                NirUnaryOp::Ref,
+                global_get(module, "CONFIG", cfg_ty),
+                cfg_ty,
+            ),
+        ),
+        let_stmt_b(
+            "cfg",
+            0,
+            cfg_ty,
+            struct_lit(cfg_ty, vec![(0, "width", int_lit(1, TypeTable::I32, "1"))]),
+        ),
+    ];
+    body.root = block_of(&mut body, &stmts);
+    let read = field_access(local_expr(0, cfg_ty), 0, "width", TypeTable::I32)(&mut body)
+        .as_expr()
+        .expect("a field access is a composite expression");
+
+    let mut interp = Interpreter::new(&table);
+    interp.with_global_fields(&fields);
+    interp.record_ref_global_aliases(&body);
+
+    assert_ne!(
+        interp.reduce_to_lattice(&body, read),
+        Lattice::Const(int(7)),
+        "a rebound index must keep no alias to the global it once borrowed",
+    );
+}
+
+#[test]
+fn an_orphaned_ref_global_binding_does_not_vouch_for_a_live_local() {
+    // The arena keeps every statement an in-place rewrite displaced, and the
+    // alias scan walks the arena rather than the reachable body. A `let cfg =
+    // &CONFIG` no block refers to any more cannot run, so it must not speak
+    // for the binding that replaced it.
+    let mut table = TypeTable::new();
+    let cfg_ty = table.make_struct("Cfg".to_string(), ModuleSource::default());
+    let module = ModuleSource::default();
+    let mut fields = GlobalFieldEnv::default();
+    fields.insert(
+        (module.clone(), "CONFIG".to_string()),
+        [("width".to_string(), int(7))].into_iter().collect(),
+    );
+
+    let mut body = Body::empty();
+    // Interned but parented to no block: what an in-place rewrite leaves.
+    let _orphan = let_stmt_b(
+        "cfg",
+        0,
+        cfg_ty,
+        unary(
+            NirUnaryOp::Ref,
+            global_get(module, "CONFIG", cfg_ty),
+            cfg_ty,
+        ),
+    )(&mut body);
+    let stmts = [let_stmt_b(
+        "cfg",
+        0,
+        cfg_ty,
+        struct_lit(cfg_ty, vec![(0, "width", int_lit(1, TypeTable::I32, "1"))]),
+    )];
+    body.root = block_of(&mut body, &stmts);
+    let read = field_access(local_expr(0, cfg_ty), 0, "width", TypeTable::I32)(&mut body)
+        .as_expr()
+        .expect("a field access is a composite expression");
+
+    let mut interp = Interpreter::new(&table);
+    interp.with_global_fields(&fields);
+    interp.record_ref_global_aliases(&body);
+
+    assert_ne!(
+        interp.reduce_to_lattice(&body, read),
+        Lattice::Const(int(7)),
+        "an orphaned binding must not vouch for the live one that replaced it",
+    );
+}

--- a/wado-compiler/tests/integration/niri.rs
+++ b/wado-compiler/tests/integration/niri.rs
@@ -8380,3 +8380,102 @@ fn an_orphaned_ref_global_binding_does_not_vouch_for_a_live_local() {
         "an orphaned binding must not vouch for the live one that replaced it",
     );
 }
+
+#[test]
+fn a_run_the_engine_abandoned_is_not_paid_for_twice() {
+    // A call is visited more than once per pass — the reducer asks at the node,
+    // and a projecting parent asks again — and running one copies the whole
+    // callee body and walks it for trackability before anything can refuse it.
+    // A refusal is a function of the callee and the arguments alone, so the
+    // second visit must answer from the first rather than re-pay for it. The
+    // budget is what tells the two apart: both answer `Unevaluated`.
+    let table = TypeTable::new();
+    // Statements the frame performs, then one it cannot: local 9 is bound
+    // nowhere, so the return value never lands on a constant and the run is
+    // abandoned — after the budget has been charged for everything before it.
+    let waster = make_pure_fn_stmts(
+        "waster",
+        vec![],
+        TypeTable::I32,
+        vec![
+            let_stmt_b("a", 0, TypeTable::I32, int_lit(1, TypeTable::I32, "1")),
+            let_stmt_b("b", 1, TypeTable::I32, int_lit(2, TypeTable::I32, "2")),
+            let_stmt_b("c", 2, TypeTable::I32, int_lit(3, TypeTable::I32, "3")),
+            return_stmt(local_expr(9, TypeTable::I32)),
+        ],
+    );
+    let callees = build_callee_map_test(std::slice::from_ref(&waster));
+
+    let mut interp = Interpreter::new(&table);
+    interp.with_callees(&callees);
+    interp.enter_function();
+    let (mut body, e) = into_body_expr(&call_expr(&waster, vec![]));
+
+    let before = interp.step_budget();
+    assert_eq!(
+        interp.reduce_to_lattice_full(&mut body, e),
+        Lattice::Unevaluated
+    );
+    let after_first = interp.step_budget();
+    assert!(
+        after_first < before,
+        "the first run must have been charged, or this proves nothing",
+    );
+
+    assert_eq!(
+        interp.reduce_to_lattice_full(&mut body, e),
+        Lattice::Unevaluated
+    );
+    assert_eq!(
+        interp.step_budget(),
+        after_first,
+        "an abandoned run must not be re-paid at the next visit",
+    );
+}
+
+#[test]
+fn an_abandoned_run_is_remembered_per_argument_list() {
+    // The memo keys on what the run consumed, so a second call to the same
+    // callee with different arguments is a different run and must still be
+    // attempted — a callee that folds for one argument and not another would
+    // otherwise be refused for both.
+    let table = TypeTable::new();
+    // `fn only_zero(x) { let g = 1 / x; return g; }` — folds at x = 1, and at
+    // x = 0 the division would trap, so the run is abandoned.
+    let only_zero = make_pure_fn(
+        "only_zero",
+        vec![("x", TypeTable::I32)],
+        TypeTable::I32,
+        return_stmt(binary(
+            NirBinaryOp::Div,
+            int_lit(6, TypeTable::I32, "6"),
+            local_expr(0, TypeTable::I32),
+            TypeTable::I32,
+        )),
+    );
+    let callees = build_callee_map_test(std::slice::from_ref(&only_zero));
+
+    let mut interp = Interpreter::new(&table);
+    interp.with_callees(&callees);
+    interp.enter_function();
+
+    let (mut trapping, t) = into_body_expr(&call_expr(
+        &only_zero,
+        vec![int_lit(0, TypeTable::I32, "0")],
+    ));
+    assert_eq!(
+        interp.reduce_to_lattice_full(&mut trapping, t),
+        Lattice::Unevaluated,
+        "dividing by zero traps at run time, so the call stays",
+    );
+
+    let (mut folding, f) = into_body_expr(&call_expr(
+        &only_zero,
+        vec![int_lit(3, TypeTable::I32, "3")],
+    ));
+    assert_eq!(
+        interp.reduce_to_lattice_full(&mut folding, f),
+        Lattice::Const(int(2)),
+        "a different argument list is a different run",
+    );
+}

--- a/wado-compiler/tests/integration/niri.rs
+++ b/wado-compiler/tests/integration/niri.rs
@@ -8214,11 +8214,8 @@ fn a_stored_reference_parameter_does_not_fold_into_a_snapshot() {
     //     p.x = 9;
     //     return h.inner.x;
     // }
-    // `stores[p]` declares that the callee keeps the reference past the call,
-    // so at run time `h.inner` aliases `p` and scenario() == 9. The alias
-    // escapes inside an aggregate rather than as the return type, which is
-    // what `a_ref_returning_callee_does_not_fold_through_the_lost_alias`
-    // covers — a frame that bound the result as a value snapshot answers 7.
+    // `h.inner` aliases `p`, so scenario() == 9. The alias escapes inside an
+    // aggregate rather than as the return type, which the sibling test covers.
     let mut table = TypeTable::new();
     let inner_ty = table.make_struct("Inner".to_string(), ModuleSource::default());
     let holder_ty = table.make_struct("Holder".to_string(), ModuleSource::default());
@@ -8284,10 +8281,8 @@ fn a_stored_reference_parameter_does_not_fold_into_a_snapshot() {
 
 #[test]
 fn a_ref_global_alias_rebound_by_a_later_let_does_not_vouch_for_it() {
-    // `let cfg = &CONFIG; let cfg = Cfg { width: 1 };` — one index, two
-    // bindings. The alias scan is flow-insensitive and reads the whole arena,
-    // so without noticing the second binding it answers `CONFIG` for every
-    // mention of the index, including the ones the rebinding governs.
+    // One index, two bindings: the flow-insensitive scan cannot say which one
+    // governs the read.
     let mut table = TypeTable::new();
     let cfg_ty = table.make_struct("Cfg".to_string(), ModuleSource::default());
     let module = ModuleSource::default();
@@ -8334,10 +8329,8 @@ fn a_ref_global_alias_rebound_by_a_later_let_does_not_vouch_for_it() {
 
 #[test]
 fn an_orphaned_ref_global_binding_does_not_vouch_for_a_live_local() {
-    // The arena keeps every statement an in-place rewrite displaced, and the
-    // alias scan walks the arena rather than the reachable body. A `let cfg =
-    // &CONFIG` no block refers to any more cannot run, so it must not speak
-    // for the binding that replaced it.
+    // A displaced `let cfg = &CONFIG` stays in the arena and cannot run, so it
+    // must not speak for the binding that replaced it.
     let mut table = TypeTable::new();
     let cfg_ty = table.make_struct("Cfg".to_string(), ModuleSource::default());
     let module = ModuleSource::default();
@@ -8383,16 +8376,12 @@ fn an_orphaned_ref_global_binding_does_not_vouch_for_a_live_local() {
 
 #[test]
 fn a_run_the_engine_abandoned_is_not_paid_for_twice() {
-    // A call is visited more than once per pass — the reducer asks at the node,
-    // and a projecting parent asks again — and running one copies the whole
-    // callee body and walks it for trackability before anything can refuse it.
-    // A refusal is a function of the callee and the arguments alone, so the
-    // second visit must answer from the first rather than re-pay for it. The
-    // budget is what tells the two apart: both answer `Unevaluated`.
+    // Running a call copies the whole callee body before anything can refuse
+    // it, and a call is visited more than once per pass. Both visits answer
+    // `Unevaluated`, so the budget is what shows the second was free.
     let table = TypeTable::new();
-    // Statements the frame performs, then one it cannot: local 9 is bound
-    // nowhere, so the return value never lands on a constant and the run is
-    // abandoned — after the budget has been charged for everything before it.
+    // Local 9 is bound nowhere, so the run is abandoned after the statements
+    // before it were charged for.
     let waster = make_pure_fn_stmts(
         "waster",
         vec![],
@@ -8435,13 +8424,11 @@ fn a_run_the_engine_abandoned_is_not_paid_for_twice() {
 
 #[test]
 fn an_abandoned_run_is_remembered_per_argument_list() {
-    // The memo keys on what the run consumed, so a second call to the same
-    // callee with different arguments is a different run and must still be
-    // attempted — a callee that folds for one argument and not another would
-    // otherwise be refused for both.
+    // The memo keys on the arguments too, or a callee that folds for one
+    // argument and not another would be refused for both.
     let table = TypeTable::new();
-    // `fn only_zero(x) { let g = 1 / x; return g; }` — folds at x = 1, and at
-    // x = 0 the division would trap, so the run is abandoned.
+    // `fn only_zero(x) { return 6 / x; }` — at x = 0 the division would trap,
+    // so the run is abandoned; at x = 3 it folds to 2.
     let only_zero = make_pure_fn(
         "only_zero",
         vec![("x", TypeTable::I32)],


### PR DESCRIPTION
`niri` refuses two folds that would outlive the write they depend on. Both hazards have a red fixture.

## A callee's result may carry the caller's storage

`stores[p]` declares that a callee keeps a reference past the call, so the alias it hands back leaves inside an ordinary aggregate — something neither the return type nor the `&mut` write targets name:

```wado
fn keep(p: &Inner) -> Holder with stores[p] { return Holder { inner: p }; }

let mut p = Inner { x: 7 };
let h = keep(&p);
p.x = 9;
return h.inner.x;   // 9: h.inner aliases p
```

A call whose result may carry the caller's storage runs for the writes it performs and yields no value, since the result would stand as a snapshot the next write to that storage leaves stale. Two parameter kinds reach there: a `&mut` one, whose referent the result may embed (`Formatter::new(&mut buf)`), and one `stores[p]` declares the callee keeps. A scalar embeds nothing and is handed back as usual.

The refusal is whole-value, so a scalar field naming no storage is withheld with the rest. `Array::slice` carries `stores[self]` and returns the backing it was handed beside two bounds it computes itself, so those bounds stay unfolded; the golden records the cost. Separating them is the place-valued field the WEP waits on for `Formatter { buf: &mut __r }`, recorded there with this as the second shape it buys back.

## A `&GLOBAL` alias is governed by one binding

Which locals a `let` bound to `&GLOBAL` is decided once per body over the whole arena, which is what lets a read fold through a binding an in-place rewrite has displaced. Such a scan cannot say which of two bindings of one index governs a read, so an index more than one binder names carries no alias. Pattern bindings count, since index reuse across a destructuring `let` and a match arm is real.

That covers both an orphaned `let cfg = &CONFIG` the arena still holds and a live rebinding of the same index — either would otherwise fold a field out of the global's field env.

## Compile-time calls are not re-run

A run's outcome is a function of the callee, the caller's write promise and the bound argument values alone: a frame starts empty and the callee map, globals and builtins are fixed for the pass. `niri` remembers the runs it abandons under that key and skips the whole-body copy and the trackability walk on a repeat, ahead of the step-budget charge.

Keying on the run rather than on the site shares the answer between two sites naming one callee with one argument list, and withholds it inside a loop, where each iteration binds its own values. The list is scanned linearly and capped; dropping a miss costs a re-run, never an answer. `Interpreter::step_budget` is exposed because a declined fold and an exhausted budget are the same `Unevaluated` from outside.

## Docs

The niri WEP states capabilities and leaves mechanism to the code, at 294 lines. Region seeding sits under Done, where its fixtures put it, and the TODO entries are the checklists `docs/AGENTS.md` asks for. `wado-compiler/AGENTS.md` carries the rules and the traps and links to `docs/optimizer.md` for the optimizer's design, whose standing invariants live in the architecture WEP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGt7rNsSayg7aXZqT5mdko