### PR TITLE
docs(compiler): condense long comments in wado-compiler/src

### DIFF
--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -7,9 +7,7 @@ use crate::token::Span;
 /// [`crate::parser::Parser`] draws a fresh one from a process-global counter and
 /// stamps it into every id, so a full [`AstId`] is globally unique while
 /// [`AstId::local`] stays dense per module; sub-parsers continue an existing
-/// space. It identifies a *parse*, not a `ModuleSource`, and nothing relies on
-/// ids surviving a re-parse: stdlib ASTs are parsed once per process and shared,
-/// and user-module facts never outlive their parse.
+/// space. Ids identify a *parse* and never survive a re-parse.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct AstIdSpace(u32);
 
@@ -30,12 +28,10 @@ impl AstIdSpace {
 }
 
 /// Globally-unique identifier for a semantically-significant AST node: an
-/// [`AstIdSpace`] plus a module-local dense index assigned in DFS order. Every
-/// node has a real id, with no sentinel, and builtins are parsed like any module.
-/// The space differs per module, so nodes from different ones can never collide
-/// and a per-node fact map keys by bare `AstId` even under a wrong perspective.
-/// Ordering is `(space, local)`, so ids within a module order by allocation —
-/// what parser rollback and [`crate::comment::TriviaMap`] rely on.
+/// [`AstIdSpace`] plus a module-local dense index assigned in DFS order. Spaces
+/// differ per module, so a per-node fact map keys by bare `AstId` without
+/// collision. Ordering is `(space, local)` — ids within a module order by
+/// allocation, which parser rollback and [`crate::comment::TriviaMap`] rely on.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct AstId {
     space: AstIdSpace,
@@ -262,11 +258,10 @@ impl Module {
     }
 
     /// Allocate a fresh dense [`AstId`] at the end of this module's range, for
-    /// post-parse synthesis injecting a node into [`Self::items`] that needs a
-    /// symbol-coordinate-compatible id. Never collides with a parser-allocated
-    /// one. Prefer it over [`AstId::fresh`] for anything entering a module tree:
-    /// that mints into the reserved transient space, outside this dense range,
-    /// where machinery keyed on the range cannot find it.
+    /// post-parse synthesis injecting a node into [`Self::items`]. Prefer it
+    /// over [`AstId::fresh`] for anything entering a module tree: that mints
+    /// into the reserved transient space, outside this dense range, where
+    /// machinery keyed on the range cannot find it.
     #[must_use]
     pub fn alloc_ast_id(&mut self) -> AstId {
         let id = AstId::new(self.ast_id_space, self.ast_id_count);
@@ -370,8 +365,7 @@ fn span_byte_len(span: Span) -> usize {
 /// checks) and scope-aware analyses. Every `visit_*` defaults to its free
 /// `walk_*`, which recurses through the visitor's own methods, so an implementer
 /// overrides only where its behaviour differs from plain traversal. `visit_id`
-/// sees every [`AstId`] / [`Span`] pair — containers and the leaf id-bearing
-/// nodes with no `visit_*` of their own alike.
+/// sees every [`AstId`] / [`Span`] pair, containers and leaves alike.
 pub trait AstVisitor: Sized {
     /// Invoked for every [`AstId`] emitted during traversal.
     ///
@@ -1269,10 +1263,9 @@ impl Attribute {
 
 /// Which Component Model boundary a `#[cm(…)]` / `#[canonical(…)]` declaration
 /// crosses: `Canonical` lowers to a CM canonical built-in such as
-/// `canon.task.return` rather than an interface import, `Import` resolves to a
-/// real import from `namespace:package/interface[@version][#function]`, and
-/// `Name` is a bare CM-side identifier naming a field, case or method, with no
-/// interface attached.
+/// `canon.task.return`, `Import` resolves to a real import from
+/// `namespace:package/interface[@version][#function]`, and `Name` is a bare
+/// CM-side identifier naming a field, case or method.
 #[derive(Debug, Clone)]
 pub enum CmBoundary {
     Canonical {
@@ -2375,8 +2368,7 @@ impl Expr {
     /// the mapped expression — how default-argument expansion rewrites a
     /// reference to an earlier parameter (`fn make_rect(w, h = w)`) into the
     /// caller's value. Traverses only the forms a simple, pure default may
-    /// contain; blocks, closures and match/if are left alone, being unable to
-    /// appear in one.
+    /// contain; blocks, closures and match/if cannot appear in one.
     pub fn substitute_idents(&mut self, subs: &crate::hashmap::IndexMap<String, Expr>) {
         match self {
             Expr::Ident(ident) => {

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -78,7 +78,7 @@ impl AstId {
     /// A globally-unique `AstId` for a transient node never owned by a
     /// [`Module`] — synthesized `Type::Named` / `Type::Generic` operands for
     /// type-query functions, and test fixtures. It lives in the reserved
-    /// [`AstIdSpace::FRESH`] space, so it never collides with a
+    /// `AstIdSpace::FRESH` space, so it never collides with a
     /// parser-allocated id (and must never become a fact / symbol key).
     #[must_use]
     pub fn fresh() -> Self {
@@ -1954,7 +1954,7 @@ pub struct ForStmt {
 }
 
 /// For-of loop: `for let item of array { body }`
-/// Iterates over elements of an List<T>
+/// Iterates over elements of a `List<T>`
 #[derive(Debug, Clone)]
 pub struct ForOfStmt {
     pub id: AstId,
@@ -2549,7 +2549,7 @@ pub struct StructLiteralField {
 
 /// Tuple literal expression: `[1, 2, 3]` or `[1, "hello", true]`
 /// This uses bracket syntax following TypeScript conventions.
-/// Can be coerced to List<T> when all elements have the same type.
+/// Can be coerced to `List<T>` when all elements have the same type.
 #[derive(Debug, Clone)]
 pub struct TupleLiteralExpr {
     pub id: AstId,

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -3,18 +3,13 @@
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::token::Span;
 
-/// Identity of one `AstId` allocation space — one per parse.
-///
-/// Every top-level [`crate::parser::Parser`] draws a fresh space from a
-/// process-global counter and stamps it into each id it allocates, so a full
-/// [`AstId`] is globally unique while [`AstId::local`] stays dense per module.
-/// Template-interpolation sub-parsers and [`Module::alloc_ast_id`] continue an
-/// existing space (one module tree = one space).
-///
-/// A space identifies a *parse*, not a `ModuleSource`: re-parsing mints a new
-/// one. Nothing relies on ids being stable across parses — stdlib ASTs are
-/// parsed once per process and shared (`loader::cached_stdlib_module`), and
-/// user-module facts never outlive their parse.
+/// Identity of one `AstId` allocation space — one per parse. Each top-level
+/// [`crate::parser::Parser`] draws a fresh one from a process-global counter and
+/// stamps it into every id, so a full [`AstId`] is globally unique while
+/// [`AstId::local`] stays dense per module; sub-parsers continue an existing
+/// space. It identifies a *parse*, not a `ModuleSource`, and nothing relies on
+/// ids surviving a re-parse: stdlib ASTs are parsed once per process and shared,
+/// and user-module facts never outlive their parse.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct AstIdSpace(u32);
 
@@ -34,19 +29,13 @@ impl AstIdSpace {
     }
 }
 
-/// Globally-unique identifier for a semantically-significant AST node (items,
-/// named members, parameters).
-///
-/// An `AstId` is an [`AstIdSpace`] (which parse made it) plus a module-local
-/// dense index assigned in DFS order (`0..Module::ast_id_count()`). Every node
-/// has a real id; there is no sentinel. Builtins are parsed like any module.
-///
-/// Because the space differs per module, nodes from different modules can
-/// never share an `AstId` — so per-node fact maps key by bare `AstId` without
-/// cross-module collisions even under a wrong keying perspective (issue
-/// #1342). Ordering is `(space, local)`, so within one module ids order by
-/// allocation — what parser checkpoint rollback and
-/// [`crate::comment::TriviaMap`] rely on.
+/// Globally-unique identifier for a semantically-significant AST node: an
+/// [`AstIdSpace`] plus a module-local dense index assigned in DFS order. Every
+/// node has a real id, with no sentinel, and builtins are parsed like any module.
+/// The space differs per module, so nodes from different ones can never collide
+/// and a per-node fact map keys by bare `AstId` even under a wrong perspective.
+/// Ordering is `(space, local)`, so ids within a module order by allocation —
+/// what parser rollback and [`crate::comment::TriviaMap`] rely on.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct AstId {
     space: AstIdSpace,
@@ -272,17 +261,12 @@ impl Module {
         self.ast_id_count
     }
 
-    /// Allocate a fresh dense [`AstId`] at the end of this module's
-    /// per-module range.  Use this when post-parse synthesis injects a
-    /// new AST node into [`Self::items`] and the node needs a
-    /// the symbol coordinate-compatible id (for
-    /// example an `Item::Impl` that the elaborator walks).  The returned
-    /// id is guaranteed not to collide with any parser-allocated id.
-    ///
-    /// Prefer this over [`AstId::fresh`] for nodes that enter a module
-    /// tree — `AstId::fresh` is globally unique but lives in the reserved
-    /// transient space, outside this module's dense local range, so
-    /// machinery keyed on that range cannot find them.
+    /// Allocate a fresh dense [`AstId`] at the end of this module's range, for
+    /// post-parse synthesis injecting a node into [`Self::items`] that needs a
+    /// symbol-coordinate-compatible id. Never collides with a parser-allocated
+    /// one. Prefer it over [`AstId::fresh`] for anything entering a module tree:
+    /// that mints into the reserved transient space, outside this dense range,
+    /// where machinery keyed on the range cannot find it.
     #[must_use]
     pub fn alloc_ast_id(&mut self) -> AstId {
         let id = AstId::new(self.ast_id_space, self.ast_id_count);
@@ -382,18 +366,12 @@ fn span_byte_len(span: Span) -> usize {
     span.end.saturating_sub(span.start)
 }
 
-/// Structural AST visitor used for id-based queries (LSP position lookup,
-/// density checks) and scope-aware analyses (reference collection).
-///
-/// Every `visit_*` method defaults to its corresponding free `walk_*`
-/// function, which recurses into children through the visitor's own
-/// methods. Implementers override only the nodes where their behavior
-/// differs from plain structural traversal.
-///
-/// `visit_id` receives every [`AstId`] / [`Span`] pair encountered during a
-/// walk — including container ids (items, statements, expressions, blocks)
-/// and leaf id-bearing nodes that have no dedicated `visit_*` method (struct
-/// fields, enum cases, generic/closure parameters, etc.).
+/// Structural AST visitor, for id-based queries (LSP position lookup, density
+/// checks) and scope-aware analyses. Every `visit_*` defaults to its free
+/// `walk_*`, which recurses through the visitor's own methods, so an implementer
+/// overrides only where its behaviour differs from plain traversal. `visit_id`
+/// sees every [`AstId`] / [`Span`] pair — containers and the leaf id-bearing
+/// nodes with no `visit_*` of their own alike.
 pub trait AstVisitor: Sized {
     /// Invoked for every [`AstId`] emitted during traversal.
     ///
@@ -1198,18 +1176,10 @@ pub struct GlobalDecl {
     pub span: Span,
 }
 
-/// A single argument in an attribute.
-///
-/// Distinguishes between string literals, bare identifiers, and key=value pairs so that
-/// `unparse` can reconstruct the original syntax faithfully.
-///
-/// Examples:
-/// - `#[cm("wasi:cli/stdout")]`          → `[Str("wasi:cli/stdout")]`
-/// - `#[inline(always)]`                           → `[Ident("always")]`
-/// - `#[wire(name = "type")]`                   → `[KeyValue("name", "type")]`
-/// - `#[canonical("wasi", "stream-new")]`          → `[Str("wasi"), Str("stream-new")]`
-/// - `#[timeout_ms(120000)]`                       → `[Number("120000")]`
-/// - `#![generated(sources = ["a.wit", "b.wit"])]` → `[KeyArray("sources", ["a.wit", "b.wit"])]`
+/// A single argument in an attribute, keeping string literals, bare identifiers,
+/// numbers, `key = value` pairs and `key = [array]` distinct so `unparse` can
+/// reconstruct the original syntax — `#[inline(always)]` is `[Ident("always")]`
+/// where `#[cm("wasi:cli/stdout")]` is `[Str(…)]`.
 #[derive(Debug, Clone)]
 pub enum AttrArg {
     /// A quoted string literal, e.g. `"value"`.
@@ -1297,20 +1267,12 @@ impl Attribute {
     }
 }
 
-/// Component Model boundary metadata extracted from `#[cm(...)]` or
-/// `#[canonical(...)]`.
-///
-/// Functions, methods, effects, resources, variant cases, and worlds tagged
-/// with one of these attributes cross the Component Model boundary, but the
-/// kind of boundary differs:
-///
-/// - `Canonical` — `#[canonical("namespace", "name")]` lowers to a CM
-///   canonical built-in (e.g. `canon.task.return`, `canon.stream.new`), not
-///   to an interface import.
-/// - `Import` — `#[cm("namespace:package/interface[@version][#function]")]`
-///   resolves to a real import from a CM interface.
-/// - `Name` — `#[cm("simple-name")]` is a single CM-side identifier used
-///   for naming a field, variant case, or method (no interface attached).
+/// Which Component Model boundary a `#[cm(…)]` / `#[canonical(…)]` declaration
+/// crosses: `Canonical` lowers to a CM canonical built-in such as
+/// `canon.task.return` rather than an interface import, `Import` resolves to a
+/// real import from `namespace:package/interface[@version][#function]`, and
+/// `Name` is a bare CM-side identifier naming a field, case or method, with no
+/// interface attached.
 #[derive(Debug, Clone)]
 pub enum CmBoundary {
     Canonical {
@@ -1477,17 +1439,10 @@ pub struct WorldDecl {
     pub span: Span,
 }
 
-/// A world import declaration (bare interface reference, WIT-faithful).
-///
-/// ```wado
-/// import Stdout;
-/// ```
-///
-/// Wado does not support `from "<package>"` or `as` qualifications: every
-/// importable interface is a `pub interface Foo` declaration whose
-/// `#[cm("...")]` attribute is the source of truth for its CM FQ name.
-/// Resource methods and types reach call sites through ordinary `use`
-/// statements.
+/// A world import declaration — a bare `import Stdout;`, WIT-faithful. Wado has
+/// no `from "<package>"` or `as` qualification: every importable interface is a
+/// `pub interface Foo` whose `#[cm("…")]` is the source of truth for its CM FQ
+/// name, and resource methods and types reach call sites through ordinary `use`.
 #[derive(Debug, Clone)]
 pub struct WorldImport {
     pub interface_name: String,
@@ -2416,17 +2371,12 @@ impl Expr {
         }
     }
 
-    /// Substitute free occurrences of identifiers inside this expression.
-    ///
-    /// Walks the expression tree and replaces each [`Expr::Ident`] whose name
-    /// appears as a key in `subs` with a clone of the mapped expression.
-    /// Used by default-argument expansion to rewrite references to earlier
-    /// parameters (e.g. `fn make_rect(w, h = w)`) into the caller's values.
-    ///
-    /// Only traverses expression forms that can appear inside the simple,
-    /// pure defaults permitted by the language; blocks, closures, and
-    /// match/if forms are left untouched because they cannot appear in a
-    /// pure default.
+    /// Replace each [`Expr::Ident`] whose name is a key in `subs` with a clone of
+    /// the mapped expression — how default-argument expansion rewrites a
+    /// reference to an earlier parameter (`fn make_rect(w, h = w)`) into the
+    /// caller's value. Traverses only the forms a simple, pure default may
+    /// contain; blocks, closures and match/if are left alone, being unable to
+    /// appear in one.
     pub fn substitute_idents(&mut self, subs: &crate::hashmap::IndexMap<String, Expr>) {
         match self {
             Expr::Ident(ident) => {

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -1,4 +1,4 @@
-//! Per-module structural index over an [`ast::Module`], built once after
+//! Per-module structural index over an `ast::Module`, built once after
 //! parse/bind and stored on [`crate::semantics::Semantics`]. It collects the
 //! positional facts LSP queries used to rediscover with bespoke walkers, behind
 //! one [`AstVisitor`] traversal, so a new decl-bearing AST node updates this

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -1,18 +1,8 @@
-//! Per-module structural index over an [`ast::Module`].
-//!
-//! `AstIndex` is built once per module right after parse/bind and stored on
-//! [`crate::semantics::Semantics`]. It collects positional facts that LSP
-//! queries and the semantics pipeline used to rediscover with bespoke recursive
-//! walkers — `name_span_in_module`, `collect_write_target_ids`, and the
-//! `span_of_ast_id` fallback in `wado-lsp/src/definition.rs`. By centralising
-//! these tables behind an [`AstVisitor`] traversal we keep extension cheap:
-//! when the AST grows a new decl-bearing node, only this builder needs an
-//! update instead of every consumer in the LSP layer.
-//!
-//! The index is intentionally narrow. It holds *only* facts derivable from the
-//! AST itself (spans, declaration name spans, assignment write targets); the
-//! semantic facts (resolved references, types, symbols) live elsewhere on
-//! [`crate::semantics::Semantics`].
+//! Per-module structural index over an [`ast::Module`], built once after
+//! parse/bind and stored on [`crate::semantics::Semantics`]. It collects the
+//! positional facts LSP queries used to rediscover with bespoke walkers, behind
+//! one [`AstVisitor`] traversal, so a new decl-bearing AST node updates this
+//! builder rather than every consumer. The semantic facts live elsewhere.
 
 use crate::ast::{
     AstId, AstVisitor, Expr, Function, ImplBlock, InterfaceMethod, Item, Module, Pattern,

--- a/wado-compiler/src/ast_index.rs
+++ b/wado-compiler/src/ast_index.rs
@@ -24,7 +24,7 @@ pub(crate) enum FunctionLocation {
     Method { item_idx: usize, method_idx: usize },
 }
 
-/// Structural facts about an [`ast::Module`].
+/// Structural facts about an [`crate::ast::Module`].
 #[derive(Debug, Default, Clone)]
 pub struct AstIndex {
     /// Span attached to every id-bearing AST node, exactly as the

--- a/wado-compiler/src/bind.rs
+++ b/wado-compiler/src/bind.rs
@@ -1,15 +1,7 @@
-//! Local name binding for Wado
-//!
-//! The bind phase performs local name resolution within function bodies:
-//! - Tracks variable scopes (blocks, if/while/for)
-//! - Detects use-before-define errors
-//! - Detects duplicate definitions within the same scope
-//! - Records variable mutability and reactivity
-//!
-//! This phase does NOT:
-//! - Load modules or resolve imports (that's the analyzer's job)
-//! - Resolve cross-module references (that's the resolve phase)
-//! - Perform type checking (that's the resolve phase)
+//! Local name binding: resolution *within* function bodies. It tracks variable
+//! scopes, detects use-before-define and duplicate definitions, and records
+//! mutability and reactivity. Imports belong to the analyzer, and cross-module
+//! references and type checking to the resolve phase.
 
 use crate::hashmap::IndexSet;
 

--- a/wado-compiler/src/cm_abi.rs
+++ b/wado-compiler/src/cm_abi.rs
@@ -187,7 +187,7 @@ fn cm_align_result(ok: &Type, err: &Type) -> u32 {
     1_u32.max(cm_align(ok)).max(cm_align(err))
 }
 
-/// Layout for option<T>: discriminant offset + payload offset.
+/// Layout for `option<T>`: discriminant offset + payload offset.
 pub fn layout_option(inner: &Type) -> CmLayout {
     let payload_align = cm_align(inner);
     let payload_size = cm_size(inner);
@@ -222,7 +222,7 @@ pub fn layout_result(ok: &Type, err: &Type) -> CmLayout {
     }
 }
 
-/// Registry-aware layout for option<T>.
+/// Registry-aware layout for `option<T>`.
 pub fn layout_option_with_registry(
     inner: &Type,
     registry: &crate::component_model::CmInterfaceRegistry,
@@ -230,7 +230,7 @@ pub fn layout_option_with_registry(
     layout_option_with_registry_scoped(inner, registry, None)
 }
 
-/// Package-scoped registry-aware layout for option<T>.
+/// Package-scoped registry-aware layout for `option<T>`.
 pub fn layout_option_with_registry_scoped(
     inner: &Type,
     registry: &crate::component_model::CmInterfaceRegistry,

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -1,14 +1,7 @@
-//! Component Model generator — builds a Wasm Component from a core module.
-//!
-//! This module contains all Component Model wrapping logic, handling:
-//! - WASI interface imports
-//! - Memory module
-//! - Bundled modules (FTS, libm)
-//! - Canonical intrinsics
-//! - WASI function lowering
-//! - Core module instantiation
-//! - Canonical lifting for world exports
-//! - HTTP handler export
+//! Component Model generator — wraps a core module into a Wasm Component: WASI
+//! interface imports and function lowering, the memory and bundled modules,
+//! canonical intrinsics, core-module instantiation, and the canonical lifting
+//! for world exports.
 
 use super::component_context::{CmTypeKey, ComponentModelContext};
 use super::postprocess;
@@ -452,17 +445,10 @@ fn type_to_cm_primitive_with_resources(
     wado_type_to_cm_primitive(ty)
 }
 
-/// Build CM `ComponentValType` entries for tuple elements, handling `Stream<T>` and
-/// `Future<T>` elements by emitting the necessary local types into `instance_type`.
-///
-/// Returns the `ComponentValType` list ready to pass to `instance_type.defined_type().tuple(...)`.
-/// Emit a CM type definition for a Wado type, returning the `ComponentValType`.
-///
-/// Recursively defines complex CM types (stream, future, result, list, option, tuple)
-/// inline in `instance_type`. Primitives and own resources are returned directly
-/// without creating new type definitions.
-///
-/// This is the unified entry point for converting any Wado return type into a CM type.
+/// The unified entry point for converting a Wado type into a `ComponentValType`,
+/// defining any complex CM type — stream, future, result, list, option, tuple —
+/// recursively inline in `instance_type`. A primitive or own resource is returned
+/// directly, needing no new definition.
 fn emit_cm_val_type(
     ty: &Type,
     instance_type: &mut InstanceType,
@@ -1003,27 +989,11 @@ fn expose_self_owned_resources(
     }
 }
 
-/// Emit the `core:kiln/types` record/variant surface via an imported
-/// instance. Called once per `core:kiln/generator` component.
-///
-/// Structure:
-/// - Build an `InstanceType` whose interior defines `input-file`,
-///   `output-file`, `response`, `error` as records/variants
-///   and exports each one by its WIT name. The CM validator's
-///   `all_valtypes_named_in_defined` check requires records/variants
-///   referenced by a component-level export to have their original type
-///   ids in `exported_types`; the instance-wrap satisfies that because
-///   inserting exported types into the set happens as the instance's
-///   exports are processed in declaration order.
-/// - Import that instance at the component level as
-///   `core:kiln/types@0.1.0`. No runtime code is required — wasmtime
-///   satisfies the import trivially because the instance has no function
-///   members.
-/// - Alias each exported type from the instance into the component's
-///   local type index space so `emit_world_exports` and the canon
-///   `task-return` routing can reference them by `ctx.type_idx(...)`.
-/// - Also intern the component-local `result<response, error>` handler type,
-///   which the export lift and `task-return` routing resolve by structure.
+/// Emit the `core:kiln/types` record/variant surface once per
+/// `core:kiln/generator` component: define them inside an `InstanceType`,
+/// import it as `core:kiln/types@0.1.0`, and alias each exported type into the
+/// component's local index space. The instance wrap is what satisfies the
+/// validator's `all_valtypes_named_in_defined` check.
 fn emit_kiln_world_types(builder: &mut ComponentBuilder, ctx: &mut ComponentModelContext) {
     let string_vt = ComponentValType::Primitive(PrimitiveValType::String);
     let bool_vt = ComponentValType::Primitive(PrimitiveValType::Bool);
@@ -3518,16 +3488,11 @@ fn import_interface_with_resource(
     );
 }
 
-/// Import a resource-defining source interface once and alias its resource
-/// type(s) — and its `error-code`, for transmission futures — into the outer
-/// component scope. Idempotent on `source_path` (keyed on the package-qualified
-/// instance-type name, a real builder type), so repeated requests from different
-/// consumers collapse to a single import.
-///
-/// This is the single place that emits a minimal, methods-less source instance.
-/// Both the plan-driven resource-source phase and the resource-using phase's
-/// pre-import call it, so the source-instance shape and its outer aliases live
-/// in exactly one place rather than two divergent copies.
+/// Import a resource-defining source interface once and alias its resource types
+/// — and its `error-code`, for transmission futures — into the outer component
+/// scope. Idempotent on `source_path`, keyed by the package-qualified
+/// instance-type name. The single place emitting a methods-less source instance,
+/// so the plan-driven and resource-using phases cannot diverge into two copies.
 fn import_resource_source(
     builder: &mut ComponentBuilder,
     ctx: &mut ComponentModelContext,
@@ -3862,19 +3827,11 @@ fn import_resource_using_interfaces(
             continue;
         }
 
-        // Ensure all needed resources are imported before building the instance type.
-        // A resource may appear only in a return type (e.g., preopens::get-directories
-        // returns a list of descriptors) without any of its own methods being called.
-        // In that case Phase 1/2 would not have imported the resource-defining interface,
-        // so we do it here at component scope before entering the instance-type builder.
-        // We use package-qualified names (e.g., "filesystem-types") to avoid collisions
-        // with other interfaces that share the same short interface name (e.g., "cli/types").
-        //
-        // EXCEPTION: when the resource's source path IS this interface, we do not
-        // pre-import it. The CM spec requires `[constructor]X` / `[method]X.foo`
-        // to live in the same instance that exports the resource type `X` — so
-        // such resources must be exported directly inside the per-interface
-        // instance type emitted below, not aliased through an outer scope.
+        // Import every needed resource at component scope before entering the
+        // instance-type builder: a resource appearing only in a return type had
+        // no method call to make the earlier phases import its interface. A
+        // resource whose source path *is* this interface is skipped — the CM
+        // spec requires `[method]X.foo` to sit in the instance exporting `X`.
         for resource_name in &needed_resources {
             let Some(source) = project
                 .cm_interface_registry
@@ -4371,17 +4328,11 @@ fn lower_wasi_functions(
     }
 }
 
-/// Append one CM instance export per exported interface.
-///
-/// World exports with `from_interface_fq` populated (CLI `run`, HTTP `handle`)
-/// are grouped by that FQ — an `export Foo;` with several methods yields one
-/// world export per method sharing the FQ — into a single instance carrying
-/// every method's lifted func plus the union of the named CM types their
-/// signatures reference. Freestanding exports (no parent interface, e.g. kiln's
-/// `generate`) carry no instance; `emit_world_exports` emitted them bare.
-///
-/// Runs after `builder.finish()`, appending raw CM sections; the instance index
-/// space continues from `ctx.instance_count()`. No HTTP-specific branching.
+/// Append one CM instance export per exported interface: world exports sharing a
+/// `from_interface_fq` collapse into one instance holding every lifted func plus
+/// the named CM types their signatures reference. A freestanding export has no
+/// instance — `emit_world_exports` already emitted it bare. Runs after
+/// `builder.finish()`, so the instance index space continues from `ctx`.
 fn append_interface_instance_exports(
     component_bytes: &mut Vec<u8>,
     ctx: &ComponentModelContext,

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -2062,18 +2062,11 @@ impl<'a> WirEmitter<'a> {
                 src_offset,
                 len,
             } if self.codegen_flags.array_copy => {
-                // Native lowering (the default): emit the Wasm `array.copy`
-                // instruction directly. Benchmarking showed it wins big on
-                // copy-heavy workloads (zlib decompress ~+41%, syntax-highlight
-                // ~+10%) and is neutral elsewhere, so it is the default; the
-                // arm below open-codes a loop instead and is selected with
-                // `-f no-array-copy` (kept so we can keep re-measuring as the
-                // wasmtime runtime evolves).
-                //
-                // Stack/immediate shape: `array.copy $dst $src` consumes
-                // `dst_ref, dst_offset, src_ref, src_offset, len`. It accepts
-                // nullable refs, so unlike the loop path no `ref.as_non_null`
-                // narrowing is needed.
+                // Native lowering (the default): `array.copy $dst $src` consumes
+                // `dst_ref, dst_offset, src_ref, src_offset, len` and accepts
+                // nullable refs, so unlike the loop below it needs no
+                // `ref.as_non_null`. The loop arm stays behind
+                // `-f no-array-copy` for re-measuring as wasmtime evolves.
                 let dst_wasm_idx = self.resolve_type_index(dest_type_id.index());
                 let src_wasm_idx = self.resolve_type_index(src_type_id.index());
                 self.emit_instr(f, dest);
@@ -2548,16 +2541,11 @@ impl<'a> WirEmitter<'a> {
         ConstExpr::extended(instrs)
     }
 
-    /// Recursively lower a constant-expressible `WirInstr` tree into the
-    /// instruction sequence of a Wasm constant init expression. Mirrors the
-    /// aggregate-construction arms of [`Self::emit_instr`]; only instructions
-    /// valid in a Wasm 3.0 GC constant expression are accepted (scalar consts,
-    /// `ref.null` / `ref.i31` / `ref.func`, and `struct.new` / `array.new_fixed`
-    /// / `array.new_default`). This mirrors [`WirInstr::is_const_expressible`],
-    /// the predicate `wir_optimize::const_global` gates promotion on; anything
-    /// else reaching an init slot is an optimizer bug — a non-const initializer
-    /// should never be placed here — so it ICEs rather than silently
-    /// miscompiling to `i32.const 0`.
+    /// Recursively lower a constant-expressible `WirInstr` tree into a Wasm
+    /// constant init expression, accepting only what a Wasm 3.0 GC constant
+    /// expression allows. Mirrors [`WirInstr::is_const_expressible`], which
+    /// `wir_optimize::const_global` gates promotion on, so anything else
+    /// reaching an init slot is an optimizer bug and ICEs.
     fn push_const_instrs<'i>(&'i self, instr: &'i WirInstr, out: &mut Vec<Instruction<'i>>) {
         match instr {
             WirInstr::I32Const(v) => out.push(Instruction::I32Const(*v)),
@@ -2634,20 +2622,10 @@ impl<'a> WirEmitter<'a> {
             .unwrap_or(0)
     }
 
-    /// Check if a struct field is a packed type (i8/i16).
-    /// Returns `Some(true)` for signed packed (I8/I16), `Some(false)` for unsigned packed (U8/U16),
-    /// or `None` if the field is not packed.
-    /// Check if a struct field is a packed type (i8/i16 storage).
-    /// Returns `Some(true)` for signed packed (I8/I16), `Some(false)` for unsigned packed (U8/U16/Bool),
-    /// or `None` if the field is not packed.
-    /// Check if an array type has packed elements (i8/i16 storage).
-    /// Returns `Some(true)` for signed packed (I8/I16), `Some(false)` for unsigned packed (U8/U16/Bool),
-    /// or `None` if the array element is not packed.
-    /// True when the array's Wado element type is a non-nullable reference.
-    /// The array is *declared* with a nullable element (for
-    /// `array.new_default`), but `array.get` results are narrowed back to
-    /// non-null only for these — a niche-optimized `Option<ref>` element is
-    /// legitimately nullable (`None` == null ref) and must not be narrowed.
+    /// True when the array's Wado element type is a non-nullable reference. The
+    /// array is *declared* with a nullable element, for `array.new_default`, but
+    /// only these narrow their `array.get` results back to non-null — a
+    /// niche-optimized `Option<ref>` element is legitimately nullable.
     fn is_array_element_non_nullable_ref(&self, wir_type_idx: u32) -> bool {
         let idx = wir_type_idx as usize;
         idx < self.wir.types.len()

--- a/wado-compiler/src/codegen_flags.rs
+++ b/wado-compiler/src/codegen_flags.rs
@@ -1,14 +1,10 @@
 //! Fine-grained codegen feature flags.
 //!
-//! These toggle individual codegen strategies that we want to be able to
-//! switch on and off without rebuilding the toolchain — primarily so we can
-//! A/B them under the benchmark suite. The CLI exposes them through the
-//! generic `-f <flag>` option (see `wado-cli`), which forwards the raw flag
-//! strings to [`CompilerOptions::codegen_flags`](crate::CompilerOptions); the
-//! compiler then parses them into this typed struct via [`CodegenFlags::parse`].
-//!
-//! Each flag is a plain boolean. A leading `no-` on the flag name inverts it,
-//! so a flag that is on by default can be turned off with `-f no-<flag>`.
+//! These toggle individual codegen strategies without rebuilding the toolchain,
+//! primarily to A/B them under the benchmark suite. The CLI's `-f <flag>`
+//! forwards raw strings to [`CompilerOptions::codegen_flags`](crate::CompilerOptions),
+//! which [`CodegenFlags::parse`] reads into this struct. Each flag is a boolean,
+//! and a leading `no-` inverts it.
 
 /// Codegen feature flags toggled from the CLI via `-f <flag>`.
 ///
@@ -19,45 +15,24 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CodegenFlags {
     /// Lower `builtin::array_copy` to the native Wasm `array.copy` instruction
-    /// (the default) instead of an open-coded element-wise loop.
-    ///
-    /// We originally defaulted to the loop because wasmtime's `array.copy`
-    /// runtime path was markedly slower than an inlined loop for short copies.
-    /// After a wasmtime patch improved that path, benchmarking showed the
-    /// native instruction wins big on copy-heavy workloads (zlib decompress
-    /// ~+41%, syntax-highlight ~+10%) and is neutral elsewhere (compress,
-    /// JSON parsing, float formatting all within noise), so the native
-    /// instruction is now the default. Pass `-f no-array-copy` to restore the
-    /// open-coded loop. See the `WirInstr::ArrayCopy` emitter in
-    /// `codegen/emit.rs`.
+    /// (the default) instead of an open-coded element-wise loop. The loop was
+    /// once faster for short copies; since a wasmtime patch, the instruction
+    /// wins big on copy-heavy workloads (zlib decompress ~+41%,
+    /// syntax-highlight ~+10%) and is neutral elsewhere.
     pub array_copy: bool,
 
-    /// Emit `metadata.code.branch_hint` entries (the default). Pass
-    /// `-f no-branch-hinting` to benchmark without them: `builtin::cold_path()`
-    /// then lowers to a plain no-op in `wir_build` (so no marker reaches WIR
-    /// and `apply_cold_path_hints` finds nothing) and the WIR-level trap-based
-    /// hint inference is skipped. The markers are dropped at WIR build — not
-    /// at NIR — so the NIR inliner's cold-path cost exclusion behaves
-    /// identically in both configurations and the A/B isolates the hints
-    /// themselves. `br_if` selection is unaffected by this flag — it is
-    /// instruction selection, not hinting (it runs at `-O1+`, gated by the
-    /// optimization level like any other rewrite).
+    /// Emit `metadata.code.branch_hint` entries (the default);
+    /// `-f no-branch-hinting` benchmarks without them, lowering
+    /// `builtin::cold_path()` to a no-op and skipping trap-based inference. The
+    /// markers are dropped at WIR build, not NIR, so the inliner's cold-path
+    /// cost exclusion is unchanged and the A/B isolates the hints themselves.
     pub branch_hinting: bool,
 
-    /// Lower an assertion failure to a bare `unreachable` trap
-    /// (`if !cond { unreachable() }`) instead of the power-assert diagnostic.
-    ///
-    /// An `assert` always keeps checking and trapping — only the failure
-    /// *message* is dropped. The diagnostic formats the operands through the
-    /// whole `Formatter` / `Inspect` / `String` stack, which any program that
-    /// merely indexes a `List` (`list[i]` lowers to `assert i < used`) then
-    /// drags in. `-f bare-asserts` strips it, shrinking size-sensitive builds:
-    /// `lower::bare_asserts` replaces the `assert_failed(..)` cold block with a
-    /// trap and the now-dead formatting falls out at DCE.
-    ///
-    /// Off at `-O0`/`-O1`/`-O2`/`-O3`, **on by default at `-Os`** (see
-    /// [`CodegenFlags::for_opt_level`]); `-f no-bare-asserts` restores the
-    /// diagnostic, `-f bare-asserts` forces it at any level.
+    /// Lower an assertion failure to a bare `unreachable` trap instead of the
+    /// power-assert diagnostic. The check and trap always stay; only the
+    /// *message* goes, taking with it the `Formatter` / `Inspect` / `String`
+    /// stack that even a `list[i]` drags in. Off at `-O0`…`-O3`, **on at `-Os`**
+    /// (see [`CodegenFlags::for_opt_level`]).
     pub bare_asserts: bool,
 
     /// Emit native Wasm wide-arithmetic (`i64.mul_wide_u/s`, `i64.add128`,

--- a/wado-compiler/src/comment.rs
+++ b/wado-compiler/src/comment.rs
@@ -209,7 +209,7 @@ fn collect_node_spans(module: &Module) -> Vec<(AstId, Span)> {
 
 /// Repatriate same-line trailing comments out of `leading[*]` and
 /// `dangling` into `trailing[owner]`, using the
-/// [`NodeLookup::trailing_owner`] rule. Idempotent: a second call is
+/// `NodeLookup::trailing_owner` rule. Idempotent: a second call is
 /// a no-op because the surviving `leading`/`dangling` entries by
 /// definition have no trailing owner.
 pub fn populate_trailing(trivia: &mut TriviaMap, module: &Module) {

--- a/wado-compiler/src/comment.rs
+++ b/wado-compiler/src/comment.rs
@@ -1,18 +1,8 @@
-// Comment handling for Wado formatter and `wado doc`.
-//
-// `TriviaMap` is the single AstId-keyed store for comments:
-//   * `leading_of(id)` — comments that precede the node, populated by
-//     the parser on each `alloc_ast_id` call.
-//   * `trailing_of(id)` — same-line tail comments, populated by
-//     [`populate_trailing`] after parsing completes.
-//   * `inner_tail_of(block_id)` — comments between a block's last
-//     statement and its closing `}`, populated by
-//     [`populate_inner_tail`].
-//   * `dangling()` — file-tail comments past the last AST node.
-//
-// `populate_trailing` and `populate_inner_tail` walk the parsed AST and
-// repatriate comments out of their parser-assigned slots; the unparser
-// then reads `TriviaMap` exclusively, with no positional reconstruction.
+// Comment handling for the Wado formatter and `wado doc`. `TriviaMap` is the
+// single AstId-keyed store: `leading_of` (populated by the parser at each
+// `alloc_ast_id`), `trailing_of`, `inner_tail_of`, and `dangling`. The last
+// three are repatriated out of their parser-assigned slots post-parse, so the
+// unparser reads `TriviaMap` alone with no positional reconstruction.
 
 use crate::ast::{AstId, AstVisitor, Block, Module, walk_block};
 use crate::token::Span;
@@ -42,34 +32,11 @@ pub enum CommentKind {
     ModuleDoc,
 }
 
-/// Trivia (currently: comments) attached to AST nodes by [`AstId`].
-///
-/// The parser populates this as it allocates ids: at each `alloc_ast_id`
-/// call, every still-unattached comment whose `span.start` precedes the
-/// next-to-consume token's start is attached to the new id as leading
-/// trivia. Because `alloc_ast_id` is called in DFS parse order — the
-/// outermost node being constructed at a given source position allocates
-/// first — leading comments naturally land on the outermost AST node that
-/// "starts" at that position, which matches the semantic ownership users
-/// expect (`/*flag=*/true` belongs to the literal `true`, not to the
-/// surrounding call).
-///
-/// `trailing` is populated by [`populate_trailing`] in a post-parse pass:
-/// any comment that sits on the same source line as a node's end position
-/// and starts at or after that position is repatriated from its
-/// parser-assigned `leading`/`dangling` slot to `trailing[node]`. The
-/// unparser reads `trailing_of(id)` to emit "tail" comments inline with
-/// the closing token of the node they belong to.
-///
-/// `inner_tail` is populated by [`populate_inner_tail`]: comments that
-/// fall *between the end of a block's last statement and its closing
-/// brace* are attributed to the innermost containing block's id. The
-/// unparser flushes them just before emitting the `}` of that block.
-///
-/// `dangling` collects comments that fall after the last token of the
-/// last allocated AST node — typically a comment on a trailing line of
-/// the file. Those are emitted by the unparser at a fixed sink (the end
-/// of the module) without an AST anchor.
+/// Trivia (currently: comments) attached to AST nodes by [`AstId`]. `leading` is
+/// filled by the parser in DFS order, so a comment lands on the outermost node
+/// starting at its position — `/*flag=*/true` belongs to the literal, not the
+/// call. [`populate_trailing`] and [`populate_inner_tail`] then move what they
+/// own; the rest, past the last node, stays `dangling`.
 #[derive(Debug, Clone, Default)]
 pub struct TriviaMap {
     leading: BTreeMap<AstId, Vec<Comment>>,
@@ -192,20 +159,11 @@ impl NodeLookup {
         }
     }
 
-    /// Identify the AST node that owns `c` as a trailing comment.
-    ///
-    /// A node is a candidate when its span ends at or before
-    /// `c.span.start` on the same source line as `c`. Among
-    /// candidates we pick the one with the largest `span.end` (the
-    /// one whose closing token is closest to the comment) and, on
-    /// ties, the smallest `span.start` (the outermost of perfectly
-    /// nested nodes). Returns `None` if no node fits.
-    ///
-    /// Comments that are followed by another AST node on the same
-    /// line — e.g. `foo(1, /*flag=*/true)` — are *interior* trivia
-    /// of the surrounding construct and remain leading of the next
-    /// node; they are never reclassified as trailing of the previous
-    /// one.
+    /// The AST node owning `c` as a trailing comment: among the nodes ending at
+    /// or before `c.span.start` on its line, the largest `span.end` wins, ties
+    /// going to the smallest `span.start`. `None` if none fits, including when
+    /// another node follows on the same line — `foo(1, /*flag=*/true)` is
+    /// interior trivia and stays leading of the next node.
     fn trailing_owner(&self, c: &Comment) -> Option<AstId> {
         if let Some(starts) = self.starts_by_line.get(&c.span.end_line()) {
             // Sorted ascending; if any value is >= c.span.end, the
@@ -293,16 +251,11 @@ fn collect_block_ranges(module: &Module) -> Vec<(AstId, usize, usize)> {
     c.0
 }
 
-/// Repatriate comments that sit between a block's last statement and
-/// its closing `}` into `inner_tail[block.id]`. Innermost block wins
-/// for nested cases. Idempotent: the surviving `leading`/`dangling`
-/// entries by definition contain no comments inside any block's
-/// inner-tail range.
-///
-/// Run *after* [`populate_trailing`] — comments already moved to a
-/// trailing slot are no longer in `leading`/`dangling` and are
-/// therefore left alone, preserving their stronger same-line tail
-/// attribution.
+/// Repatriate comments between a block's last statement and its closing `}`
+/// into `inner_tail[block.id]`, innermost block winning. Idempotent, the
+/// survivors being outside every inner-tail range by definition. Run *after*
+/// [`populate_trailing`], so a comment already moved to a trailing slot keeps
+/// its stronger same-line attribution.
 pub fn populate_inner_tail(trivia: &mut TriviaMap, module: &Module) {
     let blocks = collect_block_ranges(module);
     populate_inner_tail_from_blocks(trivia, &blocks);

--- a/wado-compiler/src/compiler_host.rs
+++ b/wado-compiler/src/compiler_host.rs
@@ -355,51 +355,14 @@ impl SpanEmitter for NullSpanEmitter {
     fn debug(&self, _message: &str) {}
 }
 
-/// Abstraction for compiler I/O operations
-///
-/// This trait enables the compiler to work in different environments:
-/// - `FilesystemCompilerHost` for CLI usage (implemented in wado-cli)
-/// - `InMemoryCompilerHost` for testing
-/// - `BrowserCompilerHost` for browser/playground usage
-/// - `LspCompilerHost` for LSP integration
-///
-/// # Standard Library Handling
-///
-/// Standard library paths (`core:*`, `wasi:*`) are NOT passed to `load_source`.
-/// They are handled directly by the compiler via embedded sources (`include_str!`).
-///
-/// # Example
-///
-/// ```ignore
-/// struct MyHost { /* ... */ }
-///
-/// impl CompilerHost for MyHost {
-///     async fn load_source(&self, path: &str) -> Result<String, SourceError> {
-///         // Load source from custom storage
-///     }
-///
-///     fn emit_diagnostic(&self, diagnostic: Diagnostic) {
-///         // Handle diagnostic (print, collect, send to UI, etc.)
-///     }
-/// }
-/// ```
+/// Abstraction for compiler I/O, letting the compiler run under a filesystem,
+/// in-memory, browser, or LSP host. Standard library paths (`core:*`, `wasi:*`)
+/// never reach `load_source`; the compiler serves them from embedded sources.
 pub trait CompilerHost: Send + Sync {
-    /// Load a file as raw bytes.
-    ///
-    /// This is the single I/O primitive for the compiler. Both source files
-    /// (`.wado`) and binary assets (`#include_bytes`) are loaded through this
-    /// method. The compiler interprets the bytes as UTF-8 where appropriate.
-    ///
-    /// # Arguments
-    /// * `path` - File path, which can be:
-    ///   - Local path (e.g., "./lib.wado", "../utils.wado")
-    ///   - Remote URL (e.g., "<https://example.com/lib.wado>", "<http://example.com/lib.wado>")
-    ///
-    /// NOTE: Standard library paths (core:*, wasi:*) are NOT passed to this method.
-    /// They are handled directly by the compiler via embedded sources.
-    ///
-    /// # Returns
-    /// The raw bytes of the file
+    /// Load a file as raw bytes — the compiler's single I/O primitive, used for
+    /// both `.wado` sources and `#include_bytes` assets, with the compiler
+    /// interpreting them as UTF-8 where appropriate. `path` is a local path or a
+    /// remote URL; stdlib paths never arrive here.
     fn load_source(&self, path: &str) -> impl Future<Output = Result<Vec<u8>, SourceError>> + Send;
 
     /// Emit a diagnostic (error, warning, etc.)
@@ -409,19 +372,11 @@ pub trait CompilerHost: Send + Sync {
     /// a list, send to an LSP client, etc.
     fn emit_diagnostic(&self, diagnostic: Diagnostic);
 
-    /// Execute a Kiln generator component and return its response.
-    ///
-    /// `component_wasm` is the compiled generator component. The host is
-    /// responsible for instantiating it, linking `core:kiln/host` so that
-    /// `emit-diagnostic` forwards back into this same host,
-    /// and returning the generator's response.
-    ///
-    /// The default implementation returns `Unsupported`, which drives
-    /// "consume-only" mode (the compiler reuses the most recent cached
-    /// outputs on disk and warns on drift). Hosts that have a Wasm runtime
-    /// available (e.g. `wado-cli` via wasmtime) override this method.
-    ///
-    /// See WEP 2026-04-12 (Kiln) for the full protocol.
+    /// Execute a Kiln generator component and return its response. The host
+    /// instantiates `component_wasm` and links `core:kiln/host` so
+    /// `emit-diagnostic` forwards back into itself. The default `Unsupported`
+    /// drives consume-only mode, reusing cached outputs and warning on drift;
+    /// a host with a Wasm runtime overrides it. Protocol: WEP 2026-04-12.
     fn run_generator(
         &self,
         _component_wasm: &[u8],

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -1,10 +1,8 @@
 //! Compiler-recognized stdlib items — Wado's analogue of rustc's lang items.
 //! Each names a stdlib symbol the Rust side references directly, bound by a
 //! `#[compiler_item("…")]` attribute on the Wado declaration and looked up
-//! through the [`CompilerItems`] registry instead of by string. So a stdlib
-//! rename is invisible here, while renaming the `compiler_item` value breaks the
-//! compiler's own build at [`CompilerItem::from_attr_name`]. The attribute is
-//! meaningful only inside `core::*`; the elaborator rejects it on user code.
+//! through the [`CompilerItems`] registry, so a stdlib rename is invisible here.
+//! The attribute is meaningful only inside `core::*`.
 
 use std::fmt;
 
@@ -51,8 +49,7 @@ impl SeqField {
 /// [`CompilerItem::attr_name`] must match the `#[compiler_item("…")]` argument
 /// on the Wado declaration. Names are flat `snake_case`: `<type>_<method>` for a
 /// method, the lowercase name for a type or trait, `<variant>_<case>` for a
-/// case. The parser only checks the argument names a known variant, so the
-/// convention itself is enforced socially.
+/// case.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum CompilerItem {
     // ── Types (structs / generic structs) ────────────────────────────
@@ -750,13 +747,10 @@ impl CompilerItem {
     }
 
     /// Whether the registry must hold this item for `world` to compile. A
-    /// `core::prelude` item always is — the prelude is auto-loaded and underpins
-    /// the type system — while one from a world the user did not opt into is
-    /// required only when that module is actually loaded, which keeps the
+    /// `core::prelude` item always is; one from a world the user did not opt
+    /// into is required only once that module is loaded, which keeps the
     /// validator from failing a CLI build that pulls in neither kiln nor serde.
-    /// It scans every [`Self::ALL`] variant after `annotate_modules`, so a
-    /// missing stdlib annotation is a compile-time error rather than a surprise
-    /// at the first synthesis call.
+    /// The scan runs after `annotate_modules`, ahead of any synthesis call.
     pub fn is_required(self, world: &str) -> bool {
         match self {
             // Always loaded — `core:prelude` is auto-imported.
@@ -1107,9 +1101,8 @@ impl fmt::Display for CompilerItemKind {
 /// One associated type declared on a registered trait, carrying its source-side
 /// name and those of its bounds — `type SeqSerializer: SerializeSeq;` becomes
 /// `{ name: "SeqSerializer", bound_names: ["SerializeSeq"] }`. The bound list is
-/// what makes [`CompilerItems::trait_assoc_type_by_bound`] rename-stable: the
-/// synthesiser asks which assoc type `SerializeSeq` bounds, not whether one is
-/// named `SeqSerializer`.
+/// what makes [`CompilerItems::trait_assoc_type_by_bound`] rename-stable: it
+/// asks which assoc type `SerializeSeq` bounds, not for one named by spelling.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TraitAssocType {
     pub name: String,
@@ -1149,19 +1142,15 @@ pub enum Resolved {
         decl: crate::ast::AstId,
         /// Primary method name of a **single-method** trait, captured when the
         /// elaborator registers its annotation; `None` for a multi-method trait
-        /// such as `Serializer`. The format family (`Display`, `Inspect`, and
-        /// their `Alt` / radix siblings) all have exactly one method by design,
-        /// so the synthesiser reads the name from the registration rather than
-        /// hard-coding `"fmt"` at each call site. Read via
+        /// such as `Serializer`. Lets the synthesiser read the name of a format
+        /// trait's one method rather than hard-coding `"fmt"`. Read via
         /// [`CompilerItems::trait_method_name`].
         method_name: Option<String>,
         /// The trait's associated types in source order, each a
         /// [`TraitAssocType`], captured when the elaborator registers the
         /// annotation. The serde synthesiser identifies one by its *bound* trait
-        /// — itself registry-resolved — rather than its spelling, so renaming
-        /// either end keeps flowing through the registry instead of panicking on
-        /// a missing name. Read via
-        /// [`CompilerItems::trait_assoc_type_by_bound`].
+        /// rather than its spelling, so renaming either end keeps resolving. Read
+        /// via [`CompilerItems::trait_assoc_type_by_bound`].
         assoc_types: Vec<TraitAssocType>,
     },
     Method {

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -1,30 +1,10 @@
-//! Compiler-recognized stdlib items (the Wado compiler's analogue of
-//! rustc's lang items).
-//!
-//! A `CompilerItem` identifies a specific stdlib symbol that the Wado
-//! compiler — Rust-side — needs to reference directly: types it
-//! instantiates (`Option<T>`, `Box<T>`), traits whose impls it
-//! synthesises (`Default`, `From`, `Serialize`), or methods it lowers
-//! into calls (`String::push_str`, `List::push`). Each item is bound
-//! to its resolution by a `#[compiler_item("...")]` attribute on the
-//! Wado-side declaration; the elaborator populates the
-//! [`CompilerItems`] registry during the annotate phase and downstream
-//! passes look symbols up through the registry instead of by string
-//! name.
-//!
-//! Why this exists: pre-`CompilerItem`, the compiler hard-coded paths
-//! and names (`LocalMethodName::new("String", None, "push_str")`,
-//! `name == "Option"`) at every site. Renaming a stdlib item would
-//! silently break those sites — failures showed up only at runtime as
-//! "unresolved call" errors. With the registry, renames on the
-//! Wado side are invisible to the Rust side as long as the
-//! `#[compiler_item("...")]` value stays put; renaming the
-//! `compiler_item` value, in turn, fails the compiler's own build by
-//! breaking the enum variant ↔ string mapping in
-//! [`CompilerItem::from_attr_name`].
-//!
-//! Scope: `#[compiler_item("...")]` is only meaningful inside
-//! `core::*` modules. The elaborator rejects the attribute on user code.
+//! Compiler-recognized stdlib items — Wado's analogue of rustc's lang items.
+//! Each names a stdlib symbol the Rust side references directly, bound by a
+//! `#[compiler_item("…")]` attribute on the Wado declaration and looked up
+//! through the [`CompilerItems`] registry instead of by string. So a stdlib
+//! rename is invisible here, while renaming the `compiler_item` value breaks the
+//! compiler's own build at [`CompilerItem::from_attr_name`]. The attribute is
+//! meaningful only inside `core::*`; the elaborator rejects it on user code.
 
 use std::fmt;
 
@@ -67,18 +47,12 @@ impl SeqField {
     }
 }
 
-/// Every compiler-recognized stdlib item.
-///
-/// Each variant has a canonical `snake_case` name (see
-/// [`CompilerItem::attr_name`]) that must match the argument of the
-/// `#[compiler_item("...")]` attribute on the Wado-side declaration.
-///
-/// Naming convention: flat `snake_case`. Methods use
-/// `<type>_<method>` (e.g. [`Self::StringPushStr`]); types and traits
-/// use the lowercase type/trait name; variant cases use
-/// `<variant>_<case>`. The convention is enforced socially, not by
-/// the parser — the parser only checks that the argument names a
-/// known [`CompilerItem`] variant.
+/// Every compiler-recognized stdlib item. Each variant's canonical
+/// [`CompilerItem::attr_name`] must match the `#[compiler_item("…")]` argument
+/// on the Wado declaration. Names are flat `snake_case`: `<type>_<method>` for a
+/// method, the lowercase name for a type or trait, `<variant>_<case>` for a
+/// case. The parser only checks the argument names a known variant, so the
+/// convention itself is enforced socially.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum CompilerItem {
     // ── Types (structs / generic structs) ────────────────────────────
@@ -775,24 +749,14 @@ impl CompilerItem {
         Self::ALL.iter().copied().find(|i| i.attr_name() == name)
     }
 
-    /// Whether the registry must contain this item by the end of
-    /// resolution for compilation of `world` to succeed.
-    ///
-    /// Items declared in `core::prelude::*` are always required — they
-    /// underpin the core type system and the prelude is auto-loaded
-    /// regardless of target world. Items declared in worlds the user
-    /// did not opt into (e.g. `core:kiln/generator` for
-    /// [`Self::KilnRequest`], `core:serde` for [`Self::Serialize`] /
-    /// [`Self::Deserialize`]) are only required when the matching
-    /// world / module is actually loaded; tracking that here keeps the
-    /// validator from spuriously failing in CLI / HTTP builds that
-    /// don't pull in kiln or serde.
-    ///
-    /// The validator scans this method for every [`Self::ALL`]
-    /// variant after `annotate_modules` runs; a `true` return on an
-    /// unregistered item is a hard error at compile time, surfacing
-    /// the missing stdlib annotation immediately rather than at the
-    /// first synthesis call that reaches for it.
+    /// Whether the registry must hold this item for `world` to compile. A
+    /// `core::prelude` item always is — the prelude is auto-loaded and underpins
+    /// the type system — while one from a world the user did not opt into is
+    /// required only when that module is actually loaded, which keeps the
+    /// validator from failing a CLI build that pulls in neither kiln nor serde.
+    /// It scans every [`Self::ALL`] variant after `annotate_modules`, so a
+    /// missing stdlib annotation is a compile-time error rather than a surprise
+    /// at the first synthesis call.
     pub fn is_required(self, world: &str) -> bool {
         match self {
             // Always loaded — `core:prelude` is auto-imported.
@@ -1140,18 +1104,12 @@ impl fmt::Display for CompilerItemKind {
     }
 }
 
-/// The resolved data for a registered [`CompilerItem`].
-/// One associated type declaration captured from a trait registered
-/// via `#[compiler_item("...")]`. Carries the source-side name plus
-/// the source-side names of all trait bounds (e.g.
-/// `type SeqSerializer: SerializeSeq;` →
-/// `{ name: "SeqSerializer", bound_names: ["SerializeSeq"] }`).
-///
-/// The bound list is what makes
-/// [`CompilerItems::trait_assoc_type_by_bound`] stable across stdlib
-/// renames: the synthesiser asks "which assoc type is bound by
-/// `SerializeSeq`?" instead of "is there an assoc type named
-/// `SeqSerializer`?".
+/// One associated type declared on a registered trait, carrying its source-side
+/// name and those of its bounds — `type SeqSerializer: SerializeSeq;` becomes
+/// `{ name: "SeqSerializer", bound_names: ["SerializeSeq"] }`. The bound list is
+/// what makes [`CompilerItems::trait_assoc_type_by_bound`] rename-stable: the
+/// synthesiser asks which assoc type `SerializeSeq` bounds, not whether one is
+/// named `SeqSerializer`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TraitAssocType {
     pub name: String,
@@ -1189,40 +1147,21 @@ pub enum Resolved {
         /// that trait?" compares this rather than the spelling (WEP
         /// 2026-08-10).
         decl: crate::ast::AstId,
-        /// Primary method name for **single-method** traits, captured
-        /// automatically by the elaborator when registering the trait's
-        /// `#[compiler_item("...")]` annotation. `None` for
-        /// multi-method traits (`Serializer`, `Deserializer`, …).
-        ///
-        /// The format-family traits (`Display` / `DisplayAlt` /
-        /// `Inspect` / `InspectAlt` / `Binary` / `BinaryAlt` / `Octal`
-        /// / `OctalAlt` / `LowerHex` / `LowerHexAlt` / `UpperHex` /
-        /// `UpperHexAlt` / `LowerExp` / `UpperExp`) all have exactly
-        /// one method by design, so the synthesiser can look up the
-        /// method name from the trait registration alone instead of
-        /// hard-coding `"fmt"` / `"inspect"` at every call site.
-        ///
-        /// Reading: [`CompilerItems::trait_method_name`].
+        /// Primary method name of a **single-method** trait, captured when the
+        /// elaborator registers its annotation; `None` for a multi-method trait
+        /// such as `Serializer`. The format family (`Display`, `Inspect`, and
+        /// their `Alt` / radix siblings) all have exactly one method by design,
+        /// so the synthesiser reads the name from the registration rather than
+        /// hard-coding `"fmt"` at each call site. Read via
+        /// [`CompilerItems::trait_method_name`].
         method_name: Option<String>,
-        /// Associated types declared on the trait, in source order.
-        /// Each entry pairs the assoc type's source-side name with the
-        /// source-side names of its trait bounds (e.g. for
-        /// `type SeqSerializer: SerializeSeq;` the entry is
-        /// `TraitAssocType { name: "SeqSerializer", bound_names: ["SerializeSeq"] }`).
-        /// Auto-captured by the elaborator when registering the trait's
-        /// `#[compiler_item("...")]` annotation; empty for traits
-        /// without associated types.
-        ///
-        /// The serde synthesiser identifies each assoc type by its
-        /// **bound trait** (itself a `#[compiler_item("...")]`-
-        /// registered trait whose current spelling comes from the
-        /// registry), not by its source-side spelling. That makes both
-        /// ends rename-stable: renaming `SeqSerializer` to `SeqWriter`
-        /// or renaming the bound `SerializeSeq` to `SeqWriterTrait`
-        /// both keep flowing through the registry instead of panicking
-        /// on a missing source-side name.
-        ///
-        /// Reading: [`CompilerItems::trait_assoc_type_by_bound`].
+        /// The trait's associated types in source order, each a
+        /// [`TraitAssocType`], captured when the elaborator registers the
+        /// annotation. The serde synthesiser identifies one by its *bound* trait
+        /// — itself registry-resolved — rather than its spelling, so renaming
+        /// either end keeps flowing through the registry instead of panicking on
+        /// a missing name. Read via
+        /// [`CompilerItems::trait_assoc_type_by_bound`].
         assoc_types: Vec<TraitAssocType>,
     },
     Method {
@@ -1544,15 +1483,11 @@ impl CompilerItems {
     }
 
     /// Resolved method name of a **single-method** trait — `"fmt"` for
-    /// `Display`, `"inspect"` for `Inspect`, and so on across the
-    /// format-family traits. Panics for multi-method traits where
-    /// `method_name` was not captured during registration; callers
-    /// that need such method names must reach for a dedicated method
-    /// `CompilerItem` instead.
-    ///
-    /// Routing the synthesiser's `Display::fmt` / `Inspect::inspect`
-    /// call construction through this method removes the last hard
-    /// dependency on the conventional source-side method spelling.
+    /// `Display`, `"inspect"` for `Inspect`. Routing the synthesiser's call
+    /// construction through here is what removes its last dependency on the
+    /// source-side spelling. Panics for a multi-method trait, whose
+    /// `method_name` was never captured; those need a dedicated method
+    /// [`CompilerItem`].
     pub fn trait_method_name(&self, item: CompilerItem) -> &str {
         match self.require(item) {
             Resolved::Trait {
@@ -1578,16 +1513,11 @@ impl CompilerItems {
         }
     }
 
-    /// Single associated type name on a trait, identified by the
-    /// source-side name of its trait bound. Both the bound trait's
-    /// spelling (passed in by the caller) and the associated type's
-    /// spelling (returned) come from the registry, so renaming either
-    /// end in the stdlib flows through without hand-edits.
-    ///
-    /// Panics if no associated type with the given bound is found —
-    /// the only legitimate way to hit that is to break the structural
-    /// shape of the trait, which the synthesiser does not silently
-    /// handle anywhere else either.
+    /// The associated type a given trait bound identifies. Both the bound's
+    /// spelling and the returned name come from the registry, so a stdlib rename
+    /// at either end flows through without hand-edits. Panics when no assoc type
+    /// carries that bound: the only way to reach it is to break the trait's
+    /// structural shape, which the synthesiser handles silently nowhere else.
     pub fn trait_assoc_type_by_bound(&self, item: CompilerItem, bound_trait_name: &str) -> &str {
         let assoc = self
             .trait_assoc_types(item)
@@ -1791,17 +1721,11 @@ impl fmt::Display for RegisterError {
     }
 }
 
-/// Parse all `#[compiler_item("...")]` arguments from a declaration's
-/// attribute list.
-///
-/// Returns the matched [`CompilerItem`] values in encounter order,
-/// plus a [`Vec`] of *unrecognised* argument strings so the elaborator
-/// can emit a diagnostic without losing the original spelling.
-///
-/// In valid stdlib code, a single declaration carries at most one
-/// `#[compiler_item("...")]` attribute. Multiple matches are not
-/// rejected here; the elaborator decides whether to fold the bits
-/// (legacy behaviour from the original `comp_feature` mechanism) or flag duplicates.
+/// Parse a declaration's `#[compiler_item("…")]` arguments, returning the
+/// matched [`CompilerItem`]s in encounter order plus the unrecognised argument
+/// strings, so the elaborator can report one without losing its spelling. Valid
+/// stdlib code carries at most one such attribute per declaration, but multiple
+/// matches are not rejected here — the elaborator decides.
 pub fn parse_compiler_item_attrs(
     attrs: &[crate::ast::Attribute],
 ) -> (Vec<CompilerItem>, Vec<String>) {

--- a/wado-compiler/src/compiler_item.rs
+++ b/wado-compiler/src/compiler_item.rs
@@ -1117,7 +1117,7 @@ pub struct TraitAssocType {
 ///
 /// Consumers should generally not match on `Resolved` directly; use
 /// the kind-checked accessors on [`CompilerItems`]
-/// (e.g. [`CompilerItems::require_trait_module`]) instead.
+/// (e.g. `CompilerItems::require_trait_module`) instead.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Resolved {
     Struct {

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -487,10 +487,8 @@ pub struct CmVariantCase {
 /// Strip an `AsyncCall<T>` wrapper from an `async` interface method's declared
 /// return type, recovering the CM-level result `T`. WIT lowers
 /// `async func foo(…) -> T` with result `T`, but the Wado-facing declaration
-/// exposes `AsyncCall<T>` so user code can defer `wait()`-ing past any stream
-/// parameter rendezvous — and the binding synthesiser needs the raw `T` for
-/// outptr layout. A no-op for non-async methods, and a return type that is not
-/// `AsyncCall<_>` passes through unchanged.
+/// exposes `AsyncCall<T>` so user code can defer `wait()`-ing — and the binding
+/// synthesiser needs the raw `T` for outptr layout. Otherwise a no-op.
 pub fn unwrap_async_call_if_async(is_async: bool, declared: &Option<Type>) -> Option<Type> {
     if !is_async {
         return declared.clone();
@@ -1471,8 +1469,7 @@ impl CmInterfaceRegistry {
     /// fragment before the `#`, e.g. `"wasi:filesystem/types@0.3.0"`. `kind` is
     /// `"variants"`, `"enums"`, `"resources"`, `"structs"`, `"flags"` or
     /// `"newtypes"`. `Some` only when exactly one WASI interface declares the
-    /// bare name; a name in several (`ErrorCode`) gives `None`, and the caller
-    /// must use a source-scoped accessor such as `get_variant_cases_by_source`.
+    /// bare name; for an ambiguous one use `get_variant_cases_by_source`.
     pub fn bare_name_owner(&self, kind: &str, name: &str) -> Option<&str> {
         let candidates: Vec<&str> = match kind {
             "variants" => self
@@ -1985,9 +1982,7 @@ impl CmInterfaceRegistry {
     /// effect left unhandled at the library boundary lowers to a component
     /// import instead of an unresolved-call ICE. Mints a CM identity for a user
     /// `interface X { … }`: FQ `ns:pkg/<effect>@ver`, operation names kebabed.
-    /// An interface already carrying `#[cm]` is a real binding and is skipped.
-    /// Errors when an effect's kebab name equals the library's own interface
-    /// name, which would collide the import with the export.
+    /// Errors when an effect's kebab name collides with the library's export.
     pub fn register_lib_guest_effect_imports(
         &mut self,
         interfaces: &[&crate::ast::InterfaceDecl],
@@ -2521,12 +2516,10 @@ impl CmInterfaceRegistry {
     }
 
     /// Resolve the `wasi:*` source interface for a `NamedType`. The reference's
-    /// own `source_interface` answers when bootstrap filled it, giving `None` if
-    /// it points outside `wasi:*`. A reference synthesized at lower time from a
-    /// TIR type has none, so every wasi kind is searched, preferring
-    /// `wasi:{wasi_package_hint}/` — which is what separates the `ErrorCode`
-    /// declared independently in filesystem, http and sockets — and otherwise
-    /// taking the unique registrant, or `None` when the name is ambiguous.
+    /// own `source_interface` answers when bootstrap filled it. A reference
+    /// synthesized at lower time has none, so every wasi kind is searched,
+    /// preferring `wasi:{wasi_package_hint}/` — which separates the `ErrorCode`
+    /// of filesystem, http and sockets — else taking the unique registrant.
     pub fn resolve_wasi_source_for(
         &self,
         named: &crate::ast::NamedType,
@@ -2750,11 +2743,10 @@ impl CmInterfaceRegistry {
     }
 
     /// Find the interface declaring a WASI struct with CM kebab name `cm_name`,
-    /// for the component builder's import aliasing. Scoped to `wasi:`, and
-    /// `Some` only when exactly one interface declares it. The key returned is
-    /// package-qualified (`"http-types"`), matching how codegen registers
-    /// imported instances — a bare interface name would collide across packages,
-    /// `wasi:cli/types` against `wasi:http/types`.
+    /// for the component builder's import aliasing. Scoped to `wasi:`, and `Some`
+    /// only when exactly one interface declares it. The key is package-qualified
+    /// (`"http-types"`), matching how codegen registers imported instances — a
+    /// bare name would collide `wasi:cli/types` with `wasi:http/types`.
     pub fn find_interface_for_struct_cm_name(&self, cm_name: &str) -> Option<String> {
         let mut found: Option<String> = None;
         for ((source_path, wado_name), (struct_cm_name, _, _)) in &self.structs {

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -484,26 +484,13 @@ pub struct CmVariantCase {
     pub payload: Option<Type>,
 }
 
-/// Extract the CM name from a `#[cm("...")]` attribute.
-///
-/// Handles two formats:
-/// - Type-level: `#[cm("wasi:pkg/iface@ver#cm-name")]` → takes the fragment after `#`
-/// - Case-level: `#[cm("cm-name")]` → uses the whole arg directly
-///
-/// Strip a `AsyncCall<T>` wrapper from the declared return type of an `async`
-/// interface method, recovering the CM-level result type `T`.
-///
-/// In WIT, `async func foo(...) -> T` lowers the CM-level result as `T`, but
-/// the Wado-facing interface declaration exposes `AsyncCall<T>` so user code can
-/// defer `wait()`-ing until after any stream parameter rendezvous
-/// completes. The CM binding synthesiser needs the raw `T` when computing
-/// outptr layout.
-///
-/// For non-async methods this is a no-op. For async methods whose return
-/// type is missing or not `AsyncCall<_>` we return the original type —
-/// defensive in case hand-written interface declarations predate the
-/// `AsyncCall<T>` convention (in which case the compiler's earlier
-/// expectations still apply).
+/// Strip an `AsyncCall<T>` wrapper from an `async` interface method's declared
+/// return type, recovering the CM-level result `T`. WIT lowers
+/// `async func foo(…) -> T` with result `T`, but the Wado-facing declaration
+/// exposes `AsyncCall<T>` so user code can defer `wait()`-ing past any stream
+/// parameter rendezvous — and the binding synthesiser needs the raw `T` for
+/// outptr layout. A no-op for non-async methods, and a return type that is not
+/// `AsyncCall<_>` passes through unchanged.
 pub fn unwrap_async_call_if_async(is_async: bool, declared: &Option<Type>) -> Option<Type> {
     if !is_async {
         return declared.clone();
@@ -719,16 +706,11 @@ impl CmFunctionInfo {
     }
 }
 
-/// Build a local alias name for a WASI function.
-///
-/// Format: `wasi:{package}/{interface_name}::{method_name}`
-/// Example: `wasi:cli/Stdout::write_via_stream`
-///
-/// This naming scheme:
-/// - Uses `wasi:` prefix for clarity
-/// - Includes package for uniqueness across packages
-/// - Uses Wado effect/method names (not WIT interface/function names)
-/// - Uses `::` as method separator (Wado convention)
+/// Build a WASI function's local alias name,
+/// `wasi:{package}/{interface_name}::{method_name}` — e.g.
+/// `wasi:cli/Stdout::write_via_stream`. The package keeps it unique across
+/// packages, and the segments are the Wado effect / method names, not the WIT
+/// interface / function ones.
 pub fn build_local_alias_name(package: &str, interface_name: &str, method_name: &str) -> String {
     format!("wasi:{package}/{interface_name}::{method_name}")
 }
@@ -1213,17 +1195,11 @@ fn collect_cm_definitions(module: &crate::ast::Module) -> IndexMap<String, Strin
     out
 }
 
-/// Build the `name -> source_interface` map that applies inside `module_path`.
-///
-/// Entries come from three sources, in order of precedence (later wins if
-/// there were duplicates, but stdlib currently never introduces them):
-///   1. Types declared in this module (`collect_cm_definitions`).
-///   2. Named imports: `use { X } from "other/path.wado"` contributes `X` →
-///      whatever interface `other/path.wado` declares it in.
-///   3. `use { X as Y } from ...` contributes `Y` with the same target.
-///
-/// Names the lookup cannot resolve (primitives, generics, `String`, unknown
-/// references) are left out; downstream consumers treat a missing key as
+/// Build the `name -> source_interface` map that applies inside `module_path`,
+/// from this module's own declarations plus its named imports (an
+/// `X as Y` contributing `Y`). Later entries win, though stdlib introduces no
+/// duplicates. A name the lookup cannot resolve — a primitive, a generic, an
+/// unknown reference — is left out, and consumers read a missing key as
 /// `source_interface = None`.
 fn build_local_name_resolver(
     module_path: &str,
@@ -1279,16 +1255,11 @@ fn resolve_use_source<'a>(
     defs_by_module: &'a IndexMap<&'static str, IndexMap<String, String>>,
 ) -> Option<&'a IndexMap<String, String>> {
     defs_by_module.get(source).or_else(|| {
-        // Flat package form: fold every interface under the same package into
-        // a synthetic merged view. We build this lazily only when needed.
-        // In stdlib, flat package .wado files are pure re-exports whose
-        // definitions each still carry their own `#[cm]` — but `use "wasi:http"`
-        // may be used to grab any of them. Rather than caching the merged map,
-        // we return None and let the caller handle flat imports via per-item
-        // resolution below. Returning None here means bindings like
-        // `use { ErrorCode } from "wasi:http"` in stdlib are not resolved.
-        // Stdlib does not currently rely on flat-package imports for type
-        // references (verified by grep), so this is acceptable.
+        // Flat package form. Rather than caching a merged view of every
+        // interface in the package, return None and let the caller resolve
+        // per-item below — so `use { ErrorCode } from "wasi:http"` does not
+        // resolve here. Stdlib does not rely on flat-package imports for type
+        // references, so nothing needs it yet.
         let _ = source;
         None
     })
@@ -1496,17 +1467,12 @@ impl CmInterfaceRegistry {
         self.source_interfaces.extend(batch);
     }
 
-    /// Return the canonical source interface that owns `(kind, name)` — i.e.
-    /// the `#[cm("...")]` fragment before the `#` (e.g.
-    /// `"wasi:filesystem/types@0.3.0"`). `kind` is one of
-    /// `"variants"`, `"enums"`, `"resources"`, `"structs"`, `"flags"`, or
-    /// `"newtypes"`.
-    ///
-    /// Returns `Some` only when exactly one WASI interface declares the bare
-    /// name. Same-named types from multiple interfaces (e.g. `ErrorCode` in
-    /// `wasi:filesystem/types` vs `wasi:http/types`) return `None` — callers
-    /// must then disambiguate with a source-interface-scoped accessor
-    /// (e.g. `get_variant_cases_by_source`).
+    /// The canonical source interface owning `(kind, name)` — the `#[cm("…")]`
+    /// fragment before the `#`, e.g. `"wasi:filesystem/types@0.3.0"`. `kind` is
+    /// `"variants"`, `"enums"`, `"resources"`, `"structs"`, `"flags"` or
+    /// `"newtypes"`. `Some` only when exactly one WASI interface declares the
+    /// bare name; a name in several (`ErrorCode`) gives `None`, and the caller
+    /// must use a source-scoped accessor such as `get_variant_cases_by_source`.
     pub fn bare_name_owner(&self, kind: &str, name: &str) -> Option<&str> {
         let candidates: Vec<&str> = match kind {
             "variants" => self
@@ -1601,18 +1567,11 @@ impl CmInterfaceRegistry {
             parser.parse_strict().expect("parser error in stdlib")
         }
 
-        // Two-pass bootstrap so every stdlib `Type::Named` reference carries
-        // an exact source interface.
-        //
-        // Pass 1: parse every stdlib module and record the declared type
-        // names and their `#[cm(...)]` interface paths per module. This lets
-        // cross-module `use { X } from "path"` be resolved in pass 2 even
-        // when `path` is parsed after the importer.
-        //
-        // Pass 2: for each module, build a local name -> source_interface map
-        // (local definitions + resolved `use` imports) and walk every `Type`
-        // node to populate `self.source_interface(NamedType)`. Register the
-        // walked module afterwards.
+        // Two-pass bootstrap so every stdlib `Type::Named` carries an exact
+        // source interface. Pass 1 records each module's declared type names and
+        // `#[cm(…)]` paths, so pass 2 can resolve a cross-module `use` whose
+        // target parses after the importer; pass 2 then builds each module's
+        // local name → source_interface map and walks its `Type` nodes.
         let mut modules: Vec<(&'static str, crate::ast::Module)> = Vec::new();
         let mut defs_by_module: IndexMap<&'static str, IndexMap<String, String>> =
             IndexMap::default();
@@ -1838,16 +1797,10 @@ impl CmInterfaceRegistry {
                             })
                             .collect();
 
-                        // Keep original return type for newtype semantics
-                        // The elaborator will handle Mark -> newtype mapping.
-                        //
-                        // For `async fn foo(...) -> AsyncCall<T>` CM imports,
-                        // strip the `AsyncCall<T>` wrapper at registration so
-                        // the stored return type is the CM-ABI `T`. The
-                        // elaborator re-wraps it as `AsyncCall<T>` when
-                        // answering Wado-level type queries (so user code
-                        // sees the new API), and the CM binding synthesiser
-                        // also re-wraps when constructing its adapter.
+                        // Store the CM-ABI return type: an async import's
+                        // `AsyncCall<T>` wrapper is stripped here, and both the
+                        // elaborator and the binding synthesiser re-wrap it so
+                        // user code still sees `AsyncCall<T>`.
                         let return_type =
                             unwrap_async_call_if_async(method.is_async, &method.return_type);
 
@@ -2006,15 +1959,10 @@ impl CmInterfaceRegistry {
     }
 
     /// Register a `--lib` entry module's own named types under the synthesized
-    /// default-interface FQ.
-    ///
-    /// Unlike [`Self::register_module_decls`], library types carry no
-    /// `#[cm(...)]` attribute — they are the package's own declarations, not WIT
-    /// bindings — so CM names are derived by kebab-casing the Wado identifiers
-    /// and the source interface is the library's default-interface FQ. After
-    /// this runs, both the export type plan (`resolve_cm_export_type`) and the
-    /// CM type emitter (`ast_type_to_cm`) resolve these types through the
-    /// registry exactly like WASI types, with no library-specific path.
+    /// default-interface FQ. These carry no `#[cm(…)]` — they are the package's
+    /// declarations, not WIT bindings — so CM names come from kebab-casing the
+    /// Wado identifiers. Afterwards the export type plan and the CM type emitter
+    /// resolve them through the registry exactly like WASI types.
     pub fn register_lib_local_decls(
         &mut self,
         module: &crate::ast::Module,
@@ -2033,20 +1981,13 @@ impl CmInterfaceRegistry {
         }
     }
 
-    /// Register a `--lib` package's locally-defined guest effect interfaces as
-    /// CM imports, so an effect left unhandled at the library boundary lowers to
-    /// a component import the consumer satisfies (rather than an unresolved-call
-    /// ICE). Unlike [`Self::register_module_decls`] — which registers only
-    /// `#[cm(...)]`-tagged stdlib interfaces — this mints a CM identity for a
-    /// user `interface X { ... }`: the interface FQ is the package coordinate
-    /// with the effect's kebab name (`ns:pkg/<effect>@ver`) and each operation's
-    /// CM name is the kebab of its Wado name. An interface already carrying a
-    /// `#[cm]` attribute is a real binding, not a guest effect, and is skipped.
-    ///
-    /// # Errors
-    /// A guest effect whose kebab name equals the library's own interface name
-    /// would mint the library's default-interface FQ, colliding an import with
-    /// the export interface; reported so the user renames the effect.
+    /// Register a `--lib` package's guest effect interfaces as CM imports, so an
+    /// effect left unhandled at the library boundary lowers to a component
+    /// import instead of an unresolved-call ICE. Mints a CM identity for a user
+    /// `interface X { … }`: FQ `ns:pkg/<effect>@ver`, operation names kebabed.
+    /// An interface already carrying `#[cm]` is a real binding and is skipped.
+    /// Errors when an effect's kebab name equals the library's own interface
+    /// name, which would collide the import with the export.
     pub fn register_lib_guest_effect_imports(
         &mut self,
         interfaces: &[&crate::ast::InterfaceDecl],
@@ -2257,18 +2198,10 @@ impl CmInterfaceRegistry {
 
     // -- Strict, source-aware lookups --------------------------------------
     //
-    // Every stdlib `Type::Named` reference carries an exact
-    // `source_interface` populated during bootstrap (see
-    // `populate_named_type_sources`), so these accessors key directly on
-    // `(interface, name)`. They never fall back to a bare-name scan — the
-    // caller must supply the resolved source — which means a same-named
-    // type in another namespace (e.g. `core:kiln/types::Response` vs.
-    // `wasi:http/types::Response`) cannot shadow a lookup.
-    //
-    // Each accessor returns `Option` so the caller can distinguish "no
-    // registration for that (interface, name) pair" from a specific wrong
-    // interface. When the caller *knows* the registration must exist, use
-    // `.expect("<context>")` to panic loudly if the invariant is violated.
+    // Keyed on `(interface, name)`, never falling back to a bare-name scan, so
+    // a same-named type in another namespace cannot shadow a lookup. The caller
+    // supplies the resolved source, which bootstrap populated on every stdlib
+    // `Type::Named`. `.expect("<context>")` where the registration must exist.
 
     /// Newtype registered at `(interface, name)`, if any.
     pub fn get_newtype_by_source(
@@ -2587,20 +2520,13 @@ impl CmInterfaceRegistry {
             .or_else(|| find_unique_source_with_prefix(&self.newtypes, prefix, name))
     }
 
-    /// Resolve the `wasi:*` source interface for a `NamedType` reference,
-    /// optionally biased by the WASI package currently being synthesized.
-    ///
-    /// Resolution order:
-    ///   1. The reference's own populated `source_interface` (stdlib bootstrap
-    ///      always fills this). Returns `None` if it points outside `wasi:*`.
-    ///   2. When the reference is unresolved (synthesized at lower time from
-    ///      a TIR `ResolvedType`), search every wasi type kind. If a
-    ///      `wasi_package_hint` is supplied, prefer an interface under
-    ///      `wasi:{hint}/` — this disambiguates cross-package same-named
-    ///      types such as `ErrorCode` defined independently in
-    ///      `wasi:filesystem`, `wasi:http`, and `wasi:sockets`.
-    ///   3. Otherwise fall through to the unique wasi-namespace registrant,
-    ///      returning `None` if the name is ambiguous.
+    /// Resolve the `wasi:*` source interface for a `NamedType`. The reference's
+    /// own `source_interface` answers when bootstrap filled it, giving `None` if
+    /// it points outside `wasi:*`. A reference synthesized at lower time from a
+    /// TIR type has none, so every wasi kind is searched, preferring
+    /// `wasi:{wasi_package_hint}/` — which is what separates the `ErrorCode`
+    /// declared independently in filesystem, http and sockets — and otherwise
+    /// taking the unique registrant, or `None` when the name is ambiguous.
     pub fn resolve_wasi_source_for(
         &self,
         named: &crate::ast::NamedType,
@@ -2823,18 +2749,12 @@ impl CmInterfaceRegistry {
             || self.flags.keys().any(|(fq, n)| declared_here(fq, n))
     }
 
-    /// Find the interface name (e.g., `"types"`) for a WASI struct given its
-    /// CM kebab name (e.g., `"directory-entry"`). Used by the component
-    /// builder to alias types from WASI interface imports. Scoped to the
-    /// `wasi:` namespace — non-WASI structs are never considered — and
-    /// returns `Some` only when exactly one wasi interface declares the
-    /// struct under that CM name (or a matching Wado name).
-    ///
-    /// The returned key is the package-qualified component-instance key
-    /// `"{package}-{interface}"` (e.g. `"http-types"`), matching how codegen
-    /// registers imported interface instances. A bare interface name would
-    /// collide across packages (`wasi:cli/types` vs `wasi:http/types`, both
-    /// interface `types`).
+    /// Find the interface declaring a WASI struct with CM kebab name `cm_name`,
+    /// for the component builder's import aliasing. Scoped to `wasi:`, and
+    /// `Some` only when exactly one interface declares it. The key returned is
+    /// package-qualified (`"http-types"`), matching how codegen registers
+    /// imported instances — a bare interface name would collide across packages,
+    /// `wasi:cli/types` against `wasi:http/types`.
     pub fn find_interface_for_struct_cm_name(&self, cm_name: &str) -> Option<String> {
         let mut found: Option<String> = None;
         for ((source_path, wado_name), (struct_cm_name, _, _)) in &self.structs {

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -1912,7 +1912,7 @@ impl CmInterfaceRegistry {
     }
 
     /// Register a component dependency's binding module via the stdlib's
-    /// [`Self::register_module_decls`] path, recording each interface FQ as a
+    /// `Self::register_module_decls` path, recording each interface FQ as a
     /// component import for [`crate::wir::ImportKind::Component`] classification.
     pub fn register_component_decls(
         &mut self,

--- a/wado-compiler/src/const_eval.rs
+++ b/wado-compiler/src/const_eval.rs
@@ -352,8 +352,9 @@ impl Value {
         }
     }
 
-    /// Project an [`Operand`] to the constant it denotes. Constants live in
-    /// the `ValuePool`, so only `Operand::Value` can be one.
+    /// Project an [`Operand`](crate::nir_arena::Operand) to the constant it
+    /// denotes. Constants live in the `ValuePool`, so only `Operand::Value`
+    /// can be one.
     #[must_use]
     pub fn from_operand(
         body: &Body,

--- a/wado-compiler/src/const_eval.rs
+++ b/wado-compiler/src/const_eval.rs
@@ -29,17 +29,11 @@ pub enum Value {
     Null,
     /// The unit value, `()`.
     Unit,
-    /// A struct or tuple whose every field is itself a compile-time value.
-    ///
-    /// Fields are keyed by `field_index` — the key `FieldAccess`,
-    /// `StructLiteral`, and struct patterns all carry — and kept sorted by it,
-    /// so structural equality is independent of literal field order. A NIR
-    /// aggregate literal always lists every field (the elaborator fills
-    /// defaults and rejects omissions), so the field list is complete and
-    /// equality is exact.
-    ///
-    /// Aggregates exist only inside the interpreter: the value pool holds pure
-    /// *scalars*, so what reaches the IR is the scalars projected out of them.
+    /// A struct or tuple whose every field is itself a compile-time value, keyed
+    /// by `field_index` and kept sorted, so structural equality ignores literal
+    /// field order. A NIR aggregate literal always lists every field, so the
+    /// list is complete and equality exact. Aggregates exist only inside the
+    /// interpreter; what reaches the IR is the scalars projected out of them.
     Aggregate {
         type_id: TypeId,
         fields: Rc<[(u32, Value)]>,
@@ -425,29 +419,11 @@ pub(crate) fn eval_unary(op: NirUnaryOp, operand: Value) -> Option<Value> {
     }
 }
 
-/// Evaluate an `as` cast at compile time.
-///
-/// Source values are the lattice-resolved [`Value`] of the cast input;
-/// `target` is the destination primitive (resolved from the cast node's
-/// `type_id`). Returns `None` for unsupported pairs — the caller maps
-/// that to [`Lattice::NonConst`] so the runtime cast still happens, no
-/// bogus value gets folded in.
-///
-/// The supported set mirrors what the elaborator permits in source:
-///
-/// - `Int` source ↦ Int (already supported), Float, Char (only when
-///   source is `U8` per [`expr.rs`]'s `u8 as char` carve-out).
-/// - `Float` source ↦ Float, Int (saturating, matching Wasm's
-///   `*.trunc_sat_*` semantics — Rust's `as` since 1.45 implements the
-///   same rounding/saturation rules so we forward to it).
-/// - `Bool` source ↦ Int (0/1), Float (0.0/1.0). Bool → Bool is the
-///   identity.
-/// - `Char` source ↦ Int (codepoint, then truncated). Char → Char is the
-///   identity.
-///
-/// 128-bit (`I128`/`U128`) and SIMD (`V128`) targets are reachable here
-/// (they are valid `Primitive` variants) but currently unsupported and
-/// fall through to `None`.
+/// Evaluate an `as` cast at compile time, from the lattice-resolved [`Value`] of
+/// the input to the `target` primitive. The supported set mirrors what the
+/// elaborator permits in source; a float → int cast saturates, matching Wasm's
+/// `trunc_sat` and Rust's own `as`. `None` for an unsupported pair, including a
+/// 128-bit or SIMD target, leaving the caller to keep the runtime cast.
 pub(crate) fn eval_cast(source: Value, target: PrimitiveType) -> Option<Value> {
     let int_target = is_int_prim(target);
     let float_target = matches!(target, PrimitiveType::F32 | PrimitiveType::F64);

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -272,7 +272,7 @@ pub fn check_effects_semantic(sem: &Semantics) -> Vec<EffectError> {
 }
 
 /// All three Design-B semantic diagnostics, computed in one pass that builds the
-/// shared [`OwnedEffectData`] once. Used by the batch driver and the LSP so
+/// shared `OwnedEffectData` once. Used by the batch driver and the LSP so
 /// effect / stores / purity stay in lockstep across both.
 #[must_use]
 pub fn check_semantics(

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -1,14 +1,8 @@
-//! Effect, stores, and default-purity checking for Wado (Design B).
-//!
-//! These checks validate, respectively, that every call holds the effects its
-//! callee requires, that a reference parameter that escapes declares
-//! `stores[param]`, and that parameter / field defaults are pure.
-//!
-//! All three operate on [`Semantics`] (the AST plus the facts recorded during
-//! `annotate`), not on the emitted TIR. They therefore see every source
-//! function regardless of what reify emits — immune to dead-code gating — and
-//! run on the LSP path, which builds no TIR. Each returns its violations so the
-//! caller can route them (LSP diagnostics or the batch logger).
+//! Effect, stores, and default-purity checking for Wado (Design B): that every
+//! call holds the effects its callee requires, that an escaping reference
+//! parameter declares `stores[param]`, and that defaults are pure. All three
+//! read [`Semantics`] rather than the emitted TIR, so they see every source
+//! function and run on the LSP path. Violations are returned, not emitted.
 
 use crate::hashmap::{IndexMap, IndexSet};
 
@@ -261,16 +255,11 @@ fn collect_resource_refs(
 // Semantics-based effect checking (Design B, Phase 1b)
 // ---------------------------------------------------------------------------
 
-/// Effect checking over [`Semantics`] (AST + recorded facts) — the Design B
-/// effect checker. It runs after `annotate_bodies`, so it sees every function,
-/// dead or live, and is independent of what reify emits. It also works on the
-/// LSP path, which builds no TIR. Violations are returned rather than emitted
-/// so the caller routes them (LSP diagnostics or the batch logger).
-///
-/// Covers free-function, method, and static dispatch with resource injection,
-/// the effect / resource propagation closure, signature-resource inference,
-/// effect-parameter resolution, `#[benign]`, handler-scope grants, and
-/// indirect (closure) calls, over user-authored modules.
+/// Effect checking over [`Semantics`], run after `annotate_bodies` so it sees
+/// every function, dead or live. Covers free-function, method, and static
+/// dispatch with resource injection, the effect / resource propagation closure,
+/// signature-resource inference, effect-parameter resolution, `#[benign]`,
+/// handler-scope grants, and closure calls, over user-authored modules.
 #[must_use]
 pub fn check_effects_semantic(sem: &Semantics) -> Vec<EffectError> {
     let mut out = Vec::new();
@@ -1261,28 +1250,10 @@ impl SemEffectWalker<'_> {
 // ---------------------------------------------------------------------------
 
 /// Stores checking over [`Semantics`] — the Design B reference-escape checker.
-///
-/// Two soundness obligations, both enforced before lowering so the functor
-/// optimization can trust a functor slot's declared `stores`:
-///
-/// 1. **Named-function / method honesty.** Every function whose reference
-///    parameter *escapes* (is returned, placed in an aggregate / global, stored
-///    through a reference, or forwarded to a callee that stores that position)
-///    must declare `stores[param]`.
-/// 2. **Closure coercion.** A closure type is always `stores=[]` (never
-///    inferred) and functor coercion ignores `stores`, so a closure that stores
-///    one of its own reference parameters would slip through type-checking. Each
-///    closure body is analysed with allowance `[]` — no closure parameter may
-///    escape.
-///
-/// The escape analysis mirrors `lower/plan/value_copy/stores.rs` but stays
-/// *precise* rather than the optimizer's conservative over-approximation: a
-/// value only carries a parameter reference when reference-flow reaches it, and
-/// a storing call *folds* its stored argument into the call result (gated by
-/// whether the result type can hold a reference) rather than being an
-/// unconditional escape — so a locally-consumed borrow (`self.as_bytes()` fed
-/// to a loop) is not flagged, while a genuine persistence (`return g(p)`,
-/// `GLOBAL = p`, `Wrapper { r: p }`) is.
+/// Two obligations, both enforced before lowering so the functor optimization
+/// can trust a slot's declared `stores`: a function whose reference parameter
+/// escapes must declare `stores[param]`, and every closure body is analysed with
+/// allowance `[]`, closure types being `stores=[]` and coercion ignoring it.
 #[must_use]
 pub fn check_stores_semantic(sem: &Semantics) -> Vec<StoresError> {
     let mut out = Vec::new();
@@ -1407,21 +1378,10 @@ fn functions_of(item: &Item) -> Vec<&Function> {
 }
 
 /// Least-fixpoint return provenance: for every function / constructor, the
-/// parameter positions its return value may borrow. The value-copy optimizer
-/// trusts a functor slot's `stores`, and the escape walk folds a call's
-/// arguments at these positions to decide what the result carries, so this must
-/// be a sound upper bound.
-///
-/// Seeds:
-/// - Variant / enum constructors wrap their single payload argument into the
-///   result, so a payload-bearing case borrows position 0.
-/// - A bodyless callee (intrinsic such as `array_get_ref`) is unanalyzable;
-///   conservatively its result may borrow any reference-holding argument.
-///
-/// Bodied functions start at ∅ and grow: each round re-derives a function's
-/// return provenance from its `return` / `task return` values (with `let` and
-/// whole-local-assign carry propagation), folding nested calls at the callees'
-/// current provenance, until no set changes.
+/// parameter positions its return value may borrow — a sound upper bound, since
+/// the escape walk folds a call's arguments at these positions. Seeded from
+/// constructors (position 0) and bodyless callees (any reference argument);
+/// bodied functions start at ∅ and grow until no set changes.
 fn build_returns(
     sem: &Semantics,
     state: &crate::elaborator::orchestration::AnnotateState,
@@ -1995,14 +1955,8 @@ fn ident_returns(
 /// The parameter positions a call's *result* provably borrows, and the call's
 /// arguments in callee-position order. Mirrors `call_stored_args` but reads the
 /// per-function return provenance (`fn_returns` / `mangled_returns`) instead of
-/// declared `stores`: a result borrows an argument only at the positions the
-/// callee's return value borrows. A variant / enum constructor call resolves to
-/// its case decl id. An unresolvable direct callee borrows nothing. A functor
-/// callee is bounded by its slot's declared `stores`: obligation #2 and functor
-/// coercion already reject any function / closure that returns a borrow of a
-/// reference argument the slot does not store, so those positions soundly bound
-/// what the result can borrow (a functor slot with no `stores` on that ref
-/// parameter cannot leak it into the result).
+/// declared `stores`. An unresolvable direct callee borrows nothing; a functor
+/// callee is bounded by its slot's `stores`, which the closure obligation pins.
 fn resolve_returned_args<'e>(
     expr: &'e Expr,
     sem: &Semantics,

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -1869,7 +1869,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             // (`impl Future<i32>` → `[i32]`), resolved in the
             // impl's type-param scope so generic impls
             // round-trip their `TypeParam` ids. Mirrors
-            // `resolve_impl_block`.
+            // `record_impl_sig`.
             let trait_type_args: Vec<crate::tir::TypeId> = match &impl_block.trait_type {
                 Some(ast::Type::Generic(generic)) => generic
                     .args

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -259,10 +259,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
     /// Canonicalize a `<ns>::<member>` reference — one `::`, the prefix a
     /// namespace import alias — to bare `<member>`. `None` for any other shape,
-    /// multi-segment `<ns>::<Type>::<case>` included, which the elaborator routes
-    /// through its own paths. The AST keeps what the user wrote so LSP cursors
-    /// land on it, while the name lookups see the canonical form their registries
-    /// were populated with.
+    /// multi-segment `<ns>::<Type>::<case>` included. The AST keeps what the user
+    /// wrote so LSP cursors land on it, while name lookups see the canonical
+    /// form their registries were populated with.
     pub(super) fn strip_ns_prefix<'s>(&self, name: &'s str) -> Option<&'s str> {
         self.sem.imports.strip_ns_prefix(name)
     }
@@ -300,13 +299,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     }
 
     /// Run `body` in `module`'s perspective, swapping the current module and its
-    /// import scope — type sources and namespace imports both, so `ns::Type`
-    /// resolves canonically — and clearing locals, which describe in-progress
-    /// resolution rather than the target's definitions. For callee-scope work
-    /// only, such as resolving a parameter default the callee's scope must answer
-    /// for; a *query* never enters another module, every fact it needs having been
-    /// resolved in the declaring frame. Already being there skips the swap, which
-    /// also keeps the locals a same-module resolution legitimately reads.
+    /// import scope — type sources and namespace imports both — and clearing
+    /// locals, which describe in-progress resolution rather than the target's
+    /// definitions. For callee-scope work only, such as a parameter default;
+    /// already being there skips the swap, keeping the locals in reach.
     pub(super) fn with_module_perspective_for<R>(
         &mut self,
         module: &ModuleSource,
@@ -477,12 +473,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     }
 
     /// The receiver keys a static-method lookup may be filed under, in the order
-    /// to try them. Neither vantage answers alone: the call site's own scope
-    /// resolves a name it declares or imports, and an alias is reachable no other
-    /// way, but a name that arrived through a namespace prefix lost its qualifier
-    /// before reaching here — canonicalising *that* from the call site would find
-    /// the caller's own `Pair` for `helper::Pair::new`. So a consumer tries both
-    /// and takes whichever the index answers for.
+    /// to try them. Neither vantage answers alone: the call site's scope resolves
+    /// a name it declares or imports, but one that arrived through a namespace
+    /// prefix lost its qualifier, and canonicalising *that* from the call site
+    /// finds the caller's own `Pair` for `helper::Pair::new`.
     pub(super) fn static_receiver_keys(
         &self,
         receiver_module: Option<&ModuleSource>,
@@ -557,11 +551,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
     /// Emit `MissingReturn` when a declared non-Unit return type cannot be
     /// satisfied. Skipped for `Unit` / `Never`, for a bodyless external, and for a
-    /// body whose every control path provably exits first — an explicit `return`,
-    /// a divergent statement, or a fully-diverging labeled block or `loop`. The
-    /// analysis is definite-exit rather than "contains a `return` somewhere":
-    /// accepting one carried by a single `if` branch let the fall-through path
-    /// through and produced an invalid core Wasm module.
+    /// body whose every control path provably exits first. The analysis is
+    /// definite-exit, not "contains a `return` somewhere": accepting one carried
+    /// by a single `if` branch produced an invalid core Wasm module.
     pub(super) fn validate_missing_return_ast(
         &self,
         return_type: TypeId,
@@ -587,10 +579,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// Record the resolved [`TypeId`] for the expression at `ast_id` — the
     /// annotation reify reads to set `TirExpr::type_id` without re-inferring.
     /// Skipped for [`TypeTable::ERROR`] and for a type still mentioning
-    /// [`TypeTable::UNKNOWN`]: both mark a result the body walk will revisit, as
-    /// an untyped `null` is once its `Option<T>` becomes known, and recording the
-    /// sentinel would leave an entry reify cannot consume and the patched TIR
-    /// would disagree with.
+    /// [`TypeTable::UNKNOWN`]: both mark a result the body walk will revisit, and
+    /// recording the sentinel would leave an entry reify cannot consume.
     pub(super) fn record_expression_type(&mut self, ast_id: crate::ast::AstId, type_id: TypeId) {
         if type_id == TypeTable::ERROR {
             return;
@@ -607,12 +597,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     }
 
     /// Record a method-dispatch decision, centralised here rather than at the AST
-    /// wrapper so every path through [`Self::build_tir_method_call`] — the
-    /// `container[i].method()` rewrite included — leaves one uniform entry.
-    /// A synthetic call passes `ast_id == None` and records nothing, per the
-    /// [`sem::types::MethodDispatch`] contract. `is_ref_impl` comes from
-    /// `lookup_method_info` alongside the target; reify feeds it and `self_kind`
-    /// to `adjust_receiver_for_self_kind` instead of re-running impl lookup.
+    /// wrapper so every path through [`Self::build_tir_method_call`] leaves one
+    /// uniform entry. A synthetic call passes `ast_id == None` and records
+    /// nothing. Reify feeds `is_ref_impl` and `self_kind` to
+    /// `adjust_receiver_for_self_kind` instead of re-running impl lookup.
     pub(super) fn record_method_dispatch(
         &mut self,
         ast_id: Option<crate::ast::AstId>,
@@ -812,9 +800,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// holding a name and no reference site to key on. Runs the resolution
     /// table's own scope lookup rather than a second chain beside it, so a
     /// name-only caller and the site that wrote the same name cannot disagree.
-    /// `None` when the name reaches no declaration: answering with the writing
-    /// module would hand back a key indistinguishable from a real one, so the
-    /// caller decides what its own absence means.
+    /// `None` when the name reaches no declaration; the caller decides.
     pub(crate) fn canonical_decl_key(&self, name: &str) -> Option<trait_env::DeclKey> {
         self.tysys
             .resolutions
@@ -1979,13 +1965,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 .unwrap_or_default();
 
             // A default method's body is foreign AST owned by the trait module,
-            // whose globally-unique `AstId`s cannot collide with impl-module
-            // nodes. One `AstId` serves N impls, though, so each needs its own
+            // and one `AstId` serves N impls, so each needs its own
             // `ModuleSemantics` snapshot on `default_method_semantics` or the
-            // synthesis would overwrite its own per-node facts each time. The
-            // snapshot's `types` / `bindings` capture just this synthesis, while
-            // `decls` and `imports` are cloned from the impl module so name
-            // resolution works during the walk. Reify reads them back.
+            // synthesis would overwrite its own per-node facts. `decls` and
+            // `imports` are cloned from the impl module for name resolution.
             for default_method in &default_methods {
                 // Build a synthetic `ModuleSemantics` for this
                 // one (impl, default_method) synthesis. Fresh

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -257,16 +257,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         }
     }
 
-    /// Canonicalize a `<ns>::<member>` reference (single `::`, prefix is a
-    /// namespace import alias) to the bare `<member>` form. Returns `None`
-    /// when the name isn't of that shape — including multi-segment cases like
-    /// `<ns>::<Type>::<case>`, which the elaborator routes through dedicated
-    /// namespace paths (see `resolve_ident` / `resolve_call`).
-    ///
-    /// The AST keeps the user-written `ns::member` so LSP cursors land on it
-    /// as typed; the name lookups against `imported_functions`,
-    /// `imported_globals`, struct registries, etc. see the canonical form
-    /// they were populated with.
+    /// Canonicalize a `<ns>::<member>` reference — one `::`, the prefix a
+    /// namespace import alias — to bare `<member>`. `None` for any other shape,
+    /// multi-segment `<ns>::<Type>::<case>` included, which the elaborator routes
+    /// through its own paths. The AST keeps what the user wrote so LSP cursors
+    /// land on it, while the name lookups see the canonical form their registries
+    /// were populated with.
     pub(super) fn strip_ns_prefix<'s>(&self, name: &'s str) -> Option<&'s str> {
         self.sem.imports.strip_ns_prefix(name)
     }
@@ -303,21 +299,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         self.lookup_variant_case(name).is_some()
     }
 
-    /// Run `body` in `module`'s perspective: the walker's "current module" and
-    /// its import scope (type sources *and* namespace imports, so `ns::Type`
-    /// types resolve canonically — issue #1415) swapped for the duration.
-    /// Locals are cleared because they describe in-progress resolution, not the
-    /// target module's definitions; everything is restored on return.
-    ///
-    /// Callee-scope work only: the walker resolving a parameter default at the
-    /// call site, which the callee's own scope has to answer for (WEP
-    /// 2026-04-11). A *query* never enters another module's perspective —
-    /// every declaration fact it needs is one the decl pass already resolved
-    /// in the declaring frame (WEP 2026-05-26).
-    ///
-    /// Already being in `module`'s perspective skips the swap entirely — which
-    /// also leaves the in-progress locals in place, as a same-module resolution
-    /// legitimately resolves against them.
+    /// Run `body` in `module`'s perspective, swapping the current module and its
+    /// import scope — type sources and namespace imports both, so `ns::Type`
+    /// resolves canonically — and clearing locals, which describe in-progress
+    /// resolution rather than the target's definitions. For callee-scope work
+    /// only, such as resolving a parameter default the callee's scope must answer
+    /// for; a *query* never enters another module, every fact it needs having been
+    /// resolved in the declaring frame. Already being there skips the swap, which
+    /// also keeps the locals a same-module resolution legitimately reads.
     pub(super) fn with_module_perspective_for<R>(
         &mut self,
         module: &ModuleSource,
@@ -487,17 +476,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         }
     }
 
-    /// The receiver keys a static-method lookup may be filed under, in the
-    /// order a consumer should try them.
-    ///
-    /// Neither vantage answers alone. The call site's own scope resolves a
-    /// name it declares or imports, and an alias
-    /// (`use { Instant as ClockInstant }`) is reachable no other way. But a
-    /// name that arrived through a namespace prefix lost its qualifier before
-    /// reaching here, and canonicalising *that* from the call site answers
-    /// with the caller's own same-named type — `helper::Pair::new` finding
-    /// the caller's `Pair`. So a consumer tries both and takes the one the
-    /// index answers for.
+    /// The receiver keys a static-method lookup may be filed under, in the order
+    /// to try them. Neither vantage answers alone: the call site's own scope
+    /// resolves a name it declares or imports, and an alias is reachable no other
+    /// way, but a name that arrived through a namespace prefix lost its qualifier
+    /// before reaching here — canonicalising *that* from the call site would find
+    /// the caller's own `Pair` for `helper::Pair::new`. So a consumer tries both
+    /// and takes whichever the index answers for.
     pub(super) fn static_receiver_keys(
         &self,
         receiver_module: Option<&ModuleSource>,
@@ -570,20 +555,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         control_flow::block_result_type(self.ctrl_flow_ctx(), block)
     }
 
-    /// Emit a `MissingReturn` diagnostic when a declared non-Unit
-    /// return type cannot be satisfied by the body. Skipped for
-    /// `Unit`/`Never` declarations, for missing bodies (declared-only
-    /// externals), and for bodies whose every control path provably
-    /// exits before the end — either via an explicit `return`, a
-    /// divergent statement like `panic("…")`, or a fully-diverging
-    /// labeled block / `loop`.
-    ///
-    /// The previous heuristic accepted any nested `return` even when
-    /// only one branch of an `if` carried one, which let partial-return
-    /// bodies through and produced an invalid core Wasm module ("type
-    /// mismatch: expected i32 but nothing on stack") for the
-    /// fall-through path. AST-walker mirrors that strict definite-exit
-    /// analysis using recorded `expression_types`.
+    /// Emit `MissingReturn` when a declared non-Unit return type cannot be
+    /// satisfied. Skipped for `Unit` / `Never`, for a bodyless external, and for a
+    /// body whose every control path provably exits first — an explicit `return`,
+    /// a divergent statement, or a fully-diverging labeled block or `loop`. The
+    /// analysis is definite-exit rather than "contains a `return` somewhere":
+    /// accepting one carried by a single `if` branch let the fall-through path
+    /// through and produced an invalid core Wasm module.
     pub(super) fn validate_missing_return_ast(
         &self,
         return_type: TypeId,
@@ -606,18 +584,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         });
     }
 
-    /// Record the resolved [`TypeId`] for the expression at `ast_id` —
-    /// the per-`AstId` annotation reify reads to set `TirExpr::type_id`
-    /// without re-running inference.
-    ///
-    /// Skipped when the resolution failed (yielding [`TypeTable::ERROR`])
-    /// or when the recorded type still mentions
-    /// [`TypeTable::UNKNOWN`]. Both signal a result the body walk is
-    /// going to revisit (the unknown-typed `null` literal is patched up
-    /// once the surrounding `Option<T>` becomes known by
-    /// [`crate::elaborator::expr::patch_unresolved_null`]); recording
-    /// the sentinel here would leave a stale entry the reify pass cannot
-    /// consume and the post-patch TIR would disagree with.
+    /// Record the resolved [`TypeId`] for the expression at `ast_id` — the
+    /// annotation reify reads to set `TirExpr::type_id` without re-inferring.
+    /// Skipped for [`TypeTable::ERROR`] and for a type still mentioning
+    /// [`TypeTable::UNKNOWN`]: both mark a result the body walk will revisit, as
+    /// an untyped `null` is once its `Option<T>` becomes known, and recording the
+    /// sentinel would leave an entry reify cannot consume and the patched TIR
+    /// would disagree with.
     pub(super) fn record_expression_type(&mut self, ast_id: crate::ast::AstId, type_id: TypeId) {
         if type_id == TypeTable::ERROR {
             return;
@@ -633,21 +606,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         self.sem.types.expression_types.insert(ast_id, type_id);
     }
 
-    /// Record a method-dispatch decision for the [`crate::ast::MethodCallExpr`]
-    /// at `ast_id`. Centralised here (rather than at the AST wrapper) so
-    /// every TIR-construction path that flows through
-    /// [`Self::build_tir_method_call`] — including the `container[i].method()`
-    /// `IndexMut` rewrite — leaves a single, uniform entry in
-    /// [`sem::types::TypeAnnotations::method_dispatch`].
-    ///
-    /// Synthetic calls (for-of's `.into_iter()` / `.next()`) pass
-    /// `ast_id == None` and skip recording per the
-    /// [`sem::types::MethodDispatch`] contract.
-    ///
-    /// `is_ref_impl` is the flag `lookup_method_info` produces alongside
-    /// the dispatch target; reify uses it together with `self_kind` to
-    /// drive `adjust_receiver_for_self_kind` without re-running impl
-    /// lookup.
+    /// Record a method-dispatch decision, centralised here rather than at the AST
+    /// wrapper so every path through [`Self::build_tir_method_call`] — the
+    /// `container[i].method()` rewrite included — leaves one uniform entry.
+    /// A synthetic call passes `ast_id == None` and records nothing, per the
+    /// [`sem::types::MethodDispatch`] contract. `is_ref_impl` comes from
+    /// `lookup_method_info` alongside the target; reify feeds it and `self_kind`
+    /// to `adjust_receiver_for_self_kind` instead of re-running impl lookup.
     pub(super) fn record_method_dispatch(
         &mut self,
         ast_id: Option<crate::ast::AstId>,
@@ -843,17 +808,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         self.decl_key_or_local(trait_name).1
     }
 
-    /// The declaration `name` means from this module's vantage, for the callers
-    /// that hold a name and no reference site to key on.
-    ///
-    /// Runs the resolution table's own scope lookup rather than a second chain
-    /// beside it, so a name-only caller and the site that wrote the same name
-    /// cannot disagree.
-    ///
-    /// `None` when the name reaches no declaration. Answering with the writing
-    /// module instead would hand back a key indistinguishable from a real
-    /// declaration's, which is the confusion this whole design exists to end —
-    /// so the caller decides what its own absence means.
+    /// The declaration `name` means from this module's vantage, for a caller
+    /// holding a name and no reference site to key on. Runs the resolution
+    /// table's own scope lookup rather than a second chain beside it, so a
+    /// name-only caller and the site that wrote the same name cannot disagree.
+    /// `None` when the name reaches no declaration: answering with the writing
+    /// module would hand back a key indistinguishable from a real one, so the
+    /// caller decides what its own absence means.
     pub(crate) fn canonical_decl_key(&self, name: &str) -> Option<trait_env::DeclKey> {
         self.tysys
             .resolutions
@@ -2017,26 +1978,14 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 })
                 .unwrap_or_default();
 
-            // A default method's body is *foreign* AST owned by
-            // the trait module; its nodes carry the trait
-            // module's globally-unique `AstId`s, so the facts the
-            // walk records cannot collide with impl-module nodes.
-            //
-            // The body walk's only output is a per-impl
-            // `ModuleSemantics` snapshot stored on
-            // `ModuleSemantics::default_method_semantics`. Reify
-            // (the sole TIR source) reads those snapshots and
-            // produces the impl's default-method `TirFunction`s.
-            //
-            // Per-impl snapshots are required because the same
-            // trait body synthesised for many impls would
-            // otherwise overwrite its own per-node facts on each
-            // iteration (one `AstId`, N impls). Each impl gets a
-            // fresh `ModuleSemantics` whose `types` / `bindings`
-            // capture only this one synthesis; `decls` and
-            // `imports` are cloned from the surrounding
-            // (impl-module) `ModuleSemantics` so name resolution
-            // / decl indices work during the body walk.
+            // A default method's body is foreign AST owned by the trait module,
+            // whose globally-unique `AstId`s cannot collide with impl-module
+            // nodes. One `AstId` serves N impls, though, so each needs its own
+            // `ModuleSemantics` snapshot on `default_method_semantics` or the
+            // synthesis would overwrite its own per-node facts each time. The
+            // snapshot's `types` / `bindings` capture just this synthesis, while
+            // `decls` and `imports` are cloned from the impl module so name
+            // resolution works during the walk. Reify reads them back.
             for default_method in &default_methods {
                 // Build a synthetic `ModuleSemantics` for this
                 // one (impl, default_method) synthesis. Fresh

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -1869,7 +1869,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             // (`impl Future<i32>` → `[i32]`), resolved in the
             // impl's type-param scope so generic impls
             // round-trip their `TypeParam` ids. Mirrors
-            // `item.rs:1621`.
+            // `resolve_impl_block`.
             let trait_type_args: Vec<crate::tir::TypeId> = match &impl_block.trait_type {
                 Some(ast::Type::Generic(generic)) => generic
                     .args

--- a/wado-compiler/src/elaborator/assert.rs
+++ b/wado-compiler/src/elaborator/assert.rs
@@ -1,14 +1,8 @@
-//! Annotation pass for `assert`.
-//!
-//! Power-assert capture-slot discovery still runs here: the read-only AST
-//! scanner picks which sub-expressions deserve a `let __vK = …;` binding, the
-//! capture hook on [`Elaborator::resolve_expr`] flags each as `emitted` once
-//! it actually fires during body resolution, and the recorded
-//! [`super::sem::types::AssertCaptureInfo`] carries the result to reify.
-//!
-//! Reify rebuilds the expansion shape (`__assert_N` labeled block, `let
-//! __cond = …`, `if !__cond { panic(<template>); }`, the per-slot
-//! interpolation lines) from the AST + the recorded slot table.
+//! Annotation pass for `assert`, where power-assert capture-slot discovery runs:
+//! a read-only AST scanner picks the sub-expressions deserving a `let __vK = …`,
+//! the capture hook on [`Elaborator::resolve_expr`] marks each `emitted` when it
+//! fires, and the recorded [`super::sem::types::AssertCaptureInfo`] carries that
+//! to reify, which rebuilds the whole expansion from the AST and the slot table.
 
 use crate::ast::{AssertStmt, AstId, Expr, Literal, UnaryOp};
 use crate::compiler_host::CompilerHost;
@@ -178,17 +172,11 @@ impl AssertCaptureContext {
     }
 }
 
-/// Read-only AST scanner: decides which sub-expressions of the assert
-/// condition deserve a `__vK` capture and records each capture's
-/// originating [`AstId`] so the elaborator hook in `resolve_expr` can find
-/// it.
-///
-/// One slot per capturable `Expr` — no source-text deduplication. Two
-/// syntactically identical sub-terms (e.g. `f() == f()`) each get their
-/// own `__vK` and evaluate independently, matching the source as
-/// written. Such code is degenerate anyway; the dedup logic the old
-/// AST-substitution `CaptureFolder` ran for it isn't worth the
-/// complexity in the new hook.
+/// Read-only AST scanner deciding which sub-expressions of the assert condition
+/// deserve a `__vK` capture, recording each one's originating [`AstId`] for the
+/// `resolve_expr` hook to find. One slot per capturable `Expr`, with no
+/// source-text dedup: two identical sub-terms (`f() == f()`) each get their own
+/// slot and evaluate independently, matching the source as written.
 struct CaptureScanner {
     slots: Vec<Capture>,
     /// `AstId` of each captureable sub-expression → its capture slot

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -725,11 +725,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                     // Reflexive `T::from(T_val)`: the outer Call evaporates, so
                     // tag it `NewtypeFromCollapse` or reify emits a `Call` the
-                    // elaborator never built. Matched by canonical decl identity
-                    // — two modules' `Instant` share a bare name, and matching on
-                    // that would collapse a real conversion into an identity.
-                    // Generic instances still compare by name: a decl key drops
-                    // type args and cannot tell `Foo<A>` from `Foo<B>`.
+                    // elaborator never built. Matched by canonical decl identity,
+                    // since two modules' `Instant` share a bare name. Generic
+                    // instances compare by name: a decl key drops type args.
                     let arg_is_generic = {
                         let tt = self.tysys.type_table.borrow();
                         matches!(
@@ -1731,8 +1729,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// resolving each in the caller's context. A default may name an earlier
     /// parameter (`fn rect(w, h = w)`), so param-name idents in its cloned AST
     /// are substituted with the caller's argument AST before resolution. A
-    /// position with no declared default is left alone for the arity check to
-    /// report.
+    /// position with no declared default is left for the arity check.
     pub(super) fn pad_args_with_defaults(
         &mut self,
         callee: &Expr,
@@ -1869,9 +1866,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Infer a generic call's type arguments from its actual argument types, in
     /// three [`InferCtx`] tiers: typed arguments first, numeric literals second
     /// so a literal's default cannot clobber a typed neighbour's binding, then
-    /// the declared return type against `expected_type` to reach a parameter no
-    /// argument mentioned. Returns declaration order, or empty if any parameter
-    /// is left unbound — plain function calls stay strictly all-or-nothing.
+    /// the declared return type against `expected_type`. Returns declaration
+    /// order, or empty if any parameter is left unbound — all-or-nothing.
     pub(super) fn infer_fn_type_args(
         &mut self,
         callee: &CalleeRef,
@@ -2022,8 +2018,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// associated-type-equality bound (`fn f<T, I: Iterator<Item = T>>`), which
     /// [`Self::infer_fn_type_args`] leaves unbound since it is in no parameter
     /// type. For each `Owner: Trait<Assoc = Target>` with `Owner` already
-    /// concrete, project its `Assoc` to bind `Target`, iterating to a fixpoint
-    /// for chained bounds. Otherwise `T` survives to trap codegen.
+    /// concrete, project its `Assoc` to bind `Target`, iterating to a fixpoint.
     fn infer_type_args_from_assoc_bounds(
         &mut self,
         callee: &CalleeRef,
@@ -2057,11 +2052,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Report "cannot infer type parameter" at the call site rather than letting
-    /// an unsubstituted `TypeParam` reach codegen and trap. Only a genuinely
-    /// unresolvable parameter is flagged: effect parameters are handled
-    /// elsewhere, `fn`-bound ones are constrained structurally rather than by
-    /// inference, defaulted ones are filled later, and one bound to an
-    /// outer-scope `TypeParam` is the caller forwarding its own generics.
+    /// an unsubstituted `TypeParam` reach codegen and trap. Effect parameters,
+    /// `fn`-bound ones (constrained structurally), defaulted ones (filled
+    /// later), and ones bound to an outer-scope `TypeParam` (the caller
+    /// forwarding its own generics) are all excluded.
     fn report_uninferred_fn_type_args(
         &mut self,
         callee: &CalleeRef,
@@ -2195,11 +2189,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Substitute a declared default (`fn f<T = Fallback>`) into any dense
     /// type-arg slot call-site inference left unbound, seeding an empty
-    /// `type_args` first so an omitted turbofish is covered. A non-defaulted slot
-    /// keeps its `TypeParam` for the defer/report step. Each default resolves
-    /// with the callee's params in scope, so `<T, U = T>` picks up `T`'s inferred
-    /// type, and with `default_scope_module` at the callee, so a default may name
-    /// a type private to it.
+    /// `type_args` first so an omitted turbofish is covered. Each default
+    /// resolves with the callee's params in scope (`<T, U = T>` picks up `T`)
+    /// and at `default_scope_module`, so it may name a type private to it.
     fn fill_defaulted_fn_type_args(&mut self, callee: &CalleeRef, type_args: &mut Vec<TypeId>) {
         let params = self.lookup_function_type_params(callee);
         let space: Vec<ast::GenericParam> = params
@@ -2374,8 +2366,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// method paths: for each already-concrete parameter, read its bounds'
     /// `Trait<Assoc = Target>` bindings and, where `Target` names a still-unbound
     /// parameter, project the owner's `Assoc` to bind it. `params` and `args`
-    /// share an index space; iterates to a fixpoint so chained bounds resolve
-    /// whatever the declaration order.
+    /// share an index space; iterates to a fixpoint for chained bounds.
     pub(super) fn resolve_assoc_bound_args(
         &mut self,
         params: &[ast::GenericParam],
@@ -2533,8 +2524,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// [`InferCtx`] model with [`Self::infer_fn_type_args`]. Returns
     /// `(declaring_args, method_args)` — the first from `impl Container<T>`, the
     /// second from `fn make<U>()` — either possibly empty. Reads the signature's
-    /// canonical types directly: it is solving *for* the arguments an
-    /// instantiation would need.
+    /// canonical types directly, solving *for* an instantiation's arguments.
     fn infer_static_method_type_args(
         &mut self,
         struct_name: &str,

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -2053,8 +2053,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Report "cannot infer type parameter" at the call site rather than letting
     /// an unsubstituted `TypeParam` reach codegen and trap. Effect parameters,
-    /// `fn`-bound ones (constrained structurally), defaulted ones (filled
-    /// later), and ones bound to an outer-scope `TypeParam` (the caller
+    /// `fn`-bound ones (constrained structurally), defaulted ones (already
+    /// filled), and ones bound to an outer-scope `TypeParam` (the caller
     /// forwarding its own generics) are all excluded.
     fn report_uninferred_fn_type_args(
         &mut self,

--- a/wado-compiler/src/elaborator/call.rs
+++ b/wado-compiler/src/elaborator/call.rs
@@ -94,16 +94,11 @@ pub(super) struct FnSignature {
     pub(super) return_type: TypeId,
 }
 
-/// Classification of an `Ident`-form call callee after resolving any
-/// `Self::` / `T::` prefix that needs to be substituted before
-/// `resolve_call` does its parameter-type lookup and argument resolution.
-///
-/// Hoisting this classification to the top of `resolve_call` lets the
-/// argument resolution run once with the correct expected-type hints
-/// (issue #1181). The previous implementation re-entered `resolve_call`
-/// with a freshly built synthetic `CallExpr`, which made the assert
-/// capture hook fire twice on each scanner-flagged sub-expression and
-/// caused `let __vK = ...` bindings to be emitted twice.
+/// Classification of an `Ident`-form call callee, with any `Self::` / `T::`
+/// prefix already substituted, so `resolve_call` can look up parameter types and
+/// resolve arguments once with the right expected-type hints. Re-entering
+/// `resolve_call` with a synthetic `CallExpr` instead fired the assert-capture
+/// hook twice per sub-expression, emitting each `let __vK = …` binding twice.
 enum CalleeIdentKind<'a> {
     /// No prefix substitution needed. Covers plain ident calls
     /// (`foo(x)`), already-concrete qualified calls (`Type::method(x)`,
@@ -701,16 +696,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let holes = turbofish_holes(&call.type_args);
                     merge_turbofish_type_args(&mut method_type_args, &holes, &method_args);
                 }
-                // WEP 2026-05-26: record the combined
-                // `(impl_args, method_args)` for the static-method call
-                // site. Reify needs both halves to reconstruct the
-                // mangled `__<Type>__<method>` name with the same type
-                // arg shape annotate computed. The combined order is
-                // `[impl_args, method_args]` — same as
-                // `lookup_static_method_param_types`'s substitution
-                // input below. Instance type is UNKNOWN: a static-method
-                // call has no decl-anchored `GenericInstance`; reify
-                // reads `expression_types[call.id]` for the result type.
+                // Record `[impl_args, method_args]` — the same order
+                // `lookup_static_method_param_types` substitutes in — since reify
+                // needs both halves to rebuild the mangled `__<Type>__<method>`.
+                // The instance type is UNKNOWN: a static call anchors no
+                // `GenericInstance`, so reify reads `expression_types` instead.
                 {
                     let mut combined = impl_type_args_inferred.clone();
                     combined.extend_from_slice(&method_type_args);
@@ -733,21 +723,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     let arg_type = args[0].type_id;
                     let arg_type_name = self.tysys.type_table.borrow().type_name(arg_type);
 
-                    // Reflexive: T::from(T_val) — identity conversion. The
-                    // outer Call AstId evaporates, so tag it with
-                    // `NewtypeFromCollapse` for reify to recognise — otherwise
-                    // reify would emit a `TirExprKind::Call` the elaborator
-                    // never built. The inner argument's `expression_types`
-                    // entry survives because it was recorded by the
-                    // `resolve_expr` wrapper for the argument itself.
-                    //
-                    // Match by canonical decl identity, not bare name: two types
-                    // from different modules can share a name
-                    // (`core:temporal::Instant` vs `wasi:clocks::Instant`) and a
-                    // bare-name match would collapse a real conversion into an
-                    // identity. Generic instances keep the name compare — a decl
-                    // key drops type args, so it cannot tell `Foo<A>` from
-                    // `Foo<B>`.
+                    // Reflexive `T::from(T_val)`: the outer Call evaporates, so
+                    // tag it `NewtypeFromCollapse` or reify emits a `Call` the
+                    // elaborator never built. Matched by canonical decl identity
+                    // — two modules' `Instant` share a bare name, and matching on
+                    // that would collapse a real conversion into an identity.
+                    // Generic instances still compare by name: a decl key drops
+                    // type args and cannot tell `Foo<A>` from `Foo<B>`.
                     let arg_is_generic = {
                         let tt = self.tysys.type_table.borrow();
                         matches!(
@@ -1745,19 +1727,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         (Vec::new(), Vec::new())
     }
 
-    /// Fill missing trailing arguments with the callee's declared default
-    /// expressions, resolving each default in the caller's function context.
-    ///
-    /// A default may reference earlier parameters by name (e.g. `fn rect(w, h = w)`).
-    /// To make the caller's supplied value visible to the default expression,
-    /// we textually substitute param-name [`Expr::Ident`] occurrences inside
-    /// the default's cloned AST with the corresponding argument's AST before
-    /// resolving it. The elaborator then type-checks the result against the
-    /// declared parameter type.
-    ///
-    /// Appends newly-synthesized arguments to `args`. Leaves `args` unchanged
-    /// for positions without a declared default; the caller's arity check
-    /// reports the remaining shortfall as a mismatch.
+    /// Fill missing trailing arguments from the callee's declared defaults,
+    /// resolving each in the caller's context. A default may name an earlier
+    /// parameter (`fn rect(w, h = w)`), so param-name idents in its cloned AST
+    /// are substituted with the caller's argument AST before resolution. A
+    /// position with no declared default is left alone for the arity check to
+    /// report.
     pub(super) fn pad_args_with_defaults(
         &mut self,
         callee: &Expr,
@@ -1891,23 +1866,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         Vec::new()
     }
 
-    /// Infer type arguments for a generic function call from the actual argument types.
-    ///
-    /// Uses pre-resolved param types from the current-module cache when available,
-    /// otherwise falls back to looking up imported functions in loaded modules and
-    /// resolving their param types in a temporary type-param scope.
-    ///
-    /// Inference runs in three tiers via [`InferCtx`]:
-    /// 1. Typed (non-literal) argument types are unified first.
-    /// 2. Numeric-literal argument types are unified after, so a literal's
-    ///    default type cannot clobber a stronger binding from a typed neighbour.
-    /// 3. If `expected_type` is supplied (e.g. `let x: i32 = foo()`), the
-    ///    declaration's return type is unified against it to fill any
-    ///    parameters that never appeared in the argument list.
-    ///
-    /// Returns the inferred type args in declaration order, or empty vec if
-    /// any parameter remains unbound (legacy strict all-or-nothing behaviour
-    /// preserved for plain function calls).
+    /// Infer a generic call's type arguments from its actual argument types, in
+    /// three [`InferCtx`] tiers: typed arguments first, numeric literals second
+    /// so a literal's default cannot clobber a typed neighbour's binding, then
+    /// the declared return type against `expected_type` to reach a parameter no
+    /// argument mentioned. Returns declaration order, or empty if any parameter
+    /// is left unbound — plain function calls stay strictly all-or-nothing.
     pub(super) fn infer_fn_type_args(
         &mut self,
         callee: &CalleeRef,
@@ -2054,16 +2018,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         inferred
     }
 
-    /// Resolve type parameters that appear only inside another parameter's
-    /// associated-type-equality bound, e.g. `fn f<T, I: Iterator<Item = T>>`.
-    ///
-    /// [`Self::infer_fn_type_args`] binds `I` from the argument but leaves `T`
-    /// unbound, because `T` never appears in a parameter type. For each bound
-    /// `Owner: Trait<Assoc = Target>` whose `Owner` is already inferred to a
-    /// concrete type, project that type's `Assoc` to bind `Target`. Without
-    /// this, `T` would survive monomorphization and trap codegen as an
-    /// unsubstituted type parameter. Iterates to a fixpoint so chained
-    /// bounds resolve regardless of declaration order.
+    /// Resolve a type parameter appearing only inside another's
+    /// associated-type-equality bound (`fn f<T, I: Iterator<Item = T>>`), which
+    /// [`Self::infer_fn_type_args`] leaves unbound since it is in no parameter
+    /// type. For each `Owner: Trait<Assoc = Target>` with `Owner` already
+    /// concrete, project its `Assoc` to bind `Target`, iterating to a fixpoint
+    /// for chained bounds. Otherwise `T` survives to trap codegen.
     fn infer_type_args_from_assoc_bounds(
         &mut self,
         callee: &CalleeRef,
@@ -2096,19 +2056,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.resolve_assoc_bound_args(&params, type_args);
     }
 
-    /// Report a clean "cannot infer type parameter" diagnostic when a generic
-    /// function call leaves one of its declared type parameters unbound, so it
-    /// fails at the call site instead of reaching codegen as an unsubstituted
-    /// `TypeParam` (which traps). Mirrors the method-call path in
-    /// `infer_method_type_args`.
-    ///
-    /// A parameter is only flagged when it is genuinely unresolvable:
-    /// - effect parameters are skipped (handled separately);
-    /// - `fn`-bound parameters (`<F: fn(...) -> ...>`) are skipped — they are
-    ///   constrained structurally by the bound, not by call-site inference;
-    /// - parameters with a declared default are skipped;
-    /// - a parameter bound to an outer-scope `TypeParam` (the caller forwarding
-    ///   its own generics) is fine and left for monomorphization.
+    /// Report "cannot infer type parameter" at the call site rather than letting
+    /// an unsubstituted `TypeParam` reach codegen and trap. Only a genuinely
+    /// unresolvable parameter is flagged: effect parameters are handled
+    /// elsewhere, `fn`-bound ones are constrained structurally rather than by
+    /// inference, defaulted ones are filled later, and one bound to an
+    /// outer-scope `TypeParam` is the caller forwarding its own generics.
     fn report_uninferred_fn_type_args(
         &mut self,
         callee: &CalleeRef,
@@ -2240,21 +2193,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         });
     }
 
-    /// Substitute the declared default type (`fn f<T = Fallback>`) into any
-    /// dense type-arg slot still left unbound by call-site inference. The
-    /// dense index space matches [`Self::defer_or_report_uninferred_fn_type_args`]
-    /// (non-effect, non-`fn`-bound params in declaration order). Seeds an
-    /// empty `type_args` first so a fully-omitted turbofish is handled too;
-    /// non-defaulted slots keep their unbound `TypeParam`, leaving the
-    /// defer/report step to handle them.
-    ///
-    /// Each default type is resolved with the callee's type params in scope, so
-    /// a param-referencing default (`<T, U = T>`) resolves `T` to the callee's
-    /// own `TypeParam` and then picks up `T`'s inferred type via
-    /// [`Self::substitute_type_params`]. `default_scope_module` is pointed at
-    /// the callee so a default naming a type private to the callee's module
-    /// (`<T = Priv>`, `Priv` private) resolves through the fallback in
-    /// [`Self::resolve_named_type`].
+    /// Substitute a declared default (`fn f<T = Fallback>`) into any dense
+    /// type-arg slot call-site inference left unbound, seeding an empty
+    /// `type_args` first so an omitted turbofish is covered. A non-defaulted slot
+    /// keeps its `TypeParam` for the defer/report step. Each default resolves
+    /// with the callee's params in scope, so `<T, U = T>` picks up `T`'s inferred
+    /// type, and with `default_scope_module` at the callee, so a default may name
+    /// a type private to it.
     fn fill_defaulted_fn_type_args(&mut self, callee: &CalleeRef, type_args: &mut Vec<TypeId>) {
         let params = self.lookup_function_type_params(callee);
         let space: Vec<ast::GenericParam> = params
@@ -2425,16 +2370,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         *type_args = new_args;
     }
 
-    /// Shared core of bound-driven inference: for each generic parameter in
-    /// `params` already inferred to a concrete type, look at its trait bounds'
-    /// associated-type-equality bindings (`Trait<Assoc = Target>`); when
-    /// `Target` names another, still-unbound parameter, project the owner's
-    /// `Assoc` and bind it. `params` and `args` are parallel (same index
-    /// space). Iterates to a fixpoint so chained bounds resolve regardless of
-    /// declaration order.
-    ///
-    /// Used by both free-function calls ([`Self::infer_type_args_from_assoc_bounds`])
-    /// and method calls (`infer_method_type_args`).
+    /// Shared core of bound-driven inference, used by both the free-function and
+    /// method paths: for each already-concrete parameter, read its bounds'
+    /// `Trait<Assoc = Target>` bindings and, where `Target` names a still-unbound
+    /// parameter, project the owner's `Assoc` to bind it. `params` and `args`
+    /// share an index space; iterates to a fixpoint so chained bounds resolve
+    /// whatever the declaration order.
     pub(super) fn resolve_assoc_bound_args(
         &mut self,
         params: &[ast::GenericParam],
@@ -2588,18 +2529,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.infer_static_method_type_args(prefix, suffix, raw_args, args, expected_type)
     }
 
-    /// Infer the declaring block's and the method's own type arguments for a
-    /// generic static method.
-    ///
-    /// Shares the three-tier constraint model with [`Self::infer_fn_type_args`]
-    /// via [`InferCtx`]: typed args, then literal-number args, then
-    /// expected-return back-inference.
-    ///
-    /// Returns `(declaring_args, method_args)` — the first from
-    /// `impl Container<T>` / `resource Stream<T>`, the second from
-    /// `fn make<U>()`. Either may be empty if nothing on that level was
-    /// inferable. Inference reads the signature's canonical types directly:
-    /// it is solving *for* the arguments an instantiation would need.
+    /// Infer a generic static method's type arguments, sharing the three-tier
+    /// [`InferCtx`] model with [`Self::infer_fn_type_args`]. Returns
+    /// `(declaring_args, method_args)` — the first from `impl Container<T>`, the
+    /// second from `fn make<U>()` — either possibly empty. Reads the signature's
+    /// canonical types directly: it is solving *for* the arguments an
+    /// instantiation would need.
     fn infer_static_method_type_args(
         &mut self,
         struct_name: &str,

--- a/wado-compiler/src/elaborator/callee.rs
+++ b/wado-compiler/src/elaborator/callee.rs
@@ -1,19 +1,8 @@
-//! Resolved call-target identities.
-//!
-//! `CalleeRef` and `StaticMethodRef` bundle the `(module, name)` pairs that
-//! identify a free function or a static method. Historically these were
-//! threaded through the elaborator as separate `&ModuleSource` + `&str`
-//! parameters, which allowed the defining-module name and the caller-visible
-//! alias to drift apart (see the bug where cross-module aliased generic calls
-//! without turbofish failed: `lookup_generic_func_for_inference` re-looked up
-//! a symbol by the defining-module name even though the symbol table is keyed
-//! by the local alias).
-//!
-//! By forcing every downstream consumer to take `&CalleeRef` / `&StaticMethodRef`,
-//! there is no way to accidentally split the pair, and the alias→defining-name
-//! translation lives in exactly one place: the factory methods below. The
-//! `name` fields are always the name *as defined in `module`*, never a local
-//! alias.
+//! Resolved call-target identities: `CalleeRef` and `StaticMethodRef` bundle the
+//! `(module, name)` pair naming a free function or static method. Threaded
+//! separately, the defining-module name and the caller-visible alias could drift
+//! apart; the bundle leaves no way to split them and confines the
+//! alias→defining-name translation to the factory methods below.
 
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use crate::symbol::Symbol;

--- a/wado-compiler/src/elaborator/closure.rs
+++ b/wado-compiler/src/elaborator/closure.rs
@@ -1,13 +1,8 @@
-//! Annotation pass for closure expressions.
-//!
-//! The body walk still allocates the synthetic `__ref_<var>` locals,
-//! address-takes their outer bindings, walks the body so its
-//! `ModuleSemantics` lands, projects the closure's `fn(...)` / `fn mut(...)`
-//! type (so the caller's typecheck sees the right `expression_types`), and
-//! records [`super::sem::types::ClosureCaptureInfo`]. Reify rebuilds the
-//! `let __ref_* = &mut <var>;` materialisation, the
-//! `TirExprKind::Closure { params, body, captures, … }`, and the optional
-//! enclosing `Block` wrapper from the AST + that record.
+//! Annotation pass for closure expressions. The body walk allocates the
+//! synthetic `__ref_<var>` locals, address-takes their outer bindings, walks the
+//! body so its `ModuleSemantics` lands, projects the closure's `fn(…)` type for
+//! the caller's typecheck, and records the
+//! [`super::sem::types::ClosureCaptureInfo`] reify rebuilds from.
 
 use crate::hashmap::IndexSet;
 

--- a/wado-compiler/src/elaborator/coercion.rs
+++ b/wado-compiler/src/elaborator/coercion.rs
@@ -262,16 +262,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         None
     }
 
-    /// Re-coerce numeric literal arguments to inferred parameter types.
-    ///
-    /// When a generic call has its type arguments inferred (e.g. `two<T>(1 as u8, 2)`),
-    /// numeric literal arguments resolved before inference may have picked up the
-    /// default `i32`/`f64` type because the expected type was an unsubstituted
-    /// `TypeParam`. After inference, we know the concrete `T`, so any literal arg
-    /// whose corresponding parameter is now a numeric type should be re-coerced.
-    ///
-    /// `expected_param_types` should be the parameter types after substituting the
-    /// inferred type arguments.
+    /// Re-coerce numeric literal arguments to inferred parameter types: a literal
+    /// resolved before inference took the default `i32` / `f64`, its expected
+    /// type still being an unsubstituted `TypeParam`, so once `T` is concrete
+    /// every literal at a now-numeric parameter is coerced again.
+    /// `expected_param_types` must already carry the inferred type arguments.
     pub(super) fn recoerce_literal_args(
         &mut self,
         raw_args: &[Expr],
@@ -309,22 +304,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Try to coerce an expression to match the expected type.
-    /// Handles numeric literals, null, string newtypes, and tuple-to-array coercion.
-    /// Returns `None` if no coercion applies.
-    ///
-    /// WEP 2026-05-26: each successful branch records the
-    /// chosen [`super::sem::types::CoercionKind`] in
-    /// [`super::sem::types::TypeAnnotations::coercions`] keyed by
-    /// `expr.id()`. The variants that fan out into shared
-    /// `try_coerce_*` sub-helpers (numeric / tuple-to-sequence /
-    /// struct-to-map) record from inside those helpers so direct callers
-    /// (`resolve_cast`, struct-field deferred-coercion, `resolve_let`,
-    /// `recoerce_literal_args`) record uniformly. The variants
-    /// implemented inline in this function (null / string-newtype /
-    /// closure-fn-newtype) record here at the decision point. The future
-    /// `reify` pass replays the same adaptation without re-checking
-    /// expected-type compatibility.
+    /// Try to coerce an expression to the expected type — numeric literals,
+    /// null, string newtypes, tuple-to-array — or `None` when none applies. Each
+    /// success records its [`super::sem::types::CoercionKind`] keyed by
+    /// `expr.id()`, from inside the shared `try_coerce_*` helpers where one
+    /// exists, so reify can replay the adaptation without re-checking.
     pub(super) fn try_coerce(
         &mut self,
         expr: &Expr,
@@ -687,19 +671,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         Some(placeholder(target_type, span))
     }
 
-    /// Try to coerce a tuple/sequence literal `[e0, e1, ...]` to a user-defined type
-    /// implementing `SequenceLiteralBuilder`.
-    ///
-    /// Coerce a tuple/sequence literal `[e0, e1, ...]` to a type implementing
-    /// `SequenceLiteralBuilder` (including built-in `List<T>` and user types).
-    ///
-    /// `&mut <tuple-literal>` / `&<tuple-literal>` are looked through: the cast
-    /// `&mut [...] as List<T>` parses as `(&mut [...]) as List<T>` (`&mut`
-    /// binds tighter than `as`), but the user-facing semantics is to construct
-    /// an `List<T>` and let the call site auto-borrow it. Without this
-    /// passthrough the inner `[...]` would lower as a `tuple<>` `struct.new`
-    /// and the call site's Wasm validation would fail because the tuple
-    /// struct type is unrelated to the expected `List` struct type.
+    /// Coerce a tuple/sequence literal `[e0, e1, …]` to a type implementing
+    /// `SequenceLiteralBuilder`, built-in `List<T>` included. A leading `&` /
+    /// `&mut` is looked through: `&mut [...] as List<T>` parses as
+    /// `(&mut [...]) as List<T>`, but means a `List<T>` the call site
+    /// auto-borrows — lowering the inner literal as a tuple fails validation.
     pub(super) fn try_coerce_tuple_to_sequence(
         &mut self,
         expr: &Expr,

--- a/wado-compiler/src/elaborator/control_flow.rs
+++ b/wado-compiler/src/elaborator/control_flow.rs
@@ -1,21 +1,8 @@
-//! Control-flow analyses for missing-return diagnosis (WEP 2026-05-26).
-//!
-//! These walks consume the parsed AST and look up types from
-//! [`crate::elaborator::sem::types::TypeAnnotations::expression_types`].
-//! They replace the equivalent `block_always_exits` /
-//! `find_return_type_in_block` TIR walkers in `expr.rs`, freeing the
-//! combined walk to stop producing body TIR.
-//!
-//! Both phases consult identical analyses: the combined walk's
-//! diagnostic point (via [`super::Elaborator`]) and reify's closure
-//! return-type derivation (via [`super::reify::Reify`]) construct a
-//! [`CtrlFlowCtx`] over their respective `expression_types` map and
-//! current module key, then dispatch to the free walker functions.
-//!
-//! The shape mirrors the TIR walkers exactly: an `ast::Block` /
-//! `ast::Stmt` / `ast::Expr` arm corresponds 1:1 to the TIR arm.
-//! NEVER detection (TIR walker's `expr.type_id == TypeTable::NEVER`)
-//! becomes an `expression_types[(module, expr.id)] == NEVER` lookup.
+//! Control-flow analyses for missing-return diagnosis (WEP 2026-05-26): walks
+//! over the parsed AST reading types from `TypeAnnotations::expression_types`,
+//! replacing the TIR walkers so the combined walk need not produce body TIR.
+//! Both the diagnostic point and reify's closure return-type derivation build a
+//! [`CtrlFlowCtx`] and dispatch to the same free functions, arm for arm.
 
 use std::cell::RefCell;
 
@@ -121,25 +108,11 @@ pub(super) fn expr_always_exits(ctx: CtrlFlowCtx<'_>, expr: &ast::Expr) -> bool 
     }
 }
 
-/// Result type of `block` — the type of its trailing expression, or
-/// `Unit`. AST mirror of [`crate::tir::block_result_type`] (which reads
-/// the built `TirBlock`); this reads `expression_types[(module, id)]`
-/// instead so the combined walk can compute a block's value type without
-/// inspecting the body TIR it builds.
-///
-/// Unlike the missing-return walk this does NOT filter `contains_unknown`:
-/// an unresolved-`null` tail is `Option<UNKNOWN>` here exactly as the TIR
-/// walker saw `null_tir.type_id`, so the if/match result-type inference
-/// (which special-cases `contains_unknown` branches) behaves identically.
-///
-/// The arm-to-arm correspondence with the TIR walker:
-/// - trailing `Stmt::Expr(e)` ↔ `TirStmtKind::Expr` — the recorded type of
-///   `e` (an `if`/`match`/block tail keeps its already-recorded result
-///   type here).
-/// - trailing `Stmt::If` with an `else` ↔ `TirStmtKind::If` — the branches
-///   agree via [`crate::tir::agree_branch_types`].
-/// - trailing `Return`/`Break`/`Continue` ↔ the diverging arms — `Never`.
-/// - anything else ↔ the TIR walker's `_ => None` — `Unit`.
+/// Result type of `block` — its trailing expression's type, or `Unit`. The AST
+/// mirror of [`crate::tir::block_result_type`], reading
+/// `expression_types[(module, id)]` so a block's value type needs no body TIR.
+/// Unlike the missing-return walk it does *not* filter `contains_unknown`: an
+/// unresolved-`null` tail stays `Option<UNKNOWN>`, as the TIR walker saw it.
 pub(super) fn block_result_type(ctx: CtrlFlowCtx<'_>, block: &ast::Block) -> TypeId {
     block
         .stmts

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -742,10 +742,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Resolve a qualified case reference `Type::Case` — a payload-less variant
     /// case, an enum case, or a flags member. `in_module: None` resolves the type
     /// name in the current scope; `Some(module)` against that module's own
-    /// declarations, for a default expression whose use site may not import the
-    /// type. `None` when the prefix names no such type, so the caller can try
-    /// other interpretations; `Some(TypeTable::ERROR)` when it resolved but is
-    /// invalid, e.g. a payload-carrying case used without arguments.
+    /// declarations. `None` when the prefix names no such type, so the caller can
+    /// try other interpretations; `Some(TypeTable::ERROR)` when it is invalid.
     fn resolve_qualified_case(
         &mut self,
         ident: &ast::IdentExpr,
@@ -1063,8 +1061,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// `fn(…)` type. Only the simple positional case: the expected type must be a
     /// `Function` (possibly behind a ref) of matching arity, and every real type
     /// parameter must end up bound. `ArityMismatch` is separated from
-    /// `NotApplicable` so callers can raise a focused diagnostic rather than the
-    /// generic bare-reference one.
+    /// `NotApplicable` so callers can raise a focused diagnostic.
     fn infer_func_ref_type_args(
         &mut self,
         sig: &super::sem::decls::FunctionSig,
@@ -1832,10 +1829,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 if expected_type.is_some() && type_id != TypeTable::UNIT {
                     // `resolve_let_chain_stmts` resolves the then-branch under
                     // the same `expected_type`, so a mismatch there is already
-                    // diagnosed — and checking it here via `block_result_type`
-                    // would report a spurious "found ()", since that recurses
-                    // through the nested `IfLet` and collapses divergent
-                    // branches to `Unit`. The else-block is resolved
+                    // diagnosed — and re-checking via `block_result_type` would
+                    // report a spurious "found ()". The else-block is resolved
                     // independently, so check it directly.
                     if let Some(eb) = &if_expr.else_block {
                         let else_type = self.ast_block_result_type(eb);
@@ -1951,10 +1946,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
                 // Same rule as `resolve_match_expr`: an if-expression whose
                 // result is consumed needs branches that agree. Inference
-                // already diagnoses the `expected_type = None` case, but
-                // `Some(X)` bypasses it, and a divergent branch would emit an
-                // `(if (result X) …)` whose other side pushes the wrong type.
-                // Skipped at `Unit` — statement position drops the values.
+                // diagnoses the `expected_type = None` case, but `Some(X)`
+                // bypasses it and would emit an `(if (result X) …)` whose other
+                // side pushes the wrong type. Skipped at `Unit`.
                 if expected_type.is_some() && type_id != TypeTable::UNIT {
                     let then_type = self.ast_block_result_type(&if_expr.then_block);
                     self.check_branch_type(then_type, type_id, if_expr.then_block.span);
@@ -2246,9 +2240,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // Reject arms whose body type disagrees with the match's result type;
         // otherwise the wasm result is picked from one arm while another pushes
         // something else. Skipped at `Unit`, which is statement position —
-        // `translate_match` drops each arm's value there. That `Unit` is the
-        // match-level type, so a unit match may still hold `never`-typed arms;
-        // `check_assignable` already encodes those deferrals.
+        // `translate_match` drops each arm's value there.
         if type_id != TypeTable::UNIT {
             for &(arm_type, arm_span) in &arm_bodies {
                 let result = {
@@ -4081,10 +4073,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Infer a generic struct's type arguments by running [`InferCtx`] over its
     /// declared field types against the literal's values. An `expected_type`
     /// that is a `GenericInstance` of the same struct is unified in too, so a
-    /// phantom parameter — one appearing in no field — still lands concrete.
-    /// Unlike the function inference sites this returns the *partial* result:
-    /// an unbound parameter keeps its `TypeParam` id for the monomorphizer to
-    /// substitute from context.
+    /// phantom parameter still lands concrete. Returns the *partial* result: an
+    /// unbound parameter keeps its `TypeParam` id for the monomorphizer.
     pub(super) fn infer_struct_type_args(
         &mut self,
         struct_name: &str,

--- a/wado-compiler/src/elaborator/expr.rs
+++ b/wado-compiler/src/elaborator/expr.rs
@@ -290,15 +290,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 let target = ctx.labeled_block_targets.pop().unwrap();
 
                 // Unify every `break label: expr` with the fall-through path,
-                // whose value is the trailing statement's — what
-                // `translate_stmts_as_value` leaves on the stack there, or
-                // `unreachable` when the tail is not a value.
-                //
-                // The use-site expected type wins when present; otherwise pick a
-                // representative branch type, skipping `never` and types still
-                // containing UNKNOWN (a bare `null` whose `Option<...>` inner is
-                // not yet known) so a diverging or unresolved branch does not
-                // mask the real type. Mirrors `resolve_match_expr`.
+                // whose value is the trailing statement's. The use-site expected
+                // type wins when present; otherwise pick a representative branch
+                // type, skipping `never` and any still holding UNKNOWN so a
+                // diverging or unresolved branch cannot mask the real one.
                 let tail_type = self.ast_block_result_type(&lb.block);
                 let mut branch_types = target.break_types.clone();
                 branch_types.push(tail_type);
@@ -744,17 +739,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         });
     }
 
-    /// Resolve a qualified case reference `Type::Case` — a payload-less
-    /// variant case, an enum case, or a flags member. With `in_module: None`
-    /// the type name resolves in the current scope (imports + local); with
-    /// `Some(module)` it resolves against that module's own declarations —
-    /// the default-expression fallback (`default_scope_module`), where the
-    /// use site may not import the type at all (issue #1486).
-    ///
-    /// Returns `None` when the prefix names no known variant/enum/flags type
-    /// (the caller falls through to other interpretations), and
-    /// `Some(TypeTable::ERROR)` when the reference resolved but is invalid
-    /// (a payload-carrying variant case used without arguments).
+    /// Resolve a qualified case reference `Type::Case` — a payload-less variant
+    /// case, an enum case, or a flags member. `in_module: None` resolves the type
+    /// name in the current scope; `Some(module)` against that module's own
+    /// declarations, for a default expression whose use site may not import the
+    /// type. `None` when the prefix names no such type, so the caller can try
+    /// other interpretations; `Some(TypeTable::ERROR)` when it resolved but is
+    /// invalid, e.g. a payload-carrying case used without arguments.
     fn resolve_qualified_case(
         &mut self,
         ident: &ast::IdentExpr,
@@ -918,17 +909,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ))
     }
 
-    /// Resolve a bare identifier that names a user-defined function (local or
-    /// imported) as a function reference value. Implements the three policies
-    /// for generic functions referenced as values:
-    ///   (a) `name::<T, ...>` — turbofish pins the type parameters.
-    ///   (b) bare `name` with an expected `fn(...)` type — inferred positionally.
-    ///   (c) bare `name` with no expected type — dedicated diagnostic.
-    ///
-    /// For imported functions referenced through an alias (`use { foo as bar }`)
-    /// the emitted `FuncRef` carries the defining-module name (`foo`), not the
-    /// alias, so post-monomorphization keys and the closure forwarder's name
-    /// lookup land on the same identity as a direct reference would.
+    /// Resolve a bare identifier naming a user-defined function as a function
+    /// reference value. A generic one takes its type params from a turbofish,
+    /// else positionally from an expected `fn(…)` type, else gets a dedicated
+    /// diagnostic. An aliased import emits a `FuncRef` under the defining-module
+    /// name, not the alias, so it keys the same as a direct reference.
     fn resolve_func_ref_ident(
         &mut self,
         ident: &ast::IdentExpr,
@@ -1074,21 +1059,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         Some((sig, src, original))
     }
 
-    /// Try to derive type arguments for a generic function reference from an
-    /// expected `fn(...)` type. Only the simple positional case is handled:
-    /// the expected type must itself be a `Function` (or a `Ref`/`MutRef`
-    /// thereof) whose parameter count matches the declaration, and every
-    /// real (non-effect, non-fn-bound) type parameter must end up bound.
-    ///
-    /// Returns:
-    ///   * [`FuncRefInference::Ok`] with the inferred args when inference
-    ///     succeeds.
-    ///   * [`FuncRefInference::ArityMismatch`] when the expected type is a
-    ///     `fn(...)` but its parameter count disagrees — callers turn this
-    ///     into a focused diagnostic instead of the generic bare-reference
-    ///     message.
-    ///   * [`FuncRefInference::NotApplicable`] when the expected type is
-    ///     not a function shape at all (or no expected type was supplied).
+    /// Derive type arguments for a generic function reference from an expected
+    /// `fn(…)` type. Only the simple positional case: the expected type must be a
+    /// `Function` (possibly behind a ref) of matching arity, and every real type
+    /// parameter must end up bound. `ArityMismatch` is separated from
+    /// `NotApplicable` so callers can raise a focused diagnostic rather than the
+    /// generic bare-reference one.
     fn infer_func_ref_type_args(
         &mut self,
         sig: &super::sem::decls::FunctionSig,
@@ -1848,36 +1824,19 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 // type unresolved; report it rather than ICEing in codegen.
                 self.report_uninferable_result(type_id, if_expr.span, "if expression");
 
-                // Same arm-agreement rule as the `Condition::Expr` arm
-                // below: when `expected_type=Some(X)` pinned `type_id`
-                // to `X` unconditionally, the chain and else blocks
-                // could still produce different types — a divergent
-                // `if let` branch in expression position would
-                // silently miscompile the same way the
-                // `Condition::Expr` arm did before this PR. Mirror
-                // the check here so both `if` shapes share the
-                // soundness guarantee. Skipped for `type_id == Unit`
-                // (statement-position use, branches drop their
-                // values per `translate_stmts`).
+                // Same arm-agreement rule as the `Condition::Expr` arm below:
+                // `expected_type = Some(X)` pins `type_id` unconditionally, so
+                // the chain and else blocks could still disagree and a divergent
+                // branch would silently miscompile. Skipped at `Unit`, which is
+                // statement position — the branches drop their values there.
                 if expected_type.is_some() && type_id != TypeTable::UNIT {
-                    // The chain's then-branch is resolved inside
-                    // `resolve_let_chain_stmts` with the same
-                    // `expected_type`, so a then-block that can't
-                    // satisfy `type_id` already surfaces a
-                    // diagnostic from `resolve_expr` /
-                    // `try_coerce` during that walk — no separate
-                    // chain-side check is needed (and using
-                    // `block_result_type(&chain_block)` to check
-                    // here would emit a spurious "expected X,
-                    // found ()" because `block_result_type`
-                    // recurses through the chain's nested
-                    // `TirStmtKind::IfLet` and `agree_branch_types`
-                    // collapses divergent then/else to `Unit`).
-                    //
-                    // The else-block sits outside the chain and is
-                    // resolved independently, so check it
-                    // directly. Missing-else falls back to the
-                    // implicit `else { () }` rule below.
+                    // `resolve_let_chain_stmts` resolves the then-branch under
+                    // the same `expected_type`, so a mismatch there is already
+                    // diagnosed — and checking it here via `block_result_type`
+                    // would report a spurious "found ()", since that recurses
+                    // through the nested `IfLet` and collapses divergent
+                    // branches to `Unit`. The else-block is resolved
+                    // independently, so check it directly.
                     if let Some(eb) = &if_expr.else_block {
                         let else_type = self.ast_block_result_type(eb);
                         self.check_branch_type(else_type, type_id, eb.span);
@@ -1990,19 +1949,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     self.report_unresolved_null_tails_in_blocks(type_id, &blocks);
                 }
 
-                // Same rule as `resolve_match_expr`: an if-expression
-                // whose result is consumed must have branches that
-                // agree on a common type. When `expected_type=None`
-                // the existing inference logic above already
-                // diagnosed the mismatch (line ~1318), but when
-                // `expected_type=Some(X)` the inference was bypassed
-                // (`type_id = X` unconditionally) and a divergent
-                // branch would silently produce a wasm `(if (result
-                // X) ...)` whose other branch pushes the wrong
-                // type. Skip when `type_id == Unit`: that's
-                // statement-position use, where each branch's value
-                // gets dropped at the WIR stmt level. Branch types read
-                // from `expression_types` (AST level), not the built block.
+                // Same rule as `resolve_match_expr`: an if-expression whose
+                // result is consumed needs branches that agree. Inference
+                // already diagnoses the `expected_type = None` case, but
+                // `Some(X)` bypasses it, and a divergent branch would emit an
+                // `(if (result X) …)` whose other side pushes the wrong type.
+                // Skipped at `Unit` — statement position drops the values.
                 if expected_type.is_some() && type_id != TypeTable::UNIT {
                     let then_type = self.ast_block_result_type(&if_expr.then_block);
                     self.check_branch_type(then_type, type_id, if_expr.then_block.span);
@@ -2014,20 +1966,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                             if_expr.else_block.as_ref().unwrap().span,
                         );
                     } else {
-                        // See the `Condition::LetChain` arm for the
-                        // rationale. Without an explicit `else`, the
-                        // implicit branch is `()`, which cannot
-                        // satisfy a non-Unit expected type. Emit the
-                        // diagnostic; the surrounding context (e.g.
-                        // `let x: T = ...`) typically emits a
-                        // redundant secondary mismatch on the same
-                        // span, which the user will see as a single
-                        // grouped error in editor diagnostics. We
-                        // don't downgrade `type_id` here — the
-                        // elaborator-recorded diagnostic will abort
-                        // compilation before WIR build runs, so the
-                        // result-typed `if` with no else never
-                        // reaches `wasmparser`.
+                        // Without an explicit `else` the implicit branch is `()`,
+                        // which cannot satisfy a non-Unit expected type.
+                        // `type_id` is left as-is: the recorded diagnostic
+                        // aborts before WIR build, so a result-typed `if` with
+                        // no else never reaches `wasmparser`.
                         self.check_branch_type(TypeTable::UNIT, type_id, if_expr.span);
                     }
                 }
@@ -2300,24 +2243,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         }
 
-        // Reject arms whose body type disagrees with the match's overall
-        // result type. Skipped when `type_id == Unit`: that means the
-        // match sits in statement position (see `elaborator::resolve_stmt`
-        // for `Stmt::Match`, which pins `expected_type = Some(Unit)`),
-        // and the WIR builder's `translate_match` already drops each
-        // arm body's value via `WirInstr::Drop`. In every other context
-        // (`let x = match {...}`, `f(match {...})`, a match as the
-        // trailing expression of a block whose result is consumed)
-        // divergent arms would silently miscompile — the match's wasm
-        // result type would be picked from one arm, but the other
-        // arm's branch pushes a different type onto the stack, which
-        // either trips wasmparser or produces type-confused output.
-        //
-        // `Unit` here is the match-level type, not the arm-level type:
-        // a unit-typed match can still have `never`-typed arms (e.g.
-        // a `panic`), and those remain compatible. `check_assignable`
-        // already encodes `NEVER` / `UNKNOWN` / type-param deferrals,
-        // so we route through it instead of repeating the rules here.
+        // Reject arms whose body type disagrees with the match's result type;
+        // otherwise the wasm result is picked from one arm while another pushes
+        // something else. Skipped at `Unit`, which is statement position —
+        // `translate_match` drops each arm's value there. That `Unit` is the
+        // match-level type, so a unit match may still hold `never`-typed arms;
+        // `check_assignable` already encodes those deferrals.
         if type_id != TypeTable::UNIT {
             for &(arm_type, arm_span) in &arm_bodies {
                 let result = {
@@ -3621,19 +3552,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             }
         }
 
-        // Check if this is a generic struct and infer type arguments.
-        // Reify rebuilds the mangled name + fields; the combined
-        // walk only needs the substitution / coercion side effects below and
-        // the resulting struct type. `struct_name`/`struct_module_source`
-        // were just reassigned (above) to the canonical storage identity —
-        // the internal mangled name for a local struct (`Stmt::Item`, see
-        // `resolve_local_struct`), or the bare declared name for a
-        // module-level one — so a single `struct_fields_in` lookup on that
-        // identity decides "is this generic" the same way it decides "which
-        // struct's info is this", instead of checking a module-level name set
-        // and a local-struct table separately: two lookups that could name
-        // different structs if a local struct shadows a same-named
-        // module-level generic one.
+        // `struct_name` / `struct_module_source` were just reassigned to the
+        // canonical storage identity, so one `struct_fields_in` lookup on it
+        // answers both "is this generic" and "whose fields are these". Checking
+        // a module-level name set and a local-struct table separately could name
+        // two different structs when a local shadows a module-level generic.
         let is_generic_struct = self
             .lookup_struct_fields_in(&struct_name, &struct_module_source)
             .is_some_and(|info| !info.type_param_bounds.is_empty());
@@ -4155,21 +4078,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Infer type arguments for a generic struct from its field values, with
-    /// optional expected-type driven back-inference for phantom parameters.
-    ///
-    /// Runs [`InferCtx`] over the struct's declared field types
-    /// against the literal's resolved field values. If `expected_type` is a
-    /// `GenericInstance` of the same struct (e.g. the caller wrote
-    /// `let m: DirMap<Direction, i32> = DirMap { values: [] }`), the expected
-    /// type-arguments are unified against the struct's declaration-order
-    /// type-parameter ids so that phantom parameters (those that appear in no
-    /// field) still end up concrete.
-    ///
-    /// Unlike the function/method inference sites this returns the *partial*
-    /// result — unbound parameters fall back to their original `TypeParam`
-    /// ids, which the monomorphizer then substitutes from the surrounding
-    /// context. This matches the historical "phantoms are OK" behaviour.
+    /// Infer a generic struct's type arguments by running [`InferCtx`] over its
+    /// declared field types against the literal's values. An `expected_type`
+    /// that is a `GenericInstance` of the same struct is unified in too, so a
+    /// phantom parameter — one appearing in no field — still lands concrete.
+    /// Unlike the function inference sites this returns the *partial* result:
+    /// an unbound parameter keeps its `TypeParam` id for the monomorphizer to
+    /// substitute from context.
     pub(super) fn infer_struct_type_args(
         &mut self,
         struct_name: &str,
@@ -4583,16 +4498,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         )
     }
 
-    /// Resolve the postfix `?` operator.
-    ///
-    /// Desugars `expr?` into a match that unwraps the success case and
-    /// performs an early return for the failure case.
-    ///
-    /// For `Result<T, E>` in a function returning `Result<U, F>`:
-    ///   match expr { Ok(v) => v, Err(e) => return `Result::Err(F::from(e))` }
-    ///
-    /// For `Option<T>` in a function returning `Option<U>`:
-    ///   match expr { Some(v) => v, None => return null }
     /// Reconstruct the operand's expected type for `?` from the `?`-stripped
     /// expected payload `u` and the function's return type: `Option<u>` or
     /// `Result<u, F>`. `None` when there is no payload or the return type is not
@@ -4629,6 +4534,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         })
     }
 
+    /// Resolve the postfix `?`, desugaring `expr?` into a match that unwraps the
+    /// success case and returns early on failure: `Result<T, E>` in a function
+    /// returning `Result<U, F>` becomes
+    /// `match expr { Ok(v) => v, Err(e) => return Result::Err(F::from(e)) }`,
+    /// and `Option<T>` becomes `match expr { Some(v) => v, None => return null }`.
     pub(super) fn resolve_question_mark(
         &mut self,
         qm: &ast::TryOpExpr,
@@ -4779,17 +4689,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ok_type
     }
 
-    /// Generate a call to `From::from(value)` that converts `value` of type
-    /// `from_type` to `target_type`.
-    ///
-    /// Looks up `impl From<from_type> for target_type` and generates
-    /// `target_type::from(value)` as a static method call.
-    ///
-    /// `caller_id` is the [`AstId`] of the source-level expression that
-    /// triggered this conversion (the `?` operator, a static `T::from(v)`
-    /// call, etc.). The resolved facts are recorded under that key so
-    /// reify can rebuild the same `Call` without re-walking impl blocks or
-    /// re-mangling the method name.
+    /// Generate `target_type::from(value)` as a static call, off the
+    /// `impl From<from_type> for target_type`. `caller_id` is the source
+    /// expression that triggered the conversion — the `?` operator, an explicit
+    /// `T::from(v)` — and the resolved facts are recorded under it so reify can
+    /// rebuild the `Call` without re-walking impl blocks or re-mangling.
     pub(super) fn resolve_from_call(
         &mut self,
         target_type: TypeId,
@@ -5100,21 +5004,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 }
 
-/// Walks a closure body and records outer-binding names that the body
-/// mutates. Built on `AstVisitor`'s `walk_*` defaults, so every AST
-/// node is descended into automatically — including future syntax that
-/// adds new `Expr` / `Stmt` variants. Only three observations are
-/// recorded:
-///
-/// * `Assign { target, .. }` / `CompoundAssign { target, .. }` —
-///   extract the target's *root identifier* (a name that survives
-///   `.field` and `[index]` accessors) and record it.
-/// * Nested closures (`Expr::Closure(_)`) are NOT descended; they have
-///   their own capture context and run their own collector.
-///
-/// Everything else falls through to `walk_*`, which recurses without
-/// any per-variant code on this side. That's the property we want: no
-/// `_ => {}` catch-all to silently miss new syntax.
+/// Walks a closure body and records the outer bindings it mutates: the root
+/// identifier of each `Assign` / `CompoundAssign` target, the one that survives
+/// `.field` and `[index]` accessors. A nested closure is not descended — it runs
+/// its own collector. Everything else falls through to `AstVisitor`'s `walk_*`
+/// defaults, so there is no `_ => {}` here for new syntax to slip past.
 struct MutatedVarsCollector<'a> {
     result: &'a mut IndexSet<String>,
 }

--- a/wado-compiler/src/elaborator/handlers.rs
+++ b/wado-compiler/src/elaborator/handlers.rs
@@ -1,29 +1,8 @@
-//! Annotation pass for effect handler installation (`with E => h do { ... }`)
-//! and the `resume` control-flow expression.
-//!
-//! See WEP 2026-04-11 (Effect Handler) for the language semantics.
-//!
-//! Validation responsibilities here (preserved post-7-B):
-//! - Each binding's effect name must resolve to a known effect declaration
-//!   (not a regular trait, struct, or unknown name).
-//! - The handler value's underlying type (after stripping `&` / `&mut`) must
-//!   have an `impl <Effect> for <Type>` block in scope.
-//! - `resume` is only valid inside a handler method body. The actual
-//!   type-check of the resume value against the operation's return type is
-//!   performed by the existing return-type checker (resume lowers to
-//!   `Return { value }` in the dispatch synthesis pass).
-//!
-//! The combined walk records `HandlerBindingFacts` (and walks every handler
-//! value + body for sub-expression facts); it constructs no
-//! `TirHandlerBinding` / `TirExprKind::WithHandler` / `TirExprKind::Resume`.
-//! Reify rebuilds those from the AST + the recorded facts
-//! (`sem.types.handler_bindings`).
-//!
-//! Bundled handlers (`with &mut h do`) record the per-effect enumeration
-//! (one entry per `impl <Effect> for <Type>` in scope) plus a shared
-//! `bundle_group` so reify emits one `TirHandlerBinding` per recorded
-//! effect, all sharing the same bundle group's synthesised
-//! `__h_<bundle>` local.
+//! Annotation pass for effect handler installation (`with E => h do { … }`) and
+//! `resume`; see WEP 2026-04-11. It validates that each binding names a real
+//! effect declaration, that the handler's stripped type has an `impl` in scope,
+//! and that `resume` sits in a handler method, recording only
+//! `HandlerBindingFacts` for reify to rebuild the TIR nodes from.
 
 use crate::ast;
 use crate::compiler_host::CompilerHost;
@@ -349,27 +328,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         );
     }
 
-    /// Walk every `impl Trait for <type_name>` block in scope and return
-    /// the `(base_trait_name, defining_module, trait_type_args)` triple
-    /// for each impl whose `trait_type` resolves to an effect *or*
-    /// resource declaration. Both kinds are installable as handlers
-    /// (see WEP 2026-04-11), so the bundled `with h do` form expands to
-    /// one binding per impl regardless of kind. The `trait_type_args`
-    /// component carries the impl's instantiation (`[u8]` for
-    /// `impl Stream<u8> for MockCM`, `[]` for non-generic impls) so the
-    /// dispatch synthesis can route each binding to the right
-    /// per-monomorphisation infrastructure.
-    ///
-    /// Discovery order: `trait_env.impl_index` entries first (loaded
-    /// modules), then any extra impls in the current module's items
-    /// that aren't covered by the index. Within each source the order
-    /// matches the original module-walk order, which gives users a
-    /// stable, predictable install order for bundled handlers.
-    ///
-    /// Duplicates are filtered by `(decl_module, base_name,
-    /// trait_type_args)` — distinct instantiations of the same generic
-    /// resource (`impl Stream<u8>` vs `impl Stream<i32>`) install
-    /// separately; pure aliasing duplicates collapse.
+    /// The `(base_trait_name, defining_module, trait_type_args)` triple for every
+    /// in-scope `impl` whose trait resolves to an effect or resource — both are
+    /// installable, so a bundled `with h do` expands to one binding each. Dedup
+    /// by that triple keeps `Stream<u8>` and `Stream<i32>` separate. Discovery
+    /// runs the impl index first, then the module's own items, in walk order.
     fn collect_effect_impls_for_type(
         &mut self,
         type_name: &str,
@@ -458,20 +421,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Annotate `resume value`.
-    ///
-    /// The expression itself yields `()` — `resume` is control-flow rather
-    /// than a value-producing expression at the source level. The dispatch
-    /// synthesis pass (running on reify's TIR) lowers `Resume { value }`
-    /// into `Return { value }`, which is checked against the enclosing
-    /// handler method's return type by the existing return-type rules.
-    ///
-    /// Returns a placeholder. Missing-return analysis recognises
-    /// `fn handler_method(&self) -> Mark { resume self.mark }` as a definite
-    /// exit off the AST (`control_flow::expr_always_exits`'s `Expr::Resume`
-    /// arm), and reify rebuilds the `Resume` node from the AST, so the
-    /// combined walk only resolves the value for its fact-recording and
-    /// type-checking side effects.
+    /// Annotate `resume value`, which yields `()` — at source level it is
+    /// control flow, and dispatch synthesis later lowers it to `Return { value }`
+    /// for the ordinary return-type rules to check. Returns a placeholder:
+    /// missing-return analysis reads the definite exit off the AST and reify
+    /// rebuilds the node, so this walk only resolves the value for its facts.
     pub(super) fn resolve_resume(
         &mut self,
         resume: &ast::ResumeExpr,

--- a/wado-compiler/src/elaborator/infer.rs
+++ b/wado-compiler/src/elaborator/infer.rs
@@ -1,45 +1,19 @@
-//! Unified type-argument inference engine for generic functions, methods,
-//! structs, and variants.
-//!
-//! The elaborator has historically carried several near-duplicate inference
-//! routines — one each for function calls, static-method calls, struct
-//! literals, variant constructors, and instance method calls — plus a
-//! weaker re-inference pass in the monomorphizer. Each copy made slightly
-//! different choices about literal-number handling, expected-type driven
-//! back-inference, and phantom type-parameter preservation, so bugs were
-//! fixed in one place but not the others.
-//!
-//! This module is the single home of the inference logic those callers
-//! share. Phase 0 of the refactor only moves the core structural
-//! unifier here — later phases add a richer [`InferCtx`] that owns the
-//! whole solve (two-phase literal deferral, expected-type back-inference,
-//! phantom parameter preservation) so every caller just builds a set of
-//! constraints and asks this module to resolve them.
+//! Unified type-argument inference for generic functions, methods, structs, and
+//! variants — the single home of logic that was once duplicated per caller, each
+//! copy diverging on literal-number handling, expected-type back-inference, and
+//! phantom parameter preservation. A caller builds constraints and asks
+//! [`InferCtx`] to solve them.
 
 use std::cell::RefCell;
 
 use crate::hashmap::IndexMap;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 
-/// Recursively unify an `expected` type (which may contain `TypeParam` /
-/// `TypePack` holes) with an `actual` concrete type, extending `bindings`
-/// with `TypeParam TypeId -> concrete TypeId` mappings discovered along
-/// the way.
-///
-/// This is a best-effort, non-failing unifier: mismatches that cannot be
-/// bridged are silently ignored so that the caller can try a different
-/// argument or fall through to a fallback. The `or_insert` policy ensures
-/// that an earlier (higher-confidence) binding is never overwritten by a
-/// later weaker one.
-///
-/// Supported cases:
-/// * Direct `TypeParam` on the expected side (binds the type parameter)
-/// * Tuple types containing a `TypePack` element (variadic splice)
-/// * Same-named `GenericInstance` recursively on type arguments
-/// * `List<K>` matched against a homogeneous tuple literal type
-/// * `BuiltinArray<T>` matched against `BuiltinArray<U>`
-/// * `Ref<T>` / `MutRef<T>` matched against the same shape
-/// * `Function` types matched parameter-by-parameter plus return type
+/// Recursively unify an `expected` type, possibly holding `TypeParam` /
+/// `TypePack` holes, against a concrete `actual`, extending `bindings` with what
+/// it learns. Best-effort and non-failing: an unbridgeable mismatch is ignored
+/// so the caller can try another argument, and `or_insert` keeps an earlier,
+/// higher-confidence binding from being overwritten by a weaker one.
 pub(super) fn unify(
     type_table: &RefCell<TypeTable>,
     expected: TypeId,
@@ -194,37 +168,15 @@ pub(super) fn unify(
     }
 }
 
-/// A reusable solver for one generic-inference problem.
+/// A reusable solver for one generic-inference problem, collecting constraints
+/// in three confidence tiers and resolving them in order: argument-derived
+/// ([`add`]), the declared return against the caller's expected type
+/// ([`add_expected_return`]), then queued numeric literals ([`add_deferred`]).
+/// `or_insert` keeps a literal from clobbering a typed neighbour.
 ///
-/// `InferCtx` collects unification constraints in three confidence tiers
-/// and resolves them in order so that higher-confidence information always
-/// wins:
-///
-/// 1. **Strong (argument-derived)** constraints — added via [`add`]. These
-///    are unified immediately into the shared bindings map, so the first
-///    typed argument to mention a type parameter pins its binding.
-/// 2. **Medium (expected-return)** constraints — added via
-///    [`add_expected_return`]. The declaration's return type is unified
-///    against the caller's expected type after every strong argument
-///    constraint has run. An LHS type annotation
-///    (`let x: List<u16> = List::filled(n, 0)`) is more precise than
-///    the default type of a numeric literal argument, so it is processed
-///    before the literal-deferred pass and pins type parameters that no
-///    typed argument constrains.
-/// 3. **Weak (literal-number)** constraints — added via [`add_deferred`].
-///    These are queued and only unified after both stronger tiers have
-///    run. Because [`unify`] uses `or_insert`, a literal `0` cannot
-///    clobber a binding already produced from a neighbouring typed
-///    argument or an LHS annotation. This preserves the
-///    `fn two<T>(x: T, y: T); two(1, 2 as u8)` ⇒ `T = u8` behaviour
-///    historically only supported for plain function calls and only kicks
-///    in when nothing stronger pinned the parameter.
-///
-/// Use [`solve`](Self::solve) to get the final type arguments in
-/// declaration order. A slot nothing bound comes back as whatever was
-/// registered for it — a use site registers the inference variable it minted,
-/// so "unsolved" is `answer == var`, which is what `record_instantiation` and
-/// `blame_unsolved` test.
+/// [`solve`](Self::solve) returns the type arguments in declaration order. An
+/// unbound slot comes back as the inference variable the use site registered, so
+/// "unsolved" is `answer == var`.
 pub(super) struct InferCtx<'a> {
     type_table: &'a RefCell<TypeTable>,
     /// What this solve is trying to bind, in declaration order: a use site's

--- a/wado-compiler/src/elaborator/infer_hole.rs
+++ b/wado-compiler/src/elaborator/infer_hole.rs
@@ -1,15 +1,8 @@
-//! Deferred type-argument inference via inference holes.
-//!
-//! When a generic call's type parameter appears only in its return type and the
-//! call site has no expected type yet (e.g. `p.get()` in `p.get().unwrap()`),
-//! the elaborator mints an *inference hole* and lets the holey type flow up
-//! until a concrete expected type solves it. The module-end sweep substitutes
-//! solved holes into recorded facts; an unsolved hole raises "cannot infer" and
-//! is pinned to `error`.
-//!
-//! A hole is a [`ResolvedType::InferVar`] — a *flexible* variable, distinct
-//! from the *rigid* `TypeParam` it stands in for. A name already mangled from
-//! one is rebuilt from the swept type arguments, not patched.
+//! Deferred type-argument inference via inference holes. Where a generic call's
+//! type parameter appears only in its return type and the call site has no
+//! expected type yet — `p.get()` in `p.get().unwrap()` — the elaborator mints a
+//! *flexible* [`ResolvedType::InferVar`] and lets the holey type flow up until
+//! one solves it; the module-end sweep substitutes it or errors.
 
 use crate::compiler_host::CompilerHost;
 use crate::hashmap::{IndexMap, IndexSet};

--- a/wado-compiler/src/elaborator/instantiate.rs
+++ b/wado-compiler/src/elaborator/instantiate.rs
@@ -1,14 +1,8 @@
-//! Instantiating a polymorphic signature at a use site.
-//!
-//! A declaration is written in its own frame: `fn id<T>(x: T) -> T` names slot
-//! 0 as a rigid `T`. A use of it does not mention `T` — it stands for whatever
-//! this call needs. Instantiation says so: each slot gets a fresh
-//! [`ResolvedType::InferVar`], and the signature is rewritten into those
-//! variables before anything is checked against it.
-//!
-//! The variables join the lifecycle [`super::infer_hole`] owns: solved ones
-//! are substituted away, unsolved ones raise "cannot infer" and are pinned to
-//! `error`, and neither reaches a recorded fact.
+//! Instantiating a polymorphic signature at a use site. A declaration is written
+//! in its own frame — `fn id<T>(x: T) -> T` names slot 0 a rigid `T` — but a use
+//! of it stands for whatever this call needs, so each slot gets a fresh
+//! [`ResolvedType::InferVar`] and the signature is rewritten into those before
+//! anything is checked. They then join the lifecycle [`super::infer_hole`] owns.
 
 use crate::compiler_host::CompilerHost;
 use crate::hashmap::IndexMap;

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -1981,9 +1981,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Resolve parameters. A default expression resolves in the callee's
         // lexical scope with only the earlier parameters visible, so it reaches
-        // the definition module's private items. A function crossing the
-        // Component Model boundary takes neither a default nor a closure in its
-        // signature: the ABI requires every parameter.
+        // the definition module's private items. An `export fn` takes no
+        // parameter default, and nothing crossing the Component Model boundary
+        // takes a closure: the ABI represents neither.
         let is_cm_import =
             func.body.is_none() && func.attrs.iter().any(|a| a.cm_boundary.is_some());
         let crosses_cm_boundary = func.is_export || is_cm_import;

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -808,10 +808,8 @@ impl<H: CompilerHost> TypeParamScope<'_, '_, H> {
     /// Require the impl's target and trait reference to name, between them, every
     /// type parameter it declares — a use site determines them from the receiver
     /// and trait arguments alone, so one they never mention has no value to be
-    /// given (Rust's E0207). A predicate determines one too, so the arguments a
-    /// bound writes count as mentions, though its subject does not: `A` in
-    /// `A: Eq` is what the bound constrains. A name that is really a concrete
-    /// type does not count, and an effect parameter is bound by the handler.
+    /// given (Rust's E0207). A bound's arguments count as mentions, its subject
+    /// does not; an effect parameter is bound by the handler.
     fn check_impl_params_constrained(&mut self, impl_block: &ast::ImplBlock) {
         let mut named: Vec<String> = Vec::new();
         impl_block.ty.mentioned_names(&mut named);
@@ -854,10 +852,7 @@ impl<H: CompilerHost> TypeParamScope<'_, '_, H> {
     /// effect, or a resource, the latter two installing handlers through the same
     /// syntax. Nothing else resolves it: every downstream index keys off the
     /// written string, so an `impl` of an undeclared name registers happily,
-    /// matches no query, and reaches the back end unmentioned. The head resolves
-    /// through the same chain the block's own facts use, so the two cannot
-    /// disagree; a synthesized head, having no reference site, falls back to the
-    /// name-only chain.
+    /// matches no query, and reaches the back end unmentioned.
     fn check_impl_trait_resolves(&mut self, impl_block: &ast::ImplBlock, trait_type: &Type) {
         let name = super::trait_env::get_type_name_static(trait_type);
         let key = match crate::resolve::head_site(trait_type) {
@@ -1479,9 +1474,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Lower an effect or resource declaration's method list to [`TirEffectOp`]s,
     /// with the enclosing type-param scope set up first so a generic resource's
     /// signatures can mention `T`. `resource_self` marks a resource decl, whose
-    /// `&self` shorthand becomes a real parameter at index 0 so dispatch wrapper
-    /// signatures match `__cm_binding__<R>_<op>(self, args)`; an effect decl
-    /// takes no receiver, so any `self_kind` is dropped.
+    /// `&self` shorthand becomes a real parameter at index 0 to match
+    /// `__cm_binding__<R>_<op>(self, args)`; an effect decl takes no receiver.
     pub(super) fn resolve_effect_ops(
         &mut self,
         type_params: &[ast::GenericParam],
@@ -1987,10 +1981,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         // Resolve parameters. A default expression resolves in the callee's
         // lexical scope with only the earlier parameters visible, so it reaches
-        // the definition module's private items without call-site substitution.
-        // A function crossing the Component Model boundary — exported, or an
-        // import carrying `#[canonical]` / `#[cm]` — takes neither a default nor
-        // a closure in its signature: the ABI requires every parameter.
+        // the definition module's private items. A function crossing the
+        // Component Model boundary takes neither a default nor a closure in its
+        // signature: the ABI requires every parameter.
         let is_cm_import =
             func.body.is_none() && func.attrs.iter().any(|a| a.cm_boundary.is_some());
         let crosses_cm_boundary = func.is_export || is_cm_import;
@@ -2208,9 +2201,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// `impl Tag for [i32, i32]`) — a generic self type, tuples included, whose
     /// every argument is concrete. Its methods are per-instantiation functions
     /// named `List<u8>::method` and called directly. The tuple arm carries
-    /// coherence Rule 1: `impl Tag for [i32, i32]` names its method
-    /// `[i32,i32]^Tag::tag`, the name that receiver looks up, so the variadic
-    /// template is never instantiated for that arity.
+    /// coherence Rule 1: the variadic template is skipped for that arity.
     pub(super) fn impl_is_concrete_instantiation(
         &self,
         impl_ty: &ast::Type,
@@ -2234,10 +2225,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Resolve a method. Under `impl_is_concrete` the surrounding impl is a fully
     /// concrete instantiation, so its arguments are *not* registered as impl type
-    /// params: with no free parameter to keep aligned — unlike
-    /// `impl TreeMap<String, V>`, where `String` holds its slot so `V`'s index
-    /// stays put — the signature resolves to `&List<u8>` rather than
-    /// `&List<TypeParam>`, and reify emits a standalone `List<u8>::method`.
+    /// params — there is no free parameter to keep aligned, unlike
+    /// `impl TreeMap<String, V>`. The signature then resolves to `&List<u8>` and
+    /// reify emits a standalone `List<u8>::method`.
     pub(super) fn resolve_method(
         &mut self,
         func: &Function,

--- a/wado-compiler/src/elaborator/item.rs
+++ b/wado-compiler/src/elaborator/item.rs
@@ -805,21 +805,13 @@ impl<H: CompilerHost> TypeParamScope<'_, '_, H> {
         );
     }
 
-    /// Require that the impl's target and trait reference between them name
-    /// every type parameter it declares.
-    ///
-    /// A use site determines them from the receiver and the trait arguments
-    /// and from nothing else, so one the two do not mention has no value to be
-    /// given. Rust rejects the same shape (E0207).
-    ///
-    /// A *predicate* determines one too: `impl<S: ReflectStruct<FieldTypes =
-    /// [..F]>, ..F> Inspect for S` fixes `F` once `S` is known, so the
-    /// arguments a bound writes count as mentions. Its subject does not — `A`
-    /// in `A: Eq` is what the bound constrains, not what constrains `A`.
-    ///
-    /// A parameter whose name is really a concrete type (`impl<i32, T>`) is not
-    /// one, and an effect parameter is bound by the handler rather than the
-    /// target.
+    /// Require the impl's target and trait reference to name, between them, every
+    /// type parameter it declares — a use site determines them from the receiver
+    /// and trait arguments alone, so one they never mention has no value to be
+    /// given (Rust's E0207). A predicate determines one too, so the arguments a
+    /// bound writes count as mentions, though its subject does not: `A` in
+    /// `A: Eq` is what the bound constrains. A name that is really a concrete
+    /// type does not count, and an effect parameter is bound by the handler.
     fn check_impl_params_constrained(&mut self, impl_block: &ast::ImplBlock) {
         let mut named: Vec<String> = Vec::new();
         impl_block.ty.mentioned_names(&mut named);
@@ -858,18 +850,14 @@ impl<H: CompilerHost> TypeParamScope<'_, '_, H> {
         }
     }
 
-    /// Require that the name an `impl` implements is declared.
-    ///
-    /// `impl X for T` names a trait, an effect or a resource — the latter two
-    /// install handlers through the same syntax — so all three declaration
-    /// kinds satisfy it. Nothing else resolves this name: every index downstream
-    /// keys off the written string, so an `impl` of a name nothing declares
-    /// registers happily, matches no query, and reaches the back end unmentioned.
-    ///
-    /// The head resolves through the same chain the block's own facts use, so
-    /// the check and the facts cannot disagree about which declaration it
-    /// names. A head with a reference site answers from the site; a synthesized
-    /// one, which has none, falls back to the name-only chain.
+    /// Require that the name an `impl` implements is declared — as a trait, an
+    /// effect, or a resource, the latter two installing handlers through the same
+    /// syntax. Nothing else resolves it: every downstream index keys off the
+    /// written string, so an `impl` of an undeclared name registers happily,
+    /// matches no query, and reaches the back end unmentioned. The head resolves
+    /// through the same chain the block's own facts use, so the two cannot
+    /// disagree; a synthesized head, having no reference site, falls back to the
+    /// name-only chain.
     fn check_impl_trait_resolves(&mut self, impl_block: &ast::ImplBlock, trait_type: &Type) {
         let name = super::trait_env::get_type_name_static(trait_type);
         let key = match crate::resolve::head_site(trait_type) {
@@ -1341,24 +1329,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Resolve the `methods` list of an effect or resource declaration into
-    /// TIR operations. Generic type parameters declared on the enclosing
-    /// resource (e.g. `resource Stream<T>`) are brought into scope before
-    /// resolving each method's params and return type so that `T` maps to a
-    /// proper `TypeParam` rather than `UNKNOWN`.
-    /// Lower a resource / effect declaration's method list to
-    /// [`TirEffectOp`]s. Type-param scope is set up once at the start
-    /// (so operation signatures can mention `T` for generic resources)
-    /// and then each method's params + return are resolved.
-    ///
-    /// `resource_self`, when `Some((name, module))`, signals that this
-    /// is a resource decl rather than an effect decl: methods declared
-    /// with `&self`/`&mut self` shorthand get the receiver synthesised
-    /// as a real `TirEffectOp` parameter at index 0 (with type
-    /// `&Self`/`&mut Self`) so dispatch wrapper signatures match the
-    /// post-cm-binding call shape `__cm_binding__<R>_<op>(self, args)`.
-    /// For effects (where `resource_self == None`) any `self_kind` is
-    /// silently dropped — effect declarations don't take receivers.
     /// Operation signatures the decl pass recorded for `decl_id`.
     fn declared_effect_ops(&self, decl_id: ast::AstId) -> Vec<TirEffectOp> {
         self.sem
@@ -1506,6 +1476,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .insert(trait_decl.id, super::sig::TraitSig { module, methods });
     }
 
+    /// Lower an effect or resource declaration's method list to [`TirEffectOp`]s,
+    /// with the enclosing type-param scope set up first so a generic resource's
+    /// signatures can mention `T`. `resource_self` marks a resource decl, whose
+    /// `&self` shorthand becomes a real parameter at index 0 so dispatch wrapper
+    /// signatures match `__cm_binding__<R>_<op>(self, args)`; an effect decl
+    /// takes no receiver, so any `self_kind` is dropped.
     pub(super) fn resolve_effect_ops(
         &mut self,
         type_params: &[ast::GenericParam],
@@ -1827,16 +1803,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Populate the generic-function inference caches (type params,
-    /// resolved param types, resolved return type) for `func` without
-    /// resolving its body. Used as a pre-pass before body resolution so
-    /// that same-module forward references to other generic functions
-    /// (e.g. `outer<T>` defined before `inner<T>` in the same file) can
-    /// run argument-derived type inference at the call site.
-    ///
-    /// Idempotent: may be called multiple times. Uses fresh `TypeId`s
-    /// each time; subsequent overwrites inside `resolve_function` keep
-    /// the cache consistent with the body's own `TypeId`s.
+    /// Populate `func`'s generic-inference caches without resolving its body, so
+    /// a same-module forward reference — `outer<T>` written before `inner<T>` —
+    /// can still run argument-derived inference at the call site. Idempotent, and
+    /// mints fresh `TypeId`s each time; `resolve_function`'s later overwrite is
+    /// what keeps the cache consistent with the body's own ids.
     pub(super) fn precompute_generic_function_cache(&mut self, func: &Function) {
         // Mirrors `resolve_function`'s guard: fn-bound params are realised
         // eagerly, so a function whose only non-effect params are fn-bound
@@ -1975,16 +1946,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         scope.register_generic_params(&func.type_params, 0);
 
-        // Populate the generic-function inference caches
-        // (`generic_function_params`, `generic_function_resolved_param_types`,
-        // `generic_function_resolved_return_types`). Populated before the
-        // `function_return_types` update below because that map is shared
-        // with non-generic callers and may be overwritten by external
-        // registrations (trait methods, etc.) over time. The declared return
-        // type is also used for `task_return_type` in async fns.
-        // `<F: fn(...)>` bounds are eagerly realised to the bound's function
-        // type and do not consume a `TypeParam` slot — they're not generic
-        // parameters that need monomorphisation.
+        // Populate the generic-inference caches before the `function_return_types`
+        // update below, which shares its map with non-generic callers and can be
+        // overwritten by an external registration. A `<F: fn(…)>` bound is
+        // eagerly realised to its function type and consumes no `TypeParam` slot,
+        // being nothing monomorphisation needs to substitute.
         let has_real_type_params = func
             .type_params
             .iter()
@@ -2019,19 +1985,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             ctx.task_return_type = Some(declared_return_type);
         }
 
-        // Resolve parameters. Each default expression is resolved in the
-        // callee's lexical scope, with only the earlier parameters in scope
-        // (a default cannot reference its own parameter or any later one).
-        // This gives defaults access to the definition module's private items
-        // and earlier parameters without needing call-site substitution.
-        //
-        // `export fn` is rejected: the Component Model ABI requires every
-        // parameter at the boundary, so defaults cannot divergently exist
-        // only on the Wado side.
-        // A function crosses the Component Model boundary when it is either
-        // exported (`export fn ...`) or imported (declaration with no body
-        // carrying `#[canonical(...)]` or `#[cm(...)]`). Closures may not
-        // appear in either side's signature.
+        // Resolve parameters. A default expression resolves in the callee's
+        // lexical scope with only the earlier parameters visible, so it reaches
+        // the definition module's private items without call-site substitution.
+        // A function crossing the Component Model boundary — exported, or an
+        // import carrying `#[canonical]` / `#[cm]` — takes neither a default nor
+        // a closure in its signature: the ABI requires every parameter.
         let is_cm_import =
             func.body.is_none() && func.attrs.iter().any(|a| a.cm_boundary.is_some());
         let crosses_cm_boundary = func.is_export || is_cm_import;
@@ -2246,17 +2205,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Whether `impl_block` is a concrete generic instantiation (`impl List<u8>`,
-    /// `impl Tag for List<u8>`, `impl Tag for [i32, i32]`): its self type is a
-    /// generic type — tuples included, since a tuple is a generic instance of
-    /// the tuple family — all of whose arguments are concrete (no free type
-    /// params, accounting for any impl-declared parameters). Methods on such an
-    /// impl are per-instantiation concrete functions, named `List<u8>::method`
-    /// and called directly.
-    ///
-    /// The tuple arm carries coherence Rule 1 (WEP 2026-03-14 §5):
-    /// `impl Tag for [i32, i32]` names its method `[i32,i32]^Tag::tag`, the
-    /// name a `[i32, i32]` receiver looks up, so the variadic template is never
-    /// instantiated for that arity.
+    /// `impl Tag for [i32, i32]`) — a generic self type, tuples included, whose
+    /// every argument is concrete. Its methods are per-instantiation functions
+    /// named `List<u8>::method` and called directly. The tuple arm carries
+    /// coherence Rule 1: `impl Tag for [i32, i32]` names its method
+    /// `[i32,i32]^Tag::tag`, the name that receiver looks up, so the variadic
+    /// template is never instantiated for that arity.
     pub(super) fn impl_is_concrete_instantiation(
         &self,
         impl_ty: &ast::Type,
@@ -2278,18 +2232,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 .all(|a| self.is_concrete_type_arg(a, impl_type_params, impl_module))
     }
 
-    /// Resolve a method (function with &self parameter).
-    ///
-    /// `impl_is_concrete` is `true` when the surrounding impl is a fully
-    /// concrete generic instantiation (`impl List<u8>`, all args concrete).
-    /// Such impls define per-instantiation *concrete* methods. Unlike a
-    /// partially-generic impl (`impl TreeMap<String, V>`, where `String` must
-    /// keep its positional slot so `V`'s index stays aligned for
-    /// monomorphization), a fully-concrete impl has no free param to align, so
-    /// its args are NOT registered as impl type params: the method's `self` /
-    /// param / return types resolve to the concrete instantiation (`&List<u8>`,
-    /// not `&List<TypeParam>`), and reify emits a standalone concrete function
-    /// named `List<u8>::method`.
+    /// Resolve a method. Under `impl_is_concrete` the surrounding impl is a fully
+    /// concrete instantiation, so its arguments are *not* registered as impl type
+    /// params: with no free parameter to keep aligned — unlike
+    /// `impl TreeMap<String, V>`, where `String` holds its slot so `V`'s index
+    /// stays put — the signature resolves to `&List<u8>` rather than
+    /// `&List<TypeParam>`, and reify emits a standalone `List<u8>::method`.
     pub(super) fn resolve_method(
         &mut self,
         func: &Function,

--- a/wado-compiler/src/elaborator/liveness.rs
+++ b/wado-compiler/src/elaborator/liveness.rs
@@ -1,57 +1,19 @@
-//! Source-level liveness / dead-code analysis.
-//!
-//! Implements the `liveness` pass described in
-//! [`wep-2026-05-16-unused-diagnostics.md`] (policy) and
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`] (mechanism). The pass
-//! runs after `annotate_bodies` and before `reify`, computing source-level
-//! reachability from the package-external boundary (`pub` and `export`
-//! items) over the call graph the elaborator recorded in `references`.
-//!
-//! # Current scope
-//!
-//! The pass classifies **free functions and globals** as live / test-only /
-//! dead (see [`Liveness`]) and reports `DeadFunction` / `DeadGlobal` /
-//! `TestOnlyFunction` / `TestOnlyGlobal` accordingly. Reify gates emission of
-//! those two item kinds on `live_items` (`E ∪ T`). Every impl/trait method is
-//! seeded as a production root, so it serves as a live intermediary in the call
-//! graph without itself being a report or gating candidate. This keeps the
-//! analysis sound against false positives (the failure the WEP optimises
-//! against) while deferring method-level dead detection — which needs the
-//! operator / `?` / for-of dispatch edges that leave no `references` entry — to
-//! a follow-up slice.
-//!
-//! The graph traces every site where reify can emit a call: function and
-//! method bodies, global initializers, parameter defaults, and struct field
-//! defaults. A callee reachable only through one of those still stays live.
-//!
-//! # Suppression
-//!
-//! `#[allow(dead_code)]` on a function or global (or `#![allow(dead_code)]` at
-//! the module level, covering every item in the file) drops the item from the
-//! lint's report candidates while leaving its call-graph edges intact, so a
-//! callee it reaches still stays live. The attribute name matches rustc's
-//! `dead_code` lint.
+//! Source-level liveness / dead-code analysis (WEP 2026-05-16, 2026-05-26):
+//! between `annotate_bodies` and `reify`, reachability from the
+//! package-external boundary over the call graph `references` recorded, tracing
+//! every site reify can emit a call from. Only free functions and globals are
+//! classified; every method is seeded as a production root.
 
 use crate::ast::{self, AstId, AstVisitor, Block, Expr, Function, Item, Module};
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
 use crate::token::Span;
 
-/// Result of the source-level liveness analysis.
-///
-/// Reachability is computed from two independent root sets over the same
-/// call graph: `E` = reachable from production roots (world exports, `pub`
-/// / `export` items, `#[export]`, methods, struct-field defaults), `T` =
-/// reachable from `test` blocks. Each user-authored free function / global
-/// is then classified:
-///
-/// - **live** (`∈ E`): used by production. Not reported.
-/// - **test-only** (`∈ T \ E`): used by tests but not production → `test_only_items`.
-/// - **dead** (`∉ E ∧ ∉ T`): used by neither → `dead_items`.
-///
-/// `live_items = E ∪ T` is the set reify gates emission on (a test-reachable
-/// item is still kept so test code compiles); the split only affects which
-/// diagnostic the emitter raises.
+/// Result of the source-level liveness analysis. Two root sets run over one call
+/// graph: `E` reachable from production roots, `T` from `test` blocks. A
+/// user-authored free function or global is live in `E`, test-only in `T \ E`,
+/// dead in neither. Reify gates emission on `live_items = E ∪ T`, so test code
+/// still compiles; the split only picks which diagnostic is raised.
 #[derive(Default, Clone)]
 pub(crate) struct Liveness {
     /// Reachable from production roots ∪ tests (`E ∪ T`). Reify gates
@@ -966,16 +928,11 @@ impl AstVisitor for IdCollector {
     }
 }
 
-/// User-authored modules are the entry point and the files / URLs it
-/// transitively imports. Stdlib is never reported — and never reify-gated:
-/// stdlib functions reached only through compiler synthesis (CM bindings,
-/// effect dispatch) have no source-level caller, so the optimize-time DCE
-/// removes their dead ones.
-///
-/// Stdlib lives in the `Core` / `Wasi` / `Wasm` variants *and* in bundled
-/// `.wado` files that the loader registers as `Local` with a scheme-prefixed
-/// path (`wasi:cli/terminal_stdout.wado`, `core:…`). Those must be excluded
-/// too; a user's `Local` import is a relative path with no such scheme.
+/// User-authored modules are the entry point and what it transitively imports.
+/// Stdlib is never reported nor reify-gated — a function reached only through
+/// compiler synthesis has no source-level caller, and optimize-time DCE handles
+/// it. Stdlib is the `Core` / `Wasi` / `Wasm` variants plus the bundled `.wado`
+/// files the loader registers as `Local` with a scheme-prefixed path.
 pub(crate) fn is_user_authored(source: &ModuleSource) -> bool {
     match source {
         ModuleSource::EntryPoint { .. }

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -2735,8 +2735,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// namespaces: usually a declaration, but an impl binding it as its own type
     /// parameter (`impl<V: Bound> Trait for V`) keys under that binder instead.
     /// Both are searched in the current module, only the declaration namespace
-    /// outside it. Consumers re-check the impl's spelling, so this cannot
-    /// over-match.
+    /// outside it. Consumers re-check the impl's spelling.
     fn trait_impl_keys_current_first(&self, struct_name: &str) -> Vec<(ModuleSource, AstId)> {
         let env = &self.tysys.trait_env;
         let declared = env.entries_by_receiver_vec(&self.impl_target(struct_name).receiver());
@@ -2984,11 +2983,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// The argument preselect over a receiver's conversion impls: `Selected` and
     /// `Ambiguous` short-circuit resolution, so it decides calls. It must run
     /// *before* the argument is elaborated — the expected type shaping a literal
-    /// comes from the selected impl, and choosing afterwards is circular. An
-    /// `Opaque` argument, or a class several impls answer alike, passes through.
-    /// Admissibility is [`Elaborator::class_admits`] over each impl's *resolved*
-    /// source type: a spelling table would under-admit newtypes, and
-    /// under-admission is what selects wrongly.
+    /// comes from the selected impl. Admissibility is [`Elaborator::class_admits`]
+    /// over each impl's *resolved* source type, since spelling under-admits.
     pub(super) fn conversion_preselect(
         &mut self,
         struct_name: &str,

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -32,22 +32,11 @@ fn static_call_symbol_name(static_call: &ast::StaticMethodCallExpr) -> String {
 }
 
 /// Inputs to [`Elaborator::resolve_method_call_with`], the TIR-level method-call
-/// dispatcher. The AST-driven [`Elaborator::resolve_method_call`] is a thin
-/// wrapper that resolves the receiver / type args / args from the
-/// [`ast::MethodCallExpr`] and forwards here; sites that synthesise method
-/// calls without a backing AST node (e.g. the for-of loop's `into_iter()` /
-/// `next()` dispatches) call this directly with their already-resolved
-/// receiver and an empty `args` slice.
-///
-/// `method_id == None` signals a synthetic call: no use→def edge is
-/// recorded against any AST node for the method name token. This is what
-/// keeps internal helper calls out of LSP jump-to-definition.
-///
-/// `call_id == None` likewise suppresses recording the dispatch decision
-/// in [`super::sem::TypeAnnotations::method_dispatch`]: the future
-/// `reify` pass (WEP 2026-05-26) only walks source-level
-/// `MethodCallExpr` nodes, so a synthesised call has no AST id under which
-/// to file an entry.
+/// dispatcher. [`Elaborator::resolve_method_call`] wraps it for AST-driven calls;
+/// a synthesised one (for-of's `into_iter()` / `next()`) calls it directly with
+/// an already-resolved receiver. Both ids are then `None`, which suppresses the
+/// use→def edge — keeping internal helpers out of jump-to-definition — and the
+/// `method_dispatch` entry, since reify walks source-level nodes only.
 pub(super) struct MethodCallInput<'a> {
     pub receiver: TirExpr,
     /// The receiver's source AST when the call comes from user syntax.
@@ -1094,19 +1083,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             method_info: Some(method_info),
         };
 
-        // WEP 2026-05-26: record the dispatch decision so the
-        // future `reify` pass can emit the same method-call TIR without
-        // re-running trait lookup / method-name mangling. Skipped when:
-        //  - `call_id == None` (synthetic call: for-of's `.into_iter()`
-        //    / `.next()`),
-        //  - The early-returning short-circuits above (tuple `.len()` /
-        //    `.zip()`, static-method-as-instance error) returned before
-        //    reaching here, or
-        //  - Method lookup failed and we are in the error-recovery
-        //    placeholder path (`method_found == false`).
-        // Only the trait-qualified caller reads the signature facts back
-        // (`required_trait` is its marker); ordinary method calls skip the
-        // four vector clones, incl. deep default-expression ASTs.
+        // Record the dispatch decision so reify can emit the same TIR without
+        // re-running trait lookup or mangling. Skipped for a synthetic call, for
+        // the short-circuits that returned above, and on the error-recovery path.
+        // Only a trait-qualified caller reads the signature facts back, so an
+        // ordinary call skips the four vector clones and their default ASTs.
         let signature = (method_found && required_trait.is_some()).then(|| MethodSignatureFacts {
             param_is_mut: param_is_mut.clone(),
             param_names: param_names.clone(),
@@ -2750,16 +2731,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Keys of the *trait* impl blocks whose target head is written
-    /// `struct_name`, current-module-first.
-    ///
-    /// A written name reaches two receiver namespaces. It usually names a
-    /// declaration, but an impl that bound it as its own type parameter
-    /// (`impl<V: Bound> Trait for V`) keys under that parameter's *binder*,
-    /// which no declaration lookup can reach. Both are searched inside the
-    /// current module, where a bare name may mean either; outside it only the
-    /// declaration namespace is, since a foreign impl's type parameter is not
-    /// this name. Consumers re-check the impl's own spelling, so the widening
-    /// cannot over-match.
+    /// `struct_name`, current-module-first. A written name reaches two receiver
+    /// namespaces: usually a declaration, but an impl binding it as its own type
+    /// parameter (`impl<V: Bound> Trait for V`) keys under that binder instead.
+    /// Both are searched in the current module, only the declaration namespace
+    /// outside it. Consumers re-check the impl's spelling, so this cannot
+    /// over-match.
     fn trait_impl_keys_current_first(&self, struct_name: &str) -> Vec<(ModuleSource, AstId)> {
         let env = &self.tysys.trait_env;
         let declared = env.entries_by_receiver_vec(&self.impl_target(struct_name).receiver());
@@ -3004,24 +2981,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.keys_declare_static_method(&keys, method_name)
     }
 
-    /// The argument preselect over a receiver's conversion impls
-    /// (WEP 2026-07-31) — this DOES decide calls: `Selected` / `Ambiguous`
-    /// short-circuit resolution.
-    ///
-    /// Selection must run before the argument is elaborated: the expected
-    /// type that shapes a literal comes from the selected impl, and picking
-    /// it afterwards is the circular ordering the WEP diagnoses. Every class
-    /// that carries information participates — a synthesized type selects by
-    /// `TypeId` rather than through the name hint's spelling comparison, which
-    /// is what that mechanism's aliasing ceiling asks for. An `Opaque` argument
-    /// carries nothing and passes through, and so does a class several impls
-    /// answer without contradiction (see `Head` below).
-    ///
-    /// Admissibility is [`Elaborator::class_admits`] over each impl's
-    /// *resolved* source type — the same table argument-directed selection
-    /// uses — so an integer newtype admits an integer literal here exactly as
-    /// it does there. A spelling table would under-admit newtypes, and
-    /// under-admission selects wrongly (the forbidden direction).
+    /// The argument preselect over a receiver's conversion impls: `Selected` and
+    /// `Ambiguous` short-circuit resolution, so it decides calls. It must run
+    /// *before* the argument is elaborated — the expected type shaping a literal
+    /// comes from the selected impl, and choosing afterwards is circular. An
+    /// `Opaque` argument, or a class several impls answer alike, passes through.
+    /// Admissibility is [`Elaborator::class_admits`] over each impl's *resolved*
+    /// source type: a spelling table would under-admit newtypes, and
+    /// under-admission is what selects wrongly.
     pub(super) fn conversion_preselect(
         &mut self,
         struct_name: &str,
@@ -3127,11 +3094,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         (candidates, has_blanket)
     }
 
-    /// Locate a static trait method impl, returning the resolved identity
-    /// (`module`, `type_name`, `method_name`, `trait_name`). Used so that
-    /// `FunctionRef` gets the correct `module_source` — especially when a
-    /// user defines `impl From<MyType> for i32` in the entry module (or
-    /// another module), so DCE and WIR building can find it.
     /// The original (un-aliased) name `name` resolves to *within `module`* — its
     /// `use { Original as name }` original, or `name` itself when not aliased.
     /// Resolving in the impl's own module (not the call site) makes `From`-impl

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -434,19 +434,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 }
 
 impl TypeSystem {
-    /// Return `Some(struct_type)` when `struct_name` is a non-generic struct
-    /// whose fields all carry a declared default expression, making it
-    /// eligible for auto-derived `Default::default()` synthesis.
-    ///
-    /// Returns `None` when:
-    /// - the name is unknown (only visible structs are considered, matching
-    ///   Eq/Ord auto-derive eligibility),
-    /// - any field is required (no `= expr`),
-    /// - the struct has no fields (empty structs opt out),
-    /// - the struct is generic (left for a follow-up).
-    ///
-    /// Does not check whether the user wrote their own `impl Default`;
-    /// callers should consult this only as a fallback after the regular
+    /// `Some(struct_type)` when `struct_name` is a non-generic struct whose
+    /// fields all declare a default, making it eligible for auto-derived
+    /// `Default::default()`. `None` for an unknown name, a required field, no
+    /// fields at all, or a generic struct. Does not check for a user-written
+    /// `impl Default`, so consult it only as a fallback after the regular
     /// impl-lookup paths.
     pub(super) fn auto_derive_default_struct_type(
         &self,
@@ -1037,24 +1029,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Infer method-level type arguments for an instance method call using
-    /// the method's already-resolved parameter and return types.
-    ///
-    /// `param_types` and `decl_return_type` must come from a method lookup
-    /// (`lookup_method_info` / `find_trait_method_for_type`), so the slots
-    /// they mention are the ones that lookup reported and the caller binds.
-    ///
-    /// This intentionally does **not** re-resolve the method's AST: doing so
-    /// in a fresh scope would emit spurious errors for references like
-    /// `Self::Item` that depend on assoc-type bindings the outer elaborator
-    /// context has but that `infer_method_type_args` cannot easily
-    /// reconstruct.
-    ///
-    /// Returns a vector sized to the method's own non-effect type parameters
-    /// in declaration order. Unbound parameters fall back to their original
-    /// `TypeParam` ids; an empty vector is returned when there is nothing to
-    /// infer (no method type params, or the receiver is not a struct /
-    /// generic instance).
+    /// Infer an instance call's method-level type arguments from the method's
+    /// already-resolved parameter and return types, which must come from a method
+    /// lookup so their slots are the ones the caller binds. Deliberately does not
+    /// re-resolve the method's AST: a fresh scope would report spurious errors for
+    /// a `Self::Item` depending on assoc-type bindings only the outer context has.
+    /// Sized to the method's non-effect type params in declaration order, with an
+    /// unbound one keeping its `TypeParam` id and nothing to infer giving empty.
     pub(super) fn infer_method_type_args(
         &mut self,
         input: MethodInferenceInput<'_>,
@@ -1629,16 +1610,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         })
     }
 
-    /// Whether a concrete `impl Trait for <NamedType>` actually targets the
-    /// receiver. The bare-name check in `candidate_matches_receiver` accepts
-    /// every same-named impl, so two `impl Describe for Data` in different
-    /// modules both reach here; resolve the impl's receiver in its own module
-    /// and compare `TypeId`s (each module's `Data` interns distinctly), walking
-    /// the receiver's newtype chain. Widely-applicable receivers — blanket,
-    /// ref-shape, and *parametric* generic impls (`impl<V> X for Bag<V>`) — are
-    /// exempt (`true`), since their `ty` is `TypeParam`-bearing; a fully
-    /// concrete generic impl (`impl X for List<u8>`) interns concretely and is
-    /// checked (else it would also match `List<i32>`).
+    /// Whether a concrete `impl Trait for <NamedType>` really targets the
+    /// receiver. `candidate_matches_receiver`'s bare-name check accepts every
+    /// same-named impl, so two modules' `impl Describe for Data` both arrive
+    /// here; resolve each impl's receiver in its own module and compare `TypeId`s
+    /// along the newtype chain. A blanket, ref-shape, or parametric generic impl
+    /// is exempt, its `ty` being `TypeParam`-bearing — but a fully concrete
+    /// `impl X for List<u8>` is checked, or it would also match `List<i32>`.
     fn concrete_impl_matches_receiver(
         &mut self,
         impl_ref: &ImplBlockRef,
@@ -2364,19 +2342,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         found_traits.into_iter().next()
     }
 
-    /// One trait implemented for this receiver at two argument lists
-    /// (`impl Take<A> for bool` beside `impl Take<B> for bool`) leaves the
-    /// method name pointing at two signatures. Nothing downstream can choose:
+    /// One trait implemented for a receiver at two argument lists leaves the
+    /// method name pointing at two signatures, and nothing downstream can choose:
     /// arguments are elaborated *against* the chosen signature, and Wado has no
-    /// qualified call form to name one.
-    ///
-    /// Operators do not come through here — [`Self::find_indexing_trait_impl`]
-    /// and friends pick by operand type, which is why `List<T>` can carry
-    /// `IndexValue<i32>` alongside `IndexValue<RangeExclusive<i32>>`.
-    ///
-    /// `classes` is what each argument contributed, so the message can say
-    /// which one gave selection nothing to work with — after synthesis the
-    /// residual failures are exactly those.
+    /// qualified call form to name one. Operators do not come through here —
+    /// [`Self::find_indexing_trait_impl`] and friends pick by operand type, which
+    /// is how `List<T>` carries two `IndexValue` impls. `classes` is what each
+    /// argument contributed, so the message can name the one that gave selection
+    /// nothing to work with.
     fn report_trait_argument_ambiguity(
         &self,
         found_traits: &[super::types::TraitMethodMatch],
@@ -3285,16 +3258,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             )),
         };
 
-        // WEP 2026-05-26: the IndexMut rewrite is the only
-        // path that builds the user-visible method-call TIR without going
-        // through `resolve_method_call_with`. Record dispatch here so
-        // `m["k"].push(1)` and friends leave the same annotation as the
-        // ordinary path.
-        //
-        // The call's AstId is additionally tagged with
-        // `DesugarKind::IndexMutMethodCall` so reify knows to follow the
-        // IndexMut expansion path (synthesise `__index_mut_val`) instead
-        // of the plain method-call path.
+        // The IndexMut rewrite is the only path building user-visible
+        // method-call TIR without going through `resolve_method_call_with`, so
+        // record dispatch here and let `m["k"].push(1)` leave the same annotation
+        // as an ordinary call. The `AstId` is also tagged
+        // `DesugarKind::IndexMutMethodCall`, so reify takes the expansion path
+        // and synthesises `__index_mut_val` rather than a plain method call.
         self.record_method_dispatch(
             Some(method_call.id),
             &func,
@@ -3320,23 +3289,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         Some(placeholder(return_type, method_call.span))
     }
 
-    /// Sole elaborator-side constructor of a method call: a
-    /// [`TirExprKind::Call`] whose receiver heads its `args`.
-    ///
-    /// Centralizing construction here establishes a single audit point for
-    /// the invariant "every elaborator-emitted method call has been
-    /// typechecked against the callee's declared parameter types before
-    /// it flows into TIR".  Typecheck is the caller's responsibility —
-    /// the helper exists so that any future machine-enforced invariant
-    /// (e.g. privatizing the enum variant's fields, adding a debug
-    /// assertion, wiring a `LocalMethodName` witness type) can plug in
-    /// here without having to chase down scattered `Call { … }` literals.
-    ///
-    /// Post-resolve phases (monomorphize / lower / optimize / codegen)
-    /// rebuild method-call nodes from already-checked
-    /// expressions and legitimately bypass this helper; they operate on
-    /// TIR that is guaranteed to have been produced through this path
-    /// originally.
+    /// The sole elaborator-side constructor of a method call — a
+    /// [`TirExprKind::Call`] whose receiver heads its `args`. Centralising it
+    /// gives one audit point for "every elaborator-emitted method call was
+    /// typechecked against the callee's declared parameter types", so a future
+    /// machine-enforced version of that invariant can plug in here rather than
+    /// chasing scattered `Call { … }` literals. Typechecking itself stays the
+    /// caller's job. Post-resolve phases rebuild such nodes from already-checked
+    /// expressions and legitimately bypass this.
     pub(super) fn build_tir_method_call(
         receiver: TirExpr,
         func: FunctionRef,

--- a/wado-compiler/src/elaborator/method_lookup.rs
+++ b/wado-compiler/src/elaborator/method_lookup.rs
@@ -1033,9 +1033,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// already-resolved parameter and return types, which must come from a method
     /// lookup so their slots are the ones the caller binds. Deliberately does not
     /// re-resolve the method's AST: a fresh scope would report spurious errors for
-    /// a `Self::Item` depending on assoc-type bindings only the outer context has.
-    /// Sized to the method's non-effect type params in declaration order, with an
-    /// unbound one keeping its `TypeParam` id and nothing to infer giving empty.
+    /// a `Self::Item`. An unbound parameter keeps its `TypeParam` id.
     pub(super) fn infer_method_type_args(
         &mut self,
         input: MethodInferenceInput<'_>,
@@ -1612,11 +1610,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Whether a concrete `impl Trait for <NamedType>` really targets the
     /// receiver. `candidate_matches_receiver`'s bare-name check accepts every
-    /// same-named impl, so two modules' `impl Describe for Data` both arrive
-    /// here; resolve each impl's receiver in its own module and compare `TypeId`s
-    /// along the newtype chain. A blanket, ref-shape, or parametric generic impl
-    /// is exempt, its `ty` being `TypeParam`-bearing — but a fully concrete
-    /// `impl X for List<u8>` is checked, or it would also match `List<i32>`.
+    /// same-named impl, so resolve each impl's receiver in its own module and
+    /// compare `TypeId`s along the newtype chain. A `TypeParam`-bearing impl is
+    /// exempt; a concrete `impl X for List<u8>` is checked, or `List<i32>` matches.
     fn concrete_impl_matches_receiver(
         &mut self,
         impl_ref: &ImplBlockRef,
@@ -3258,12 +3254,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             )),
         };
 
-        // The IndexMut rewrite is the only path building user-visible
-        // method-call TIR without going through `resolve_method_call_with`, so
-        // record dispatch here and let `m["k"].push(1)` leave the same annotation
-        // as an ordinary call. The `AstId` is also tagged
-        // `DesugarKind::IndexMutMethodCall`, so reify takes the expansion path
-        // and synthesises `__index_mut_val` rather than a plain method call.
+        // The IndexMut rewrite is the only path building user-visible method-call
+        // TIR without going through `resolve_method_call_with`, so record
+        // dispatch here and let `m["k"].push(1)` leave the same annotation as an
+        // ordinary call. The `AstId` is also tagged
+        // `DesugarKind::IndexMutMethodCall`, so reify takes the expansion path.
         self.record_method_dispatch(
             Some(method_call.id),
             &func,
@@ -3292,11 +3287,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// The sole elaborator-side constructor of a method call — a
     /// [`TirExprKind::Call`] whose receiver heads its `args`. Centralising it
     /// gives one audit point for "every elaborator-emitted method call was
-    /// typechecked against the callee's declared parameter types", so a future
-    /// machine-enforced version of that invariant can plug in here rather than
-    /// chasing scattered `Call { … }` literals. Typechecking itself stays the
-    /// caller's job. Post-resolve phases rebuild such nodes from already-checked
-    /// expressions and legitimately bypass this.
+    /// typechecked against the callee's declared parameter types", though the
+    /// typechecking itself stays the caller's job.
     pub(super) fn build_tir_method_call(
         receiver: TirExpr,
         func: FunctionRef,

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -73,8 +73,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// numeric-literal coercion, shared with [`Self::desugar_comparison_chain`].
     /// A primitive coerces the literal to the other operand's type; a struct type
     /// such as `i128` takes each expected type from the operator trait's method
-    /// signature, which handles an asymmetric operator like
-    /// `Shl::shl(&self, rhs: u32)` without special-casing it.
+    /// signature, which covers an asymmetric `Shl::shl(&self, rhs: u32)`.
     pub(super) fn resolve_binary_operands_with_coercion(
         &mut self,
         left_ast: &ast::Expr,
@@ -185,12 +184,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Whether an operand's own elaboration would consult the expected type, so a
-    /// comparison resolves the *other* side first and hands this one its type. A
-    /// syntactic subset of what argument synthesis calls
-    /// [`super::synth::ArgClass::Opaque`], syntactic on purpose: reify decides the
-    /// same order with no synthesis to ask, and a type-dependent order would
-    /// desync the two walks inside a tuple `for-of`. Subset rather than equality
-    /// is the safe side — a form left out just resolves on its own.
+    /// comparison resolves the *other* side first and hands this one its type.
+    /// Syntactic on purpose: reify decides the same order with no synthesis to
+    /// ask, and a type-dependent order would desync the two walks inside a tuple
+    /// `for-of`. A form left out just resolves on its own, so a subset is safe.
     pub(super) fn takes_shape_from_expected_type(expr: &ast::Expr) -> bool {
         match expr {
             ast::Expr::TupleLiteral(_) | ast::Expr::StaticMethodCall(_) => true,
@@ -329,12 +326,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         if is_comparison {
             // The receiver for trait lookup, named by its declaring module and
-            // read off the resolved type — the declaration is right here, so no
-            // written name is re-resolved. `Enum` is deliberately absent, its
-            // `==` lowering to a native discriminant compare; `Variant` must be
-            // present, since only reaching `resolve_trait_method_for_op` records
-            // the bound-driven synthesis request, and otherwise its comparison
-            // falls through to monomorphize time, after synthesis already ran.
+            // read off the resolved type. `Enum` is deliberately absent, its `==`
+            // lowering to a native discriminant compare; `Variant` must be
+            // present, since only `resolve_trait_method_for_op` records the
+            // bound-driven synthesis request, and synthesis has already run.
             let struct_name = match &left_type {
                 ResolvedType::Struct {
                     decl_name: name,
@@ -1130,9 +1125,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// path is an assignable place — index-assignable receivers already returned
     /// above. A read-only `Index` access lowers to `*recv.index(i)` over
     /// `&Output`, so writing through it is an immutable-reference error; an
-    /// `IndexValue` access is a by-value call and no place at all; and with no
-    /// recorded read dispatch only a tuple index is assignable, an unindexable
-    /// receiver having been diagnosed by `resolve_index`.
+    /// `IndexValue` access is a by-value call and no place at all.
     fn index_target_assignable(&mut self, index_expr: &ast::IndexExpr) -> bool {
         let needs_deref = self
             .sem
@@ -1479,9 +1472,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// read side is an ordinary `resolve_expr` on the target, which dispatches
     /// the `Index` trait for a custom indexed read; the write side reuses
     /// [`Self::assign_to_target`], fed the already-resolved value through
-    /// [`AssignValue::Resolved`] so no synthesised AST is involved. `target` is
-    /// evaluated twice, which is fine for a pure l-value and runs the inner
-    /// sub-expressions of `arr[bump()] += 1` twice.
+    /// [`AssignValue::Resolved`]. `target` is evaluated twice.
     pub(super) fn resolve_compound_assign(
         &mut self,
         compound: &ast::CompoundAssignExpr,
@@ -1666,11 +1657,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// The single TIR-level builder for every operator dispatching to a trait
     /// method, unary and binary alike, over already-resolved operands matching
-    /// `resolved.param_types` in order. It is the sole authority for four things:
-    /// type-checking each argument against the declared parameter type — with a
-    /// `&Self` parameter expecting the receiver's own type, so newtype dispatch
-    /// accepts the newtype on both sides — adjusting the receiver, wrapping an
-    /// argument in `&` iff its parameter is a reference, and building the `Call`.
+    /// `resolved.param_types` in order. Sole authority for four things:
+    /// type-checking each argument (a `&Self` parameter expects the receiver's
+    /// own type), adjusting the receiver, `&`-wrapping, and building the `Call`.
     fn build_trait_op_method_call_on_resolved(
         &mut self,
         receiver: TirExpr,

--- a/wado-compiler/src/elaborator/operators.rs
+++ b/wado-compiler/src/elaborator/operators.rs
@@ -69,16 +69,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.build_binary_op_tir(left, binary.op, right, binary.span, Some(binary.id))
     }
 
-    /// Resolve both operands of a binary op, applying the standard
-    /// bidirectional numeric-literal coercion. Shared between
-    /// [`Self::resolve_binary`] and elaborator-internal callers like
-    /// [`Self::desugar_comparison_chain`].
-    ///
-    /// For primitive numeric types: coerce the literal to the other operand's type.
-    /// For struct types (e.g. `i128`/`u128`): look up the operator trait to determine
-    /// the expected type for each operand from the method signature. This naturally
-    /// handles operators with asymmetric parameter types (e.g. `Shl::shl(&self, rhs: u32)`)
-    /// without special-casing specific operators.
+    /// Resolve both operands of a binary op with the bidirectional
+    /// numeric-literal coercion, shared with [`Self::desugar_comparison_chain`].
+    /// A primitive coerces the literal to the other operand's type; a struct type
+    /// such as `i128` takes each expected type from the operator trait's method
+    /// signature, which handles an asymmetric operator like
+    /// `Shl::shl(&self, rhs: u32)` without special-casing it.
     pub(super) fn resolve_binary_operands_with_coercion(
         &mut self,
         left_ast: &ast::Expr,
@@ -188,16 +184,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Whether an operand's own elaboration would consult the expected type, so
-    /// a comparison resolves the *other* side first and hands this one its type.
-    /// A syntactic subset of the forms argument synthesis classifies as
-    /// [`super::synth::ArgClass::Opaque`], and syntactic on purpose: reify
-    /// decides the same order with no synthesis to ask, and a type-dependent
-    /// order would desync the two walks inside a tuple `for-of`, where one
-    /// sub-tree is visited once per element.
-    ///
-    /// Subset, not equality, is the safe side: a form left out resolves on its
-    /// own, as every operand did before.
+    /// Whether an operand's own elaboration would consult the expected type, so a
+    /// comparison resolves the *other* side first and hands this one its type. A
+    /// syntactic subset of what argument synthesis calls
+    /// [`super::synth::ArgClass::Opaque`], syntactic on purpose: reify decides the
+    /// same order with no synthesis to ask, and a type-dependent order would
+    /// desync the two walks inside a tuple `for-of`. Subset rather than equality
+    /// is the safe side — a form left out just resolves on its own.
     pub(super) fn takes_shape_from_expected_type(expr: &ast::Expr) -> bool {
         match expr {
             ast::Expr::TupleLiteral(_) | ast::Expr::StaticMethodCall(_) => true,
@@ -335,22 +328,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         );
 
         if is_comparison {
-            // Get struct name for trait lookup.
-            // Newtypes of primitives (e.g. type Radians = f64) use primitive comparison.
-            // Newtypes of structs need trait-based comparison via the base type's impl.
-            //
-            // `Enum` is deliberately absent: its `==` lowers to a native
-            // discriminant compare, no method dispatch involved. `Variant`
-            // must be present: it carries payload data, so its `==`/`Ord`
-            // dispatch to a synthesized method, and only going through
-            // `resolve_trait_method_for_op` here records the bound-driven
-            // synthesis request (WEP 2026-06-25-trait-derivation) — otherwise
-            // a plain variant's comparison falls through to
-            // `try_lower_comparison` at monomorphize time, after synthesis
-            // already ran, and the method is never generated.
-            // The receiver is named by the module that declares it, read off
-            // the resolved type itself — the declaration is right here, so
-            // nothing re-resolves a written name.
+            // The receiver for trait lookup, named by its declaring module and
+            // read off the resolved type — the declaration is right here, so no
+            // written name is re-resolved. `Enum` is deliberately absent, its
+            // `==` lowering to a native discriminant compare; `Variant` must be
+            // present, since only reaching `resolve_trait_method_for_op` records
+            // the bound-driven synthesis request, and otherwise its comparison
+            // falls through to monomorphize time, after synthesis already ran.
             let struct_name = match &left_type {
                 ResolvedType::Struct {
                     decl_name: name,
@@ -1142,17 +1126,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         self.assign_to_target(&assign.target, AssignValue::Ast(&assign.value), ctx)
     }
 
-    /// Whether an `Index` assignment target reaching `assign_to_target`'s
-    /// general path is an assignable place. The `IndexAssign` path above
-    /// already returned for index-assignable receivers, so the remaining
-    /// shapes are classified from the AST + recorded facts:
-    ///   - a read-only `Index` trait access (recorded `operator_dispatch`
-    ///     with `needs_deref`) lowers to `*recv.index(i)` over `&Output`, so
-    ///     a write would go through an immutable reference (diagnosed here);
-    ///   - an `IndexValue` access is a by-value method call — not a place;
-    ///   - with no recorded read dispatch the only assignable shape is a
-    ///     tuple index (`t[0]`, lowered to a `FieldAccess`); an unindexable
-    ///     receiver was already diagnosed by `resolve_index`.
+    /// Whether an `Index` assignment target reaching `assign_to_target`'s general
+    /// path is an assignable place — index-assignable receivers already returned
+    /// above. A read-only `Index` access lowers to `*recv.index(i)` over
+    /// `&Output`, so writing through it is an immutable-reference error; an
+    /// `IndexValue` access is a by-value call and no place at all; and with no
+    /// recorded read dispatch only a tuple index is assignable, an unindexable
+    /// receiver having been diagnosed by `resolve_index`.
     fn index_target_assignable(&mut self, index_expr: &ast::IndexExpr) -> bool {
         let needs_deref = self
             .sem
@@ -1495,21 +1475,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         TypeTable::UNIT
     }
 
-    /// Resolve `target op= value` as the equivalent `target = target op value`,
-    /// fully TIR-direct.
-    ///
-    /// The READ side comes from `resolve_expr(&compound.target, …)`, which
-    /// naturally dispatches the `Index` trait for indexed reads on custom
-    /// types. The WRITE side reuses [`Self::assign_to_target`], which
-    /// handles `GlobalVarSet`, the `IndexAssign` trait, and plain `Assign`
-    /// — feeding it the already-resolved combined value via
-    /// [`AssignValue::Resolved`] so no synthesised AST is involved.
-    ///
-    /// Note: `target` is evaluated twice. For pure l-values (locals,
-    /// globals, fields of locals) that is fine; for impure l-values like
-    /// `arr[bump()] += 1` the inner sub-expressions run twice, matching
-    /// the historical desugar-phase behaviour. Binding impure
-    /// sub-expressions to temporaries first is a separate concern.
+    /// Resolve `target op= value` as `target = target op value`, TIR-direct. The
+    /// read side is an ordinary `resolve_expr` on the target, which dispatches
+    /// the `Index` trait for a custom indexed read; the write side reuses
+    /// [`Self::assign_to_target`], fed the already-resolved value through
+    /// [`AssignValue::Resolved`] so no synthesised AST is involved. `target` is
+    /// evaluated twice, which is fine for a pure l-value and runs the inner
+    /// sub-expressions of `arr[bump()] += 1` twice.
     pub(super) fn resolve_compound_assign(
         &mut self,
         compound: &ast::CompoundAssignExpr,
@@ -1692,28 +1664,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         placeholder(type_id, span)
     }
 
-    /// Single TIR-level builder for every operator that dispatches to a
-    /// trait method — unary (`Neg::neg`, `BitNot::bitnot`) as well as
-    /// binary (`Eq::eq`, `Ord::cmp`, `Add::add`, …, `Shl::shl`).  Inputs
-    /// are already-resolved [`TirExpr`]s: the receiver and zero or more
-    /// argument operands matching `resolved.param_types` in order.
-    ///
-    /// The builder is the single source of truth for:
-    ///
-    /// 1. Type-checking each argument against the trait's declared
-    ///    parameter type.  Mismatches emit `TypeMismatch` and return an
-    ///    `ERROR` expression; there is no way for a caller to skip the
-    ///    check.  For `&Self` parameters the expected value type is the
-    ///    receiver's own type so newtype dispatch (base-impl method
-    ///    called through the newtype) still accepts the newtype on both
-    ///    sides.
-    /// 2. Adjusting the receiver via
-    ///    [`Self::adjust_receiver_for_self_kind`].
-    /// 3. Wrapping each argument in `&` iff the matching parameter type
-    ///    is a reference — never otherwise, so `Shl::shl(&self, rhs:
-    ///    u32)` receives the `u32` by value.
-    /// 4. Constructing the method [`TirExprKind::Call`] with the correct
-    ///    mangled name and `resolved.return_type`.
+    /// The single TIR-level builder for every operator dispatching to a trait
+    /// method, unary and binary alike, over already-resolved operands matching
+    /// `resolved.param_types` in order. It is the sole authority for four things:
+    /// type-checking each argument against the declared parameter type — with a
+    /// `&Self` parameter expecting the receiver's own type, so newtype dispatch
+    /// accepts the newtype on both sides — adjusting the receiver, wrapping an
+    /// argument in `&` iff its parameter is a reference, and building the `Call`.
     fn build_trait_op_method_call_on_resolved(
         &mut self,
         receiver: TirExpr,
@@ -1735,18 +1692,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, span);
         }
 
-        // For each argument, decide whether the trait parameter is by
-        // reference, compute the logical expected value type for the arg,
-        // and delegate to `Elaborator::typecheck` — the same helper that
-        // `resolve_method_call` uses at its own argument-typecheck tail.
-        //
-        // Using the shared primitive means operator dispatch and direct
-        // method calls apply identical `check_assignable` rules
-        // (Unknown/Error deferral, newtype propagation, reference
-        // unwrapping) and any divergence there is impossible by
-        // construction.  We no longer early-return on mismatch; errors
-        // are accumulated via the logger and compilation fails at the
-        // end, matching method-call behavior.
+        // Per argument, decide whether the parameter is by reference, compute the
+        // logical expected type, and delegate to the same `typecheck` helper
+        // `resolve_method_call` uses — so operator dispatch and a direct call
+        // apply identical `check_assignable` rules and cannot diverge. Mismatches
+        // accumulate in the logger rather than early-returning, as method calls do.
         let mut wrap_flags: Vec<bool> = Vec::with_capacity(args.len());
         for (arg, &param_ty) in args.iter().zip(resolved.param_types.iter()) {
             let wrap = matches!(

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -3237,7 +3237,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                         .collect();
                     // A generic newtype (`type MyArray<T> = List<T>`)
                     // resolves to a `Newtype` over the instantiated base,
-                    // mirroring `type_resolution.rs:418`. Without this it
+                    // mirroring `type_resolution`. Without this it
                     // falls through to `UNKNOWN`, the newtype's inherited
                     // base methods (`MyArray<i32>::len` → `List<i32>::len`)
                     // never resolve, and monomorphization can't reach them.
@@ -3397,7 +3397,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             }
             // A variadic type-pack spread `..T` resolves to a `TypePack`
             // keyed by the param's positional index, mirroring the instance
-            // resolver's `trait_ctx.type_params` lookup (type_resolution.rs:103).
+            // resolver's `trait_ctx.type_params` lookup.
             // Without this arm a `[..T]` parameter resolves its element to
             // `UNKNOWN`, so a generic tuple method (`Tuple<..T>^Eq::eq`)
             // monomorphizes against `Tuple<unknown>` and never registers at

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -1,25 +1,10 @@
-//! Multi-module resolution orchestration.
-//!
-//! Resolution runs in two phases:
-//!
-//! - [`Elaborator::annotate_modules`] collects decl-level type information
-//!   (struct field maps, variant cases, flags, newtypes, resource methods)
-//!   and interns every declaration in the shared [`TypeTable`]. It also
-//!   populates [`TypeTable::type_by_symbol`]/[`TypeTable::symbol_by_type`]
-//!   so LSP queries can resolve a [`AstId`](crate::ast::AstId) to a decl-backed type
-//!   without running TIR lowering. The output is an [`AnnotateState`] that
-//!   both `build_tir` and the LSP consume.
-//! - [`Elaborator::build_tir_from_state`] reads that state and produces one
-//!   [`TirModule`] per source module. It also extends the per-module
-//!   [`super::sem::ModuleSemantics`] entries on `state.module_semantics`
-//!   with the body-walk results (use→def edges, local symbols, local
-//!   types), and new types created during lowering (anonymous structs,
-//!   monomorphic instances) are interned through the shared
-//!   `Rc<RefCell<TypeTable>>`.
-//!
-//! This split keeps the annotate phase self-contained and cheap enough to
-//! run on every `didChange` while reusing its results for the full
-//! compilation pipeline.
+//! Multi-module resolution orchestration, in two phases.
+//! [`Elaborator::annotate_modules`] collects decl-level type information, interns
+//! every declaration in the shared [`TypeTable`], and produces the
+//! [`AnnotateState`] both the LSP and `build_tir` consume;
+//! [`Elaborator::build_tir_from_state`] reads it back for one [`TirModule`] per
+//! module, extending each `ModuleSemantics` with the body-walk results. The
+//! split keeps annotate cheap enough to run on every `didChange`.
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -47,24 +32,13 @@ use super::types::{
 use super::tysys::TypeSystem;
 
 /// Analysis state produced by [`Elaborator::annotate_modules`] and consumed by
-/// [`Elaborator::build_tir_from_state`].
-///
-/// The shared [`TypeSystem`] internals (type arena, decl maps, registries)
-/// are reference-counted so per-module elaborators can clone them cheaply.
-/// The [`TypeTable`] itself remains behind `Rc<RefCell<…>>` because lowering
-/// interns additional types (anonymous structs, monomorphic instances) into
-/// the same table.
-///
-/// Per-module semantic facts (use→def edges, local symbols, decl tables,
-/// import context) live in [`Self::module_semantics`] as a `IndexMap` of
-/// [`super::sem::ModuleSemantics`]. Each entry is owned by exactly one
-/// place at a time — the driver hands the entry to the body walk via
-/// `swap_remove` + `insert`, so no shared-mutability plumbing is needed
-/// (WEP 2026-05-26).
-///
-/// `AnnotateState` is slated to dissolve: its contents redistribute into
-/// [`super::tysys::TypeSystem`] (pipeline-wide), per-module
-/// [`super::sem::ModuleSemantics`] instances, and driver locals.
+/// [`Elaborator::build_tir_from_state`]. The [`TypeSystem`] internals are
+/// reference-counted so per-module elaborators clone them cheaply, and the
+/// [`TypeTable`] stays behind `Rc<RefCell<…>>` because lowering interns into it.
+/// Per-module facts live in [`Self::module_semantics`], each entry owned by one
+/// place at a time — the driver hands it to the body walk by `swap_remove` +
+/// `insert`, so no shared-mutability plumbing is needed. Slated to dissolve into
+/// `TypeSystem`, `ModuleSemantics`, and driver locals.
 pub(crate) struct AnnotateState {
     /// Pipeline-wide type knowledge: the type arena, decl-interned type
     /// tables, registries, included-files map, and read-only caches
@@ -85,16 +59,11 @@ pub(crate) struct AnnotateState {
     /// so a `TirModule`'s position in the result map matches the
     /// dependency order downstream phases expect.
     pub(crate) sorted_sources: Vec<ModuleSource>,
-    /// Per-module semantic facts produced by the elaborator. One entry per
-    /// loaded module. Stdlib entries are seeded from the snapshot in
-    /// [`Self::annotate_modules`]; per-compile entries are produced by the
-    /// body walk in [`Self::build_tir_from_state`].
-    ///
-    /// Replaces the previous trio of `Rc<RefCell<…>>` maps
-    /// (`references` / `local_symbols` / `local_types`) — each module's
-    /// data now lives in its own owned [`super::sem::ModuleSemantics`], so
-    /// the body walk's `&mut` access stays disjoint across modules and the
-    /// shared-mutability plumbing disappears (WEP 2026-05-26).
+    /// Per-module semantic facts, one entry per loaded module: stdlib entries
+    /// seeded from the snapshot in [`Self::annotate_modules`], the rest produced
+    /// by the body walk in [`Self::build_tir_from_state`]. Each module owns its
+    /// own [`super::sem::ModuleSemantics`], so the walk's `&mut` access stays
+    /// disjoint and needs no shared-mutability plumbing.
     pub(crate) module_semantics: IndexMap<ModuleSource, super::sem::ModuleSemantics>,
     /// Kiln invocation redirects consulted by `resolve_import` call sites
     /// when walking `use` declarations. Populated from [`crate::loader::LoadResult`].
@@ -352,18 +321,11 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             }
         }
 
-        // Newtype pre-pass: resolve every module's concrete newtypes (and
-        // record generic-newtype defs) BEFORE any struct field is resolved.
-        //
-        // Newtypes are not name-registered in the first pass (unlike structs
-        // / variants / enums), so a struct field that references a newtype
-        // defined in another module would otherwise resolve to `unknown`
-        // whenever that module is processed later in `modules` order — e.g. a
-        // user `struct Color { v: f32x4 }` resolved before `core:simd`'s
-        // `pub type f32x4 = v128` is registered. Resolving all newtypes up
-        // front removes the ordering dependency. Newtype bases reference
-        // primitives or structs (name-registered above); newtype→newtype
-        // chains across modules are resolved in dependency order by repeating
+        // Newtype pre-pass, before any struct field is resolved. Unlike structs
+        // and variants, newtypes are not name-registered in the first pass, so a
+        // field referencing one from a module processed later would resolve to
+        // `unknown`. Newtype bases name primitives or structs, already
+        // registered; a cross-module newtype→newtype chain resolves by repeating
         // to a fixpoint.
         loop {
             let mut newly_resolved = false;
@@ -1137,18 +1099,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             module_semantics.entry(ms.clone()).or_default();
         }
         if let Some(snap) = snapshot {
-            // Seed each stdlib module's per-module `types` facts from the
-            // snapshot's annotate state. The flattened `snap` maps below carry
-            // only the facts `semantics_of` drains into `Semantics`
-            // (references, local_*, expression_types, method_dispatch,
-            // coercions, desugars — all empty in `snap_state` after the drain).
-            // The rest — `function_effects`, `effect_ops`, `fn_param_types`,
-            // `fn_return_types`, `method_names`, static / operator / from / for-of
-            // dispatch, `struct_field_types`, … — live only here, and the
-            // Semantics-based effect check needs them for stdlib (callee
-            // effects and the effect→resource propagation closure). Cloning the
-            // whole `types` keeps the two sources in sync; the drained fields
-            // are then re-seeded from the flattened `snap` maps below.
+            // Seed each stdlib module's `types` facts from the snapshot. The
+            // flattened `snap` maps below carry only what `semantics_of` drained
+            // into `Semantics`; everything else — signatures, effects, the
+            // dispatch maps — lives only here, and the effect check needs it for
+            // stdlib. Cloning the whole `types` keeps both sources in sync, and
+            // the drained fields are re-seeded from `snap` afterwards.
             if let Some(snap_state) = snapshot_state {
                 for (ms, snap_sem) in &snap_state.module_semantics {
                     if let Some(sem) = module_semantics.get_mut(ms) {
@@ -1159,17 +1115,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     }
                 }
             }
-            // Snapshot keys must always reference modules in the current
-            // compile's `modules` set — the loader's implicit-modules pass
-            // pulls in the snapshot's stdlib closure on every compile. Use
-            // `get_mut` so a divergence shows up as a `debug_assert` failure
-            // rather than silently creating phantom `ModuleSemantics` entries
-            // that LSP would later flatten into `Semantics::references`.
-            // Snapshot ids route back to a per-module `ModuleSemantics` via
-            // the snapshot's `AstIdSpace → ModuleSource` registry: stdlib
-            // ASTs are parsed once per process and shared, so the snapshot's
-            // spaces are the current compile's spaces. A miss shows up as a
-            // `debug_assert` failure rather than silently dropping facts.
+            // A snapshot id routes back to a per-module `ModuleSemantics` through
+            // the snapshot's `AstIdSpace → ModuleSource` registry: stdlib ASTs
+            // are parsed once per process and shared, so its spaces are this
+            // compile's. Every key must name a module in the current `modules`
+            // set, so use `get_mut` — a miss then fails a `debug_assert` instead
+            // of dropping facts or minting a phantom entry LSP would flatten in.
             let snapshot_invariant =
                 "snapshot id must belong to a module in the current compile's loaded set";
             for (use_id, def_key) in &snap.references {
@@ -1301,16 +1252,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         }
     }
 
-    /// Run the per-module decl pass over every module, then the body walk
-    /// (populating each `ModuleSemantics` with facts), and — when
-    /// `build_tir` is set — reify each module to its final [`TirModule`].
-    /// Errors are collected in the logger; returns [`Bail`] if any module
-    /// failed.
-    ///
-    /// The LSP path passes `build_tir = false`: it needs only the recorded
-    /// facts (use→def edges, types, dispatch) and never reads TIR, so reify and
-    /// the stdlib-snapshot `TirModule` rehydration are skipped and the returned
-    /// map is empty. The batch path (and stdlib-snapshot build) passes `true`.
+    /// Run the per-module decl pass, then the body walk that populates each
+    /// `ModuleSemantics`, and — under `build_tir` — reify each module to its
+    /// [`TirModule`]. Errors collect in the logger; [`Bail`] if any module
+    /// failed. The LSP path passes `false`, needing only the recorded facts, so
+    /// reify and the snapshot rehydration are skipped and the map comes back
+    /// empty.
     pub(crate) fn build_tir_from_state(
         state: &mut AnnotateState,
         symbols: &'a SymbolTable,
@@ -1433,15 +1380,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             }
 
             // Take this module's `ModuleSemantics` out of `state` so the
-            // elaborator can own it for the body walk. The map entry was
-            // pre-populated in `annotate_modules` for every `modules.keys()`
-            // (and `sorted_sources` is derived from `modules`), so the entry
-            // is guaranteed to exist; `expect` rather than `unwrap_or_default`
-            // surfaces any future divergence between `sorted_sources` and
-            // `module_semantics.keys()` loudly. Any bindings the snapshot
-            // contributed survive in the taken instance. We seed the
-            // imports / decls populated above and reinstall the populated
-            // instance after `resolve_module` returns.
+            // elaborator owns it for the body walk, then reinstall it after
+            // `resolve_module` returns. `annotate_modules` pre-populated an
+            // entry per module, so `expect` rather than `unwrap_or_default`
+            // surfaces any divergence from `sorted_sources` loudly.
             let mut sem = state
                 .module_semantics
                 .swap_remove(module_source)
@@ -1648,16 +1590,12 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         logger.ok_or_bail(result)
     }
 
-    /// Intern every declaration (struct/enum/variant/resource) in the type
-    /// table so that `find_decl_type_by_name` returns a `TypeId` for every
-    /// declared symbol. Flags and newtypes are already interned during the
-    /// annotate second sub-pass, so this covers only the remaining four kinds.
-    ///
-    /// Generic structs with type parameters use the mangled monomorphic form
-    /// at each usage site; the base decl is interned here with the canonical
-    /// name so `register_symbol_key_type_indices` can resolve the owning
-    /// symbol. Monomorphizations created during lowering are separate
-    /// `TypeId`s and do not collide with this base entry.
+    /// Intern every struct / enum / variant / resource declaration so
+    /// `find_decl_type_by_name` answers for each declared symbol — flags and
+    /// newtypes are already interned by the annotate sub-pass. A generic
+    /// struct's base decl is interned under its canonical name, which is what
+    /// `register_symbol_key_type_indices` resolves against; the monomorphic
+    /// forms minted at each use site are separate `TypeId`s and do not collide.
     fn intern_all_decl_types(
         modules: &IndexMap<ModuleSource, Module>,
         all_struct_fields: &IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>,
@@ -1709,16 +1647,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     }
 
     /// Populate `TypeTable::type_by_symbol` / `symbol_by_type` by walking every
-    /// type-declaring symbol and looking up the `TypeId` the elaborator created
-    /// for it.
-    ///
-    /// This runs as a post-pass over the whole symbol table rather than being
-    /// instrumented at each `make_struct` / `make_enum` / ... call site: the
-    /// decl-creation sites are spread across elaborator/module.rs,
-    /// `elaborator/type_resolution.rs`, elaborator/orchestration.rs, elaborator/call.rs,
-    /// and elaborator/expr.rs, and threading a `AstId` through every one of
-    /// them would churn ~40 call sites. The symbol-table walk is O(symbols) and
-    /// touches only declarations, so the cost is negligible.
+    /// type-declaring symbol and looking up the `TypeId` minted for it. A
+    /// post-pass rather than instrumentation at each `make_*` call site: those
+    /// are spread across five elaborator modules, and threading an `AstId`
+    /// through all of them would churn ~40 sites for a walk that is O(symbols).
     fn register_symbol_key_type_indices(
         symbols: &SymbolTable,
         type_table: &Rc<RefCell<TypeTable>>,

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -2,9 +2,7 @@
 //! [`Elaborator::annotate_modules`] collects decl-level type information, interns
 //! every declaration in the shared [`TypeTable`], and produces the
 //! [`AnnotateState`] both the LSP and `build_tir` consume;
-//! [`Elaborator::build_tir_from_state`] reads it back for one [`TirModule`] per
-//! module, extending each `ModuleSemantics` with the body-walk results. The
-//! split keeps annotate cheap enough to run on every `didChange`.
+//! [`Elaborator::build_tir_from_state`] reads it back for one [`TirModule`] each.
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -35,10 +33,7 @@ use super::tysys::TypeSystem;
 /// [`Elaborator::build_tir_from_state`]. The [`TypeSystem`] internals are
 /// reference-counted so per-module elaborators clone them cheaply, and the
 /// [`TypeTable`] stays behind `Rc<RefCell<…>>` because lowering interns into it.
-/// Per-module facts live in [`Self::module_semantics`], each entry owned by one
-/// place at a time — the driver hands it to the body walk by `swap_remove` +
-/// `insert`, so no shared-mutability plumbing is needed. Slated to dissolve into
-/// `TypeSystem`, `ModuleSemantics`, and driver locals.
+/// Each [`Self::module_semantics`] entry is owned by one place at a time.
 pub(crate) struct AnnotateState {
     /// Pipeline-wide type knowledge: the type arena, decl-interned type
     /// tables, registries, included-files map, and read-only caches
@@ -1101,10 +1096,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         if let Some(snap) = snapshot {
             // Seed each stdlib module's `types` facts from the snapshot. The
             // flattened `snap` maps below carry only what `semantics_of` drained
-            // into `Semantics`; everything else — signatures, effects, the
-            // dispatch maps — lives only here, and the effect check needs it for
-            // stdlib. Cloning the whole `types` keeps both sources in sync, and
-            // the drained fields are re-seeded from `snap` afterwards.
+            // into `Semantics`; signatures, effects and the dispatch maps live
+            // only here, and the effect check needs them for stdlib. The drained
+            // fields are re-seeded from `snap` afterwards.
             if let Some(snap_state) = snapshot_state {
                 for (ms, snap_sem) in &snap_state.module_semantics {
                     if let Some(sem) = module_semantics.get_mut(ms) {
@@ -1119,8 +1113,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             // the snapshot's `AstIdSpace → ModuleSource` registry: stdlib ASTs
             // are parsed once per process and shared, so its spaces are this
             // compile's. Every key must name a module in the current `modules`
-            // set, so use `get_mut` — a miss then fails a `debug_assert` instead
-            // of dropping facts or minting a phantom entry LSP would flatten in.
+            // set, so `get_mut`'s miss fails a `debug_assert` rather than minting.
             let snapshot_invariant =
                 "snapshot id must belong to a module in the current compile's loaded set";
             for (use_id, def_key) in &snap.references {
@@ -1255,9 +1248,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// Run the per-module decl pass, then the body walk that populates each
     /// `ModuleSemantics`, and — under `build_tir` — reify each module to its
     /// [`TirModule`]. Errors collect in the logger; [`Bail`] if any module
-    /// failed. The LSP path passes `false`, needing only the recorded facts, so
-    /// reify and the snapshot rehydration are skipped and the map comes back
-    /// empty.
+    /// failed. The LSP path passes `false`, needing only the recorded facts, and
+    /// gets an empty map back.
     pub(crate) fn build_tir_from_state(
         state: &mut AnnotateState,
         symbols: &'a SymbolTable,
@@ -1592,10 +1584,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
     /// Intern every struct / enum / variant / resource declaration so
     /// `find_decl_type_by_name` answers for each declared symbol — flags and
-    /// newtypes are already interned by the annotate sub-pass. A generic
-    /// struct's base decl is interned under its canonical name, which is what
-    /// `register_symbol_key_type_indices` resolves against; the monomorphic
-    /// forms minted at each use site are separate `TypeId`s and do not collide.
+    /// newtypes are already interned by the annotate sub-pass. A generic struct's
+    /// base decl is interned under its canonical name, which
+    /// `register_symbol_key_type_indices` resolves against.
     fn intern_all_decl_types(
         modules: &IndexMap<ModuleSource, Module>,
         all_struct_fields: &IndexMap<ModuleSource, IndexMap<String, StructFieldInfo>>,

--- a/wado-compiler/src/elaborator/reify.rs
+++ b/wado-compiler/src/elaborator/reify.rs
@@ -1,63 +1,8 @@
 //! Reify — AST + [`super::sem::ModuleSemantics`] → [`crate::tir::TirModule`].
-//!
-//! Introduced by [`wep-2026-05-26-elaborator-rearchitecture.md`].
-//! The reify pass is the mechanical half of the annotate/reify split:
-//! every TIR-shaping decision is already recorded on `ModuleSemantics`
-//! during `annotate_bodies`; this walker reads those annotations and emits
-//! the corresponding TIR nodes. It never re-runs type inference, name
-//! resolution, or method dispatch.
-//!
-//! # Surface
-//!
-//! `reify_module(module, tysys, sem, …) → TirModule` mirrors
-//! [`super::Elaborator::resolve_module`]'s per-Item dispatch shape. Each
-//! `Item::*` arm calls a `reify_*` helper; decl-only items (`Enum`,
-//! `Flags`, `Newtype`, `Variant`, `Effect`, `Resource`, `Struct`) read
-//! decl-interned types from `TypeSystem.all_*` and produce TIR without
-//! consulting `TypeAnnotations`; function / impl-method / test / global
-//! bodies build a fresh [`super::types::FunctionContext`] and walk the
-//! AST via `reify_block` / `reify_stmt` / `reify_expr` / `reify_pattern`.
-//!
-//! # What reify reads
-//!
-//! - `ModuleSemantics.types.expression_types[id]` → `TirExpr::type_id`
-//! - `ModuleSemantics.types.method_dispatch[id]` → dispatch target +
-//!   `self_kind` + `is_ref_impl`
-//! - `ModuleSemantics.types.coercions[id]` → coercion wrapper to emit
-//!   around the raw expression
-//! - `ModuleSemantics.types.desugars[id]` → which expansion path to take
-//!   (assert / matches / for-of / while / compound-assign / comparison
-//!   chain / `IndexMut` method call / newtype-from collapse)
-//! - `ModuleSemantics.types.generic_instantiations[id]` → `type_args`
-//!   for call / struct / variant constructions
-//! - `ModuleSemantics.types.closure_captures[id]` → closure capture list
-//!   and `__ref_*` materialisation
-//! - `ModuleSemantics.types.assert_captures[id]` → assert slot map
-//! - `ModuleSemantics.types.for_of_iterator[id]` → for-of iterator
-//!   dispatch target
-//! - `ModuleSemantics.bindings.references` / `bindings.local_symbols` →
-//!   identifier resolution
-//! - `ModuleSemantics.imports.*` → name lookups
-//! - `ModuleSemantics.decls.*` → function return types, generic
-//!   parameter tables, anonymous-struct registry
-//!
-//! # What reify mutates
-//!
-//! Reify takes `&mut TypeSystem` because monomorphic struct / variant
-//! instances reached for the first time at reify time must intern through
-//! the shared [`crate::tir::TypeTable`]. Reify does **not** mutate
-//! `TraitEnv` or any impl tables — those are read-only inputs.
-//!
-//! # `FunctionContext` walk-order invariant
-//!
-//! Reify maintains its own [`super::types::FunctionContext`] per function
-//! body. Local indices, capture indices, and synthetic-local counters
-//! (`next_assert_id`, `next_loop_id`, the `__ref_*` ordering) must match
-//! what `annotate_bodies` produced. The contract is documented at
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`] §`Reify — mechanical`.
-//! The unit
-//! test contract: for every function `f`, the `Vec<TirLocal>` annotate
-//! emitted equals the `Vec<TirLocal>` reify emits.
+//! The mechanical half of the annotate/reify split (WEP 2026-05-26): every
+//! TIR-shaping decision is already recorded on `ModuleSemantics`, so this walker
+//! only reads them — never re-running inference, resolution, or dispatch. Its
+//! `FunctionContext` must land the same locals, at the same indices, annotate did.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -280,16 +225,11 @@ pub(crate) struct Reify<'a, H: CompilerHost> {
     /// the liveness pass found unreachable from the export boundary, which
     /// downstream phases would discard anyway. `None` reifies everything.
     pub(crate) live_items: Option<&'a IndexSet<crate::ast::AstId>>,
-    /// Active parameter-name → already-reified-argument substitutions for
-    /// the default-argument expression currently being reified. A
-    /// cross-module default is reified under the *callee's* module
-    /// perspective (so its own items resolve), but a default may reference
-    /// an earlier parameter, whose substituted value is the *caller's*
-    /// argument expression — already reified under the caller's
-    /// perspective in the surrounding call. `reify_ident` returns the
-    /// pre-reified TIR for such names instead of re-resolving the spliced
-    /// caller AST under the wrong perspective. Empty outside a default
-    /// walk. See [`Self::reify_pad_args_with_defaults`].
+    /// Active parameter-name → already-reified-argument substitutions for the
+    /// default-argument expression being reified. A default resolves under the
+    /// *callee's* perspective, but a reference to an earlier parameter is the
+    /// *caller's* argument, already reified under the caller's — so `reify_ident`
+    /// returns the pre-reified TIR instead of re-resolving the spliced AST.
     pub(crate) default_arg_overrides: IndexMap<String, TirExpr>,
     /// Active `AstId` → already-reified-`Local` substitutions for the
     /// side-effecting sub-pieces of a compound-assign target, bound once to
@@ -344,19 +284,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             .cloned()
     }
 
-    /// Construct a per-module `Reify` for the orchestration driver.
-    /// The `tysys` clone is the shallow Rc/Arc copy
-    /// [`TypeSystem`] supports; per-module state (`sem`,
-    /// `current_module_*`) is borrowed from
-    /// [`crate::elaborator::orchestration::AnnotateState`] for the
-    /// duration of the reify walk.
-    ///
-    /// `current_module_source` / `current_module_items` are
-    /// placeholders at construction time — the driver overwrites them
-    /// inside [`Self::reify_module`]. Keeping them on the struct
-    /// matches the elaborator's shape (avoids threading them through
-    /// every method signature) and keeps the walk-order invariant
-    /// tractable.
+    /// Construct a per-module `Reify` for the orchestration driver. The `tysys`
+    /// clone is the shallow one [`TypeSystem`] supports. `current_module_source`
+    /// / `current_module_items` are placeholders here — [`Self::reify_module`]
+    /// overwrites them; keeping them on the struct saves threading them through
+    /// every method signature.
     pub(crate) fn new(
         tysys: TypeSystem,
         sem: &'a ModuleSemantics,
@@ -391,19 +323,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         }
     }
 
-    // Per-element annotation accessors (`ann_*`) that honour active tuple
-    // `for-of` overlays.
-    //
-    // A tuple for-of's body is a single source sub-tree resolved once per
-    // element by annotate; to keep each element's distinct facts, annotate
-    // moved them out of the base `sem.types` maps into per-element
-    // `ElementOverlay`s (and *truncated* the base maps — so for body
-    // `AstId`s the fact lives ONLY in the overlay). Every reify read of one
-    // of those maps must therefore go through the matching `ann_*`
-    // accessor, which walks `tuple_overlay_stack` innermost-first and falls
-    // back to `sem.types`. Outside a tuple for-of the stack is empty and
-    // the accessor is just the base-map lookup. The macro keeps the 14-map
-    // list in one place, mirroring `TypeAnnotations::split_off_overlay`.
+    // Annotation accessors that honour active tuple `for-of` overlays. A tuple
+    // for-of body is resolved once per element, and annotate moved each
+    // element's facts out of the base `sem.types` maps into an `ElementOverlay`,
+    // truncating the base — so every read of one of these maps must go through
+    // its `ann_*` accessor, which walks the overlay stack innermost-first.
     reify_annotation_accessors! {
         ann_local_type => local_types: crate::tir::TypeId,
         ann_let_annotated_type => let_annotated_types: crate::tir::TypeId,
@@ -445,17 +369,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         }
     }
 
-    // Decl/signature facts the combined walk records once per decl (the
-    // single source of truth), read straight from `sem.types` with no overlay
-    // walk:
-    //   - `method_impl_type_params`: the impl-type-param scheme
-    //     `resolve_method` recorded per impl-method `AstId`.
-    //   - `fn_param_types` / `fn_return_types`: a function/method's resolved
-    //     param types (declaration order, receiver included) and
-    //     post-async-erasure return type.
-    //   - `effect_ops`: an effect/resource decl's resolved op signatures.
-    //   - `decl_type_params`: TIR type params per decl (function, method,
-    //     struct, variant), defaults resolved with the scope alive.
+    // Decl/signature facts the combined walk records once per decl, read
+    // straight from `sem.types` with no overlay walk.
     reify_annotation_accessors! {
         base {
             ann_method_impl_type_params => method_impl_type_params: Vec<crate::tir::TirTypeParam>,
@@ -630,22 +545,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         }
     }
 
-    /// Reify one module: emit a [`TirModule`] from the AST + the
-    /// `ModuleSemantics` `annotate_bodies` populated.
-    ///
-    /// The flow mirrors [`super::Elaborator::resolve_module`] item by
-    /// item; only the per-Item dispatch shape is reproduced here, the
-    /// body of each branch is delegated to a `reify_*` helper.
-    /// True when liveness gating is active and `(module, id)` is a
-    /// user-authored free function unreachable from the export boundary. Skips
-    /// dead free functions so they never reach monomorphization (WEP
-    /// 2026-05-16, reify gating). Globals are intentionally not gated here.
-    ///
-    /// Only user-authored modules are gated. Stdlib functions can be reached
-    /// solely through compiler synthesis (e.g. `memory_to_gc_string` from CM
-    /// bindings), which the source-level call graph cannot see; gating them
-    /// would drop a live function and trap WIR build. The optimize-time DCE
-    /// removes their dead ones instead.
+    /// True when liveness gating is active and `(module, id)` is a user-authored
+    /// free function unreachable from the export boundary, so it never reaches
+    /// monomorphization. Only user-authored modules are gated: a stdlib function
+    /// can be reached by compiler synthesis alone, which the source-level call
+    /// graph cannot see, so optimize-time DCE removes the dead ones instead.
     fn is_dead_item(&self, module: &ModuleSource, id: crate::ast::AstId) -> bool {
         super::liveness::is_user_authored(module)
             && self.live_items.is_some_and(|live| !live.contains(&id))
@@ -1354,22 +1258,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         })
     }
 
-    /// Reify every method on an `impl` block. Reads the impl-block
-    /// resolution facts annotate recorded
-    /// (`sem.types.impl_facts[impl_block.id]`) and threads
-    /// them into [`Self::reify_method`] per AST `Function`.
+    /// Reify every method on an `impl` block, threading
+    /// `sem.types.impl_facts[impl_block.id]` into [`Self::reify_method`].
     ///
-    /// Synthesis-request impls (`impl Trait for Type;`) emit no
-    /// methods — the request itself lives on
-    /// `sem.decls.pending_synthesis_requests` and is forwarded to
-    /// `TirModule::synthesis_requests` at [`Self::reify_module`].
-    ///
-    /// Default-method synthesis is also out of scope here: the
-    /// synthesised `TirFunction`s live on
-    /// `sem.decls.pending_default_methods` and forward through the
-    /// per-module path. This keeps the responsibility split clean
-    /// (per-impl-block code in `reify_impl`, per-module aggregation
-    /// in `reify_module`).
+    /// Synthesis requests and default-method synthesis are out of scope here:
+    /// both live on `sem.decls` and are aggregated by [`Self::reify_module`].
     fn reify_impl(&mut self, impl_block: &ast::ImplBlock) -> Vec<TirFunction> {
         if impl_block.is_synthesize_request {
             return Vec::new();
@@ -1395,24 +1288,12 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             .collect()
     }
 
-    /// Synthesise the trait default-method `TirFunction`s for `impl_block`.
-    ///
-    /// Mirrors the combined walk's default-method loop in
-    /// `elaborator.rs`'s `Item::Impl` arm: for each default method on the
-    /// impl's trait that the impl does not override, build a `TirFunction`
-    /// keyed `Struct^Trait::method`. Reify reads the per-impl body-walk
-    /// facts from `sem.default_method_semantics[(impl_block.id,
-    /// default_method.id)]` (recorded by the combined walk) — each entry
-    /// is a full `ModuleSemantics` cloned with the trait module's facts in
-    /// its `types` / `bindings` and the impl module's `decls` / `imports`
-    /// so [`Self::reify_method`] sees both.
-    ///
-    /// The swap pattern is identical to
-    /// [`Self::with_const_module_perspective`]: `self.sem`,
-    /// `self.current_module_source`, and `self.current_module_items` are
-    /// replaced with the trait module's view for the duration of the body
-    /// walk so the `ann_*` accessors' `AstId`s name the trait module
-    /// (where the facts were keyed).
+    /// Synthesise a `Struct^Trait::method` `TirFunction` for each default method
+    /// the impl does not override, reading the body-walk facts from
+    /// `sem.default_method_semantics[(impl_block.id, default_method.id)]`. The
+    /// module perspective is swapped to the trait module for the walk — same
+    /// pattern as [`Self::with_const_module_perspective`] — since the facts are
+    /// keyed by `AstId`s that name it.
     fn reify_impl_default_methods(&mut self, impl_block: &ast::ImplBlock) -> Vec<TirFunction> {
         use crate::name::MethodName;
 
@@ -1549,19 +1430,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                  impl method reify emits",
             );
 
-        // Type-param scope for resolving the method's own param/return
-        // types. Every impl-self-type arg occupies its positional slot —
-        // including concrete / known-named args (`String` in
-        // `TreeMap<String, V>`) — exactly as the elaborator's
-        // `resolve_method` registers them (item.rs). They are NOT excluded:
-        // doing so was a reify-only divergence that disagreed with the
-        // battle-tested original path; the elaborator treats such an arg as a
-        // positional param and monomorph substitutes it back to the concrete
-        // type by identity. Method-level params continue after the impl param
-        // count, matching `resolve_method`'s `next_idx = impl_type_params.len()`
-        // — the same base the monomorphizer uses
-        // (`impl_type_params.len() + param.index` in
-        // `func_inst::instantiate_function`).
+        // Type-param scope for the method's own param/return types. Every
+        // impl-self-type arg occupies its positional slot, concrete ones
+        // (`String` in `TreeMap<String, V>`) included — monomorph substitutes
+        // those back by identity. Method-level params continue after the impl
+        // param count, the same base `func_inst::instantiate_function` uses.
         let mut type_param_names: Vec<String> = Vec::new();
         for p in &impl_type_params {
             let idx = p.index as usize;
@@ -2588,19 +2461,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 if let Some(tir) = self.try_reify_int128_cast(cast, target_type, ctx) {
                     return tir;
                 }
-                // `expr as Ty` — emit `Cast` with the recorded target
-                // type. Numeric vs newtype-cast handling is downstream;
-                // reify just produces the shape.
-                //
-                // Re-type a numeric-literal operand (possibly negated) to
-                // the cast's target width. annotate propagates the target
-                // type to a *direct* literal cast operand (`9e15 as i64`
-                // types the literal `i64`) but not through a `Neg`
-                // (`-9e15 as i64` leaves the inner literal `i32`), so at
-                // codegen an `i32.const` truncates a value > `i32::MAX`
-                // (`2^53 mod 2^32 == 0`) before the cast widens it. Mirror
-                // the production resolver, which types the operand at the
-                // target width in this position.
+                // `expr as Ty` — emit `Cast` with the recorded target type, and
+                // re-type a numeric-literal operand to the target width.
+                // annotate propagates the target to a *direct* literal operand
+                // but not through a `Neg`, so `-9e15 as i64` would otherwise
+                // emit an `i32.const` that truncates before the cast widens.
                 let target_is_int = self.tysys.type_table.borrow().is_integer(target_type);
                 let is_number_lit = |e: &ast::Expr| matches!(e, ast::Expr::Literal(l) if matches!(l.value, ast::Literal::Number(_)));
                 let inner = if target_is_int && is_number_lit(&cast.expr) {
@@ -3348,20 +3213,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         )]
     }
 
-    /// Reify a `for x of expr { body }` loop. Reads the
-    /// `DesugarKind` tag (`ForOfTuple` / `ForOfVariadic` /
-    /// `ForOfIterator`) annotate placed on `for_of.id` to pick the
-    /// expansion path.
-    ///
-    /// - `ForOfIterator` consumes the
-    ///   `for_of_iterator` record and emits
-    ///   `match next() { Some(v) => body, _ => break }`.
-    /// - `ForOfTuple` compile-time-unrolls into per-element
-    ///   labelled blocks (mirrors `resolve_tuple_for_of`),
-    ///   handling the `.enumerate()` unwrap.
-    /// - `ForOfVariadic` emits a deferred `VariadicForOf` TIR
-    ///   node the monomorphizer expands after `TypePack`
-    ///   substitution.
+    /// Reify a `for x of expr { body }` loop, picking the expansion path from
+    /// the `DesugarKind` tag on `for_of.id`: `ForOfIterator` emits
+    /// `match next() { Some(v) => body, _ => break }`, `ForOfTuple`
+    /// compile-time-unrolls into per-element labelled blocks, and
+    /// `ForOfVariadic` defers to the monomorphizer via a `VariadicForOf` node.
     fn reify_for_of(&mut self, for_of: &ast::ForOfStmt, ctx: &mut FunctionContext) -> Vec<TirStmt> {
         use crate::tir::{TirExprKind, TirStmtKind, TypeTable};
 
@@ -4233,19 +4089,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             .unwrap_or_default()
     }
 
-    /// Reify a let-chain (`if let PAT = e [&& BOOL]* { … }`) into
-    /// nested Match / If stmts. Mirrors
-    /// `Elaborator::resolve_let_chain_stmts` (stmt.rs:1099+).
-    /// Shared by the `LetChain` branches of `reify_if_expr`,
-    /// `reify_if_stmt`, and `reify_while`.
-    ///
-    /// Each `Let` element becomes a two-arm Match: the recorded
-    /// pattern arm continues the chain via recursion, the
-    /// wildcard arm falls back to the chain's `else_block`. Each
-    /// `Expr` element becomes a single-branch `If` whose body is
-    /// the recursive continuation. The recursion terminates at
-    /// an empty element list, where the `then_block` is reified
-    /// directly.
+    /// Reify a let-chain (`if let PAT = e [&& BOOL]* { … }`) into nested Match /
+    /// If stmts, shared by `reify_if_expr` / `reify_if_stmt` / `reify_while`.
+    /// A `Let` element becomes a two-arm Match (pattern arm recurses, wildcard
+    /// falls back to `else_block`), an `Expr` element a single-branch `If`; the
+    /// recursion bottoms out on the empty list by reifying `then_block`.
     fn reify_let_chain_stmts(
         &mut self,
         elements: &[ast::ConditionElement],
@@ -4487,18 +4335,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         expected_type: Option<TypeId>,
         recorded_type: TypeId,
     ) -> TirExpr {
-        // When no expected type propagated from the use site (e.g. an
-        // unannotated `let x = if cond { Option::Some(v) } else { null };`),
-        // fall back to the if-expression's own already-unified `recorded_type`
-        // (computed by `Elaborator::resolve_if_expr`'s branch-agreement logic,
-        // expr.rs:1829-1858) so a bare `null` branch reifies with a concrete
-        // `Option<T>` type instead of `UNKNOWN` (`ann_expression_types`,
-        // reify.rs:317-329, discards UNKNOWN-containing recorded types and
-        // falls back to `expected_type` — which was `None` here without this).
-        // An inconsistency between the `If` node's own type and an untyped
-        // branch produces invalid Wasm at codegen (mismatched block/branch
-        // types). Mirrors the same fallback already used for labeled-block
-        // break values (reify.rs:2374-2381, `LabeledBlockTarget`).
+        // With no expected type from the use site (`let x = if c { Some(v) }
+        // else { null };`), fall back to the if-expression's own unified
+        // `recorded_type` so the bare `null` branch reifies as `Option<T>`
+        // rather than UNKNOWN — a branch type disagreeing with the `If` node's
+        // own produces invalid Wasm. Same fallback as `LabeledBlockTarget`.
         let branch_expected = expected_type.or(Some(recorded_type));
         let cond_expr = match &if_expr.condition {
             ast::Condition::Expr(e) => e,
@@ -4748,16 +4589,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         )
     }
 
-    /// Reify a template string `"…{expr}…"`. Mirrors
-    /// `Elaborator::resolve_template_string` (template.rs:16+):
-    /// - Constant fast path: no interpolations → concatenate the
-    ///   string parts at reify time and emit a `StringLiteral`.
-    /// - Single-`String`-typed interpolation with no format spec →
-    ///   forward the resolved expression unchanged.
-    /// - General case: build a `Vec<TirTemplatePart>` where each
-    ///   `Interpolation` part carries an optional
-    ///   [`crate::tir::TemplateFormatSpec`] parsed by
-    ///   [`super::template::parse_format_spec`].
+    /// Reify a template string `"…{expr}…"`: no interpolations concatenates to a
+    /// `StringLiteral` at reify time, a lone `String` interpolation with no
+    /// format spec forwards its expression unchanged, and everything else builds
+    /// `Vec<TirTemplatePart>` with specs from
+    /// [`super::template::parse_format_spec`].
     fn reify_template_string(
         &mut self,
         template: &ast::TemplateStringExpr,
@@ -5363,15 +5199,10 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     }
 
     /// Reify a compound assignment `x += y` as `x = x op y`, evaluating each
-    /// target sub-expression once: impure value operands are bound to `let
-    /// __caN` and replayed through an `AstId` override while the place skeleton
-    /// stays inline and writes back. Pure targets bind nothing.
-    ///
-    /// Residual: an intermediate `Index` read in a nested index's *receiver*
-    /// (`m.index(i)` in `m[i][j] += 1`) is still duplicated — harmless for pure
-    /// builtin reads, but a side-effecting custom `Index::index` runs twice.
-    /// Binding the reference can't fix it under value semantics (the `let`
-    /// would copy the referent) and there is no `IndexMut` to borrow.
+    /// target sub-expression once: impure value operands bind to `let __caN`
+    /// while the place skeleton stays inline. Residual: a nested index's
+    /// receiver (`m.index(i)` in `m[i][j] += 1`) is still duplicated, so a
+    /// side-effecting custom `Index::index` runs twice.
     fn reify_compound_assign(
         &mut self,
         compound: &ast::CompoundAssignExpr,
@@ -5485,16 +5316,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         self.wrap_prelude(prelude, write, span)
     }
 
-    /// Reify the `?` postfix operator. The elaborator desugars
-    /// `expr?` based on the operand's type:
-    /// - `Option<T>`: `match expr { Some(v) => v, None => return null }`
-    /// - `Result<T, E>`: `match expr { Ok(v) => v, Err(e) =>
-    ///   return Err(From::from(e)) }`
-    ///
-    /// The annotate-side validation (operand is `Option` / `Result`,
-    /// function return type is compatible) has already fired, so
-    /// reify trusts the recorded shape and produces the matching
-    /// `Match` TIR.
+    /// Reify the `?` postfix operator into the `Match` its operand type calls
+    /// for: `match expr { Some(v) => v, None => return null }` for `Option<T>`,
+    /// `match expr { Ok(v) => v, Err(e) => return Err(From::from(e)) }` for
+    /// `Result<T, E>`. Annotate has already validated both the operand and the
+    /// function's return type.
     fn reify_question_mark(
         &mut self,
         qm: &ast::TryOpExpr,
@@ -5761,17 +5587,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         )
     }
 
-    /// Reify a comparison chain `a < b < c …`. Mirrors
-    /// `Elaborator::desugar_comparison_chain` (operators.rs:1313+):
-    /// each middle term `m_k` binds to a `__m{k}` local so it is
-    /// not re-evaluated, and the chain reduces to
-    /// `(a < m_0) && (m_0 < m_1) && … && (m_{n-1} < tail)` wrapped
-    /// in a block that holds the `__mK` bindings.
-    ///
-    /// Primitive comparisons emit `TirExprKind::Binary` directly;
-    /// non-primitive operands dispatch through the `operator_dispatch`
-    /// record annotate left on the chain's own `AstId` (the synthesised
-    /// inner comparisons have no source id of their own).
+    /// Reify a comparison chain `a < b < c …` into
+    /// `(a < m_0) && (m_0 < m_1) && …` inside a block holding one `__mK` binding
+    /// per middle term, so no term is re-evaluated. Non-primitive operands
+    /// dispatch through the `operator_dispatch` record on the chain's own
+    /// `AstId` — the synthesised inner comparisons have no source id.
     fn reify_comparison_chain(
         &mut self,
         chain: &ast::ComparisonChainExpr,
@@ -5986,18 +5806,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         )
     }
 
-    /// Reify an `expr[idx]` index expression.
-    ///
-    /// Three shapes per `Elaborator::resolve_index` (expr.rs:1659+):
-    /// - Tuple constant index → `TirExprKind::FieldAccess` with the
-    ///   constant index as `field_index` / `field_name`.
-    /// - `Index` trait dispatch → `*receiver.index(idx)` wrapped in
-    ///   `Unary { Deref }`; the `operator_dispatch[index.id]` record
-    ///   carries the dispatch target. The `Ref(Output)`
-    ///   `return_type` on the record is the signal that the outer
-    ///   `Deref` wrap is needed.
-    /// - `IndexValue` trait dispatch → `receiver.index_value(idx)`
-    ///   returns the value by copy; no outer wrap.
+    /// Reify an `expr[idx]` index expression into one of three shapes: a tuple
+    /// constant index becomes a `FieldAccess`, an `Index` dispatch becomes
+    /// `*receiver.index(idx)` (the record's `Ref(Output)` return type is what
+    /// signals the `Deref` wrap), and an `IndexValue` dispatch becomes
+    /// `receiver.index_value(idx)` with no wrap.
     fn reify_index(
         &mut self,
         index: &ast::IndexExpr,
@@ -6083,20 +5896,12 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         TirExpr::new(TirExprKind::Unit, TypeTable::ERROR, index.span)
     }
 
-    /// Reify a closure expression. The
-    /// `sem.types.closure_captures[closure.id]` record carries the
-    /// capture-analysis result annotate computed:
-    /// - `mut_captures`: outer mut-locals to materialise as
-    ///   `let __ref_v = &mut v;` before the closure body opens, in
-    ///   declaration order.
-    /// - `captures`: the closure's final capture list (name +
-    ///   outer-index + type + mut flag).
-    /// - `is_mutating`: drives the `fn mut(...)` vs `fn(...)` tag on
-    ///   the closure type.
-    ///
-    /// Mirror `Elaborator::resolve_closure` (closure.rs:127+) step
-    /// by step so the walk-order invariant lands the same locals at the
-    /// same indices.
+    /// Reify a closure expression from the capture analysis in
+    /// `sem.types.closure_captures[closure.id]`: `mut_captures` materialise as
+    /// `let __ref_v = &mut v;` ahead of the body in declaration order,
+    /// `captures` is the final capture list, and `is_mutating` picks
+    /// `fn mut(…)` over `fn(…)`. Follows `resolve_closure` step by step so the
+    /// walk-order invariant holds.
     fn reify_closure(
         &mut self,
         closure: &ast::ClosureExpr,
@@ -6163,20 +5968,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             FunctionContext::new_closure(TypeTable::UNKNOWN, ctx, &self.tysys.type_table);
         closure_ctx.deref_overrides = deref_overrides;
 
-        // Step 3: add closure parameters. Param types come from the
-        // AST (resolved via the outer scope's type-param view); if
-        // the expected fn type is available, prefer its param types
-        // for cases where the closure has no explicit annotation.
-        // Peel newtypes so a closure coerced to a `type Reducer = fn(..)`
-        // newtype still sees the underlying function signature; otherwise
-        // unannotated closure params (`|a, b| ...`) resolve to UNKNOWN and
-        // the functor signature diverges from the call site, leaving the
-        // `__call` method unreachable. Mirrors production's coercion-aware
-        // param inference.
-        // Closure param types come from `local_types`, which
-        // `resolve_closure` populated via `record_local_symbol(p.id, …,
-        // type_id)`. Reify is a pure read; the prior fallback over
-        // `resolve_type(ty)` + the expected-fn-type peeling is gone.
+        // Step 3: add closure parameters. Their types come from `local_types`,
+        // which `resolve_closure` populated per param `AstId` — reify is a pure
+        // read here. The expected fn type is still peeled through newtypes so a
+        // closure coerced to `type Reducer = fn(..)` sees the underlying
+        // signature.
         let expected_fn_type = expected_type.map(|t| {
             let table = self.tysys.type_table.borrow();
             table.get_ultimate_base_type(table.peel_refs(t))
@@ -6316,19 +6112,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         )
     }
 
-    /// Synthesise a `<TargetType>::from(<value>)` call for the `?`
-    /// operator's error-conversion path. Mirrors
-    /// `Elaborator::resolve_from_call` (expr.rs:4263+): builds a
-    /// mangled `__<Target>__From<From>__from` method name with the
-    /// `LocalMethodName` carrying the canonical From-impl
-    /// Reify a tuple-to-sequence coercion (`[1, 2, 3]: List<i32>`).
-    /// Mirrors `try_coerce_tuple_to_sequence_inner`'s desugar block
-    /// shape (`__seq_lit: { let __b = Builder::new_literal(N); __b.push_literal(...); ...; break __seq_lit: __b.build(); }`).
-    /// The walk-order invariant keeps the `__b` local at the same
-    /// `FunctionContext` index reify reserves for it.
     /// True when `type_id` is a `TypePack` or a tuple whose elements
-    /// transitively contain a `TypePack`. Mirrors
-    /// `Elaborator::type_contains_pack` (expr.rs:3752).
+    /// transitively contain one.
     fn type_contains_pack(&self, type_id: TypeId) -> bool {
         use crate::tir::{ResolvedType, TypeTable};
         let ty = self.tysys.type_table.borrow().get(type_id).clone();
@@ -6376,19 +6161,12 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         }
     }
 
-    /// Reify a tuple literal, handling spread elements (`[..rest, b]`,
-    /// `[a, ..middle, b]`). Mirrors `Elaborator::resolve_tuple_literal`
-    /// (expr.rs:3768): the tuple `TypeId` is built bottom-up from the
-    /// resolved element types via `make_tuple` so a nested tuple's element
-    /// type is the identical interned id as the inner literal's own type
-    /// (avoiding the `nir/sroa` `TypeId`-identity divergence at `-O2`).
-    /// Spread elements expand per `type_contains_pack`:
-    /// - a direct `TypePack` → `TypePackExpansion`,
-    /// - a mapped pack (`..F::method()`, pack-independent return) → the same,
-    ///   with the plain pack driving the per-element rewrite,
-    /// - a tuple containing a pack → `TupleSpread` (monomorphize expands),
-    /// - a concrete tuple → inline `FieldAccess` per element (binding
-    ///   non-trivial spread operands to a `__spread_N` temporary).
+    /// Reify a tuple literal, handling spread elements. The tuple `TypeId` is
+    /// built bottom-up via `make_tuple` so a nested tuple's element type is the
+    /// same interned id as the inner literal's, which `nir/sroa` relies on at
+    /// `-O2`. A spread expands per `type_contains_pack`: a pack (direct or
+    /// mapped) to `TypePackExpansion`, a tuple containing one to `TupleSpread`,
+    /// and a concrete tuple to inline per-element `FieldAccess`.
     fn reify_tuple_literal(
         &mut self,
         tuple_lit: &ast::TupleLiteralExpr,
@@ -7387,18 +7165,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         )
     }
 
-    /// Reify a `StaticMethodCallExpr` (AST shape:
-    /// `Type::method(args)` with the type parsed as a `Type` node
-    /// rather than a `Call { callee: Ident("Type::method") }`).
-    /// Used for fully-qualified static method calls like
-    /// `Stream<u8>::new()` where the target carries type args.
-    ///
-    /// Reify follows the same shape as the qualified-callee
-    /// branch of `reify_call`: resolve the target type, derive the
-    /// impl module from the resolved struct's `module_source`,
-    /// build the mangled `__Type__method` `FunctionRef`. Type
-    /// args come from the call's turbofish, else from the
-    /// `generic_instantiations` record.
+    /// Reify a `StaticMethodCallExpr` — a fully-qualified static call like
+    /// `Stream<u8>::new()`, whose target parses as a `Type` node rather than an
+    /// `Ident` callee. Same shape as `reify_call`'s qualified-callee branch:
+    /// resolve the target type, take the impl module from the resolved struct,
+    /// and build the mangled `__Type__method` `FunctionRef`.
     fn reify_static_method_call(
         &mut self,
         static_call: &ast::StaticMethodCallExpr,
@@ -7634,17 +7405,10 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             });
         }
 
-        // A default expression otherwise resolves in the *callee's*
-        // lexical scope: it may reference items private to the callee
-        // module that the caller cannot see (`paint(c = DEFAULT_VALUE)`
-        // where `DEFAULT_VALUE` is a callee-module-private global).
-        // Production routes this through `default_scope_module`, consulted
-        // during ident resolution (expr.rs:914). Reify reads recorded
-        // facts keyed by `AstId` from `self.sem`, so swap the module
-        // triple to the callee around the default walk when the callee is
-        // a different, loaded module. The caller's `ctx` (locals) stays so
-        // any earlier-param substitutions resolved above keep their
-        // bindings.
+        // A default expression otherwise resolves in the *callee's* lexical
+        // scope and may name items the caller cannot see, so swap the module
+        // triple to the callee around the walk. The caller's `ctx` stays, so
+        // earlier-param substitutions keep their bindings.
         let loaded = self.loaded_modules;
         let all_sem = self.all_module_semantics;
         let callee_ctx: Option<(&[Item], &ModuleSemantics)> =
@@ -7828,16 +7592,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         // impl lookup, mangled-name construction, or monomorph-info
         // shaping (none of which are tractable from the AST alone).
         if let Some(dispatch) = self.ann_static_method_dispatch(call.id) {
-            // Forward per-argument expected types for closure args that have
-            // an unannotated param, so `|a, b| ...` coerced to a `fn`-typed
-            // (or `fn`-newtype) param infers its params; otherwise the
-            // closure's params stay UNKNOWN and its functor `__call` is
-            // generated with `unknown` param types and dropped before codegen.
-            // Restricted to unannotated-param closures so we never override the
-            // body-inferred effects of an effect-polymorphic closure (an
-            // expected `fn() with E` whose `E` is a generic effect param would
-            // otherwise pin `declared_effects` to the param instead of the
-            // closure's actual effects).
+            // Forward per-argument expected types to closure args with an
+            // unannotated param, or their params stay UNKNOWN and the functor's
+            // `__call` is dropped before codegen. Restricted to those closures
+            // so an effect-polymorphic one keeps its body-inferred effects
+            // instead of being pinned to a generic effect param.
             let call_param_types = self.ann_call_param_types(call.id);
             let mut arg_exprs: Vec<CallArg> = call
                 .args
@@ -8304,21 +8063,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         TirExpr::new(TirExprKind::Unit, crate::tir::TypeTable::ERROR, span)
     }
 
-    /// Reify the `container[i].method(args)` `IndexMut` rewrite. Mirrors
-    /// `Elaborator::try_resolve_index_mut_method_call`
-    /// (`method_lookup.rs:3390`+).
-    ///
-    /// Two dispatch records drive the shape:
-    /// - The inner `IndexMut::index_mut(idx)` call lives on
-    ///   `sem.types.operator_dispatch[index_expr.id]`, recorded
-    ///   alongside the desugar tag.
-    /// - The outer method call's dispatch lives on
-    ///   `sem.types.method_dispatch[method_call.id]`.
-    ///
-    /// Reify reads both, reifies the container + index, builds
-    /// `container.index_mut(idx)`, then adjusts the receiver via
-    /// the outer dispatch's `self_kind` / `is_ref_impl` and emits
-    /// the outer method-call TIR.
+    /// Reify the `container[i].method(args)` `IndexMut` rewrite from two
+    /// dispatch records: `operator_dispatch[index_expr.id]` for the inner
+    /// `index_mut(idx)` and `method_dispatch[method_call.id]` for the outer
+    /// call. Builds `container.index_mut(idx)`, then adjusts the receiver by
+    /// the outer dispatch's `self_kind` / `is_ref_impl`.
     fn reify_index_mut_method_call(
         &mut self,
         method_call: &ast::MethodCallExpr,
@@ -8402,19 +8151,12 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         )
     }
 
-    /// Reify a `MethodCallExpr`. Every decision — the resolved
-    /// `FunctionRef`, the receiver-adjustment kind, the ref-impl flag, the
-    /// expression's final type — is already on `sem.types`
-    /// (`method_dispatch`, `expression_types`). Reify reads them and emits
-    /// the same TIR shape
-    /// `Elaborator::resolve_method_call_with` produced, sharing the
-    /// receiver-adjustment helper
-    /// [`super::Elaborator::adjust_receiver_for_self_kind_static`].
-    ///
-    /// The `IndexMutMethodCall` desugar routes through here too: when
-    /// `sem.types.desugars[id] == IndexMutMethodCall`, the receiver is an
-    /// `IndexExpr` and reify materialises the `__index_mut_val` local
-    /// before dispatching the method.
+    /// Reify a `MethodCallExpr`. Every decision — resolved `FunctionRef`,
+    /// receiver-adjustment kind, ref-impl flag, final type — is already on
+    /// `sem.types`; receiver adjustment shares
+    /// [`super::Elaborator::adjust_receiver_for_self_kind_static`]. An
+    /// `IndexMutMethodCall` desugar routes through here too, materialising
+    /// `__index_mut_val` before the dispatch.
     fn reify_method_call(
         &mut self,
         method_call: &ast::MethodCallExpr,
@@ -8684,19 +8426,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         )
     }
 
-    /// Resolve a struct field name to its `(index, name)` pair via
-    /// the resolved struct type. Tuple-struct projections (`t.0`)
-    /// resolve through the tuple element index. Returns `(0, name)` on
-    /// lookup failure so reify doesn't panic on a type the dispatch
-    /// hasn't ported yet — the produced TIR is wrong, but downstream
-    /// validation flags it loudly.
-    /// Resolve a field access to its `(index, canonical_name,
-    /// field_type)` against the receiver's struct decl. The field type is
-    /// generic-substituted with the receiver's `type_args` and is the
-    /// authoritative source for the access's `TirExpr::type_id` — unlike
-    /// `expression_types[field.id]`, which collides across template
-    /// sub-parsers. `None` for the type means the receiver was not a known
-    /// struct; the caller falls back to the recorded type.
+    /// Resolve a field access to `(index, canonical_name, field_type)` against
+    /// the receiver's struct decl. The field type is generic-substituted with
+    /// the receiver's `type_args` and is the authoritative source for the
+    /// access's `TirExpr::type_id` — unlike `expression_types[field.id]`, which
+    /// collides across template sub-parsers. `None` means an unknown receiver.
     fn lookup_struct_field_index(
         &self,
         receiver_type: TypeId,
@@ -8790,16 +8524,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         (idx, canonical, Some(field_type))
     }
 
-    /// Run `body` with reify's module perspective (`current_module_source`
-    /// / `current_module_items` / `sem`) swapped to `module` when it is a
-    /// different, loaded module, restoring the originals afterward. Used to
-    /// reify an AST fragment that belongs to another module (e.g. an
-    /// associated constant's body): the `ann_*` accessors key on
-    /// `current_module_source`, so swapping it makes their `AstId`
-    /// lookups hit that module's `ModuleSemantics` rather than the use
-    /// site's. Same mechanism the default-argument path uses inline
-    /// (cross-module AST reify). A no-op when `module` is the current module
-    /// or is not loaded.
+    /// Run `body` with reify's module perspective swapped to `module`, restoring
+    /// it afterward. Reifying an AST fragment from another module (an associated
+    /// constant's body, say) needs this because the `ann_*` accessors key on
+    /// `current_module_source`. A no-op when `module` is the current one or is
+    /// not loaded.
     fn with_const_module_perspective<R>(
         &mut self,
         module: &ModuleSource,
@@ -8983,17 +8712,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             );
         }
 
-        // 3b. Current-module global declared in the module AST but absent
-        //     from `current_module_globals`. This happens when reify is
-        //     walking a *swapped-in* callee module (a default-argument
-        //     expression resolved in the callee's scope) whose
-        //     `ModuleSemantics` came from the stdlib snapshot, which does
-        //     not rehydrate `current_module_globals`. The module's AST
-        //     items are available (the swap sets `current_module_items`),
-        //     so resolve the global from there — mirroring production's
-        //     `resolve_ident_in_fallback_module` (expr.rs:936). Without this
-        //     a callee-module global default (e.g. `Z_DEFAULT_COMPRESSION`)
-        //     resolves to `()` and the call lowers to an invalid module.
+        // 3b. Current-module global declared in the AST but absent from
+        //     `current_module_globals` — the case when reify walks a swapped-in
+        //     callee module whose `ModuleSemantics` came from the stdlib
+        //     snapshot, which does not rehydrate that map. Resolve it from
+        //     `current_module_items`; otherwise it lowers to `()`.
         if let Some(global_decl) = self
             .current_module_items
             .iter()
@@ -9252,17 +8975,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         TirExpr::new(TirExprKind::Unit, crate::tir::TypeTable::ERROR, ident.span)
     }
 
-    /// Reify a literal expression into its TIR shape. The recorded
-    /// `TypeId` from `sem.types.expression_types` carries the final
-    /// numeric type (e.g. an `i32` literal coerced to `i64` is recorded
-    /// as `i64`), so this helper does not re-run literal-type defaulting.
-    /// Replay an `i128` / `u128` numeric-literal coercion recorded by
-    /// annotate (`coercion::try_coerce_numeric_literal`). Returns `None`
-    /// for every other shape so the caller falls through to the normal
-    /// walk. The 128-bit types are prelude structs, so the coerced value
-    /// is materialized by a `from_u64` / `from_i64` / `from_pair` call
-    /// rather than a bare literal; all other `NumericLiteral` coercions
-    /// are free (the literal already carries the coerced type).
+    /// Replay an `i128` / `u128` numeric-literal coercion recorded by annotate,
+    /// returning `None` for every other shape. The 128-bit types are prelude
+    /// structs, so the value is materialized by a `from_u64` / `from_i64` /
+    /// `from_pair` call; every other `NumericLiteral` coercion is free, the
+    /// literal already carrying its coerced type.
     fn try_reify_int128_coercion(&self, expr: &ast::Expr) -> Option<TirExpr> {
         let choice = self.ann_coercions(expr.id())?;
         if choice.kind != super::sem::types::CoercionKind::NumericLiteral {
@@ -9633,22 +9350,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         use crate::tir::{TirExprKind, TypeTable};
         let kind = match &lit.value {
             ast::Literal::Number(repr) => {
-                // Parse the literal value with the shared `util` helpers
-                // (which handle digit separators, scientific notation, and
-                // hex/oct/bin radix) rather than a hand-rolled decoder.
-                // The *recorded type* decides whether to emit an Int or a
-                // Float TIR literal; the literal's *syntactic form*
-                // (`is_float_only_literal`) decides how to read its value.
-                // A radix/scientific int literal coerced to a float target
-                // (`let x: f64 = 0xFF` / `1e2`) reads as an integer then
-                // converts; a float literal to an int target never occurs
-                // (the elaborator rejects it). Mirrors
-                // `Elaborator::resolve_numeric_literal` (expr.rs:337) plus
-                // the numeric coercion.
-                // Peel newtypes (`type Meters = f64`) to the ultimate base
-                // so a float literal bound to a float-newtype target still
-                // takes the float path; otherwise it falls to the integer
-                // path and codegen sees `i32` where `f64` is expected.
+                // The *recorded type* decides Int vs Float TIR literal; the
+                // literal's *syntactic form* (`is_float_only_literal`) decides
+                // how to read its value, so `let x: f64 = 0xFF` reads as an
+                // integer then converts. Peel newtypes first, or a float literal
+                // bound to a float-newtype target takes the integer path.
                 let base_target = self
                     .tysys
                     .type_table
@@ -9838,17 +9544,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         TirExpr::new(kind, recorded_type, lit.span)
     }
 
-    /// Reify a pattern in a `let`, `match`, `if let`, or `while let`.
-    /// Binding patterns add locals to `ctx` in the same order annotate
-    /// did (per the walk-order invariant). The variant binding order
-    /// mirrors `Elaborator::resolve_if_pattern_inner`'s recursion.
-    /// Resolve a nullary qualified pattern (`TokenKind::FOO`, `i32::MAX`)
-    /// to its associated-constant value, mirroring the elaborator's
-    /// pattern lowering (stmt.rs:1428+). Integer constants become
-    /// `Literal` patterns (signed/unsigned per the scrutinee) so they
-    /// benefit from switch lowering; everything else becomes a
-    /// `ConstantValue`. Returns `None` when the name is not a recorded
-    /// associated constant (i.e. it is a real variant case).
+    /// Resolve a nullary qualified pattern (`TokenKind::FOO`, `i32::MAX`) to its
+    /// associated-constant value. An integer constant becomes a `Literal`
+    /// pattern, signed per the scrutinee, so it benefits from switch lowering;
+    /// everything else becomes a `ConstantValue`. `None` when the name is not a
+    /// recorded associated constant — i.e. it is a real variant case.
     fn reify_associated_const_pattern(
         &mut self,
         variant_name: &str,
@@ -10349,17 +10049,11 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                     (payload, type_args.1)
                 };
 
-                // Match ergonomics: when the scrutinee is a reference
-                // (`match self { Some(v) => … }` with `self: &Option<T>`),
-                // the payload binding inherits the reference kind — `v` is
-                // `&T`, not `T`, so it forwards directly to a `&self`
-                // method. Mirrors `Elaborator::resolve_if_pattern`'s
-                // `RefBinding` handling (stmt.rs:1213+): `&` downgrades a
-                // `&mut` (most restrictive wins). The `payload_type` field
-                // and `enum_type` stay the unwrapped (peeled) forms — the
-                // variant extraction reads the value through the peeled
-                // variant type; only the binding scrutinee carries the
-                // reference.
+                // Match ergonomics: a reference scrutinee (`self: &Option<T>`)
+                // gives the payload binding the reference kind, so `v` is `&T`
+                // and forwards to a `&self` method; `&` downgrades a `&mut`.
+                // `payload_type` / `enum_type` stay peeled — only the binding
+                // scrutinee carries the reference.
                 let binding_scrutinee = self.apply_scrutinee_ref_kind(scrutinee_type, payload_type);
                 let sub_patterns: Vec<TirPattern> = bindings
                     .iter()

--- a/wado-compiler/src/elaborator/reify.rs
+++ b/wado-compiler/src/elaborator/reify.rs
@@ -425,9 +425,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Resolve an effect-name list into [`crate::tir::EffectRef`]s
     /// for a function signature. Mirrors
-    /// [`super::Elaborator::resolve_effects`] (elaborator.rs:948+)
-    /// without the use→def recording side-effect (annotate already
-    /// recorded the edges).
+    /// [`super::Elaborator::resolve_effects`] without the use→def
+    /// recording side-effect (annotate already recorded the edges).
     fn reify_effects(&self, effects: &[String]) -> Vec<crate::tir::EffectRef> {
         effects
             .iter()
@@ -787,9 +786,9 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // Field-default expressions resolve in a per-struct
         // `FunctionContext` keyed `struct:<name>` (no self, no other
-        // fields in scope), matching `Elaborator::resolve_struct` at
-        // item.rs:461 byte-for-byte so the synthesized purity check
-        // and reify see identical TIR.
+        // fields in scope), matching `Elaborator::resolve_struct`
+        // byte-for-byte so the synthesized purity check and reify see
+        // identical TIR.
         let mut field_ctx = FunctionContext::new(
             crate::tir::TypeTable::UNIT,
             format!("struct:{}", struct_decl.name),
@@ -1487,7 +1486,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         // (recorded on `ImplFacts::struct_name`). Reconstructing it from
         // `facts.self_type` would need the `&` / `&mut` / tuple
         // special-cases and the `&T`-blanket "bare `&`" carve-out that
-        // `get_type_name` (module.rs:581) already encodes — exactly the
+        // `get_type_name` already encodes — exactly the
         // parity-bug class WEP 2026-05-26 §"Reify — mechanical" calls out.
         let _base_struct_name = facts.struct_name.clone();
         // Mangled / display names — read straight off the per-method facts
@@ -1507,8 +1506,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             info.is_ref_impl = facts.is_ref_impl;
             // Carry the impl's trait type args (`impl Future<i32> for …`
             // → `[i32]`). The effect-dispatch synthesis keys its handler
-            // index on `(struct, effect_module, base_trait, trait_type_args)`
-            // (effect_dispatch.rs:2984); without the args a generic-effect
+            // index on `(struct, effect_module, base_trait, trait_type_args)`;
+            // without the args a generic-effect
             // handler is keyed `Future<>` and the `Future<i32>` binding
             // finds no `DispatchPlan`.
             info.trait_type_args.clone_from(&facts.trait_type_args);
@@ -1663,7 +1662,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify a `test "…" { … }` block. Returns the synthesised
     /// `TirFunction` plus the `TirTest` metadata. Mirrors
-    /// `Elaborator::resolve_test_decl` (item.rs:1233+): the function
+    /// `Elaborator::resolve_test_decl`: the function
     /// name encodes `test_index` + attributes (`expect_trap`, `TODO`,
     /// `timeout_ms`); the body reifies into a unit-returning
     /// no-parameter function.
@@ -2106,8 +2105,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 // Inside a C-style `for`, `continue` must break to the
                 // body label so the `update` expression runs before the
                 // next iteration; only while/loop bodies use a plain
-                // `Continue`. Mirror `Elaborator::resolve_continue`
-                // (stmt.rs:251), keyed off `ctx.for_continue_labels`.
+                // `Continue`. Mirror `Elaborator::resolve_continue`,
+                // keyed off `ctx.for_continue_labels`.
                 let stmt_kind = if let Some(body_label) = ctx.for_continue_labels.last() {
                     TirStmtKind::Break {
                         label: Some(body_label.clone()),
@@ -2140,7 +2139,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             ast::Stmt::Loop(loop_stmt) => {
                 // `loop { … }` — direct lowering. The
                 // `for_continue_labels` save/restore mirrors
-                // `Elaborator::resolve_loop` (stmt.rs:2092–2101).
+                // `Elaborator::resolve_loop`.
                 let saved = std::mem::take(&mut ctx.for_continue_labels);
                 let body = self.reify_block(&loop_stmt.body, ctx, None);
                 ctx.for_continue_labels = saved;
@@ -2148,7 +2147,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             }
             ast::Stmt::LabeledBlock(labeled_block) => {
                 // `LABEL: { … }` stmt — mirrors
-                // `Elaborator::resolve_labeled_block` (stmt.rs:116+).
+                // `Elaborator::resolve_labeled_block`.
                 // Push the label onto `active_labels` so a nested
                 // `break LABEL` lowers against this frame, walk the
                 // inner block, pop. The block result is dropped at
@@ -2541,7 +2540,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                     );
                 }
                 // Constant-fold `-literal` into a negative literal, exactly
-                // as `Elaborator::resolve_unary` (operators.rs:949-1004).
+                // as `Elaborator::resolve_unary`.
                 // Without this reify emits `Unary { Neg, <pos literal> }`,
                 // which lowers to `i32.sub (const 0) …` / `f64.neg …` and
                 // can produce invalid modules (e.g. a negated literal that
@@ -2597,7 +2596,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 }
 
                 // Track address-taken locals for `&x` / `&mut x`, mirroring
-                // `Elaborator::resolve_unary` (operators.rs:834). The
+                // `Elaborator::resolve_unary`. The
                 // boxing pass (`lower::plan::boxing`) reads
                 // `TirFunction::address_taken_locals` to retag a borrowed
                 // local's declaration to its box type, so that mutation
@@ -2651,8 +2650,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             ast::Expr::Resume(resume) => {
                 // `resume value` inside a handler method. Reify the
                 // value with the function's return type as expected
-                // (matches `Elaborator::resolve_resume` at
-                // handlers.rs:445), then emit `TirExprKind::Resume`.
+                // (matches `Elaborator::resolve_resume`), then emit
+                // `TirExprKind::Resume`.
                 let expected = if ctx.in_handler_method {
                     Some(ctx.return_type)
                 } else {
@@ -2669,7 +2668,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             }
             ast::Expr::LabeledBlock(lb) => self.with_defaults_suppressed(|s| {
                 // Match `Elaborator::resolve_expr`'s `LabeledBlock`
-                // arm (expr.rs:234–305): push a `LabeledBlockTarget`
+                // arm: push a `LabeledBlockTarget`
                 // so any `break label: expr` inside lowers via this
                 // frame, walk the inner block, pop the frame, emit
                 // `TirExprKind::LabeledBlock`. The result type is the
@@ -2747,7 +2746,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 let value = self.reify_expr(&assign.value, ctx, Some(target.type_id));
                 // Global-var write: `g = v` lowers to `GlobalVarSet` so
                 // codegen actually mutates the global. The production
-                // `assign_to_target` rewrites here too (operators.rs:1192+).
+                // `assign_to_target` rewrites here too.
                 if let TirExprKind::GlobalVarGet {
                     module_source,
                     name,
@@ -2804,7 +2803,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify a `while cond { body }` statement. Mirrors
     /// `Elaborator::resolve_while`'s `Condition::Expr` arm
-    /// (stmt.rs:2982+): the loop lowers into
+    /// the loop lowers into
     /// `Loop { if !cond { break; } body }`, which is the desugar
     /// `DesugarKind::While` tags. `for_continue_labels` is saved /
     /// restored around the body walk so naked `continue` inside
@@ -2852,9 +2851,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 elements,
                 span: cond_span,
             } => {
-                // Mirror `Elaborator::resolve_while`'s LetChain
-                // arm (stmt.rs:3016+): the else-branch
-                // unconditionally `break`s out of the loop.
+                // Mirror `Elaborator::resolve_while`'s LetChain arm:
+                // the else-branch unconditionally `break`s out of the loop.
                 let break_stmt = TirStmt::new(
                     TirStmtKind::Break {
                         label: None,
@@ -2891,8 +2889,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     /// the sub-tree under an `in_progress` guard, allocates `__vK`,
     /// pushes the `let __vK = …;` onto the capture context, and
     /// returns `Local(__vK)` for the surrounding reify to splice in.
-    /// Mirrors [`super::Elaborator::resolve_with_assert_capture`]
-    /// (assert.rs:373+).
+    /// Mirrors [`super::Elaborator::resolve_with_assert_capture`].
     fn reify_with_assert_capture(
         &mut self,
         slot_idx: usize,
@@ -2962,7 +2959,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     }
 
     /// Reify `assert cond[, msg];` into the power-assert expansion.
-    /// Mirrors [`super::Elaborator::desugar_assert`] (assert.rs:65+).
+    /// Mirrors [`super::Elaborator::desugar_assert`].
     /// Capture slots come from the recorded
     /// [`super::sem::types::AssertCaptureInfo`] (annotate's
     /// `CaptureScanner` already chose them); the hook in `reify_expr`
@@ -3026,7 +3023,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // `expected_type = None`: a `Bool` expectation propagates into
         // `If`/`Match` branches inside the condition and rejects
-        // non-bool arm bodies. Mirrors assert.rs:108.
+        // non-bool arm bodies.
         let cond_tir = self.reify_expr(&assert_stmt.condition, ctx, None);
 
         let actx = ctx
@@ -3070,8 +3067,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             span,
         );
 
-        // Panic template, mirroring `build_assert_panic_template`
-        // (assert.rs:239+): header + `condition: <source>` + one
+        // Panic template, mirroring `build_assert_panic_template`:
+        // header + `condition: <source>` + one
         // `<label>: {__vK:?}` line per emitted slot.
         let string_type = self
             .tysys
@@ -3418,7 +3415,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Compile-time-unroll a tuple for-of into per-element
     /// labelled blocks. Mirrors `Elaborator::resolve_tuple_for_of`
-    /// (stmt.rs:2361+). Handles `.enumerate()` unwrap on the AST
+    /// Handles `.enumerate()` unwrap on the AST
     /// receiver so each iteration sees `[i, element]`.
     fn reify_tuple_for_of(
         &mut self,
@@ -3624,7 +3621,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     /// Emit a deferred `VariadicForOf` TIR node for tuples whose
     /// element types contain `TypePack`. The monomorphizer expands
     /// this after `TypePack` substitution. Mirrors
-    /// `Elaborator::resolve_variadic_for_of` (stmt.rs:2223+).
+    /// `Elaborator::resolve_variadic_for_of`.
     fn reify_variadic_for_of(
         &mut self,
         for_of: &ast::ForOfStmt,
@@ -3699,7 +3696,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         // Destructured binding (`for let [a, b] of …`): bind each inner
         // pattern variable to its element type and prepend a field-access
         // `Let` reading it from the synthetic pair temp, mirroring
-        // `resolve_variadic_for_of` (stmt.rs:2259+). Without this the inner
+        // `resolve_variadic_for_of`. Without this the inner
         // names (`a`, `b`) never enter scope, so the body resolves them to
         // `Unknown` — e.g. `a != b` in the variadic `Eq for [..T]` impl
         // dispatches to a nonexistent `unknown^Eq::eq`.
@@ -3891,7 +3888,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     }
 
     /// Reify a C-style `for init; cond; update { body }` loop into
-    /// the shape `Elaborator::resolve_for` produces (stmt.rs:3095+).
+    /// the shape `Elaborator::resolve_for` produces.
     fn reify_for(&mut self, f: &ast::ForStmt, ctx: &mut FunctionContext) -> Vec<TirStmt> {
         use crate::tir::{TirBlock, TirExprKind, TirStmtKind, TirUnaryOp, TypeTable};
 
@@ -3952,7 +3949,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             }) => {
                 // For-let-chain is restricted to a single Let
                 // element (the parser enforces this; mirror
-                // `Elaborator::resolve_for` stmt.rs:3164+). The
+                // `Elaborator::resolve_for`). The
                 // expansion shape is a single Match: the pattern
                 // arm's body is the labeled-body + update; the
                 // wildcard arm breaks.
@@ -4050,7 +4047,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     /// Reify the for-loop body wrapped in `__for_N_body:` so naked
     /// `continue` lowers as `break __for_N_body` (letting the
     /// `update` expression run before the next iteration). Mirrors
-    /// `Elaborator::resolve_for_labeled_body` (stmt.rs:3280+).
+    /// `Elaborator::resolve_for_labeled_body`.
     fn reify_for_labeled_body(
         &mut self,
         body_label: &str,
@@ -4074,7 +4071,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify the for-loop's optional `update` expression as a single
     /// stmt-list (empty when absent). Mirrors
-    /// `Elaborator::resolve_for_update` (stmt.rs:3302+).
+    /// `Elaborator::resolve_for_update`.
     fn reify_for_update(
         &mut self,
         update: Option<&ast::Expr>,
@@ -4131,7 +4128,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 );
                 let inner_block = TirBlock::new(inner_stmts, span);
                 // Use the shared `block_result_type` (mirroring
-                // `resolve_let_chain_stmts` stmt.rs:1140) so a then/else
+                // `resolve_let_chain_stmts`) so a then/else
                 // block ending in a value `If` / `Match` / nested chain
                 // contributes its real result type. A hand-rolled
                 // "last stmt is Expr" check would mis-classify those
@@ -4205,7 +4202,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify a trailing stmt-position `if` whose value flows out as the
     /// enclosing block's result. Mirrors
-    /// `Elaborator::resolve_if_stmt_with_expected` (stmt.rs:1042): the
+    /// `Elaborator::resolve_if_stmt_with_expected`: the
     /// `LetChain` arm reuses the let-chain lowering with `expected_type`
     /// threaded through so the chain's then/else blocks stay
     /// value-producing; the `Expr` arm emits an `If` *expression*
@@ -4297,7 +4294,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             }
             ast::Condition::LetChain { elements, .. } => {
                 // Mirror `Elaborator::resolve_if_stmt`'s
-                // `Condition::LetChain` arm (stmt.rs:1014+): the
+                // `Condition::LetChain` arm: the
                 // chain elements lower into nested Match / If
                 // stmts via the shared `reify_let_chain_stmts`.
                 // Else-branch resolves in the outer scope (chain
@@ -4325,8 +4322,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify an `if cond { … } else { … }` expression. `Condition::LetChain`
     /// dispatches through the `IfLetChain` desugar, whose tag annotate
-    /// records on `sem.types.desugars` (`Elaborator::resolve_if_expr` at
-    /// expr.rs:1860).
+    /// records on `sem.types.desugars` (`Elaborator::resolve_if_expr`).
     fn reify_if_expr(
         &mut self,
         if_expr: &ast::IfExpr,
@@ -4344,7 +4340,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             ast::Condition::Expr(e) => e,
             ast::Condition::LetChain { elements, .. } => {
                 // Mirror `Elaborator::resolve_if_expr`'s
-                // `Condition::LetChain` arm (expr.rs:1867+): the
+                // `Condition::LetChain` arm: the
                 // chain reduces to a `Block` of nested Match /
                 // If stmts via `reify_let_chain_stmts`. The
                 // overall block's result type is the recorded
@@ -4405,7 +4401,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     ) -> TirExpr {
         use crate::tir::{CallArg, ResolvedType, TirBinaryOp, TirExprKind, TirUnaryOp, TypeTable};
 
-        // Mirror `resolve_binary_operands_with_coercion` (operators.rs:80):
+        // Mirror `resolve_binary_operands_with_coercion`:
         // a numeric-literal operand is typed from the *other* operand (or,
         // when both are literals, from the expression's recorded type). This
         // matters for inlined associated-const bodies like
@@ -4466,8 +4462,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         // Reference equality: when both operands are references, the
         // elaborator emits `RefEq` / `RefNotEq` (identity comparison)
         // rather than dispatching to `Eq` — and records no operator
-        // dispatch. The decision is from operand types alone
-        // (operators.rs:150), so reify reproduces it here.
+        // dispatch. The decision is from operand types alone, so reify
+        // reproduces it here.
         if matches!(binary.op, ast::BinaryOp::Eq | ast::BinaryOp::NotEq) {
             let both_refs = {
                 let tt = self.tysys.type_table.borrow();
@@ -4663,7 +4659,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify a `a..<b` / `a..=b` range expression. The elaborator
     /// lowers ranges into the prelude's `RangeExclusive` /
-    /// `RangeInclusive` struct literals (expr.rs:4397+); reify
+    /// `RangeInclusive` struct literals; reify
     /// produces the same shape by reading the element type from
     /// the reified `start` expression and interning the
     /// `GenericInstance` via `make_generic_instance`.
@@ -5353,7 +5349,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     }
 
     /// `Option<T>`'s `?`-op desugar — mirrors
-    /// `Elaborator::resolve_question_mark_option` (expr.rs:4000+).
+    /// `Elaborator::resolve_question_mark_option`.
     fn reify_question_mark_option(
         &mut self,
         inner: TirExpr,
@@ -5447,7 +5443,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     }
 
     /// `Result<T, E>`'s `?`-op desugar — mirrors
-    /// `Elaborator::resolve_question_mark_result` (expr.rs:4087+).
+    /// `Elaborator::resolve_question_mark_result`.
     fn reify_question_mark_result(
         &mut self,
         inner: TirExpr,
@@ -5475,7 +5471,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // When inner and outer error types differ, synthesise a
         // `<OuterErr>::from(<InnerErr>_val)` call. Mirrors
-        // `Elaborator::resolve_from_call` (expr.rs:4263+); the
+        // `Elaborator::resolve_from_call`; the
         // module source for the impl is looked up via the same
         // search annotate runs (walk impl blocks across loaded
         // modules to find a matching `impl From<InnerErr> for
@@ -5619,8 +5615,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 };
 
             // Non-primitive comparison dispatches through `Eq::eq` /
-            // `Ord::cmp`; the recording fires on `chain.id` at
-            // operators.rs:1346.
+            // `Ord::cmp`; the recording fires on `chain.id`.
             if let Some(dispatch) = self.ann_operator_dispatch(chain.id) {
                 let receiver = super::Elaborator::<H>::adjust_receiver_for_self_kind_static(
                     left,
@@ -5823,7 +5818,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         // Tuple constant-index path: detect via the receiver's
         // resolved type + the index being a constant integer
         // literal. Matches `Elaborator::resolve_index`'s tuple
-        // branch (expr.rs:1674+).
+        // branch.
         let tuple_elems: Option<Vec<TypeId>> = {
             let tt = self.tysys.type_table.borrow();
             let base = receiver.type_id;
@@ -6800,7 +6795,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     }
 
     /// Reify a `with E => h, … do { body }` effect handler block.
-    /// Mirrors `Elaborator::resolve_with_handler` (handlers.rs:37+).
+    /// Mirrors `Elaborator::resolve_with_handler`.
     ///
     /// Both binding forms — explicit `Effect => handler_expr` and bundled
     /// `handler_expr` — read their effect list off
@@ -6866,8 +6861,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     /// Reify a `matches!`-style expression: `scrutinee matches { PAT
     /// [if guard] }`. Desugars (tagged `DesugarKind::Matches` at
     /// annotate time) into a two-arm match: pattern → true, wildcard
-    /// → false. Mirror `Elaborator::desugar_matches_expr`
-    /// (matches.rs:25+).
+    /// → false. Mirror `Elaborator::desugar_matches_expr`.
     fn reify_matches(&mut self, m: &ast::MatchesExpr, ctx: &mut FunctionContext) -> TirExpr {
         use crate::tir::{TirExprKind, TirMatchArm, TirPattern, TypeTable};
 
@@ -7327,7 +7321,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Pad missing trailing positional args with the callee's
     /// declared defaults. Mirrors `Elaborator::pad_args_with_defaults`
-    /// (call.rs:1853+); only bare-ident free functions have defaults.
+    /// Only bare-ident free functions have defaults.
     fn reify_pad_args_with_defaults(
         &mut self,
         callee: &ast::Expr,
@@ -7480,7 +7474,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     }
 
     /// Reify a `CallExpr`, mirroring `Elaborator::resolve_call`
-    /// (call.rs:200+). The arms below are ordered by precedence and each
+    /// The arms below are ordered by precedence and each
     /// documents the recorded fact it reads; nothing here re-resolves a
     /// callee.
     fn reify_call(
@@ -7495,7 +7489,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // Variant-ctor (`Variant::Case(payload)`) must beat the
         // `static_method_dispatch` arm: annotate also records the
-        // ctor at call.rs:1146+, but that shape would lower to a
+        // ctor there too, but that shape would lower to a
         // `Call` against a function that doesn't exist.
         if let ast::Expr::Ident(ident) = &call.callee
             && let Some(pos) = ident.name.find("::")
@@ -7658,7 +7652,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // `Type::from(x)` with no explicit `From` impl — reflexive and
         // newtype conversions. Production's `resolve_call` handles these
-        // inline (call.rs:514-569) and records no `static_method_dispatch`,
+        // inline and records no `static_method_dispatch`,
         // tagging the reflexive case with `NewtypeFromCollapse`; reify must
         // reproduce the same three shapes (otherwise it falls through to an
         // unresolvable `Type::from` `Call`). Only reached when a user `From`
@@ -7675,8 +7669,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             let arg_type = arg.type_id;
 
             // Bodyless `impl From<X> for Type;` marker impl — production
-            // synthesizes a `From::from` call inline (call.rs:768 →
-            // expr.rs:resolve_from_call) and records `FromCallFacts`
+            // synthesizes a `From::from` call inline via
+            // `resolve_from_call` and records `FromCallFacts`
             // under `call.id`. Reify reuses `reify_from_call` so both the
             // ?-op path and this static-call path emit identical TIR.
             let from_facts_key = call.id;
@@ -7709,8 +7703,6 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 );
             }
 
-            // Base→Newtype: `Newtype::from(Base_val)` where `Newtype` is a
-            // newtype over the arg's type — lower to a `Cast` (call.rs:549).
             // Base→Newtype: `Newtype::from(Base_val)`. Annotate records
             // `NewtypeFromWrap` on the call and lowers to a `Cast` to the
             // newtype; reify replays the shape using the recorded
@@ -7845,7 +7837,6 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         // whose type resolves to a function (e.g. `arr[i](x)`,
         // `(foo.bar)(x)`, `(get_fn())(x)`, `(|x| x)(1)`). Mirrors
         // `Elaborator::resolve_call`'s non-ident-callee path
-        // (call.rs:248+).
         if !matches!(&call.callee, ast::Expr::Ident(_)) {
             let callee_expr = self.reify_expr(&call.callee, ctx, None);
             let is_fn = {
@@ -8317,7 +8308,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // Track implicit `&mut self` borrowing for primitive / enum local
         // receivers, mirroring `Elaborator::resolve_method_call_with`
-        // (method_call.rs:517): a scalar-backed value is copied by default,
+        // a scalar-backed value is copied by default,
         // so `x.bump()` must mark `x` address-taken or the boxing pass won't
         // write the mutation back. Enums are plain discriminants — the same
         // scalar shape as primitives.
@@ -8376,7 +8367,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             .collect();
 
         // Pad missing trailing args with the method's defaults.
-        // Mirrors method_call.rs:481+; the recorded `param_names` /
+        // Mirrors `resolve_method_call_with`; the recorded `param_names` /
         // `param_defaults` arrive on `MethodDispatch` from annotate.
         if args.len() < dispatch.param_defaults.len() {
             let mut subs: IndexMap<String, ast::Expr> = IndexMap::default();
@@ -8467,7 +8458,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                     (name, Some(module_source), type_args)
                 }
                 // Peel references and newtypes and recurse, mirroring the
-                // elaborator's `lookup_field_type` (expr.rs:1500): `&Point`,
+                // elaborator's `lookup_field_type`: `&Point`,
                 // `&mut Point`, a newtype `Location = Point`, and chained
                 // newtypes / `&Location` all resolve their fields against the
                 // ultimate underlying struct. Without the `Newtype` arm a
@@ -8620,7 +8611,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         };
 
         // 1. Local / capture lookup, mirroring `resolve_ident`
-        //    (expr.rs:534+). Use the local's stored type instead of
+        //    Use the local's stored type instead of
         //    `recorded_type`: the binding's own type is authoritative
         //    for an ident and does not depend on the recorded
         //    per-expression annotation. (Historically this also worked
@@ -8746,7 +8737,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
         //    independent of the call site's scope (a pure literal /
         //    static expression in practice), so reify uses the
         //    surrounding `ctx` directly — matches the elaborator's
-        //    `resolve_expr(&const_expr, ctx, …)` (expr.rs:594–605).
+        //    `resolve_expr(&const_expr, ctx, …)`.
         if let Some((const_module, type_id, const_expr)) =
             self.lookup_associated_constant(&ident.name)
         {
@@ -8873,7 +8864,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // 6. Qualified case path `Type::Case`. Variant / enum / flags
         //    are checked in the same priority order as
-        //    `Elaborator::resolve_ident` (expr.rs:607+). The
+        //    `Elaborator::resolve_ident`. The
         //    namespace-import form `ns::Type::Case` (two `::`
         //    separators) is handled by a dedicated branch in the
         //    elaborator that resolves the namespace alias first.
@@ -9360,7 +9351,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 // missing/UNKNOWN (e.g. a stdlib const body whose
                 // `expression_types` entry is absent from the cached
                 // snapshot) the syntactic form is authoritative, matching
-                // production's `resolve_numeric_literal` (expr.rs:337). An
+                // production's `resolve_numeric_literal`. An
                 // integer literal still defers to the recorded type so
                 // `let x: f64 = 1` takes the float path via `is_float_target`.
                 let is_float_target = base_target == TypeTable::F32
@@ -9406,7 +9397,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             }
             ast::Literal::String(s) => {
                 // Decode escape sequences (`\"`, `\n`, `\\`, …) the same
-                // way the elaborator does (expr.rs:403) — the AST holds
+                // way the elaborator does — the AST holds
                 // the raw source text. Without this a literal like
                 // `"{\""` reaches codegen with the backslash intact and
                 // serializes as `{\"` instead of `{"`.
@@ -9742,9 +9733,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// A bare ident naming an immutable global lowers to a
     /// `ConstantValue` comparison against that global rather than a
-    /// binding (mirrors `Elaborator::resolve_if_pattern_inner`,
-    /// stmt.rs:1290+). Mutable globals are not constants and fall through
-    /// to a binding.
+    /// binding (mirrors `Elaborator::resolve_if_pattern_inner`). Mutable
+    /// globals are not constants and fall through to a binding.
     fn reify_immutable_global_pattern(
         &self,
         name: &str,
@@ -9829,8 +9819,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 // enum/variant case (`None`, `Red`), an immutable global
                 // constant, or a fresh binding. Disambiguate in the same
                 // order as `Elaborator::resolve_if_pattern_inner`
-                // (stmt.rs:1255+): known case first, then immutable
-                // global, then binding.
+                // known case first, then immutable global, then binding.
                 if let Some(case_index) = self.scrutinee_enum_case_index(scrutinee_type, name) {
                     return TirPattern::Enum {
                         enum_type: self.tysys.type_table.borrow().peel_refs(scrutinee_type),
@@ -9872,7 +9861,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             ast::Pattern::Literal(lit) => {
                 use crate::tir::{PrimitiveType, ResolvedType, TirLiteralPattern};
                 // Mirror `Elaborator::resolve_if_pattern_inner`'s literal
-                // arm (stmt.rs:1344): wide-int literals follow the
+                // arm: wide-int literals follow the
                 // scrutinee's signedness (a `u128` scrutinee must compare
                 // via `u128::*`, not `i128::*`, or codegen emits a
                 // `(ref $u128)` vs `(ref $i128)` mismatch), and char /
@@ -9970,7 +9959,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 // `i32::MAX`): a nullary qualified name that resolves to a
                 // recorded associated constant rather than a variant case.
                 // The elaborator inlines it to the constant's value
-                // (stmt.rs:1428+); reify reproduces the same lowering from
+                // reify reproduces the same lowering from
                 // `sem.decls.associated_constants`. Real variant cases are
                 // never in that map, so the lookup distinguishes the two.
                 if bindings.is_empty()
@@ -9999,7 +9988,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
                 // Enum-case pattern (plain discriminant, no payload):
                 // `Color::Red`. The elaborator emits `TirPattern::Enum`
-                // with the case's discriminant index (stmt.rs:1562+);
+                // with the case's discriminant index;
                 // reify reproduces it when the scrutinee is an enum.
                 if let Some(case_index) = self.scrutinee_enum_case_index(scrutinee_type, &case_name)
                 {
@@ -10067,7 +10056,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
                 // gives each its own local slot — so `Num(n) | Neg(n)`
                 // would extract the payload into one slot and the arm body
                 // read another. Mirror `resolve_if_pattern_inner`
-                // (stmt.rs:1798): remap each later alternative's binding
+                // remap each later alternative's binding
                 // locals onto the first alternative's, then point the
                 // arm-scope bindings at the first alternative's locals.
                 let mut resolved: Vec<TirPattern> = Vec::with_capacity(alternatives.len());
@@ -10252,7 +10241,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
             };
             // Extract the variant decl's type-param indices so the
             // substitution map below is keyed by `index` — matching
-            // `TypeTable::substitute_type_params` (tir.rs:1480).
+            // `TypeTable::substitute_type_params`.
             let indices: Vec<u32> = (0..variant_info.type_param_type_ids.len() as u32).collect();
             (case_data.payload, indices)
         };
@@ -10363,14 +10352,9 @@ fn ast_literal_to_pattern(lit: &ast::Literal) -> crate::tir::TirLiteralPattern {
     }
 }
 
-/// Map an AST [`ast::UnaryOp`] to its TIR counterpart. The two enums
-/// are 1:1; this helper exists so the dispatch table doesn't repeat
-/// the mapping at every Unary arm.
-/// Free-function attribute extractors — mirror
-/// `Elaborator::extract_*` (item.rs:802+). The elaborator's
-/// instance methods take only `&[Attribute]`, so we reproduce
-/// them as free functions so reify can call them without holding
-/// an Elaborator.
+/// Free-function attribute extractors — mirror `Elaborator::extract_*`.
+/// The elaborator's instance methods take only `&[Attribute]`, so reify
+/// can call these without holding an Elaborator.
 fn extract_is_ambient_attr(attrs: &[crate::ast::Attribute]) -> bool {
     attrs.iter().any(|a| a.name == "ambient")
 }

--- a/wado-compiler/src/elaborator/reify.rs
+++ b/wado-compiler/src/elaborator/reify.rs
@@ -1291,9 +1291,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
     /// Synthesise a `Struct^Trait::method` `TirFunction` for each default method
     /// the impl does not override, reading the body-walk facts from
     /// `sem.default_method_semantics[(impl_block.id, default_method.id)]`. The
-    /// module perspective is swapped to the trait module for the walk — same
-    /// pattern as [`Self::with_const_module_perspective`] — since the facts are
-    /// keyed by `AstId`s that name it.
+    /// module perspective is swapped to the trait module for the walk, since the
+    /// facts are keyed by `AstId`s that name it.
     fn reify_impl_default_methods(&mut self, impl_block: &ast::ImplBlock) -> Vec<TirFunction> {
         use crate::name::MethodName;
 
@@ -5898,10 +5897,9 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify a closure expression from the capture analysis in
     /// `sem.types.closure_captures[closure.id]`: `mut_captures` materialise as
-    /// `let __ref_v = &mut v;` ahead of the body in declaration order,
-    /// `captures` is the final capture list, and `is_mutating` picks
-    /// `fn mut(…)` over `fn(…)`. Follows `resolve_closure` step by step so the
-    /// walk-order invariant holds.
+    /// `let __ref_v = &mut v;` ahead of the body in declaration order, `captures`
+    /// is the final capture list, and `is_mutating` picks `fn mut(…)`. Follows
+    /// `resolve_closure` step by step so the walk-order invariant holds.
     fn reify_closure(
         &mut self,
         closure: &ast::ClosureExpr,
@@ -6163,10 +6161,9 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify a tuple literal, handling spread elements. The tuple `TypeId` is
     /// built bottom-up via `make_tuple` so a nested tuple's element type is the
-    /// same interned id as the inner literal's, which `nir/sroa` relies on at
-    /// `-O2`. A spread expands per `type_contains_pack`: a pack (direct or
-    /// mapped) to `TypePackExpansion`, a tuple containing one to `TupleSpread`,
-    /// and a concrete tuple to inline per-element `FieldAccess`.
+    /// same interned id as the inner literal's, which `nir/sroa` relies on. A
+    /// spread expands per `type_contains_pack`: a pack to `TypePackExpansion`, a
+    /// tuple containing one to `TupleSpread`, a concrete one to `FieldAccess`es.
     fn reify_tuple_literal(
         &mut self,
         tuple_lit: &ast::TupleLiteralExpr,
@@ -8153,10 +8150,8 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
     /// Reify a `MethodCallExpr`. Every decision — resolved `FunctionRef`,
     /// receiver-adjustment kind, ref-impl flag, final type — is already on
-    /// `sem.types`; receiver adjustment shares
-    /// [`super::Elaborator::adjust_receiver_for_self_kind_static`]. An
-    /// `IndexMutMethodCall` desugar routes through here too, materialising
-    /// `__index_mut_val` before the dispatch.
+    /// `sem.types`. An `IndexMutMethodCall` desugar routes through here too,
+    /// materialising `__index_mut_val` before the dispatch.
     fn reify_method_call(
         &mut self,
         method_call: &ast::MethodCallExpr,

--- a/wado-compiler/src/elaborator/reify.rs
+++ b/wado-compiler/src/elaborator/reify.rs
@@ -5963,9 +5963,9 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // Step 3: add closure parameters. Their types come from `local_types`,
         // which `resolve_closure` populated per param `AstId` — reify is a pure
-        // read here. The expected fn type is still peeled through newtypes so a
-        // closure coerced to `type Reducer = fn(..)` sees the underlying
-        // signature.
+        // read here. The expected fn type, peeled through newtypes so a closure
+        // coerced to `type Reducer = fn(..)` sees the underlying signature,
+        // feeds the return type only (Step 4).
         let expected_fn_type = expected_type.map(|t| {
             let table = self.tysys.type_table.borrow();
             table.get_ultimate_base_type(table.peel_refs(t))

--- a/wado-compiler/src/elaborator/scope.rs
+++ b/wado-compiler/src/elaborator/scope.rs
@@ -75,17 +75,11 @@ pub(super) struct Scope {
     pub(super) default_scope_module: Option<ModuleSource>,
 }
 
-/// RAII guard that restores `Elaborator::trait_ctx` to its saved value on drop.
-///
-/// Implements `Deref<Target = Elaborator>` so it can be used as a transparent
-/// elaborator handle inside the scope. Restoration is panic-safe: even if the
-/// scope body panics, drop still runs and the parent context is reinstated.
-///
-/// Use [`Elaborator::enter_inherited_type_param_scope`] to enter a new scope.
-/// It preserves the current `trait_ctx` so the child scope can register new
-/// entries on top of the parent's. Callers that want a clean slate for a
-/// specific field (matching the legacy `mem::take` pattern) should clear that
-/// field on `scope.annotate_ctx.trait_ctx` after entering.
+/// RAII guard restoring `Elaborator::trait_ctx` on drop, panic-safe. Derefs to
+/// the `Elaborator`, so it reads as a transparent handle inside the scope.
+/// Entered through [`Elaborator::enter_inherited_type_param_scope`], which keeps
+/// the parent's `trait_ctx` in place; a caller wanting a clean slate for one
+/// field clears it on `scope.annotate_ctx.trait_ctx` after entering.
 pub(super) struct TypeParamScope<'r, 'a, H: CompilerHost> {
     elaborator: &'r mut Elaborator<'a, H>,
     saved: TraitContext,
@@ -120,16 +114,11 @@ impl<H: CompilerHost> Drop for TypeParamScope<'_, '_, H> {
 }
 
 impl<'a, H: CompilerHost> Elaborator<'a, H> {
-    /// Enter an inherited type-param scope. The current `trait_ctx` is cloned
-    /// into the saved slot, but left in place so the inner work can register
-    /// additional type params on top of what the parent already had. The
-    /// original context is restored when the returned guard is dropped.
-    ///
-    /// Callers that want a clean slate (matching the legacy
-    /// `mem::take(&mut self.annotate_ctx.trait_ctx.type_params)` pattern) should clear the
-    /// specific fields they want to reset on `scope.annotate_ctx.trait_ctx` after entering
-    /// the scope — only the fields they touch need to be cleared, all others
-    /// are inherited from the parent scope.
+    /// Enter an inherited type-param scope: the current `trait_ctx` is cloned
+    /// into the saved slot but left in place, so the inner work registers
+    /// additional type params on top of the parent's. A caller wanting a clean
+    /// slate clears the specific fields it resets on `scope.annotate_ctx
+    /// .trait_ctx` after entering; everything else stays inherited.
     pub(super) fn enter_inherited_type_param_scope(&mut self) -> TypeParamScope<'_, 'a, H> {
         let saved = self.annotate_ctx.trait_ctx.clone();
         TypeParamScope {
@@ -193,25 +182,17 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     /// Expand a written bound list to include every bound's supertraits, so a
     /// declared `T: Ord` also demands `Eq`. For the sites that *check* a bound;
     /// what a parameter is known to satisfy is elaborated on read instead, by
-    /// [`super::tysys::TypeSystem::bound_implies`]. `fn(...)` bounds name no
-    /// trait and pass through untouched.
-    ///
-    /// One declaration is one bound, however it is spelled: `T: B + Derived`
-    /// where `B` aliases the `Base` that `Derived` implies is a two-bound list,
-    /// and keeping both would report the alias and the original as competitors
-    /// for a method only one of them can own.
+    /// [`super::tysys::TypeSystem::bound_implies`]. One declaration stays one
+    /// bound however spelled, so an alias never competes with its original.
     pub(super) fn elaborate_bounds(&self, bounds: &[ast::TraitBound]) -> Vec<ast::TraitBound> {
         self.elaborate_bounds_with(bounds, &IndexMap::default())
     }
 
-    /// [`Self::elaborate_bounds`] for bounds that carry no reference site of
-    /// their own.
-    ///
-    /// `known` maps a bound's id to the declaration it means, answered where
-    /// the bound was first read. A projection's bounds are rebuilt here with
-    /// fresh ids that the table cannot answer for, so without `known` the
-    /// dedup would fall back to the spelling and collapse two same-named
-    /// traits into one.
+    /// [`Self::elaborate_bounds`] for bounds carrying no reference site of their
+    /// own. `known` maps a bound's id to the declaration it means, answered where
+    /// the bound was first read: a projection's bounds are rebuilt here with
+    /// fresh ids the table cannot answer for, and without `known` the dedup would
+    /// fall back to the spelling and collapse two same-named traits.
     pub(super) fn elaborate_bounds_with(
         &self,
         bounds: &[ast::TraitBound],
@@ -307,19 +288,11 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     ) -> u32 {
         let mut idx = offset;
         for tp in params.iter().filter(|p| !p.is_effect) {
-            // `<F: fn(...)>` / `<F: fn mut(...)>` binds the parameter directly
-            // to the bound's function type. The closure-type bound is just
-            // surface syntax for "F is exactly this signature" — eager
-            // substitution lets `f: F` be callable inside the body and folds
-            // every callsite onto the same shared canonical closure shape.
-            //
-            // Fn-bound params do NOT consume a `TypeParam` index slot. This
-            // keeps the index space dense for real type params so the
-            // substitution map in `substitute_type_params` (which is keyed by
-            // `TypeParam.index`) lines up with the positional order used by
-            // the inference cache. Without this, mixed declarations like
-            // `<F: fn(...), T>` would leave `T` at `TypeParam(_, 1)` while
-            // the cache placed it at position 0, breaking substitution.
+            // `<F: fn(...)>` binds the parameter directly to the bound's function
+            // type: the bound is surface syntax for "F is exactly this
+            // signature". Such params consume no `TypeParam` index slot, keeping
+            // the space dense so `substitute_type_params` — keyed by
+            // `TypeParam.index` — agrees with the inference cache's positions.
             let fn_bound_sig = if tp.is_pack {
                 None
             } else {
@@ -370,16 +343,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     }
 
     /// Bind a trait's declared type parameters to the impl's concrete trait
-    /// arguments in the current scope. Given `trait Foo<T, U>` and an impl
-    /// instance `Foo<i32, String>`, this registers `T → i32` and `U → String`
-    /// in `trait_ctx.type_params` together with their declared bounds.
-    ///
-    /// Callers must have any impl-level type params already registered because
-    /// the trait args may reference them (e.g., `impl<X> Foo<Container<X>>`).
-    /// Trait args are resolved in the current scope before being inserted.
-    ///
-    /// Entries already present in `type_params` (e.g., re-used impl-level
-    /// names) are left untouched.
+    /// arguments: `trait Foo<T, U>` against `Foo<i32, String>` registers
+    /// `T → i32` and `U → String` with their bounds. Impl-level type params must
+    /// already be registered, the trait args being able to name them
+    /// (`impl<X> Foo<Container<X>>`). Existing entries are left untouched.
     pub(super) fn bind_trait_type_params_from_impl(&mut self, trait_type: &ast::Type) {
         let trait_name = self.get_type_name(trait_type);
         let Some(trait_decl_type_params) = self.find_trait_decl_type_params(&trait_name) else {

--- a/wado-compiler/src/elaborator/sem.rs
+++ b/wado-compiler/src/elaborator/sem.rs
@@ -1,13 +1,8 @@
 //! [`ModuleSemantics`] — per-module semantic facts (WEP 2026-05-26), one
-//! instance per loaded module owned by `AnnotateState::module_semantics`. The
-//! per-module [`super::Elaborator`] takes it for the length of `resolve_module`
-//! and the driver re-installs it; every other phase borrows it.
-//!
-//! Membership splits across four sub-structs, each in its own file so the
-//! "does this fit?" question that gates a new field stays reviewable:
-//! [`bindings::ModuleBindings`] for `use → def` edges, [`imports::ModuleImports`]
-//! for the name-resolution context, [`types::TypeAnnotations`] for per-`AstId`
-//! body-walk decisions, and [`decls::ModuleDecls`] for declarations.
+//! instance per loaded module that the per-module [`super::Elaborator`] takes
+//! for the length of `resolve_module` and every other phase borrows. Membership
+//! splits across four sub-structs, each in its own file so the "does this fit?"
+//! question that gates a new field stays reviewable.
 
 pub(crate) mod bindings;
 pub(crate) mod decls;
@@ -33,13 +28,8 @@ pub(crate) struct ModuleSemantics {
     /// Per-impl trait default-method `ModuleSemantics` snapshots, keyed by
     /// `(impl_block.id, trait_default_method.ast_id)`. The same trait body is
     /// synthesised once per impl, so one trait node legitimately carries a fact
-    /// set per impl — snapshot isolation is what a single flat map could not do,
-    /// globally-unique ids notwithstanding.
-    ///
-    /// Each value carries `types` / `bindings` fresh from that one pair's body
-    /// walk, `decls` / `imports` cloned from the impl module so name resolution
-    /// works inside it, and no nested snapshots. Reify reads an entry through the
-    /// same perspective swap it uses for any cross-module AST.
+    /// set per impl, which snapshot isolation gives and a flat map could not.
+    /// Each value's `decls` / `imports` are cloned from the impl module.
     pub(crate) default_method_semantics: IndexMap<(AstId, AstId), ModuleSemantics>,
 }
 

--- a/wado-compiler/src/elaborator/sem.rs
+++ b/wado-compiler/src/elaborator/sem.rs
@@ -1,36 +1,13 @@
-//! [`ModuleSemantics`] — per-module semantic facts produced by the elaborator.
+//! [`ModuleSemantics`] — per-module semantic facts (WEP 2026-05-26), one
+//! instance per loaded module owned by `AnnotateState::module_semantics`. The
+//! per-module [`super::Elaborator`] takes it for the length of `resolve_module`
+//! and the driver re-installs it; every other phase borrows it.
 //!
-//! Introduced by [`wep-2026-05-26-elaborator-rearchitecture.md`]. The four
-//! sub-structs hold the per-module state that previously lived as flat
-//! fields on [`super::Elaborator`] (and as `Rc<RefCell<…>>`-shared maps on
-//! [`super::orchestration::AnnotateState`]).
-//!
-//! # Ownership
-//!
-//! One instance per loaded module, owned by
-//! [`super::orchestration::AnnotateState::module_semantics`]. The per-module
-//! [`super::Elaborator`] takes ownership of the instance for the duration
-//! of [`super::Elaborator::resolve_module`] and the driver re-installs it
-//! into the map afterwards; every other phase (including the future
-//! `reify`) takes `&ModuleSemantics`.
-//!
-//! # Decomposition
-//!
-//! Membership is split into four sub-structs with explicit responsibility
-//! rules. Each sub-struct lives in its own file because the
-//! "does this fit the sub-struct's responsibility?" question is what gates
-//! adding a new field; a single file per rule keeps the question reviewable.
-//!
-//! - [`bindings::ModuleBindings`] — `use → def` edges and locally defined
-//!   symbols (the data the LSP reads to answer go-to-definition,
-//!   find-references, and hover-on-local).
-//! - [`imports::ModuleImports`] — per-module name resolution context derived
-//!   from `use` declarations.
-//! - [`types::TypeAnnotations`] — per-[`crate::ast::AstId`] type annotations
-//!   and dispatch decisions recorded during the body walk; consumed by
-//!   `reify`.
-//! - [`decls::ModuleDecls`] — module-internal declarations confirmed by
-//!   elaboration.
+//! Membership splits across four sub-structs, each in its own file so the
+//! "does this fit?" question that gates a new field stays reviewable:
+//! [`bindings::ModuleBindings`] for `use → def` edges, [`imports::ModuleImports`]
+//! for the name-resolution context, [`types::TypeAnnotations`] for per-`AstId`
+//! body-walk decisions, and [`decls::ModuleDecls`] for declarations.
 
 pub(crate) mod bindings;
 pub(crate) mod decls;
@@ -53,36 +30,16 @@ pub(crate) struct ModuleSemantics {
     pub(crate) imports: ModuleImports,
     pub(crate) types: TypeAnnotations,
     pub(crate) decls: ModuleDecls,
-    /// Per-impl trait default-method `ModuleSemantics` snapshots. Keyed by
-    /// `(impl_block.id, trait_default_method.ast_id)` — `impl_block.id`
-    /// from the impl module's parse tree, `default_method.id` from the
-    /// trait module's parse tree. The pair is unique per synthesis site:
-    /// the same trait body is synthesised once per impl, so the SAME trait
-    /// node legitimately has one fact set per impl — the per-snapshot
-    /// isolation is what disambiguates them (a single flat map could not,
-    /// even with globally-unique ids).
+    /// Per-impl trait default-method `ModuleSemantics` snapshots, keyed by
+    /// `(impl_block.id, trait_default_method.ast_id)`. The same trait body is
+    /// synthesised once per impl, so one trait node legitimately carries a fact
+    /// set per impl — snapshot isolation is what a single flat map could not do,
+    /// globally-unique ids notwithstanding.
     ///
-    /// Each value is a full `ModuleSemantics` with:
-    /// - `types` / `bindings`: freshly produced by the combined walk's body
-    ///   walk for that one `(impl, default_method)` pair.
-    /// - `decls` / `imports`: cloned from the surrounding impl module's
-    ///   `ModuleSemantics` so name resolution + decl indices work inside
-    ///   the default body walk.
-    /// - `default_method_semantics`: empty (no recursive synthesis).
-    ///
-    /// Reify reads each entry by doing the same `self.sem` /
-    /// `self.current_module_source` swap that
-    /// [`super::reify::Reify::with_const_module_perspective`] uses for
-    /// cross-module AST: the entry has lifetime `'a` because it lives
-    /// inside the impl module's `ModuleSemantics` (which reify borrows
-    /// at `'a`), so the swap is a pointer swap (no lifetime extension).
-    ///
-    /// Populated by the combined walk's `Item::Impl` default-method loop
-    /// (`elaborator.rs`'s trait-default synthesis branch) and consumed by
-    /// reify's `reify_impl_default_methods` to produce the same
-    /// `TirFunction`s the combined walk used to push onto
-    /// `ModuleDecls::pending_default_methods` (now gone — reify is the
-    /// sole producer of default-method TIR).
+    /// Each value carries `types` / `bindings` fresh from that one pair's body
+    /// walk, `decls` / `imports` cloned from the impl module so name resolution
+    /// works inside it, and no nested snapshots. Reify reads an entry through the
+    /// same perspective swap it uses for any cross-module AST.
     pub(crate) default_method_semantics: IndexMap<(AstId, AstId), ModuleSemantics>,
 }
 

--- a/wado-compiler/src/elaborator/sem/bindings.rs
+++ b/wado-compiler/src/elaborator/sem/bindings.rs
@@ -1,28 +1,12 @@
-//! [`ModuleBindings`] — `use → def` edges and locally defined symbols.
+//! [`ModuleBindings`] — `use → def` edges and locally defined symbols, written
+//! by the body walk (WEP 2026-05-26) wherever an identifier resolves or a
+//! user-visible local is introduced. A field belongs here when it answers a
+//! go-to-definition or find-references question over a use-site / def-site pair;
+//! per-`AstId` type facts go to [`super::types::TypeAnnotations`].
 //!
-//! Populated by the body walk
-//! ([`wep-2026-05-26-elaborator-rearchitecture.md`]) — every call site that
-//! resolves an identifier to its defining symbol writes here, and every
-//! site that introduces a user-visible local binding registers it here.
-//!
-//! # Membership rule
-//!
-//! Add a field here when it answers a question the LSP poses for
-//! go-to-definition, find-references, or hover-on-local — and only when
-//! that question depends on a use-site / def-site pair within a single
-//! module. Per-`AstId` type facts go to [`super::types::TypeAnnotations`],
-//! not here.
-//!
-//! # Ownership
-//!
-//! One instance per loaded module, owned by [`super::ModuleSemantics`].
-//! Plain owned [`crate::hashmap::IndexMap`]s replace the previous
-//! `Rc<RefCell<…>>` plumbing the elaborator shared with
-//! [`super::super::orchestration::AnnotateState`]: each module's body walk
-//! has exclusive `&mut` access to its own [`ModuleBindings`] for the
-//! duration of [`super::super::Elaborator::resolve_module`], and the
-//! driver re-installs the populated instance back into
-//! `state.module_semantics` afterwards.
+//! One instance per loaded module, owned by [`super::ModuleSemantics`] and held
+//! `&mut` by that module's body walk for its duration, so plain owned maps
+//! replace the `Rc<RefCell<…>>` the elaborator once shared with the driver.
 
 use crate::ast::AstId;
 use crate::hashmap::IndexMap;

--- a/wado-compiler/src/elaborator/sem/decls.rs
+++ b/wado-compiler/src/elaborator/sem/decls.rs
@@ -1,18 +1,8 @@
-//! [`ModuleDecls`] — module-internal declarations confirmed by elaboration.
-//!
-//! [`wep-2026-05-26-elaborator-rearchitecture.md`] populates the
-//! fields below by relocating per-module state off
-//! [`super::super::Elaborator`].
-//!
-//! # Membership rule
-//!
-//! Add a field here when it summarises a *declaration* in this module
-//! after elaboration has resolved its signature: function return types,
-//! generic parameter tables, global variable types, associated constants,
-//! synthesised structures. If the fact is a *use-site* decision
-//! (annotation on an [`crate::ast::AstId`]) it belongs in
-//! [`super::types::TypeAnnotations`]; if it is an *import* fact derived
-//! from a `use` declaration it belongs in [`super::imports::ModuleImports`].
+//! [`ModuleDecls`] — module-internal declarations confirmed by elaboration
+//! (WEP 2026-05-26). A field belongs here when it summarises a *declaration*
+//! whose signature elaboration has resolved. A use-site decision keyed by
+//! [`crate::ast::AstId`] belongs in [`super::types::TypeAnnotations`], and an
+//! import fact in [`super::imports::ModuleImports`].
 
 use crate::ast;
 use crate::hashmap::{IndexMap, IndexSet};
@@ -162,17 +152,11 @@ pub(crate) struct ModuleDecls {
     pub(crate) local_flags_cases: IndexMap<String, FlagsInfo>,
     pub(crate) local_variant_cases: IndexMap<String, VariantInfo>,
 
-    /// Function-local item declarations (`Stmt::Item` — a `struct`/`enum`/
-    /// `variant`/`flags`/`type` declared inside a function body). Distinct
-    /// from `local_struct_fields` et al above, which are module-scoped
-    /// (anonymous struct literals, in-progress module decls): these are
-    /// scoped to a single function, populated sequentially by
-    /// `Elaborator::resolve_stmt` as it walks the body (no hoisting — a
-    /// local item is visible only after its own declaration statement,
-    /// matching `let`), and cleared at the start of every
-    /// `Elaborator::resolve_function` call so sibling functions never see
-    /// each other's local items. Consulted by `TypeLookup` with the highest
-    /// precedence, ahead of `local_struct_fields` et al.
+    /// Function-local item declarations (`Stmt::Item`), as against the
+    /// module-scoped `local_struct_fields` above. Populated sequentially as
+    /// `resolve_stmt` walks the body — no hoisting, so a local item is visible
+    /// only after its own statement, like `let` — and cleared per function, so
+    /// siblings never see each other's. `TypeLookup` consults it first.
     pub(crate) fn_local_struct_fields: IndexMap<String, StructFieldInfo>,
     pub(crate) fn_local_newtypes: IndexMap<String, TypeId>,
     pub(crate) fn_local_enum_cases: IndexMap<String, EnumInfo>,

--- a/wado-compiler/src/elaborator/sem/imports.rs
+++ b/wado-compiler/src/elaborator/sem/imports.rs
@@ -1,18 +1,8 @@
-//! [`ModuleImports`] — per-module name resolution context derived from
-//! `use` declarations.
-//!
-//! Populated by [`super::super::orchestration::Elaborator::build_tir_from_state`]
-//! before the body walk starts, and consulted by name-resolution sites in
-//! the elaborator ([`wep-2026-05-26-elaborator-rearchitecture.md`]).
-//!
-//! # Membership rule
-//!
-//! Add a field here when it carries a fact derived from this module's
-//! `use` declarations (or its local declarations that participate in
-//! same-name resolution, like `interface` / `resource`). If the fact is
-//! the canonicalisation of an *imported* name to its *declaring* module,
-//! it belongs here. If the fact is a *local* declaration's body, it
-//! belongs in [`super::decls::ModuleDecls`].
+//! [`ModuleImports`] — per-module name resolution context derived from `use`
+//! declarations (WEP 2026-05-26), populated before the body walk starts. A field
+//! belongs here when it canonicalises an imported name to its declaring module,
+//! or comes from a local declaration participating in same-name resolution. A
+//! local declaration's *body* goes in [`super::decls::ModuleDecls`].
 
 use crate::hashmap::IndexMap;
 use crate::module_source::ModuleSource;

--- a/wado-compiler/src/elaborator/sem/types.rs
+++ b/wado-compiler/src/elaborator/sem/types.rs
@@ -1,9 +1,7 @@
 //! [`TypeAnnotations`] — the per-[`crate::ast::AstId`] *decisions* the body walk
 //! made and [`super::super::reify`] reads in lieu of re-running inference:
 //! resolved types, dispatch targets, coercions, desugar tags, generic
-//! instantiations, capture tables. A bare `AstId` keys them because ids are
-//! globally unique, so cross-module inlined AST cannot collide with its
-//! consumer's. Facts derivable from the AST alone belong on
+//! instantiations, capture tables. Facts derivable from the AST alone belong on
 //! [`crate::ast_index::AstIndex`], decl-level ones on [`super::decls::ModuleDecls`].
 
 use crate::ast::{self, AstId};
@@ -14,9 +12,8 @@ use crate::tir::{FunctionRef, TypeId};
 /// Method-dispatch decision for a [`crate::ast::MethodCallExpr`]:
 /// `function_ref` is the resolved target, so reify emits the call without
 /// re-running trait lookup or mangling, and `self_kind` plus `is_ref_impl` are
-/// what `adjust_receiver_for_self_kind` needs — an `impl Trait for &T` takes an
-/// extra `&`. Short-circuiting paths leave no entry: they rewrite the call into
-/// a shape reify recognises from the receiver type alone.
+/// what `adjust_receiver_for_self_kind` needs. Short-circuiting paths leave no
+/// entry: they rewrite the call into a shape reify reads off the receiver type.
 #[derive(Clone)]
 pub(crate) struct MethodDispatch {
     pub(crate) function_ref: FunctionRef,
@@ -47,8 +44,7 @@ pub(crate) struct MethodDispatch {
     /// inference-recovered alike; the monomorphizer keys off this to queue
     /// `Struct^Trait::method<Args>` instances. Kept separate from
     /// `function_ref.monomorph_info.method_type_args`, which the blanket-impl
-    /// branch leaves empty even for a turbofish call — reify needs an un-zeroed
-    /// copy rather than re-resolving the AST list against the current scope.
+    /// branch leaves empty even for a turbofish call.
     pub(crate) method_type_args: Vec<TypeId>,
     /// True when the method takes its receiver `self` by value, so the call
     /// transfers ownership of the receiver. The resource move check reads this
@@ -99,8 +95,7 @@ pub(crate) struct TypeAnnotations {
     /// and recorded alongside `local_symbols`. LSP inlay hints read it so
     /// `let x = 1` renders `: i32` without reaching into TIR. Part of
     /// [`ElementOverlay`]: a tuple-`for-of` body rebinds one pattern `AstId` to
-    /// a different type per iteration, so each iteration's value stays pinned to
-    /// its own overlay instead of overwriting the base map.
+    /// a different type per iteration.
     pub(crate) local_types: IndexMap<AstId, TypeId>,
     /// Resolved [`TypeId`] for every expression visited by
     /// [`super::super::Elaborator::resolve_expr`], keyed by the
@@ -203,9 +198,7 @@ pub(crate) struct TypeAnnotations {
     /// `SequenceLiteralBuilder` coercion data for a tuple literal coerced into a
     /// `List<T>` or user-defined sequence, keyed by the `Expr::TupleLiteral`'s
     /// [`AstId`]. The desugar block `try_coerce_tuple_to_sequence` produces
-    /// depends on impl-lookup decisions reify cannot redo from the AST; the
-    /// resolved trait info here is what makes its `__b` local land at the same
-    /// `FunctionContext` index.
+    /// depends on impl-lookup decisions reify cannot redo from the AST alone.
     pub(crate) sequence_coercions: IndexMap<AstId, SequenceCoercionFacts>,
     /// `KeyValueLiteralBuilder` coercion data for an anonymous
     /// struct literal coerced into a map-style type. Keyed by the
@@ -223,17 +216,15 @@ pub(crate) struct TypeAnnotations {
     pub(crate) from_call_facts: IndexMap<AstId, FromCallFacts>,
     /// `IndexAssign` dispatch for `arr[i] = v` and `arr[i] OP= v`, keyed by the
     /// *inner* [`crate::ast::IndexExpr`]'s [`AstId`] and recorded in
-    /// `assign_to_target` so both shapes feed one map.
-    /// [`Self::operator_dispatch`] cohabits under the same key with the
-    /// read-side `IndexValue` / `Index` dispatch: an `Expr::Index` is read in
-    /// `let x = arr[i]` and written in `arr[i] = v`, via different traits.
+    /// `assign_to_target` so both shapes feed one map. The read-side
+    /// `IndexValue` / `Index` dispatch cohabits under the same key in
+    /// [`Self::operator_dispatch`], via different traits.
     pub(crate) index_assign_dispatch: IndexMap<AstId, OperatorDispatch>,
     /// Per-element annotation overlays for compile-time-unrolled tuple `for-of`
     /// loops: one outer entry per *instantiation* in walk order (a nested for-of
     /// is instantiated once per outer element), one inner [`ElementOverlay`] per
-    /// tuple element. The body is a single sub-tree with fixed `AstId`s resolved
-    /// once per element in a different type context, so without the overlay only
-    /// the last element's facts would survive.
+    /// tuple element. The body has fixed `AstId`s resolved once per element, so
+    /// without the overlay only the last element's facts would survive.
     pub(crate) tuple_overlays: IndexMap<AstId, Vec<Vec<ElementOverlay>>>,
     /// Impl-level type parameters as `Elaborator::resolve_method` (the
     /// battle-tested original path) computed them, keyed per impl-method
@@ -273,8 +264,7 @@ pub(crate) struct TypeAnnotations {
     /// `AstId`. A simple binding also has it in `local_types`, but a
     /// destructuring pattern's binding ids carry per-element types, leaving the
     /// whole-pattern annotation nowhere else to land. Part of [`ElementOverlay`]
-    /// for the same reason as `local_types`: one `LetStmt` id is shared across
-    /// every iteration of a tuple-`for-of` unrolling.
+    /// for the same reason as `local_types`.
     pub(crate) let_annotated_types: IndexMap<AstId, TypeId>,
     /// Resolved field types per struct decl `AstId`, in declaration order, as
     /// `resolve_struct` produced them with the type-param scope in place. Reify
@@ -287,8 +277,7 @@ pub(crate) struct TypeAnnotations {
     /// `&mut`-deref-capture, or global — so `assign_to_target` can validate
     /// l-values and global mutability without reading the now-placeholder
     /// resolved `target.kind`. An ident resolving to a function, variant, enum,
-    /// flags or constant leaves no entry and is not an l-value. No overlay
-    /// needed: a place kind does not depend on a for-of element type.
+    /// flags or constant leaves no entry and is not an l-value.
     pub(crate) assign_places: IndexMap<AstId, AssignPlace>,
 }
 

--- a/wado-compiler/src/elaborator/sem/types.rs
+++ b/wado-compiler/src/elaborator/sem/types.rs
@@ -1,61 +1,22 @@
-//! [`TypeAnnotations`] — per-[`crate::ast::AstId`] type annotations
-//! and dispatch decisions recorded during the body walk.
-//!
-//! # Membership rule
-//!
-//! Add a field here when it stores a fact keyed by an [`AstId`] produced
-//! as a *decision* by the body-level elaborator: the resolved type of an
-//! expression, the chosen method dispatch target, the chosen coercion, the
-//! desugar kind of a TIR-direct rewrite. A bare `AstId` suffices because
-//! ids are globally unique (`(AstIdSpace, local)`) — cross-module inlined
-//! AST (const bodies, default arguments, trait defaults) carries its own
-//! ids and cannot collide with the consumer's. This is what
-//! [`super::super::reify`] reads in lieu of re-running inference.
-//!
-//! Facts that derive purely from the AST (spans, position lookup) belong
-//! on [`crate::ast_index::AstIndex`], not here. Decl-level facts (function
-//! return types, generic-parameter tables) belong on
-//! [`super::decls::ModuleDecls`].
-//!
-//! The map set is every decision reify cannot re-derive from the AST:
-//! resolved types (`local_types`, `expression_types`), dispatch targets
-//! (`method_dispatch`, `operator_dispatch`, `for_of_iterator`), the chosen
-//! `coercions`, the `desugars` tag for each TIR-direct rewrite (`assert`,
-//! `matches`, comparison chains, `for x of …`, `while`, compound
-//! assignment), `generic_instantiations`, and the capture tables
-//! (`closure_captures`, `assert_captures`). See
-//! `wep-2026-05-26-elaborator-rearchitecture.md` §`Reify — mechanical`.
+//! [`TypeAnnotations`] — the per-[`crate::ast::AstId`] *decisions* the body walk
+//! made and [`super::super::reify`] reads in lieu of re-running inference:
+//! resolved types, dispatch targets, coercions, desugar tags, generic
+//! instantiations, capture tables. A bare `AstId` keys them because ids are
+//! globally unique, so cross-module inlined AST cannot collide with its
+//! consumer's. Facts derivable from the AST alone belong on
+//! [`crate::ast_index::AstIndex`], decl-level ones on [`super::decls::ModuleDecls`].
 
 use crate::ast::{self, AstId};
 use crate::hashmap::IndexMap;
 use crate::name::Receiver;
 use crate::tir::{FunctionRef, TypeId};
 
-/// Method-dispatch decision recorded by the body walk for a
-/// [`crate::ast::MethodCallExpr`].
-///
-/// `function_ref` captures the resolved target (module, mangled name,
-/// monomorph info, and method-name metadata) so `reify` can emit the
-/// method [`crate::tir::TirExprKind::Call`] without re-running
-/// trait lookup, blanket-impl selection, or method-name mangling.
-/// `self_kind` carries the receiver-adjustment decision (`self` / `&self`
-/// / `&mut self`) so reify can drive `adjust_receiver_for_self_kind` with
-/// the same kind that annotate used.
-///
-/// Short-circuiting paths inside
-/// [`super::super::Elaborator::resolve_method_call_with`] (tuple `.len()`
-/// / `.zip()`, the static-method-as-instance error) do *not* leave an
-/// entry here — they rewrite the call into a non-method-call TIR shape
-/// that reify recognises from the receiver type alone. The synthetic
-/// for-of `.into_iter()` / `.next()` dispatches also skip recording
-/// because they have no source-level `MethodCallExpr` to attach to.
-///
-/// [`Self::is_ref_impl`]: receiver adjustment for `&self` /
-/// `&mut self` requires not only `self_kind` but also whether the method
-/// was found on a reference-type impl (`impl Trait for &T`), because such
-/// impls take an *extra* layer of `&` on the receiver. The flag is the
-/// output of `lookup_method_info` and the input reify feeds to
-/// `adjust_receiver_for_self_kind`.
+/// Method-dispatch decision for a [`crate::ast::MethodCallExpr`]:
+/// `function_ref` is the resolved target, so reify emits the call without
+/// re-running trait lookup or mangling, and `self_kind` plus `is_ref_impl` are
+/// what `adjust_receiver_for_self_kind` needs — an `impl Trait for &T` takes an
+/// extra `&`. Short-circuiting paths leave no entry: they rewrite the call into
+/// a shape reify recognises from the receiver type alone.
 #[derive(Clone)]
 pub(crate) struct MethodDispatch {
     pub(crate) function_ref: FunctionRef,
@@ -82,21 +43,12 @@ pub(crate) struct MethodDispatch {
     /// type makes reify emit a spurious `drop` of a value-less call →
     /// Wasm stack underflow).
     pub(crate) return_type: TypeId,
-    /// Method-level type args for the method [`crate::tir::TirExprKind::Call`]
-    /// node, in the exact form the combined walk passes to
-    /// [`super::super::Elaborator::build_tir_method_call`]. The
-    /// monomorphizer's `collect_func_instantiation_sites` keys off this
-    /// field to queue `Struct^Trait::method<Args>` instances, so it must
-    /// carry the resolved args — both explicit turbofish and
-    /// inference-recovered ones.
-    ///
-    /// Recorded separately from `function_ref.monomorph_info.method_type_args`
-    /// because the blanket-impl branch in `resolve_method_call_with`
-    /// constructs `MonomorphInfo` with `method_type_args: vec![]` even when
-    /// the call site has a non-empty turbofish — the TIR node still receives
-    /// the turbofish args (they pass straight through `build_tir_method_call`),
-    /// so reify needs its own un-zeroed copy to avoid re-resolving the AST
-    /// type-arg list against the current type-param scope.
+    /// Method-level type args for the call node, explicit turbofish and
+    /// inference-recovered alike; the monomorphizer keys off this to queue
+    /// `Struct^Trait::method<Args>` instances. Kept separate from
+    /// `function_ref.monomorph_info.method_type_args`, which the blanket-impl
+    /// branch leaves empty even for a turbofish call — reify needs an un-zeroed
+    /// copy rather than re-resolving the AST list against the current scope.
     pub(crate) method_type_args: Vec<TypeId>,
     /// True when the method takes its receiver `self` by value, so the call
     /// transfers ownership of the receiver. The resource move check reads this
@@ -143,20 +95,12 @@ pub(crate) struct CoercionChoice {
 /// Per-`AstId` type annotations recorded by the body walk.
 #[derive(Default, Clone)]
 pub(crate) struct TypeAnnotations {
-    /// Resolved [`TypeId`] for each local binding, keyed by the binding's
-    /// defining [`AstId`]. Populated alongside
-    /// [`super::bindings::ModuleBindings::local_symbols`] at every
-    /// `record_local_symbol` call. Consumed by LSP inlay hints via
-    /// [`crate::semantics::Semantics::local_type_name`] so `let x = 1` can
-    /// render the inferred `: i32` annotation without reaching into TIR.
-    ///
-    /// Part of [`ElementOverlay`]: a tuple-`for-of` body rebinds the same
-    /// pattern `AstId` to a different element type per iteration, so the
-    /// per-iteration overlay keeps each iteration's value pinned to its
-    /// own `ElementOverlay` rather than letting later iterations overwrite
-    /// earlier reads on the base map. Same applies to inner closure
-    /// params / let bindings whose inferred types depend on the iteration's
-    /// element.
+    /// Resolved [`TypeId`] per local binding, keyed by its defining [`AstId`]
+    /// and recorded alongside `local_symbols`. LSP inlay hints read it so
+    /// `let x = 1` renders `: i32` without reaching into TIR. Part of
+    /// [`ElementOverlay`]: a tuple-`for-of` body rebinds one pattern `AstId` to
+    /// a different type per iteration, so each iteration's value stays pinned to
+    /// its own overlay instead of overwriting the base map.
     pub(crate) local_types: IndexMap<AstId, TypeId>,
     /// Resolved [`TypeId`] for every expression visited by
     /// [`super::super::Elaborator::resolve_expr`], keyed by the
@@ -229,28 +173,17 @@ pub(crate) struct TypeAnnotations {
     /// expanded `TirHandlerBinding`s without re-running
     /// `collect_effect_impls_for_type`.
     pub(crate) handler_bindings: IndexMap<AstId, HandlerBindingFacts>,
-    /// Impl-block resolution facts. Keyed by
-    /// the [`crate::ast::ImplBlock`]'s [`AstId`]. Carries the
-    /// resolved `Self` type, the trait reference's canonical and
-    /// mangled forms, the impl's projected
-    /// [`crate::tir::TirTypeParam`] list, associated-type bindings
-    /// for in-body `Self::X` resolution, the handler-method flag
-    /// driving `resume` validation, and the ref-type-impl flag
-    /// for `&self` synthesis. See [`ImplFacts`].
-    ///
-    /// Recorded in the `Item::Impl` arm of `elaborator.rs`; read by reify
-    /// in `reify_impl`.
+    /// Impl-block resolution facts keyed by the [`crate::ast::ImplBlock`]'s
+    /// [`AstId`] — resolved `Self` type, canonical and mangled trait reference,
+    /// projected type-param list, associated-type bindings, and the handler /
+    /// ref-impl flags. See [`ImplFacts`]. Recorded in the `Item::Impl` arm,
+    /// read by `reify_impl`.
     pub(crate) impl_facts: IndexMap<AstId, ImplFacts>,
-    /// Resolved `with` clause for each function / method declaration
-    /// Keyed by the [`crate::ast::Function`]'s or
-    /// [`crate::ast::Method`]'s [`AstId`]. The body walk calls
-    /// [`super::super::Elaborator::resolve_effects`] while effect
-    /// parameters are still in scope and stashes the result here so
-    /// reify can drop the `Vec<EffectRef>` straight into
-    /// [`crate::tir::TirFunction::effects`] without re-running
-    /// effect-param / import / canonicalisation lookups (none of which
-    /// reify has the transient `current_effect_param_decls` scope to
-    /// reproduce faithfully).
+    /// Resolved `with` clause per function / method declaration. The body walk
+    /// resolves it while the effect parameters are still in scope and stashes
+    /// the result here, so reify drops the `Vec<EffectRef>` straight into
+    /// [`crate::tir::TirFunction::effects`] — it has no
+    /// `current_effect_param_decls` scope to redo the lookup faithfully.
     pub(crate) function_effects: IndexMap<AstId, Vec<crate::tir::EffectRef>>,
     /// Declared (pre-erasure) return [`TypeId`] for every `async`
     /// function / method, keyed by the function's [`AstId`]. An async
@@ -261,27 +194,18 @@ pub(crate) struct TypeAnnotations {
     /// for resource-store inference over the return type (e.g. an async
     /// `handle` returning `Result<Response, _>` must surface `Response`).
     pub(crate) function_task_returns: IndexMap<AstId, TypeId>,
-    /// Resolved static-method call dispatch
-    /// (`Type::method(args)` / `builtin::fn(args)` shape) recorded by
-    /// the body walk. Keyed by the [`crate::ast::CallExpr`]'s [`AstId`].
-    /// Carries the resolved [`crate::tir::FunctionRef`] (with mangled
-    /// name, `module_source`, `method_info`, and any monomorphisation
-    /// info) plus the per-arg `is_mut` flags the elaborator drained
-    /// from the looked-up parameter signature. Reify reads this to
-    /// reproduce the same TIR `Call` shape without re-running
-    /// `locate_static_method_impl` / `MethodName::format_local` and
-    /// without consulting the trait-impl index.
+    /// Resolved static-method call dispatch (`Type::method(args)` /
+    /// `builtin::fn(args)`), keyed by the [`crate::ast::CallExpr`]'s [`AstId`]:
+    /// the resolved [`crate::tir::FunctionRef`] plus the per-arg `is_mut` flags
+    /// drained from the looked-up signature, so reify rebuilds the `Call` without
+    /// `locate_static_method_impl` or the trait-impl index.
     pub(crate) static_method_dispatch: IndexMap<AstId, StaticMethodDispatch>,
-    /// `SequenceLiteralBuilder` coercion data for a tuple literal
-    /// coerced into an `List<T>` / user-defined sequence type. Keyed
-    /// by the `Expr::TupleLiteral`'s [`AstId`]. The
-    /// `try_coerce_tuple_to_sequence` path produces a desugar block
-    /// (`__seq_lit: { let __b = Builder::new_literal(N); __b.push_literal(...); ...; break __seq_lit: __b.build(); }`)
-    /// whose shape depends on impl-lookup decisions reify cannot
-    /// reproduce from the AST alone. Recording the resolved trait
-    /// info here lets reify rebuild the same desugar deterministically
-    /// — the `__b` local lands at the same `FunctionContext` index
-    /// reify reserves for it (the walk-order invariant).
+    /// `SequenceLiteralBuilder` coercion data for a tuple literal coerced into a
+    /// `List<T>` or user-defined sequence, keyed by the `Expr::TupleLiteral`'s
+    /// [`AstId`]. The desugar block `try_coerce_tuple_to_sequence` produces
+    /// depends on impl-lookup decisions reify cannot redo from the AST; the
+    /// resolved trait info here is what makes its `__b` local land at the same
+    /// `FunctionContext` index.
     pub(crate) sequence_coercions: IndexMap<AstId, SequenceCoercionFacts>,
     /// `KeyValueLiteralBuilder` coercion data for an anonymous
     /// struct literal coerced into a map-style type. Keyed by the
@@ -297,33 +221,19 @@ pub(crate) struct TypeAnnotations {
     /// [`crate::ast::AstId`] (the `?` expr / static-call expr). See
     /// [`FromCallFacts`].
     pub(crate) from_call_facts: IndexMap<AstId, FromCallFacts>,
-    /// `IndexAssign` trait dispatch decisions for `arr[i] = v` and
-    /// `arr[i] OP= v` shapes whose target is an `Expr::Index`. Keyed
-    /// by the **inner [`crate::ast::IndexExpr`]'s [`AstId`]** (the
-    /// `target` of the surrounding `Expr::Assign` /
-    /// `Expr::CompoundAssign`). The recording sites live in
-    /// `Elaborator::assign_to_target` so both `Expr::Assign` and the
-    /// compound-assign desugar feed the same map. Note that
-    /// [`Self::operator_dispatch`] keyed by the same `AstId` carries
-    /// the *read-side* `IndexValue` / `Index` dispatch — the two
-    /// annotations cohabit because an `Expr::Index` is read in
-    /// `let x = arr[i]` and written in `arr[i] = v`, and the
-    /// elaborator dispatches each shape to a different trait.
+    /// `IndexAssign` dispatch for `arr[i] = v` and `arr[i] OP= v`, keyed by the
+    /// *inner* [`crate::ast::IndexExpr`]'s [`AstId`] and recorded in
+    /// `assign_to_target` so both shapes feed one map.
+    /// [`Self::operator_dispatch`] cohabits under the same key with the
+    /// read-side `IndexValue` / `Index` dispatch: an `Expr::Index` is read in
+    /// `let x = arr[i]` and written in `arr[i] = v`, via different traits.
     pub(crate) index_assign_dispatch: IndexMap<AstId, OperatorDispatch>,
-    /// Per-element annotation overlays for compile-time-unrolled tuple
-    /// `for-of` loops. Keyed by the [`crate::ast::ForOfStmt`]'s
-    /// [`AstId`]; the outer `Vec` holds one entry per *instantiation* of
-    /// that for-of in deterministic walk order (a nested inner for-of is
-    /// instantiated once per outer element, hence multiple entries), and
-    /// the inner `Vec` holds one [`ElementOverlay`] per tuple element.
-    ///
-    /// A tuple for-of's body is a single source sub-tree (fixed `AstId`s)
-    /// that annotate resolves once per element in a *different* type
-    /// context. Every per-element map below would otherwise be overwritten
-    /// so only the last element's facts survive. Annotate captures each
-    /// element's body facts here (`resolve_tuple_for_of`) and reify replays
-    /// them per element. Populated whenever a module has tuple-for-of loops;
-    /// empty only when it has none.
+    /// Per-element annotation overlays for compile-time-unrolled tuple `for-of`
+    /// loops: one outer entry per *instantiation* in walk order (a nested for-of
+    /// is instantiated once per outer element), one inner [`ElementOverlay`] per
+    /// tuple element. The body is a single sub-tree with fixed `AstId`s resolved
+    /// once per element in a different type context, so without the overlay only
+    /// the last element's facts would survive.
     pub(crate) tuple_overlays: IndexMap<AstId, Vec<Vec<ElementOverlay>>>,
     /// Impl-level type parameters as `Elaborator::resolve_method` (the
     /// battle-tested original path) computed them, keyed per impl-method
@@ -359,45 +269,26 @@ pub(crate) struct TypeAnnotations {
     /// and the trait-omitted display form). Reify reads these instead of
     /// re-running `format_local` against the impl facts' `struct_name`.
     pub(crate) method_names: IndexMap<AstId, MethodNames>,
-    /// Resolved `let x: T = …` whole-pattern type annotation, keyed by the
-    /// `LetStmt`'s `AstId`. For simple `Ident` / `MutIdent` bindings the same
-    /// type also appears in `local_types` (keyed by the binding's id); for
-    /// destructuring patterns the binding ids carry per-element types so the
-    /// whole-pattern annotation has no `local_types` slot to land on, and
-    /// reify reads it from here instead of re-resolving the AST annotation.
-    ///
-    /// Part of [`ElementOverlay`] because the `LetStmt::AstId` is shared
-    /// across every iteration of a tuple-`for-of` unrolling, so the
-    /// per-iteration walk would otherwise overwrite earlier entries on
-    /// the base map and reify would read the last iteration's resolution
-    /// for every element. The overlay stack keeps each iteration's value
-    /// pinned to that iteration's `ElementOverlay`.
+    /// Resolved `let x: T = …` whole-pattern annotation, keyed by the `LetStmt`'s
+    /// `AstId`. A simple binding also has it in `local_types`, but a
+    /// destructuring pattern's binding ids carry per-element types, leaving the
+    /// whole-pattern annotation nowhere else to land. Part of [`ElementOverlay`]
+    /// for the same reason as `local_types`: one `LetStmt` id is shared across
+    /// every iteration of a tuple-`for-of` unrolling.
     pub(crate) let_annotated_types: IndexMap<AstId, TypeId>,
     /// Resolved field types per struct decl `AstId`, in declaration order, as
-    /// `resolve_struct` resolved them with the struct's type-param scope and
-    /// the full annotate-time resolver in place.
-    ///
-    /// Recorded so reify can read field types straight from this map instead
-    /// of relying on `tysys.all_struct_fields` + an UNKNOWN-fallback
-    /// re-resolve. The fallback existed because the static decl-field pass
-    /// (which seeds `all_struct_fields`) runs before import scopes exist and
-    /// cannot follow `pub use` re-export chains — so a field typed by a
-    /// re-exported decl (e.g. `Mark = u64` re-exported from `wasi:clocks`)
-    /// landed as `UNKNOWN` there and forced reify to re-resolve. The combined
-    /// walk already resolves these correctly during `resolve_struct`; we just
-    /// publish the resolved vector here for reify to read.
+    /// `resolve_struct` produced them with the type-param scope in place. Reify
+    /// reads these rather than `tysys.all_struct_fields`, which is seeded by the
+    /// static decl-field pass — that runs before import scopes exist and cannot
+    /// follow `pub use` chains, so a field typed by a re-exported decl lands
+    /// there as UNKNOWN.
     pub(crate) struct_field_types: IndexMap<AstId, Vec<crate::tir::TypeId>>,
-    /// Assignment-target place classification for each identifier that
-    /// resolves to a place (local / `&mut`-deref-capture / global), keyed by
-    /// the [`crate::ast::IdentExpr`]'s [`AstId`]. Recorded by
-    /// [`super::super::Elaborator::resolve_ident`] so
-    /// [`super::super::Elaborator::assign_to_target`] can validate l-values
-    /// and global mutability from the AST + this fact instead of reading the
-    /// now-placeholder resolved `target.kind`. Idents that resolve to
-    /// functions, variants, enums, flags, or constants leave no entry and are
-    /// treated as "not an l-value". Keyed by `AstId` and structurally
-    /// constant across tuple-`for-of` iterations (the place kind of an ident
-    /// does not depend on element type), so it needs no per-element overlay.
+    /// Place classification for each identifier that resolves to one — local,
+    /// `&mut`-deref-capture, or global — so `assign_to_target` can validate
+    /// l-values and global mutability without reading the now-placeholder
+    /// resolved `target.kind`. An ident resolving to a function, variant, enum,
+    /// flags or constant leaves no entry and is not an l-value. No overlay
+    /// needed: a place kind does not depend on a for-of element type.
     pub(crate) assign_places: IndexMap<AstId, AssignPlace>,
 }
 
@@ -735,16 +626,11 @@ pub(crate) struct StaticMethodDispatch {
     pub(crate) self_in_args: bool,
 }
 
-/// Generic-instantiation decision recorded by the body walk at a call,
-/// struct-literal, or variant-construction site. `type_args` is the
-/// inferred (or explicitly written) concrete type for each generic
-/// parameter in declaration order. `instance_type` is the `TypeId` of
-/// the resulting [`crate::tir::ResolvedType::GenericInstance`] (for
-/// generic struct/variant types) or the call's monomorphic
-/// [`crate::tir::FunctionRef::monomorph_info`]-keyed target — recorded
-/// alongside `type_args` so reify can drop straight into the TIR slot
-/// without re-running `make_generic_instance` or mangled-name
-/// construction.
+/// Generic-instantiation decision at a call, struct-literal, or
+/// variant-construction site. `type_args` holds the concrete type per generic
+/// parameter in declaration order, `instance_type` the resulting
+/// `GenericInstance` id or the call's monomorphic target — recorded together so
+/// reify drops into the TIR slot without re-running `make_generic_instance`.
 #[derive(Clone)]
 pub(crate) struct GenericInstantiation {
     pub(crate) type_args: Vec<TypeId>,
@@ -910,16 +796,10 @@ pub(crate) struct ImplFacts {
     /// but is decided at impl-block scope.
     pub(crate) is_ref_impl: bool,
     /// Mangled struct name the elaborator feeds into
-    /// [`crate::name::MethodName::format_local`] when naming the impl's
-    /// methods — the result of `get_type_name(&impl_block.ty)` at
-    /// elaborator-level recording time.
-    ///
-    /// Reify reads this verbatim instead of reconstructing it from the
-    /// resolved [`Self::self_type`] (which would need `&` / `&mut` / tuple
-    /// special cases and the `&T`-blanket "bare `&`" carve-out that
-    /// `get_type_name` already encodes — `module.rs:581`). Keeping the
-    /// canonical name on the impl facts prevents the parity-bug class
-    /// called out in WEP 2026-05-26 §"Reify — mechanical".
+    /// [`crate::name::MethodName::format_local`] when naming the impl's methods.
+    /// Reify reads it verbatim rather than rebuilding it from [`Self::self_type`],
+    /// which would mean re-encoding the `&` / `&mut` / tuple cases and the
+    /// `&T`-blanket carve-out that `get_type_name` already handles.
     pub(crate) struct_name: crate::name::FqTypeName,
     /// The impl target's typed receiver, decided from the AST type at record
     /// time (`Receiver::Ref` for `&T` / `&mut T`, `Receiver::Type` otherwise).

--- a/wado-compiler/src/elaborator/sem/types.rs
+++ b/wado-compiler/src/elaborator/sem/types.rs
@@ -640,7 +640,7 @@ pub(crate) struct GenericInstantiation {
 }
 
 /// A single mutating outer-binding captured by a closure. The closure
-/// pre-pass at `closure.rs:140–193` materialises a
+/// pre-pass materialises a
 /// `let __ref_<var_name> = &mut <var_name>;` in the outer scope before
 /// opening the closure body; reify replays the same `add_local` at the
 /// same point. The fields below carry every value the replay needs.
@@ -742,7 +742,7 @@ pub(crate) struct HandlerBindingFacts {
 /// One effect a handler binding installs. Mirrors the per-effect
 /// component the elaborator computes inside
 /// `resolve_explicit_handler_binding` /
-/// `resolve_bundled_handler_binding` (handlers.rs:108+, 236+).
+/// `resolve_bundled_handler_binding`.
 #[derive(Clone)]
 pub(crate) struct HandlerEffectEntry {
     pub(crate) name: String,

--- a/wado-compiler/src/elaborator/sig.rs
+++ b/wado-compiler/src/elaborator/sig.rs
@@ -10,24 +10,11 @@ use crate::tir::{TypeId, TypeTable};
 
 use super::sem::decls::FunctionSig;
 
-/// Program-wide declaration facts, resolved once by the decl pass and
-/// read-only afterwards (WEP 2026-05-26).
-///
-/// # Membership rule
-///
-/// One entry per source declaration, holding what that declaration *says* —
-/// its signature, or the declaration-level datum it is. Nothing computed
-/// from a use site, and nothing a later phase recomputes: after
-/// `annotate_decls` no phase re-resolves a declaration signature from AST.
-///
-/// AST survives inside an entry only where the value is irreducibly AST and
-/// the consumer is the walker or reify, never a query: parameter defaults
-/// (re-resolved per call site under the callee's scope, WEP 2026-04-11),
-/// associated-const value expressions, `__DATA__` contents.
-///
-/// Assembled from the per-module [`super::sem::decls::ModuleDecls`] digests
-/// once every module's decl pass has run, so a body walk reads any module's
-/// declarations without reaching for an AST.
+/// Program-wide declaration facts, resolved once by the decl pass and read-only
+/// afterwards (WEP 2026-05-26). One entry per source declaration, holding what
+/// it *says*, never anything computed from a use site. AST survives inside an
+/// entry only where the value is irreducibly AST — parameter defaults,
+/// associated-const values, `__DATA__`. Assembled from `ModuleDecls` digests.
 #[derive(Default)]
 pub(crate) struct Signatures {
     /// Canonical free-function signatures, declaring module → name.
@@ -117,18 +104,11 @@ impl Signatures {
     }
 }
 
-/// A declaration's parameter and return types, resolved once in its
-/// declaring frame and abstract over the positional slots in
-/// [`Self::type_params`] (WEP 2026-05-26).
-///
-/// Slot `i` is a `ResolvedType::TypeParam` (or `TypePack`) whose index is
-/// `i`, so a use site's type arguments fill the slots positionally.
-/// Effect parameters and `<F: fn(…)>` bounds consume no slot — they are
-/// scope entries, not substitution targets — so this list is dense.
-///
-/// A use site that knows its type arguments reads the signature through
-/// [`Self::instantiate`]. Inference, which solves *for* those arguments,
-/// is the one consumer that reads the canonical types directly.
+/// A declaration's parameter and return types, resolved once in its declaring
+/// frame and abstract over the positional slots in [`Self::type_params`]. Slot
+/// `i` is a `TypeParam` of index `i`, filled positionally; effect parameters and
+/// `<F: fn(…)>` bounds are scope entries, not substitution targets, so the list
+/// stays dense. Read through [`Self::instantiate`] — except by inference.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct DeclSig {
     pub(crate) type_params: Vec<(String, TypeId)>,

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -145,33 +145,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Resolve a local item declaration (`Stmt::Item`) — a struct/enum/
-    /// variant/flags/newtype/impl/trait declared inside a function body,
-    /// scoped to that function only (WEP local-item-definitions). Resolution
-    /// is sequential and forward-declaration-required, matching `let`: no
-    /// hoisting, no mutual reference between local declarations.
-    ///
-    /// Struct/newtype are minted under a mangled internal name
-    /// (`{name}@{AstId:?}`) so same-named locals in sibling functions never
-    /// collide in this module's shared `sem.decls.local_*` tables — the
-    /// durable storage reify recovers via `recorded_type` (see
-    /// `reify_struct_literal`). The bare declared name is additionally
-    /// registered in the function-scoped `fn_local_*` tables (cleared at the
-    /// top of every `resolve_function`), so `resolve_named_type` et al find
-    /// it by the name written in source, for the rest of this function only.
-    ///
-    /// Enum/variant/flags/impl/trait are parsed but not yet resolved here:
-    /// `Shape::Circle(1)`-style construction needs a per-AstId recorded fact
-    /// for reify's call/ident resolution, which (unlike struct literals) does
-    /// not go through `recorded_type` — a follow-up. A reference to one of
-    /// these local kinds still surfaces a clear error (`unknown identifier`,
-    /// `unknown function`, a type mismatch, or `no method found`, depending
-    /// on how it's referenced), just not a dedicated "not supported yet" one.
-    ///
-    /// `item.visibility()` is always `Private` here: the parser rejects a
-    /// `pub`/`internal`/`export` prefix before a local item with a dedicated
-    /// error (`at_visibility_prefixed_local_item_start`) rather than
-    /// producing a non-private `Item` for this to reject a second time.
+    /// Resolve a `Stmt::Item` — a declaration inside a function body, scoped to
+    /// that function. Sequential and forward-declaration-required, like `let`.
+    /// A struct or newtype is minted under a mangled `{name}@{AstId}` so
+    /// same-named locals in sibling functions cannot collide in the module's
+    /// shared tables, with the bare name additionally registered in the
+    /// function-scoped ones. The other kinds are parsed but not yet resolved:
+    /// `Shape::Circle(1)` needs a per-`AstId` fact reify's call resolution can
+    /// read, which struct literals get from `recorded_type` and these do not.
     fn resolve_local_item(&mut self, item: &ast::Item) {
         match item {
             ast::Item::Struct(struct_decl) => self.resolve_local_struct(struct_decl),
@@ -1213,24 +1194,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Resolve a let-chain condition into a nested sequence of TIR statements.
-    ///
-    /// Each element of the chain adds one nesting level: a `Let` element becomes a
-    /// two-arm `Match` expression statement (the pattern arm vs. a wildcard else
-    /// arm; the scrutinee stays inline and is hoisted into a temp local later, in
-    /// `translate::pattern`), and an `Expr` element becomes an `If` node (boolean
-    /// guard). All levels that fail fall through to `else_block`; the innermost
-    /// level runs `then_block`.
-    ///
-    /// The `else_block` TIR is cloned for each failure path. This duplicates else-block code
-    /// in the output, but is typically small (e.g., `None` or a single `panic` call).
-    ///
-    /// The combined walk does not build the
-    /// normalized `Match` / `If` chain TIR (reify rebuilds it from the
-    /// `DesugarKind::IfLetChain` tag + the AST); this walk only resolves the
-    /// scrutinees / conditions for their facts, binds the patterns into `ctx`,
-    /// and recurses into the then-block. The else-block is resolved once by
-    /// the caller (in the outer scope), so it is not threaded here.
+    /// Resolve a let-chain condition, one nesting level per element: a `Let`
+    /// becomes a two-arm `Match`, an `Expr` an `If` guard, every failure falling
+    /// through to `else_block` and the innermost success running `then_block`.
+    /// This walk only resolves the scrutinees and conditions for their facts and
+    /// binds the patterns into `ctx` — reify rebuilds the chain from the
+    /// `DesugarKind::IfLetChain` tag and the AST. The else-block is resolved once
+    /// by the caller, in the outer scope, so it is not threaded here.
     pub(super) fn resolve_let_chain_stmts(
         &mut self,
         elements: &[ConditionElement],
@@ -1486,17 +1456,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     if let Some((_const_module, type_id, const_expr)) =
                         self.lookup_associated_constant(&assoc_const_key)
                     {
-                        // Resolve for side effects (records the const body's
-                        // types for reify). `resolve_literal` is a
-                        // placeholder, so classify the Literal-vs-ConstantValue
-                        // pattern from the const body AST rather than the
-                        // resolved value's kind. A literal body becomes a
-                        // `Literal` pattern (switch optimization + exhaustiveness);
-                        // anything else is an opaque `ConstantValue`.
                         // Resolve the const body for its facts. An associated
-                        // constant introduces no binding (it is either a literal
-                        // or an opaque constant-value pattern), so return no
-                        // bindings either way.
+                        // constant introduces no binding — it is either a literal
+                        // or an opaque constant-value pattern — so return none
+                        // either way.
                         self.resolve_expr(&const_expr, ctx, Some(type_id));
                         return Vec::new();
                     }
@@ -2064,16 +2027,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // same invariant.
         let saved_continue = std::mem::take(&mut ctx.for_continue_labels);
 
-        // Check if the iterable is `.enumerate()` on something.
-        //
-        // WEP 2026-05-26 note: the `.enumerate()`
-        // `MethodCallExpr` is unwrapped here at the AST level — the
-        // elaborator never resolves it as a method call, so
-        // `expression_types` and `method_dispatch` carry no entry for
-        // `mc.id`. The future `reify` pass re-detects this pattern by
-        // looking at `for_of.iterable` directly, so missing annotations
-        // on `mc` are intentional (mirroring the `tuple.len()` /
-        // `.zip()` short-circuits documented on `MethodDispatch`).
+        // Unwrap an `.enumerate()` iterable at the AST level. The elaborator
+        // never resolves it as a method call, so `mc.id` carries no annotations
+        // — intentional, like the `tuple.len()` short-circuits on
+        // `MethodDispatch`. Reify re-detects the pattern from `for_of.iterable`.
         let (actual_iterable, is_enumerate) = match &for_of.iterable {
             Expr::MethodCall(mc) if mc.method == "enumerate" && mc.args.is_empty() => {
                 (&mc.receiver, true)
@@ -2164,17 +2121,6 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ctx.for_continue_labels = saved_continue;
     }
 
-    /// Expand `for let v of tuple { body }` by unrolling the body once per element.
-    ///
-    /// Produces:
-    /// ```text
-    /// __tuple_for_of_N: {
-    ///     let __tuple_N = <iterable>;
-    ///     { let v = __tuple_N.0; body }
-    ///     { let v = __tuple_N.1; body }
-    ///     ...
-    /// }
-    /// ```
     /// Create a deferred `VariadicForOf` TIR node for `for let v of iterable`
     /// where `iterable` has a tuple type containing `TypePack` elements.
     ///
@@ -2322,6 +2268,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
+    /// Expand `for let v of tuple { body }` by unrolling the body once per
+    /// element, binding the tuple to `__tuple_N` and each element to `v` in its
+    /// own block, all inside a `__tuple_for_of_N` label.
     fn resolve_tuple_for_of(
         &mut self,
         for_of: &ForOfStmt,
@@ -2458,40 +2407,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .push(element_overlays);
     }
 
-    /// Lower `for let v of iterable { body }` directly into TIR for non-tuple
-    /// iterables. Produces:
-    ///
-    /// ```text
-    /// __for_of_N: {
-    ///     let mut __iter_N = iterable.into_iter();
-    ///     loop {
-    ///         match __iter_N.next() {
-    ///             Option::Some(v) => body,
-    ///             _ => break,
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// The synthetic `__iter_N` local is registered with `defining_ast_id:
-    /// None` (same convention as `assert`'s `__cond` / `__vK` temps) so it
-    /// never enters `local_symbols`. That keeps LSP hover / jump-to-def on
-    /// the `for` keyword from surfacing the helper name. The `.into_iter()`
-    /// / `.next()` dispatches go through [`Self::resolve_method_call_with`]
-    /// with `method_id: None`, so no use→def edges are recorded against
-    /// `for_of.id` either — clicking the `for` keyword no longer drags the
-    /// user into `Iterator::next` in `core:prelude/list.wado`.
-    ///
-    /// `for_of.iterable` is resolved as-is — if the user wrote
-    /// `for let item of expr.enumerate()`, the `.enumerate()` is part of
-    /// the AST and flows naturally into the iterator chain. (The previous
-    /// `is_enumerate` parameter survived only because `resolve_tuple_for_of`
-    /// uses it to special-case the index binding; the iterator path has
-    /// nothing to do with it. The pre-refactor implementation wrapped the
-    /// already-enumerated AST in a second `.enumerate()`, producing
-    /// `IterEnumerate<IterEnumerate<…>>` and ICE-ing at codegen with
-    /// "unsubstituted `AssocTypeProjection` `Item` reached codegen" — see
-    /// `tests/fixtures/for_of_iterator_enumerate.wado`.)
+    /// Lower a non-tuple `for let v of iterable { body }` into a labelled block
+    /// binding `__iter_N = iterable.into_iter()` around a `loop` that matches
+    /// `__iter_N.next()`, breaking on `None`. The synthetic local and both
+    /// dispatches are registered with no defining `AstId`, so neither enters
+    /// `local_symbols` nor records a use→def edge — clicking `for` does not drag
+    /// the user into `Iterator::next`. `for_of.iterable` is resolved as written,
+    /// so a user's own `.enumerate()` flows into the chain rather than being
+    /// wrapped in a second one.
     fn resolve_iterator_for_of(&mut self, for_of: &ForOfStmt, ctx: &mut FunctionContext) {
         use super::method_call::MethodCallInput;
 
@@ -2805,28 +2728,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     ) {
     }
 
-    /// Resolve a `while` or `while let` loop directly into TIR.
-    ///
-    /// `while cond { B }` lowers to:
-    ///
-    /// ```text
-    /// loop {
-    ///     if !cond { break; }
-    ///     B
-    /// }
-    /// ```
-    ///
-    /// `while let pat = expr { B }` (and the let-chain variant) lowers to:
-    ///
-    /// ```text
-    /// loop {
-    ///     match expr { pat => B, _ => break; }
-    /// }
-    /// ```
-    ///
-    /// Naked `break` / `continue` inside `B` target the synthesised
-    /// `loop`, which is the correct semantics — no label re-targeting is
-    /// required (unlike C-style `for`).
+    /// Resolve a `while` or `while let` into a `loop`: the former guarded by
+    /// `if !cond { break; }`, the latter by `match expr { pat => B, _ => break }`.
+    /// A naked `break` / `continue` in the body already targets that synthesised
+    /// loop, so unlike the C-style `for` no label re-targeting is needed.
     pub(super) fn resolve_while(&mut self, w: &WhileStmt, ctx: &mut FunctionContext) {
         // Naked `continue` inside this while's body targets *this* loop,
         // not an enclosing C-style `for` body label.
@@ -2858,45 +2763,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ctx.for_continue_labels = saved_continue;
     }
 
-    /// Resolve a C-style `for init; cond; update { B }` loop directly into TIR.
-    ///
-    /// Lowered shape:
-    ///
-    /// ```text
-    /// {
-    ///     init;                        // when present
-    ///     loop {
-    ///         if !cond { break; }      // omitted when `cond` is absent
-    ///         __for_N_body: { B }
-    ///         update;                  // when present
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// The outer `{ … }` is a fresh elaborator scope so `init`'s bindings stay
-    /// local to the for. `B` is wrapped in `__for_N_body` so that naked
-    /// `continue` (which would otherwise skip the `update`) is rerouted via
-    /// [`Self::resolve_continue`] to `break __for_N_body`, letting control
-    /// fall through to `update;` before the next iteration. Naked `break`
-    /// already targets the innermost loop, which is the `loop {}` here, so
-    /// no extra rewriting is needed.
-    ///
-    /// `while let` form `for init; let pat = e; update { B }` lowers to:
-    ///
-    /// ```text
-    /// {
-    ///     init;
-    ///     loop {
-    ///         match e {
-    ///             pat => {
-    ///                 __for_N_body: { B }
-    ///                 update;
-    ///             }
-    ///             _ => break;
-    ///         }
-    ///     }
-    /// }
-    /// ```
+    /// Resolve a C-style `for init; cond; update { B }` into
+    /// `{ init; loop { if !cond { break; } __for_N_body: { B } update; } }`,
+    /// with the `let pat = e` form guarding on a `match` instead. The outer block
+    /// is a fresh scope, keeping `init`'s bindings local to the `for`, and `B`'s
+    /// label is what [`Self::resolve_continue`] reroutes a naked `continue` to,
+    /// so control still falls through `update`. A naked `break` already targets
+    /// the `loop`, so it needs no rewriting.
     pub(super) fn resolve_for(&mut self, f: &ForStmt, ctx: &mut FunctionContext) {
         self.record_desugar(f.id, super::sem::types::DesugarKind::CStyleFor);
         let loop_id = ctx.next_loop_id;

--- a/wado-compiler/src/elaborator/stmt.rs
+++ b/wado-compiler/src/elaborator/stmt.rs
@@ -146,13 +146,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Resolve a `Stmt::Item` — a declaration inside a function body, scoped to
-    /// that function. Sequential and forward-declaration-required, like `let`.
-    /// A struct or newtype is minted under a mangled `{name}@{AstId}` so
-    /// same-named locals in sibling functions cannot collide in the module's
-    /// shared tables, with the bare name additionally registered in the
-    /// function-scoped ones. The other kinds are parsed but not yet resolved:
-    /// `Shape::Circle(1)` needs a per-`AstId` fact reify's call resolution can
-    /// read, which struct literals get from `recorded_type` and these do not.
+    /// that function. Sequential and forward-declaration-required, like `let`. A
+    /// struct or newtype is minted under a mangled `{name}@{AstId}` so sibling
+    /// functions cannot collide in the module's shared tables. The other kinds
+    /// are parsed but not resolved, having no per-`AstId` fact for reify.
     fn resolve_local_item(&mut self, item: &ast::Item) {
         match item {
             ast::Item::Struct(struct_decl) => self.resolve_local_struct(struct_decl),
@@ -1197,10 +1194,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Resolve a let-chain condition, one nesting level per element: a `Let`
     /// becomes a two-arm `Match`, an `Expr` an `If` guard, every failure falling
     /// through to `else_block` and the innermost success running `then_block`.
-    /// This walk only resolves the scrutinees and conditions for their facts and
-    /// binds the patterns into `ctx` — reify rebuilds the chain from the
-    /// `DesugarKind::IfLetChain` tag and the AST. The else-block is resolved once
-    /// by the caller, in the outer scope, so it is not threaded here.
+    /// This walk only resolves the scrutinees and conditions and binds the
+    /// patterns; reify rebuilds the chain from the `DesugarKind::IfLetChain` tag.
     pub(super) fn resolve_let_chain_stmts(
         &mut self,
         elements: &[ConditionElement],
@@ -2410,11 +2405,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Lower a non-tuple `for let v of iterable { body }` into a labelled block
     /// binding `__iter_N = iterable.into_iter()` around a `loop` that matches
     /// `__iter_N.next()`, breaking on `None`. The synthetic local and both
-    /// dispatches are registered with no defining `AstId`, so neither enters
-    /// `local_symbols` nor records a use→def edge — clicking `for` does not drag
-    /// the user into `Iterator::next`. `for_of.iterable` is resolved as written,
-    /// so a user's own `.enumerate()` flows into the chain rather than being
-    /// wrapped in a second one.
+    /// dispatches carry no defining `AstId`, so clicking `for` does not drag the
+    /// user into `Iterator::next`. `for_of.iterable` is resolved as written.
     fn resolve_iterator_for_of(&mut self, for_of: &ForOfStmt, ctx: &mut FunctionContext) {
         use super::method_call::MethodCallInput;
 
@@ -2766,10 +2758,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     /// Resolve a C-style `for init; cond; update { B }` into
     /// `{ init; loop { if !cond { break; } __for_N_body: { B } update; } }`,
     /// with the `let pat = e` form guarding on a `match` instead. The outer block
-    /// is a fresh scope, keeping `init`'s bindings local to the `for`, and `B`'s
-    /// label is what [`Self::resolve_continue`] reroutes a naked `continue` to,
-    /// so control still falls through `update`. A naked `break` already targets
-    /// the `loop`, so it needs no rewriting.
+    /// is a fresh scope, and `B`'s label is what [`Self::resolve_continue`]
+    /// reroutes a naked `continue` to, so control still falls through `update`.
     pub(super) fn resolve_for(&mut self, f: &ForStmt, ctx: &mut FunctionContext) {
         self.record_desugar(f.id, super::sem::types::DesugarKind::CStyleFor);
         let loop_id = ctx.next_loop_id;

--- a/wado-compiler/src/elaborator/synth.rs
+++ b/wado-compiler/src/elaborator/synth.rs
@@ -1,14 +1,8 @@
 //! Argument type synthesis — what a call site knows about an argument's type
-//! before any candidate signature exists. Overload selection (WEP 2026-07-31)
-//! needs that before it can pick among a trait's argument lists, arguments being
-//! elaborated only after the winner is known, so this classifies an argument
-//! into an [`ArgClass`]: the set of types it could elaborate to.
-//!
-//! The set must *contain* the real type. Over-approximating costs a resolution,
-//! under-approximating picks the wrong impl, so an inexact premise widens to
-//! [`ArgClass::Head`] or [`ArgClass::Opaque`] rather than guessing. Running
-//! before anything is committed, synthesis must also leave no trace but
-//! interning — the lookups it makes run quiet, asserting the fact count holds.
+//! before any candidate signature exists, which overload selection (WEP
+//! 2026-07-31) needs and elaboration cannot yet give. The resulting
+//! [`ArgClass`] must *contain* the real type, so an inexact premise widens
+//! rather than guessing, and synthesis leaves no trace but interning.
 
 use crate::ast;
 use crate::compiler_host::CompilerHost;

--- a/wado-compiler/src/elaborator/synth.rs
+++ b/wado-compiler/src/elaborator/synth.rs
@@ -1,27 +1,14 @@
 //! Argument type synthesis — what a call site knows about an argument's type
-//! before any candidate signature exists.
+//! before any candidate signature exists. Overload selection (WEP 2026-07-31)
+//! needs that before it can pick among a trait's argument lists, arguments being
+//! elaborated only after the winner is known, so this classifies an argument
+//! into an [`ArgClass`]: the set of types it could elaborate to.
 //!
-//! Overload selection (WEP 2026-07-31) needs argument types before it can pick
-//! among one trait's argument lists, and arguments are elaborated *after* the
-//! winner is known. This module answers the question in between: it classifies
-//! an argument expression into an [`ArgClass`], the set of types the argument
-//! could elaborate to.
-//!
-//! # Soundness
-//!
-//! The denoted set must *contain* the type the argument really elaborates to.
-//! Over-approximating costs a resolution; under-approximating selects the wrong
-//! impl, which is a compiler bug. A premise that is not exactly known widens to
-//! [`ArgClass::Head`] or [`ArgClass::Opaque`], never to a guess.
-//!
-//! # Side-effect discipline
-//!
-//! Synthesis runs during lookup, before anything is committed, so it must leave
-//! no trace but interning: no `resolve_expr`, no `&mut FunctionContext`, no
-//! TIR, no recorded fact. The lookup queries it does call report and record on
-//! their own, so [`Elaborator::synthesize_arg_class`] runs them under the
-//! logger's quiet scope and the use→def suppression, and asserts in debug
-//! builds that the module's fact count is unchanged.
+//! The set must *contain* the real type. Over-approximating costs a resolution,
+//! under-approximating picks the wrong impl, so an inexact premise widens to
+//! [`ArgClass::Head`] or [`ArgClass::Opaque`] rather than guessing. Running
+//! before anything is committed, synthesis must also leave no trace but
+//! interning — the lookups it makes run quiet, asserting the fact count holds.
 
 use crate::ast;
 use crate::compiler_host::CompilerHost;

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -183,10 +183,8 @@ use crate::symbol::SymbolTable;
 /// Pick a `ModuleSource` from the AST and synthesised candidate lists: a
 /// `prefer` hint wins wherever it appears, else the first AST entry, else the
 /// first synthesised one. AST-first is load-bearing — where a type has both a
-/// written `impl` and generated code, the written block is the answer. Taking
-/// the union keeps one layer from masking the other on a shared key, which is
-/// where core's variadic `impl<..T> Inspect for [..T]` and a user `Tuple`'s
-/// auto-derived impl collide.
+/// written `impl` and generated code, the written block is the answer — and the
+/// union keeps one layer from masking the other on a shared key.
 fn pick_module_union<'a>(
     ast: Option<&'a Vec<ModuleSource>>,
     syn: Option<&'a Vec<ModuleSource>>,
@@ -449,9 +447,7 @@ pub(crate) enum BlanketParamSource {
 /// by the blanket's `(module, ast_id)`. `None` is the receiver, filled by the
 /// call site; `Some((trait, associated type))` is one a predicate fixes. Order
 /// is the point — type arguments are consumed positionally, so a receiver
-/// written after another parameter sits at a slot "receiver first, projections
-/// after" never fills. The bound keys by its own reference site, so it names the
-/// trait declaration rather than the spelling.
+/// written after another parameter sits at a slot the caller never fills.
 fn blanket_param_sources(
     impl_headers: &IndexMap<(ModuleSource, AstId), ImplHeader>,
     blanket_impls: &IndexMap<String, Vec<BlanketImpl>>,
@@ -683,10 +679,9 @@ pub(super) type ResourceStaticMethodIndex =
 
 /// `(type_name, trait_name)` → modules holding that `impl` block. Keyed by bare
 /// names rather than [`DeclKey`]: the multi-value `Vec` plus the caller's
-/// `type_module` hint already routes two modules' same-named receivers apart,
-/// and canonical keying would need import resolution `TraitEnv::build` has not
-/// plumbed through. Value blanket impls are excluded — they apply structurally,
-/// with no concrete receiver name — and live in `blanket_impls` instead.
+/// `type_module` hint already routes two modules' same-named receivers apart.
+/// Value blanket impls apply structurally, with no concrete receiver name, and
+/// live in `blanket_impls` instead.
 pub(crate) type TraitImplModuleIndex = IndexMap<(String, String), Vec<ModuleSource>>;
 
 /// Where each `impl <trait> for <type>` lives, reachable from both receiver
@@ -773,9 +768,7 @@ fn push_module(
 /// off the headers' resolved identities rather than the heads they wrote.
 /// `concrete_only` keeps just the parameterless blocks: the monomorphizer sends
 /// a substituted call to a concrete impl's own module, while a generic impl's
-/// instance is materialised in the receiver type's. A value blanket has no
-/// per-type home and keys as [`ImplTargetKey::TypeParam`], which is what
-/// excludes it.
+/// instance is materialised in the receiver type's.
 fn index_impl_modules(
     impl_headers: &IndexMap<(ModuleSource, AstId), ImplHeader>,
     concrete_only: bool,
@@ -812,9 +805,8 @@ fn index_impl_modules(
 /// Immutable global knowledge base for trait resolution: pre-built indices over
 /// trait impls, declarations, and blanket impls, built once before resolution
 /// and shared by `Arc` across every module elaborator. Intentionally not
-/// `Clone` — the only legitimate mutation is [`Self::extend_with_synthesised`],
-/// which moves out of a uniquely-owned `Arc`, so accidental sharing surfaces as
-/// a compile error instead of a silent deep clone of every index.
+/// `Clone` — the only mutation is [`Self::extend_with_synthesised`], which moves
+/// out of a uniquely-owned `Arc`, so sharing errors instead of deep-cloning.
 #[derive(Debug)]
 pub struct TraitEnv {
     /// Type name → impl blocks that implement traits for that type.
@@ -978,8 +970,7 @@ impl TraitEnv {
     /// resolution begins, and check the orphan rule on local impl blocks. Every
     /// receiver-type and trait-name reference in an `impl` header is
     /// canonicalised through `symbols` against that module's own import context,
-    /// so two modules' same-named traits produce distinct [`DeclKey`]s. The
-    /// symbol table comes from `analyze`, which runs first.
+    /// so two modules' same-named traits produce distinct [`DeclKey`]s.
     pub(super) fn build(
         modules: &IndexMap<ModuleSource, Module>,
         symbols: &SymbolTable,
@@ -1816,9 +1807,8 @@ impl TraitEnv {
     /// Produce a new `TraitEnv` carrying the synthesis-layer impls — every
     /// `(type_name, trait_name) -> ModuleSource` found in TIR once synthesis has
     /// added its auto-derived impls. Called once per pipeline run; calling again
-    /// replaces the layer. `prev` must be the unique owner: since `TraitEnv` is
-    /// not `Clone`, extension can only move out of the `Arc`, swap a field, and
-    /// re-wrap — so a shared `Arc` panics.
+    /// replaces the layer. `prev` must be the unique owner: extension moves out
+    /// of the `Arc`, swaps a field and re-wraps, so a shared `Arc` panics.
     pub fn extend_with_synthesised(prev: Arc<Self>, synth_impls: SynthesisedImpls) -> Arc<Self> {
         let Ok(mut env) = Arc::try_unwrap(prev) else {
             panic!("extend_with_synthesised: TraitEnv Arc must be uniquely owned")
@@ -1831,10 +1821,8 @@ impl TraitEnv {
 /// Which namespace an impl-module query spells its receiver in. The two are not
 /// interchangeable — a mangled fq receiver picks out one declaration, a declared
 /// name picks out any declaration spelling itself that way — and each has its
-/// own storage, written from one receiver identity, so a query cannot land in
-/// the wrong one. [`Self::Of`] carries the identity and derives both spellings;
-/// the others are for callers holding only one. A bare `&str` cannot claim to be
-/// mangled.
+/// own storage. [`Self::Of`] carries the identity and derives both spellings;
+/// the others are for callers holding only one.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ImplReceiver<'a> {
     /// The receiver itself. Both spellings are derived from it here, so the
@@ -1921,9 +1909,8 @@ fn impl_target_key_at(
 /// The one trait declaration named `name`, else the one effect or resource —
 /// per-family and in that order, so a `trait Encode` beside another module's
 /// `interface Encode` is one trait rather than an ambiguity. Declines when a
-/// single family holds two. Not yet identical to `decl_key_or_local`, which
-/// consults its struct-like index first; the fix is a trait-position entry point
-/// on the elaborator, not a struct-first order here.
+/// single family holds two. Differs from `decl_key_or_local`, which consults its
+/// struct-like index first.
 fn unique_declared_trait<L, E, R>(
     name: &str,
     decls: &IndexMap<DeclKey, L>,
@@ -2392,10 +2379,8 @@ impl VariadicImpl<'_> {
 /// Coherence Rule 2 (WEP 2026-03-14 §5): two variadic impls of one trait accept
 /// the same tuples, and a pack's bounds resolve only at monomorphization, so
 /// nothing separates them at selection — reject the later one where it is
-/// written. A stdlib impl is considered but never reported, being unfixable by
-/// the user. Grouping is by trait *declaration*, so two modules may each keep
-/// their own. The same walk refuses a target the compiler does not implement,
-/// which would otherwise miscompile or trip the WIR validator.
+/// written. Grouping is by trait *declaration*, so two modules may each keep
+/// their own. The same walk refuses a target the compiler cannot implement.
 fn check_variadic_impl_overlap(
     impl_headers: &IndexMap<(ModuleSource, AstId), ImplHeader>,
 ) -> Vec<(ModuleSource, TypeError)> {

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -180,17 +180,13 @@ fn collect_case_names(
 use super::types::TypeError;
 use crate::symbol::SymbolTable;
 
-/// Pick a `ModuleSource` out of the AST + synthesised candidate lists. A
-/// `prefer` hint wins wherever it appears; otherwise the first AST entry
-/// answers, then the first synthesised one.
-///
-/// AST-first is load-bearing: where a type carries both a written `impl` block
-/// and generated code, the block's module is the answer, and reordering these
-/// routes serde types to the wrong module.
-///
-/// The union is what keeps one layer from masking the other on a shared key —
-/// core's variadic `impl<..T> Inspect for [..T]` and a user `struct Tuple`'s
-/// auto-derived `Tuple^Inspect` collide there, and the hint separates them.
+/// Pick a `ModuleSource` from the AST and synthesised candidate lists: a
+/// `prefer` hint wins wherever it appears, else the first AST entry, else the
+/// first synthesised one. AST-first is load-bearing — where a type has both a
+/// written `impl` and generated code, the written block is the answer. Taking
+/// the union keeps one layer from masking the other on a shared key, which is
+/// where core's variadic `impl<..T> Inspect for [..T]` and a user `Tuple`'s
+/// auto-derived impl collide.
 fn pick_module_union<'a>(
     ast: Option<&'a Vec<ModuleSource>>,
     syn: Option<&'a Vec<ModuleSource>>,
@@ -218,14 +214,6 @@ fn pick_module_union<'a>(
 /// before consulting the index.
 pub(crate) type DeclKey = (ModuleSource, String);
 
-/// Pre-built index: type name → list of (`ModuleSource`, item index) for trait impl blocks.
-/// Built once from all loaded modules to avoid O(all items) scans per method call.
-///
-/// Keyed by the bare receiver type name on purpose: the lookup iterates the
-/// candidate `Vec` and disambiguates each entry via its `(ModuleSource,
-/// AstId)` payload plus the elaborator's per-call type-id comparison, so
-/// two `struct Widget` declarations in different modules share one bucket
-/// without ambiguity.
 /// Identity of an impl's target type. A named type keys by its *declaring*
 /// module and canonical name, so two modules' same-named structs — and one
 /// type reached under an alias — are the same key exactly when they are the
@@ -317,6 +305,8 @@ impl ImplTargetKey {
     }
 }
 
+/// Target type → the trait impl blocks written for it. Built once from all
+/// loaded modules so a method call costs a lookup rather than a scan.
 pub(super) type TraitImplIndex = IndexMap<ImplTargetKey, Vec<(ModuleSource, AstId)>>;
 
 type ReceiverImplIndex = IndexMap<name::Receiver, Vec<(ModuleSource, AstId)>>;
@@ -456,17 +446,12 @@ pub(crate) enum BlanketParamSource {
 }
 
 /// What determines each blanket impl's parameters, in declaration order, keyed
-/// by the blanket's `(module, ast_id)`.
-///
-/// `None` is the receiver, which the call site's receiver type fills;
-/// `Some((trait, associated type))` is a parameter a predicate fixes — `..F` in
-/// `impl<S: ReflectStruct<FieldTypes = [..F]>, ..F>`. Declaration order is the
-/// point: the impl's type arguments are consumed positionally, and a receiver
-/// written after another parameter sits at a slot that "receiver first,
-/// projections after" never fills.
-///
-/// The bound is keyed by its own reference site, like [`blanket_pack_assocs`],
-/// so the trait it names is the declaration rather than the spelling.
+/// by the blanket's `(module, ast_id)`. `None` is the receiver, filled by the
+/// call site; `Some((trait, associated type))` is one a predicate fixes. Order
+/// is the point — type arguments are consumed positionally, so a receiver
+/// written after another parameter sits at a slot "receiver first, projections
+/// after" never fills. The bound keys by its own reference site, so it names the
+/// trait declaration rather than the spelling.
 fn blanket_param_sources(
     impl_headers: &IndexMap<(ModuleSource, AstId), ImplHeader>,
     blanket_impls: &IndexMap<String, Vec<BlanketImpl>>,
@@ -696,20 +681,12 @@ pub(super) type StaticMethodIndex = IndexMap<DeclKey, Vec<StaticMethodEntry>>;
 pub(super) type ResourceStaticMethodIndex =
     IndexMap<DeclKey, Vec<(String, ModuleSource, AstId, usize)>>;
 
-/// `(type_name, trait_name)` → modules whose `impl <trait_name> for <type_name>`
-/// block exists.
-///
-/// Keyed by bare names (not [`DeclKey`]): the multi-value `Vec` plus the
-/// caller's `type_module` hint already lets two modules' same-named
-/// receivers each route to their own impl. Canonical disambiguation of
-/// the receiver type's *declaring* module would require build-time import
-/// resolution that the current `TraitEnv::build` doesn't have plumbed
-/// through; a follow-up could re-key by canonical pair when the
-/// inhabited-by-multiple-declarations case becomes user-visible.
-///
-/// Value blanket impls (`impl<T: Trait> Trait for T`) are represented by
-/// [`BlanketImpl`] (in `blanket_impls`); they are excluded from this map because
-/// they apply structurally and don't have a concrete receiver type name.
+/// `(type_name, trait_name)` → modules holding that `impl` block. Keyed by bare
+/// names rather than [`DeclKey`]: the multi-value `Vec` plus the caller's
+/// `type_module` hint already routes two modules' same-named receivers apart,
+/// and canonical keying would need import resolution `TraitEnv::build` has not
+/// plumbed through. Value blanket impls are excluded — they apply structurally,
+/// with no concrete receiver name — and live in `blanket_impls` instead.
 pub(crate) type TraitImplModuleIndex = IndexMap<(String, String), Vec<ModuleSource>>;
 
 /// Where each `impl <trait> for <type>` lives, reachable from both receiver
@@ -792,17 +769,13 @@ fn push_module(
     }
 }
 
-/// Where every non-blanket `impl` block lives, in both receiver namespaces,
-/// read off the headers' resolved identities rather than the heads they wrote.
-///
-/// `concrete_only` keeps just the impl blocks with no type parameters: the
-/// monomorphizer redirects a substituted call to a concrete impl's own module,
-/// while a generic impl's instance is materialised in the receiver type's
-/// module by convention.
-///
-/// A value blanket (`impl<T: Bound> Trait for T`) has no per-type home, and its
-/// target keys as [`ImplTargetKey::TypeParam`], so excluding that variant is
-/// what leaves it out.
+/// Where every non-blanket `impl` block lives, in both receiver namespaces, read
+/// off the headers' resolved identities rather than the heads they wrote.
+/// `concrete_only` keeps just the parameterless blocks: the monomorphizer sends
+/// a substituted call to a concrete impl's own module, while a generic impl's
+/// instance is materialised in the receiver type's. A value blanket has no
+/// per-type home and keys as [`ImplTargetKey::TypeParam`], which is what
+/// excludes it.
 fn index_impl_modules(
     impl_headers: &IndexMap<(ModuleSource, AstId), ImplHeader>,
     concrete_only: bool,
@@ -836,16 +809,12 @@ fn index_impl_modules(
     out
 }
 
-/// Immutable global knowledge base for trait resolution.
-///
-/// Contains pre-built indices for fast lookup of trait implementations,
-/// trait declarations, and blanket impls. Built once before resolution
-/// begins and shared (via `Arc`) across all module elaborators.
-/// `TraitEnv` is *intentionally* not `Clone`. After `build()` returns, the
-/// only legitimate way to mutate the env is `extend_with_synthesised`,
-/// which moves out of an `Arc` whose strong count must be 1. Forbidding
-/// clones at the type level surfaces accidental `Arc` sharing as a
-/// compile error rather than a silent deep-clone of every index.
+/// Immutable global knowledge base for trait resolution: pre-built indices over
+/// trait impls, declarations, and blanket impls, built once before resolution
+/// and shared by `Arc` across every module elaborator. Intentionally not
+/// `Clone` — the only legitimate mutation is [`Self::extend_with_synthesised`],
+/// which moves out of a uniquely-owned `Arc`, so accidental sharing surfaces as
+/// a compile error instead of a silent deep clone of every index.
 #[derive(Debug)]
 pub struct TraitEnv {
     /// Type name → impl blocks that implement traits for that type.
@@ -1005,20 +974,12 @@ impl SynthesisedImpls {
 }
 
 impl TraitEnv {
-    /// Build trait indices from all loaded modules.
-    ///
-    /// Called once in [`Elaborator::annotate_modules`] before per-module
-    /// resolution begins.
-    /// The indices enable O(1) trait lookup by type/trait name instead of scanning all modules.
-    /// Also performs orphan rule checking for impl blocks in local (user) modules.
-    ///
-    /// `symbols` is consulted via [`SymbolTable::lookup_in_module`] to
-    /// canonicalise every receiver-type and trait-name reference that
-    /// appears in an `impl` block: bare-name lookups are resolved against
-    /// the impl module's own import context, so two modules with same-
-    /// named traits / structs each produce a distinct [`DeclKey`] in the
-    /// affected indices. The symbol table is built by the `analyze` phase,
-    /// which runs before this routine.
+    /// Build the trait indices from all loaded modules, once, before per-module
+    /// resolution begins, and check the orphan rule on local impl blocks. Every
+    /// receiver-type and trait-name reference in an `impl` header is
+    /// canonicalised through `symbols` against that module's own import context,
+    /// so two modules' same-named traits produce distinct [`DeclKey`]s. The
+    /// symbol table comes from `analyze`, which runs first.
     pub(super) fn build(
         modules: &IndexMap<ModuleSource, Module>,
         symbols: &SymbolTable,
@@ -1852,19 +1813,12 @@ impl TraitEnv {
         self.trait_decl_headers.get(loc)
     }
 
-    /// Produce a new `TraitEnv` with the synthesis-layer impls populated.
-    ///
-    /// `synth_impls` lists every `(type_name, trait_name) -> ModuleSource`
-    /// triple discovered in TIR after the synthesis phase has finished
-    /// adding auto-derived / generated impls. Designed to be called once
-    /// per pipeline run (the synthesis phase) — calling again replaces the
-    /// existing layer.
-    ///
-    /// `prev` must be the unique owner of the inner `TraitEnv`
-    /// (`Arc::strong_count == 1`). Since `TraitEnv: !Clone`, this is the
-    /// only viable extension shape: we move out of the `Arc`, swap one
-    /// field, and re-wrap. Callers are responsible for not handing this
-    /// function a shared `Arc`.
+    /// Produce a new `TraitEnv` carrying the synthesis-layer impls — every
+    /// `(type_name, trait_name) -> ModuleSource` found in TIR once synthesis has
+    /// added its auto-derived impls. Called once per pipeline run; calling again
+    /// replaces the layer. `prev` must be the unique owner: since `TraitEnv` is
+    /// not `Clone`, extension can only move out of the `Arc`, swap a field, and
+    /// re-wrap — so a shared `Arc` panics.
     pub fn extend_with_synthesised(prev: Arc<Self>, synth_impls: SynthesisedImpls) -> Arc<Self> {
         let Ok(mut env) = Arc::try_unwrap(prev) else {
             panic!("extend_with_synthesised: TraitEnv Arc must be uniquely owned")
@@ -1874,17 +1828,13 @@ impl TraitEnv {
     }
 }
 
-/// Which namespace an impl-module query spells its receiver in.
-///
-/// The index answers in two, and they are not interchangeable: a mangled fq
-/// receiver picks out one declaration, a declared name picks out any
-/// declaration spelling itself that way. Each namespace has its own storage,
-/// written from one receiver identity, so a query cannot land in the wrong one
-/// — see WEP 2026-08-10.
-///
-/// [`Self::Of`] carries the identity and lets the index derive both spellings;
-/// the other two are for callers that hold only one. A bare `&str` cannot claim
-/// to be mangled.
+/// Which namespace an impl-module query spells its receiver in. The two are not
+/// interchangeable — a mangled fq receiver picks out one declaration, a declared
+/// name picks out any declaration spelling itself that way — and each has its
+/// own storage, written from one receiver identity, so a query cannot land in
+/// the wrong one. [`Self::Of`] carries the identity and derives both spellings;
+/// the others are for callers holding only one. A bare `&str` cannot claim to be
+/// mangled.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum ImplReceiver<'a> {
     /// The receiver itself. Both spellings are derived from it here, so the
@@ -1968,17 +1918,12 @@ fn impl_target_key_at(
     })
 }
 
-/// The one trait declaration named `name`, else the one effect or resource.
-///
-/// Per-family, in that order, matching `Elaborator::decl_key_or_local`: asking
-/// the three at once would decline where it answers, since a `trait Encode`
-/// beside another module's `interface Encode` is one trait, not an ambiguity.
-/// Declines when a family holds two.
-///
-/// Not yet identical: `decl_key_or_local` consults its struct-like index before
-/// the trait one, so a name declared as a struct in one module and a trait in
-/// another keys differently on the two sides. The fix is a trait-position entry
-/// point on the elaborator, not a struct-first order in a trait lookup.
+/// The one trait declaration named `name`, else the one effect or resource —
+/// per-family and in that order, so a `trait Encode` beside another module's
+/// `interface Encode` is one trait rather than an ambiguity. Declines when a
+/// single family holds two. Not yet identical to `decl_key_or_local`, which
+/// consults its struct-like index first; the fix is a trait-position entry point
+/// on the elaborator, not a struct-first order here.
 fn unique_declared_trait<L, E, R>(
     name: &str,
     decls: &IndexMap<DeclKey, L>,
@@ -2445,16 +2390,12 @@ impl VariadicImpl<'_> {
 }
 
 /// Coherence Rule 2 (WEP 2026-03-14 §5): two variadic impls of one trait accept
-/// the same tuples, and a pack's bounds are resolved only at monomorphization,
-/// so nothing separates them at selection. Reject the later one where it is
-/// written; a stdlib impl is considered but never reported, being unfixable by
-/// the user.
-///
-/// Grouping is by trait *declaration*, so two modules may each declare a `Tag`
-/// and keep their own variadic impls.
-///
-/// The same walk refuses a target the compiler does not implement, which would
-/// otherwise miscompile or trip the WIR validator.
+/// the same tuples, and a pack's bounds resolve only at monomorphization, so
+/// nothing separates them at selection — reject the later one where it is
+/// written. A stdlib impl is considered but never reported, being unfixable by
+/// the user. Grouping is by trait *declaration*, so two modules may each keep
+/// their own. The same walk refuses a target the compiler does not implement,
+/// which would otherwise miscompile or trip the WIR validator.
 fn check_variadic_impl_overlap(
     impl_headers: &IndexMap<(ModuleSource, AstId), ImplHeader>,
 ) -> Vec<(ModuleSource, TypeError)> {
@@ -2557,13 +2498,8 @@ fn target_mentions_impl_param(ty: &ast::Type, params: &IndexSet<&str>) -> bool {
 /// signature on both, letting coherence Rule 1 pick the specific one; an
 /// inherent impl carries no such contract, so a generic caller type-checked
 /// against the general method would link to a differently-typed function.
-/// Rejected, as in Rust.
-///
-/// Keyed by the target's resolved [`ImplTargetKey`], never by the head as
-/// written: `Box_` in one module and `Box_` in another are two types, and a
-/// spelling cannot tell them apart. Reading the resolved key off
-/// [`ImplHeader`] is what makes that structural — the identity is decided once,
-/// where the vantage exists, rather than re-derived here from a bare name.
+/// Rejected, as in Rust. Keyed by the resolved [`ImplTargetKey`], never the
+/// written head — two modules' `Box_` are two types, and a spelling cannot say so.
 fn check_inherent_impl_collisions(
     impl_headers: &IndexMap<(ModuleSource, AstId), ImplHeader>,
 ) -> Vec<(ModuleSource, TypeError)> {
@@ -2642,16 +2578,11 @@ fn check_all_orphan_rules(
         }
 
         let Some(trait_key) = &header.trait_key else {
-            // Inherent impl. The orphan rule (foreign-trait/foreign-type)
-            // does not apply, but coherence does: a user package may only
-            // define inherent methods on types it owns. Extending a foreign
-            // type (a primitive, `Array<T>`, `String`, or any other stdlib
-            // type) inherently would let two packages add colliding methods
-            // to the same type, so it is forbidden — use a trait instead.
-            // `classify_position` looks through references and treats a
-            // `LocalType` head as owned; only a genuinely foreign head is a
-            // violation. (Stdlib modules are skipped above, so their own
-            // `impl Array<T>` / `impl i32` are unaffected.)
+            // Inherent impl: the orphan rule does not apply, but coherence does
+            // — a package may only define inherent methods on types it owns, or
+            // two packages could add colliding methods to `String`. Use a trait
+            // instead. `classify_position` looks through references and counts a
+            // `LocalType` head as owned, and stdlib modules are skipped above.
             if let PositionKind::ForeignType =
                 classify_position(&header.ty, header, &local, resolve)
             {

--- a/wado-compiler/src/elaborator/trait_query.rs
+++ b/wado-compiler/src/elaborator/trait_query.rs
@@ -629,15 +629,10 @@ impl TypeSystem {
     }
 
     /// Whether a reflection written at `scope`'s module can enumerate `info`'s
-    /// fields (WEP 2026-06-13, Visibility).
-    ///
-    /// Every field must be reachable, not merely one: a declaration carries a
-    /// single synthesized impl whose `members()` is fixed, so admitting the
-    /// struct on one public field would enumerate its private ones alongside
-    /// it.
-    ///
-    /// Visibility decides only this. Eligibility is a property of the
-    /// declaration, so [`Self::is_reflect_eligible`] always sees every field.
+    /// fields (WEP 2026-06-13, Visibility). *Every* field must be reachable: a
+    /// declaration carries one synthesized impl with a fixed `members()`, so
+    /// admitting the struct on one public field would expose its private ones.
+    /// Eligibility is separate — [`Self::is_reflect_eligible`] sees every field.
     fn has_visible_fields(&self, scope: &TypeLookup, info: &super::types::StructFieldInfo) -> bool {
         if info.fields.is_empty() || &info.module_source == scope.current_module_source {
             return true;
@@ -2338,24 +2333,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         }
     }
 
-    /// Build a mapping from type parameter names to concrete type IDs.
-    /// For `impl Trait for Container<T>` with concrete type `Container<i32>`,
-    /// returns `{"T" -> i32's TypeId}`.
-    ///
-    /// When `declared_type_params` is non-empty, only names in that set are
-    /// treated as type parameters. This prevents concrete types (e.g., `String` in
-    /// `impl Trait for Map<String, V>`) from being incorrectly mapped.
-    /// When empty, all `Named` types are assumed to be type parameters (legacy behavior).
-    /// Single entry point for resolving a trait method that a binary operator
-    /// dispatches to (Eq / Ord / Add / Sub / Mul / Div / Rem / `BitAnd` / `BitOr` /
-    /// `BitXor` / Shl / Shr). Produces a fully-populated
-    /// [`ResolvedTraitMethod`] with the rhs type already substituted, so
-    /// callers need not reach into the underlying `find_*_trait_impl`
-    /// family and cannot forget to wire `rhs_type` through the typecheck.
-    ///
-    /// `struct_name` / `lookup_type_id` are the name-and-id used for impl
-    /// lookup (for newtypes this may be the ultimate base). `is_type_param`
-    /// is true for `T: Trait` type-param receivers.
+    /// Single entry point for resolving a trait method a binary operator
+    /// dispatches to (Eq / Ord / Add / … / Shr), returning a fully-populated
+    /// [`ResolvedTraitMethod`] with `rhs_type` already substituted so no caller
+    /// can forget to wire it through. `struct_name` / `lookup_type_id` are the
+    /// impl-lookup key — for a newtype, possibly the ultimate base.
     pub(super) fn resolve_trait_method_for_op(
         &mut self,
         struct_name: &str,
@@ -2364,16 +2346,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         method_name: &str,
         is_type_param: bool,
     ) -> Option<ResolvedTraitMethod> {
-        // 1. User-written impl via the shared arithmetic-trait lookup.
-        // 2. Auto-derive fallback (Eq / Ord only; other operator traits
-        //    have no auto-derive rules).
-        //
-        // Eq / Ord trait decls fix their return types (`bool` and `Ordering`
-        // respectively) regardless of what a user impl writes, so normalize
-        // those here. `find_arithmetic_trait_impl` would otherwise default
-        // `output_type` to the receiver type when no `type Output` is
-        // declared. The auto-derive set and the fixed return types come from
-        // `TypeSystem::auto_derive_by_trait` (the single source).
+        // A user-written impl first, then the Eq / Ord auto-derive fallback.
+        // Both fix their return types (`bool`, `Ordering`) whatever a user impl
+        // writes, so normalize here: `find_arithmetic_trait_impl` would default
+        // `output_type` to the receiver type absent a `type Output`. The set and
+        // the types come from `TypeSystem::auto_derive_by_trait`.
         let auto_derive = self.tysys.auto_derive_by_trait(trait_name);
         let (info_trait_name, self_kind, param_types, return_type) = if let Some(info) = self
             .find_arithmetic_trait_impl(struct_name, lookup_type_id, trait_name, method_name, None)
@@ -2416,31 +2393,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         })
     }
 
-    /// Fallback for [`Self::find_trait_method_for_type`]: when no user-written
-    /// impl of `trait_name::method_name` exists for a type that is still
-    /// auto-derive-eligible (per [`Self::type_implements_trait`]), synthesize
-    /// a [`TraitMethodMatch`] whose [`MethodInfo`] has the receiver type
-    /// fully substituted into `Self` positions. This is the single pathway
-    /// that makes auto-derived methods discoverable via method-call
-    /// resolution, mirroring what operator dispatch already got from the
-    /// arithmetic-trait lookup's own auto-derive branch.
-    ///
-    /// Only method bodies actually produced by the trait-synthesis phase
-    /// (`synthesis::traits`) are returned here; primitives are excluded
-    /// because their equality/comparison lowers to Wasm instructions, not
-    /// to a method body.
-    ///
-    /// The method ↔ trait mapping and the fixed return type come from
-    /// [`TypeSystem::auto_derive_by_method`] — the single source for which
-    /// traits the compiler auto-derives — so adding a new auto-derived trait
-    /// touches that table, not this arm.
-    ///
-    /// The synthesized [`MethodInfo`] is still built with the fixed shape the
-    /// auto-derived `Eq` / `Ord` declarations have (`self_kind: Ref`, a single
-    /// `&Self` parameter named `"other"`, no defaults, no method type params).
-    /// Should a future auto-derived trait need a different shape, read it from
-    /// the trait's `ast::Function` (via `find_trait_decl_methods`) instead of
-    /// this literal; the current two traits share this shape exactly.
+    /// Fallback for [`Self::find_trait_method_for_type`]: with no user-written
+    /// impl of `trait_name::method_name` on an auto-derive-eligible type,
+    /// synthesize a [`TraitMethodMatch`] with the receiver substituted into
+    /// `Self`. Primitives are excluded, comparing via Wasm instructions. The
+    /// method ↔ trait table is [`TypeSystem::auto_derive_by_method`].
     pub(super) fn try_auto_derived_method_match(
         &mut self,
         struct_name: &str,
@@ -2507,16 +2464,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 }
 
 impl TypeSystem {
-    /// Whether an `impl` block implements the trait a query is asking about.
-    ///
-    /// Identity when both sides have one: the query's comes from the reference
-    /// site that asked (a bound, a `T::method()` prefix), the impl's from the
-    /// site its header writes, and both were resolved by the module that wrote
-    /// them. Comparing the spellings instead is what made an aliased bound
+    /// Whether an `impl` block implements the trait a query is asking about, by
+    /// identity when both sides have one — each resolved by the module that wrote
+    /// its own reference site. Comparing spellings instead made an aliased bound
     /// unsatisfiable and a same-named foreign trait satisfied (#1785).
-    ///
-    /// `trait_ref: None` is a caller not yet carrying an identity. Those fall
-    /// back to the spelling, which two modules can share.
+    /// `trait_ref: None` falls back to the spelling, which two modules can share.
     fn same_trait(
         &self,
         trait_name: &str,

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -691,18 +691,11 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// What `bounds` say the bounded type's own associated types are, as this
-    /// frame knows them: `type Iter: Iterator<Item = Self::Item>` on a receiver
-    /// `I` asks what `I::Item` is, and `I: IntoIterator<Item = u8>` answers.
-    ///
-    /// `Self` inside a bound names the bounded type, so a `Self::X` right-hand
-    /// side asks about `base`, not about the frame's own `Self`. Only a
-    /// right-hand side the frame can answer produces a binding; the rest stay
-    /// abstract. Resolving one instead — rebinding `Self` to `base` and
-    /// resolving what it denotes — reintroduces two defects: the frame's
-    /// `assoc_type_bindings` shadow the rebound `Self`, so an unrelated
-    /// `impl`'s `type Item = …` answers for a type parameter's, and recursion
-    /// through a bound's own right-hand side has no fixpoint
-    /// (`type A: Iterator<Item = Self::B>` against `type B: Iterator<Item = Self::A>`).
+    /// frame knows them: `I: IntoIterator<Item = u8>` answers what `I::Item` is.
+    /// `Self` inside a bound names the bounded type, so only a right-hand side
+    /// the frame can answer binds and the rest stay abstract — rebinding `Self`
+    /// and resolving instead lets the frame's own bindings shadow it, and
+    /// recursion through a bound's right-hand side has no fixpoint.
     pub(super) fn frame_assoc_bindings(
         &mut self,
         base: TypeId,

--- a/wado-compiler/src/elaborator/typecheck.rs
+++ b/wado-compiler/src/elaborator/typecheck.rs
@@ -1,30 +1,8 @@
-//! Centralized type compatibility checking.
-//!
-//! This module is the single source of truth for "can type A be used where
-//! type B is expected?". All type mismatch checks route through here.
-//!
-//! # Layering
-//!
-//! The check is split across three layers, each more host-aware than the
-//! last:
-//!
-//! 1. [`check_assignable`] — pure function over the type table. Returns
-//!    [`TypeCheckResult`] (`Compatible` / `Deferred` / `Incompatible`).
-//!    No diagnostics, no host.
-//! 2. [`TypeSystem::typecheck`] and friends — type-system operations that
-//!    build a [`TypeMismatchPayload`] (the pretty-printed `expected` /
-//!    `found` names) on rejection. Still host-agnostic — `TypeSystem` does
-//!    not carry `<H: CompilerHost>`.
-//! 3. [`Elaborator::typecheck`] and friends — thin wrappers that call (2)
-//!    and emit a [`TypeError::TypeMismatch`] diagnostic via `self.logger`
-//!    on rejection. This is the layer callers in the body walk use.
-//!
-//! Layers 2 and 3 each come in two flavours: the plain check and the
-//! `_return` one (`UNIT` expected always passes).
-//!
-//! Keeping the `<H>` plumbing confined to layer 3 means future
-//! `TypeSystem` operations that report errors can mirror this split
-//! without bleeding the host trait into the type-system API.
+//! The single source of truth for "can type A be used where type B is
+//! expected?", in three layers of increasing host-awareness: the pure
+//! [`check_assignable`], then [`TypeSystem::typecheck`] adding a
+//! [`TypeMismatchPayload`], then [`Elaborator::typecheck`] emitting the
+//! diagnostic. The last two each have a `_return` flavour where `UNIT` passes.
 
 use crate::compiler_host::CompilerHost;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
@@ -46,18 +24,11 @@ pub(super) enum TypeCheckResult {
     Incompatible,
 }
 
-/// Pure type compatibility check. Does NOT emit errors.
-///
-/// Rules (in order):
-/// 1. Identity: same `TypeId` -> Compatible
-/// 2. Bottom/Top/Error: UNKNOWN, ERROR -> Deferred; NEVER -> Compatible
-/// 3. Undecided: inference variables, packs, projections, unknown -> Deferred
-/// 4. References: &T->non-ref, &T->&mut T -> Incompatible; &mut T->&T -> Compatible
-/// 5. Newtype/flags: distinct from base type and each other
-/// 6. Option: T vs Option<T>, Option<X> vs Option<Y>
-/// 7. Function types: structural comparison of params + return type
-/// 8. Generic instances: compare name + type args recursively
-/// 9. Catch-all: different concrete types -> Incompatible
+/// Pure type compatibility check, emitting no errors. Rules apply in order:
+/// identity; `NEVER` compatible and `UNKNOWN` / `ERROR` deferred; anything
+/// genuinely undecided deferred; reference variance (`&mut T` → `&T` only);
+/// newtypes and flags distinct from their base; `Option`; structural comparison
+/// for function types and generic instances; anything else incompatible.
 pub(super) fn check_assignable(
     actual: TypeId,
     expected: TypeId,
@@ -80,18 +51,11 @@ pub(super) fn check_assignable(
         return TypeCheckResult::Compatible;
     }
 
-    // Rule 3: defer only what is genuinely undecided.
-    //
-    // A rigid `TypeParam` is not undecided: it is opaque, standing for whatever
-    // a caller instantiates the binding item with, so nothing but itself is
-    // assignable to it in either direction. It reaches a check only inside the
-    // item that binds it — a *use* of a polymorphic signature instantiates its
-    // slots into `InferVar`s first (`super::instantiate`) — so there is no
-    // "maybe this gets substituted later" case left to defer.
-    //
-    // What is still undecided: an inference variable awaiting its solver, a
-    // type pack awaiting expansion (packs are not instantiated yet), an
-    // associated-type projection awaiting its impl, and `unknown` / `error`.
+    // Defer only what is genuinely undecided: an inference variable awaiting its
+    // solver, a pack awaiting expansion, a projection awaiting its impl, and
+    // `unknown` / `error`. A rigid `TypeParam` is opaque, not undecided — a use
+    // of a polymorphic signature instantiates its slots into `InferVar`s first,
+    // so nothing but itself is ever assignable to it.
     if type_table.contains_undecided(actual) || type_table.contains_undecided(expected) {
         return TypeCheckResult::Deferred;
     }

--- a/wado-compiler/src/elaborator/types.rs
+++ b/wado-compiler/src/elaborator/types.rs
@@ -2091,9 +2091,9 @@ pub(super) struct TraitMethodMatch {
 
 /// Read-only view resolving a type name from a module's perspective without
 /// cloning per-module maps. Precedence, highest first: local additions found
-/// during resolution, the current module's own definitions, its imports (with
-/// `use { Foo as Bar }` aliasing), then any module defining the name. All fields
-/// are borrowed, so a call site constructs one without allocating.
+/// during resolution, the current module's own definitions, then its imports
+/// (with `use { Foo as Bar }` aliasing) — no global scan beyond that (#1416).
+/// All fields are borrowed, so a call site constructs one without allocating.
 pub(crate) struct TypeLookup<'a> {
     pub(crate) current_module_source: &'a ModuleSource,
     pub(crate) imported_type_sources: &'a IndexMap<String, ModuleSource>,

--- a/wado-compiler/src/elaborator/types.rs
+++ b/wado-compiler/src/elaborator/types.rs
@@ -788,13 +788,6 @@ pub enum TypeError {
     },
 }
 
-/// Render the human-readable body of an [`TypeError::OperatorNotApplicable`].
-///
-/// Shared by the `Display` impl and the `From<TypeError> for Diagnostic`
-/// conversion so both surfaces phrase operator errors identically. The
-/// message names one operand type when `operands` has a single entry and
-/// both when it has two, keeping the wording symmetric regardless of which
-/// operand triggered the error.
 /// Append a trait-bound reason chain as indented `note:` lines beneath a
 /// headline message. Shared by the `Display` impl and the `Diagnostic`
 /// conversion so the chain renders identically on every surface.
@@ -2096,18 +2089,11 @@ pub(super) struct TraitMethodMatch {
     pub(super) is_variadic_impl: bool,
 }
 
-/// Read-only view that resolves a type name from a given module's perspective
-/// without cloning per-module flat maps.
-///
-/// Three-layer precedence (highest first):
-///   1. Local additions discovered during resolution (anonymous structs, in-progress
-///      newtypes/enums declared in the current module's body).
-///   2. The current module's own definitions.
-///   3. Imports of the current module (with `use { Foo as Bar }` aliasing).
-///   4. Any module that defines the name (legacy fallback for prelude-style visibility).
-///
-/// Constructed cheaply at each call site from the `Elaborator`'s context. All
-/// fields are borrowed; no heap allocation.
+/// Read-only view resolving a type name from a module's perspective without
+/// cloning per-module maps. Precedence, highest first: local additions found
+/// during resolution, the current module's own definitions, its imports (with
+/// `use { Foo as Bar }` aliasing), then any module defining the name. All fields
+/// are borrowed, so a call site constructs one without allocating.
 pub(crate) struct TypeLookup<'a> {
     pub(crate) current_module_source: &'a ModuleSource,
     pub(crate) imported_type_sources: &'a IndexMap<String, ModuleSource>,
@@ -2222,24 +2208,11 @@ impl<'a> TypeLookup<'a> {
             .or_else(|| all_per_module.get(module_source).and_then(|m| m.get(name)))
     }
 
-    /// Resolve a *source-written* bare `name` with function-local
-    /// precedence: the current function's own local items (`fn_local`, see
-    /// `ModuleDecls::fn_local_struct_fields`) shadow everything else, ahead
-    /// of `lookup_ref`'s (local → current module → imports → any) chain.
-    /// Consolidates the identical wrapper every bare-name accessor below
-    /// used to duplicate by hand.
-    ///
-    /// Only for resolving a name as *written in source* — an already-known
-    /// `(name, module_source)` identity recovered from a resolved `TypeId`
-    /// (e.g. reify's `recorded_type`) must use [`Self::lookup_ref_in`]
-    /// directly (via the `_in` accessors below) and *not* this tier: the
-    /// function-local table is a flat, unordered map mutated in place as
-    /// annotate walks the function sequentially, so by the time a later,
-    /// independent pass (reify) looks up a name, it reflects the *end* of
-    /// that function's local declarations, not the position-appropriate
-    /// state — consulting it for an already-resolved identity risks
-    /// resolving to an unrelated later-declared local item that happens to
-    /// share the same bare name as an outer, non-local type.
+    /// Resolve a *source-written* bare `name` with function-local precedence:
+    /// the current function's own local items shadow everything, ahead of
+    /// `lookup_ref`'s chain. An already-resolved `(name, module_source)` identity
+    /// must use [`Self::lookup_ref_in`] instead — the flat fn-local table
+    /// reflects the *end* of the function and could resolve to a later item.
     fn fn_local_first<V>(
         &self,
         name: &str,
@@ -2459,14 +2432,10 @@ pub(super) struct ArithmeticTraitInfo {
     pub(super) rhs_type: Option<TypeId>,
 }
 
-/// Complete, Self-substituted description of a trait method lookup.
-///
-/// Produced by [`Elaborator::resolve_trait_method_for_op`][rtq] and consumed
-/// by [`Elaborator::build_trait_op_method_call_on_resolved`][bop]. Having a
-/// single, always-populated data type for trait-method dispatch eliminates
-/// the `param_types: vec![]` anti-pattern that previously caused codegen
-/// ICEs when operator dispatch built a method call without any
-/// argument-type check.
+/// Complete, Self-substituted description of a trait method lookup, produced by
+/// [`Elaborator::resolve_trait_method_for_op`][rtq] and consumed by
+/// [`Elaborator::build_trait_op_method_call_on_resolved`][bop]. Always populated,
+/// so operator dispatch cannot build a method call without argument types.
 ///
 /// [rtq]: crate::elaborator::Elaborator::resolve_trait_method_for_op
 /// [bop]: crate::elaborator::Elaborator::build_trait_op_method_call_on_resolved

--- a/wado-compiler/src/elaborator/tysys.rs
+++ b/wado-compiler/src/elaborator/tysys.rs
@@ -1,23 +1,8 @@
-//! [`TypeSystem`] — pipeline-wide type knowledge.
-//!
-//! # Ownership
-//!
-//! Every field is `'static`, [`Arc`]-wrapped, or [`Rc`]-wrapped, so
-//! `TypeSystem` is `Clone` (a shallow copy) and is handed out cheaply to
-//! per-module phases: the driver builds one during
-//! [`super::orchestration::Elaborator::annotate_modules`], and each
-//! per-module [`super::Elaborator`] holds a clone.
-//!
-//! # Membership rule
-//!
-//! A field belongs here only when the answer to "would this fit the type
-//! system itself?" is yes. Per-call mutable state does not qualify even
-//! when it looks cache-shaped: sharing e.g. the `type_implements_trait`
-//! recursion stack across module walks would leak frames between them
-//! (it lives on [`super::scope::Scope`] instead), and the removed
-//! `method_info_cache` / `indexing_trait_cache` were both stale-prone
-//! covers over scans that the prebuilt `TraitEnv` indices already
-//! memoise.
+//! [`TypeSystem`] — pipeline-wide type knowledge. Every field is `'static`,
+//! [`Arc`]- or [`Rc`]-wrapped, so a `Clone` is a shallow copy each per-module
+//! [`super::Elaborator`] holds. A field belongs here only if it fits the type
+//! system itself: per-call mutable state does not, even when cache-shaped, since
+//! sharing a recursion stack across module walks would leak frames between them.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -170,19 +155,11 @@ impl TypeSystem {
             .any(|t| self.carries_resource_rec(t, visited))
     }
 
-    /// Whether `name` resolves to a declared type *from the perspective of
-    /// `module`* — i.e. a type that module can actually see (its own
-    /// declarations, the auto-imported prelude, a primitive, or a type it
-    /// explicitly imports). Unlike [`Self::is_known_type_name`], which is a
-    /// global union, this is immune to pollution by unrelated modules: a
-    /// user module declaring a type named `E` does not make `E` "known" in
-    /// `core:prelude/types`, so the prelude's `impl Result<T, E>` keeps
-    /// treating `E` as a free type parameter rather than a concrete
-    /// instantiation argument.
-    ///
-    /// Falls back to the global cache when `module` is unknown (e.g. a
-    /// synthetic source not present in the per-module map), which preserves
-    /// the prior behaviour for those edge cases.
+    /// Whether `name` resolves to a declared type *from `module`'s perspective*
+    /// — its own declarations, the prelude, a primitive, or an explicit import.
+    /// Unlike the global union [`Self::is_known_type_name`], no unrelated module
+    /// can pollute it: a user type named `E` does not stop the prelude's
+    /// `impl Result<T, E>` treating `E` as free. Unknown modules use the union.
     pub(crate) fn is_known_type_name_in(&self, module: &ModuleSource, name: &str) -> bool {
         match self.module_visible_types.get(module) {
             Some(visible) => visible.contains(name),
@@ -203,12 +180,6 @@ impl TypeSystem {
         declared.iter().any(|p| p.name == name) || !self.is_known_type_name_in(module, name)
     }
 
-    /// Check if an expression is a numeric literal (possibly negated).
-    ///
-    /// The non-numeric arms are enumerated explicitly rather than a
-    /// catch-all `_` so that adding a new [`Expr`] variant produces a
-    /// compile error here, forcing a deliberate decision about whether
-    /// the new shape should participate in numeric-literal coercion.
     /// Whether `expr` is the bare `null` literal. A bare `null` initially
     /// resolves to `Option<UNKNOWN>` and only acquires its inner type from an
     /// expected-type context, so callers that can supply one (e.g. binary
@@ -217,6 +188,9 @@ impl TypeSystem {
         matches!(expr, Expr::Literal(lit) if matches!(lit.value, Literal::Null))
     }
 
+    /// Whether `expr` is a numeric literal, possibly negated. The non-numeric
+    /// arms are enumerated rather than caught by `_`, so a new [`Expr`] variant
+    /// forces a decision about numeric-literal coercion here.
     pub(crate) fn is_numeric_literal(&self, expr: &Expr) -> bool {
         match expr {
             Expr::Literal(lit) => matches!(lit.value, Literal::Number(_)),
@@ -254,20 +228,11 @@ impl TypeSystem {
         }
     }
 
-    /// Map a binary operator to its `(trait_name, method_name)` pair, or
-    /// `None` for short-circuit operators that don't dispatch through a
-    /// trait.
-    ///
-    /// For operators that dispatch through a [`CompilerItem`] trait
-    /// (`Eq` for `==` / `!=`), the trait name is resolved through the
-    /// compiler-item registry so a rename on the stdlib side stays
-    /// transparent. For traits that don't yet have a `CompilerItem`
-    /// anchor (`Add`, `Sub`, …, `Ord`), the canonical stdlib name is
-    /// returned as a literal.
-    ///
-    /// The non-trait arms (`And` / `Or`) are explicit rather than a
-    /// catch-all `_` so that adding a new [`BinaryOp`] variant produces
-    /// a compile error here instead of silently returning `None`.
+    /// Map a binary operator to its `(trait_name, method_name)` pair, or `None`
+    /// for the short-circuit operators, which dispatch through no trait. A trait
+    /// with a [`CompilerItem`] anchor (`Eq`) resolves through the registry, so a
+    /// stdlib rename stays transparent; the rest are literals. `And` / `Or` are
+    /// explicit arms, so a new [`BinaryOp`] variant fails the build here.
     pub(crate) fn operator_trait_method(&self, op: &BinaryOp) -> Option<(String, &'static str)> {
         match op {
             BinaryOp::Add => Some(("Add".to_string(), "add")),

--- a/wado-compiler/src/elaborator/written.rs
+++ b/wado-compiler/src/elaborator/written.rs
@@ -1,13 +1,8 @@
-//! Binder questions over written syntax.
-//!
-//! Whether a written head names one of the enclosing item's own type parameters
-//! is a question about that item, not about which declaration a name refers to:
-//! a binder is scoped to the item that wrote it, so no module scope is
-//! consulted and no identity is produced.
-//!
-//! WEP 2026-08-10 makes the *identity* question a table keyed by the reference
-//! site (`Resolutions: AstId -> DeclRef`); this helper is the binder arm of that
-//! resolution, and the only part of the written-syntax layer that survives it.
+//! Binder questions over written syntax. Whether a written head names one of the
+//! enclosing item's own type parameters is a question about that item, not about
+//! which declaration a name refers to, so no module scope is consulted and no
+//! identity produced. WEP 2026-08-10 makes the identity question a table keyed
+//! by reference site; this is the binder arm of that resolution.
 
 use crate::ast;
 

--- a/wado-compiler/src/flat_package.rs
+++ b/wado-compiler/src/flat_package.rs
@@ -106,17 +106,11 @@ impl FlatPackage {
         self.target_world == world_registry::TEST_WORLD
     }
 
-    /// Check whether the active world declares an
-    /// `import {interface_name} { ... }` block.
-    ///
-    /// Drives world-shape decisions in codegen / lowering / DCE that used to
-    /// hinge on `target_world == "core:kiln/generator"` string matches —
-    /// `imports_interface("KilnHost")` is true for the kiln generator world and
-    /// any future world that imports the same interface, so adding a new
-    /// generator-shaped world no longer needs new branches.
-    ///
-    /// Returns `false` for the synthetic test world and for unknown worlds
-    /// (both have no entry in the registry).
+    /// Whether the active world declares an `import {interface_name} { … }`
+    /// block. Drives the world-shape decisions in codegen, lowering and DCE that
+    /// once matched on `target_world` strings, so a new generator-shaped world
+    /// needs no new branches. `false` for the synthetic test world and any
+    /// unknown one, neither having a registry entry.
     pub fn world_imports_interface(&self, interface_name: &str) -> bool {
         self.world_registry
             .get(&self.target_world)

--- a/wado-compiler/src/intern.rs
+++ b/wado-compiler/src/intern.rs
@@ -1,27 +1,12 @@
-//! Pointer-identity string interning.
+//! Pointer-identity string interning: [`InternedStr`] is an `Arc<str>` whose
+//! `Eq` / `Hash` compare pointers, so `clone` / `eq` / `hash` are O(1), and
+//! [`StringInterner`] canonicalises content into a unique `Arc<str>`.
 //!
-//! [`InternedStr`] is an `Arc<str>` newtype whose `Eq` / `Hash` are
-//! defined by pointer identity, making `clone` / `eq` / `hash` all O(1).
-//! [`StringInterner`] is a generic intern pool that canonicalises
-//! `&str` content into a unique `Arc<str>`.
-//!
-//! # Soundness contract
-//!
-//! Two `InternedStr` values compare equal iff their underlying
-//! `Arc<str>` pointers are equal. For this to coincide with content
-//! equality, every `InternedStr` that may be compared with another must
-//! share the same canonical `Arc<str>` for any given content. The crate
-//! maintains this invariant by:
-//!
-//! - constructing all `InternedStr` through a single [`StringInterner`]
-//!   pool (per logical scope, e.g. one per compilation), and
-//! - adopting any `LazyLock<Arc<str>>` statics (well-known names) into
-//!   that same pool via [`StringInterner::with_well_known_arcs`] at
-//!   construction, so `interner.intern("prelude")` returns the same
-//!   `Arc` as a statically-built [`InternedStr`] for `"prelude"`.
-//!
-//! `InternedStr::from_arc` is `pub(crate)` so external callers cannot
-//! bypass this discipline.
+//! Pointer equality coincides with content equality only while every comparable
+//! `InternedStr` shares one canonical `Arc`. The crate holds that by building
+//! them all through a single per-compilation pool and adopting the well-known
+//! `LazyLock<Arc<str>>` statics into it at construction;
+//! `InternedStr::from_arc` is `pub(crate)` so nothing outside can bypass it.
 
 use crate::hashmap::IndexSet;
 use std::fmt;
@@ -95,16 +80,11 @@ impl PartialEq<&str> for InternedStr {
     }
 }
 
-/// Generic pointer-identity string interner.
-///
-/// Owns the canonical `Arc<str>` for each interned content; calls to
-/// [`Self::intern`] with equal `&str` return pointer-equal
-/// [`InternedStr`] values. Clones of an `InternedStr` are O(1) refcount
-/// bumps and never reallocate the underlying buffer.
-///
-/// To share identity with externally-defined `LazyLock<Arc<str>>`
-/// statics, construct the interner via [`Self::with_well_known_arcs`]
-/// so those `Arc`s are adopted up-front.
+/// Generic pointer-identity string interner, owning the canonical `Arc<str>` per
+/// content: [`Self::intern`] on equal `&str` returns pointer-equal
+/// [`InternedStr`]s, and cloning one is a refcount bump. To share identity with
+/// externally-defined `LazyLock<Arc<str>>` statics, construct through
+/// [`Self::with_well_known_arcs`] so those `Arc`s are adopted up front.
 #[derive(Debug)]
 pub struct StringInterner {
     strings: IndexSet<Arc<str>>,

--- a/wado-compiler/src/kiln.rs
+++ b/wado-compiler/src/kiln.rs
@@ -1,15 +1,8 @@
-//! Kiln: schema-driven code generation for the Wado compiler.
-//!
-//! See WEP 2026-04-12 for the design. This module holds the pure-data
-//! algorithmic pieces that stay wasm32-clean: the canonical invocation
-//! representation, the DAG + topological sort, cache-key composition, and
-//! `#![generated]` header emission.
-//!
-//! The pipeline driver — which actually calls
-//! [`crate::CompilerHost::run_generator`], writes generated files, and
-//! maintains `wado.lock` — lives in `wado-cli`. That driver takes the data
-//! types exported here, schedules invocations against a [`plan::Plan`], and
-//! checks each step against the lockfile via [`cache::compose_cache_key`].
+//! Kiln: schema-driven code generation (WEP 2026-04-12). This module holds the
+//! pure-data pieces that stay wasm32-clean — the canonical invocation
+//! representation, the DAG and its topological sort, cache-key composition, and
+//! `#![generated]` header emission. The driver that runs generators, writes
+//! files and maintains `wado.lock` lives in `wado-cli` and consumes these.
 
 pub mod cache;
 pub mod header;

--- a/wado-compiler/src/kiln/cache.rs
+++ b/wado-compiler/src/kiln/cache.rs
@@ -1,21 +1,8 @@
-//! Cache-key composition for Kiln generator invocations.
-//!
-//! The cache key is a SHA-256 over a canonical byte string described in
-//! WEP 2026-04-12 §"Caching". This module is the single
-//! authority for that layout: callers (the pipeline driver, the lockfile
-//! writer) go through [`compose_cache_key`] so a cache hit is bit-identical
-//! regardless of who computed it.
-//!
-//! The options encoding is intentionally opaque here (`&[u8]`). The caller
-//! supplies already-canonical bytes produced by [`encode_options_canonical`]:
-//! a deterministic, injective serialization of the validated options tree used
-//! solely as a hash input. In protocol revision 3 the options cross the generator
-//! boundary as a typed WIT argument, not a serialized blob, so nothing ever
-//! decodes these bytes — the encoding only has to be canonical, not an
-//! interchange format.
-//!
-//! Swapping the encoder in one place keeps cache keys stable unless the
-//! user-facing options actually change.
+//! Cache-key composition for Kiln generator invocations: a SHA-256 over the
+//! canonical byte string of WEP 2026-04-12, with [`compose_cache_key`] the sole
+//! authority for that layout so a hit is bit-identical whoever computed it. The
+//! options arrive as already-canonical bytes from [`encode_options_canonical`]
+//! and are pure hash input — nothing ever decodes them.
 
 use sha2::{Digest, Sha256};
 
@@ -99,16 +86,10 @@ pub fn hex_digest(digest: &[u8; 32]) -> String {
 }
 
 /// Encode a [`CanonicalOptions`] to a deterministic byte string for the
-/// invocation cache key. This is purely a hash input — nothing ever decodes
-/// it (options now cross the generator boundary as a typed WIT argument, not a
-/// serialized blob) — so the format only has to be canonical and injective,
-/// not an interchange format.
-///
-/// A table drops `None` options, sorts the rest by field name, and writes a
-/// length-prefixed entry list; each value is a one-byte type tag followed by
-/// its little-endian / length-prefixed bytes (`Some(x)` is transparent). `F64`
-/// canonicalizes `-0.0` to `0.0` and rejects non-finite values so equal option
-/// sets share a cache key.
+/// invocation cache key — pure hash input, so it need only be canonical and
+/// injective. A table drops `None`s, sorts by field name, and writes a
+/// length-prefixed entry list, each value a type tag plus its bytes. `F64`
+/// canonicalizes `-0.0` and rejects non-finites, so equal sets share a key.
 #[must_use]
 pub fn encode_options_canonical(options: &CanonicalOptions) -> Vec<u8> {
     let mut out = Vec::new();

--- a/wado-compiler/src/kiln/header.rs
+++ b/wado-compiler/src/kiln/header.rs
@@ -1,18 +1,8 @@
-//! `#![generated]` header emission and parsing.
-//!
-//! Every file a Kiln generator produces is stamped with a
-//! `#![generated(by = "...", sources = [...])]` module attribute. The
-//! compiler uses this for two things:
-//!
-//! 1. Tools (formatter, linter, VS Code) can show a subtle banner.
-//! 2. The pipeline's stale-output GC deletes files inside an invocation's
-//!    `output-dir` that bear `#![generated]` but were *not* produced by
-//!    the current run. Hand-authored files in the same directory are
-//!    untouched.
-//!
-//! The header is line-based and kept near the top of the file; parsing
-//! here is intentionally tolerant (whitespace, trailing comma) but
-//! emission is canonical.
+//! `#![generated(by = …, sources = […])]` header emission and parsing. Every
+//! file a Kiln generator produces is stamped with it, so tools can show a banner
+//! and the pipeline's stale-output GC can delete a stamped file the current run
+//! did not produce, leaving hand-authored neighbours alone. Parsing is
+//! deliberately tolerant of whitespace and trailing commas; emission is canonical.
 
 use super::invocation::InvocationPath;
 

--- a/wado-compiler/src/kiln/import_check.rs
+++ b/wado-compiler/src/kiln/import_check.rs
@@ -1,21 +1,8 @@
-//! Kiln generator import-refusal check.
-//!
-//! When the target world is `core:kiln/generator`, the generator package
-//! must not transitively import any WASI interface at the Wado source
-//! level. The sandbox guarantee (WEP 2026-04-12, "Design principles" #1)
-//! depends on the generator being deterministic: no clocks, randomness,
-//! network, filesystem, or environment. This pass catches the obvious
-//! case where a generator writes
-//! `use { now } from "wasi:clocks"` directly. The `CompilerHost`'s
-//! `run_generator` runtime link refuses any `wasi:*` CM import as defense
-//! in depth for the transitive case (a stdlib helper pulling in a WASI
-//! interface).
-//!
-//! Runs after Phase 1 (module loading) and before analysis so the
-//! diagnostic points at the user's `use` statement with the same span
-//! machinery as any other import error.
-//!
-//! See WEP 2026-04-12 §"Authoring a generator".
+//! Kiln generator import-refusal check: under `core:kiln/generator` the package
+//! must import no WASI interface, the sandbox guarantee (WEP 2026-04-12) resting
+//! on the generator being deterministic. `run_generator`'s runtime link refuses
+//! any `wasi:*` CM import as depth. Runs after loading and before analysis, so
+//! the diagnostic points at the user's `use` like any other import error.
 use crate::ast::{
     AstId, Expr, GenericType, IdentExpr, Item, LetStmt, Module, NamedType, Param, Pattern,
     SelfKind, Stmt, StructLiteralExpr, StructLiteralField, Type, UseDecl, UseItem,
@@ -60,25 +47,11 @@ pub fn check_loaded<H: CompilerHost>(
     count
 }
 
-/// Rewrite a kiln generator's `fn generate(req: Request<T>) -> Result<...>`
-/// into the typed-options wire shape (Kiln WEP §"Options are a typed argument
-/// in each generator's own world"):
-/// the single `req` parameter is replaced by `primary: InputFile`, `inputs:
-/// List<InputFile>`, and `options: T`, and the body starts with `let req =
-/// Request { primary, inputs, options };`. The user's subsequent body keeps
-/// seeing `req` as `Request<T>` via same-scope shadowing (WEP 2026-03-25),
-/// so the UX is "author writes `fn generate(req: Request<Options>)`".
-///
-/// Options cross the boundary as a typed WIT value — not a CBOR blob — so
-/// there is no `bind_request` / `RawRequest`. A no-`Options` generator
-/// (`T = NoOptions`) omits the `options` parameter entirely (an empty record
-/// has no Component Model representation) and its `Request` is built with a
-/// literal `NoOptions {}`.
-///
-/// Gated on `target_world == core:kiln/generator`. Fires when the first
-/// param's type is syntactically `Request<T>` (one type argument) or the
-/// bare `Request` (a no-options generator), in which case `T` is the
-/// default `NoOptions`.
+/// Rewrite a kiln generator's `fn generate(req: Request<T>)` into the
+/// typed-options wire shape: `req` becomes `primary`, `inputs` and `options`,
+/// and the body opens with `let req = Request { primary, inputs, options };`,
+/// which same-scope shadowing keeps looking like the author's `req`. A
+/// `NoOptions` generator omits `options`, an empty record having no CM form.
 pub fn inject_kiln_request_adapter(
     target_world: Option<&str>,
     entry_module: &ModuleSource,

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -1,15 +1,8 @@
-//! Inline-invocation collection for `use ... with { generator: { ... } }`.
-//!
-//! Every Kiln invocation is declared at the import site; the manifest does
-//! not declare invocations. This module walks the parsed [`UseDecl`]s,
-//! extracts the `generator: {...}` object from
-//! [`crate::ast::ImportAttributes`], and builds matching
-//! [`crate::kiln::Invocation`]s before [`crate::kiln::plan::build_plan`] runs.
-//!
-//! Two clauses with identical `(module, from, inputs, output_dir,
-//! options_canonical)` tuples are merged into a single invocation. Two
-//! clauses that share `from` but disagree on any other field produce a
-//! diagnostic citing both spans.
+//! Inline-invocation collection for `use ... with { generator: { ... } }`. Every
+//! Kiln invocation is declared at its import site, never in the manifest, so
+//! this walks the parsed [`UseDecl`]s and builds [`crate::kiln::Invocation`]s
+//! ahead of [`crate::kiln::plan::build_plan`]. Identical clauses merge; two
+//! sharing `from` but disagreeing elsewhere produce a diagnostic on both spans.
 
 use sha2::{Digest, Sha256};
 
@@ -26,19 +19,11 @@ use super::options_check::{CanonicalOptions, validate};
 /// under `build/kiln/<synthetic_id>` unless it declares its own `output_dir`.
 pub const DEFAULT_INLINE_OUTPUT_DIR_PREFIX: &str = "build/kiln";
 
-/// Elaborator-side lookup table that redirects a `use ... from "<from>"` whose
-/// `<from>` path matches an inline Kiln invocation's primary source to the
-/// invocation's generated entry module.
-///
-/// Built once per compilation unit from the inline invocation set, after the
-/// pipeline has populated `build/kiln/…` so the entry module's on-disk
-/// location is known. For consume-only mode (no pipeline run), the index is
-/// built from the last recorded lockfile entry's `output.entry = true` path
-/// — that path lives on disk already or the cache check failed.
-///
-/// Lookups are keyed by `(declaring_file_normalized, from_path_normalized)`.
-/// A bare `use ... from "./schema.<ext>"` in any other file fails with
-/// `Code::KilnMissingWith`.
+/// Elaborator-side lookup table redirecting a `use ... from "<from>"` that
+/// matches an inline Kiln invocation's primary source to the generated entry
+/// module. Built once per compilation unit, after the pipeline populates
+/// `build/kiln/…`, or in consume-only mode from the lockfile's `output.entry`
+/// path. Keyed by `(declaring_file, from_path)`, both normalized.
 #[derive(Debug, Default, Clone)]
 pub struct InvocationIndex {
     /// Entries mapping `(decl_file, from_path)` → entry module URI. The URI
@@ -102,23 +87,14 @@ impl InvocationIndex {
     }
 }
 
-/// Scan every `UseDecl` in `modules` for an inline
-/// `with { generator: { ... } }` clause and lower it to a canonical
-/// [`Invocation`].
-///
-/// `descriptors` is a per-module-spec lookup — when present, the inline
-/// clause's `options` object is validated and encoded through the typed
-/// pipeline. Missing descriptors fall through to an empty canonical options
-/// blob (matching the behavior for a generator without a declared
-/// `Options` struct).
-///
-/// Diagnostics are batched: a single malformed clause does not prevent the
-/// rest of the tree from being collected. Returns `Err` only when at least
-/// one `Severity::Error` diagnostic was emitted.
+/// Scan every `UseDecl` in `modules` for an inline `with { generator: { … } }`
+/// clause and lower it to a canonical [`Invocation`]. A present `descriptors`
+/// entry validates and encodes the clause's `options` through the typed
+/// pipeline; a missing one yields an empty canonical blob.
 ///
 /// # Errors
-/// Every shape mismatch, options-validation error, and dedup conflict is
-/// reported through the returned `Vec<Diagnostic>`.
+/// Diagnostics are batched, so one malformed clause does not stop the rest of
+/// the tree. `Err` only when at least one was `Severity::Error`.
 pub fn collect_inline_invocations<'a, I>(
     modules: I,
     descriptors: &IndexMap<String, OptionsDescriptor>,
@@ -514,20 +490,11 @@ fn lower_module_specifier(
     None
 }
 
-/// Re-anchor `resolved` (project-root-relative) to `manifest_root` so the
-/// resulting [`GeneratorModule::LocalPath`] is relative to the manifest
-/// root; the provider resolves it as `manifest_root.join(path)`.
-///
-/// When `resolved` lies under `manifest_root` the shared prefix is stripped.
-/// When `resolved` lies above or beside `manifest_root` (e.g. an inline
-/// clause in `wasm-size/foo/bar.wado` referencing
-/// `../../package-gale/src/generator.wado`), `..` segments are emitted to
-/// walk up out of `manifest_root` before descending into `resolved`.
-///
-/// An empty or `.` `manifest_root` returns the path verbatim. `.` segments are
-/// dropped on both sides, so a `.` root (compiling an entry next to
-/// `wado.toml`) does not emit a spurious leading `..` that would put output
-/// outside the project (e.g. `output_dir: "generated"` → `../generated`).
+/// Re-anchor `resolved` (project-root-relative) to `manifest_root`, which the
+/// provider resolves as `manifest_root.join(path)`: a shared prefix is stripped,
+/// and a `resolved` above or beside the root gets `..` segments to walk out
+/// first. An empty or `.` root returns the path verbatim, `.` segments being
+/// dropped on both sides so no spurious `..` sends output out of the project.
 fn strip_manifest_root_prefix(manifest_root: &str, resolved: &str) -> String {
     let is_segment = |p: &&str| !p.is_empty() && *p != ".";
     let root_parts: Vec<&str> = manifest_root.split('/').filter(is_segment).collect();

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -428,20 +428,6 @@ fn resolve_or_reject(
     InvocationPath::normalize(raw)
 }
 
-/// Lower an inline `module: "<specifier>"` value to a [`GeneratorModule`].
-///
-/// Accepted shapes mirror the `<source>` slot of a regular `use ... from
-/// "<source>"` clause:
-///
-/// - `./...` / `../...` — relative path resolved against the file that
-///   carries the inline clause (`module_path`). This matches what the
-///   loader does for the `from` slot two lines above.
-/// - `<ns>:<name>[@<ver>]` — registry / stdlib namespace identifier.
-///   Stored verbatim as a [`GeneratorModule::Spec`] string until the
-///   build-dependency elaborator lands.
-///
-/// A bare relative name without `./` is rejected with a hint to add the
-/// prefix — the same diagnostic regular `use` clauses produce.
 /// Read an optional string field (`version` / `registry`) from the inline
 /// `generator` object. Absent → `None`; a non-string value pushes a diagnostic
 /// and yields `None`.
@@ -470,6 +456,12 @@ fn optional_source_string(
     }
 }
 
+/// Lower an inline `module: "<specifier>"` to a [`GeneratorModule`], accepting
+/// the same shapes as a regular `use … from "<source>"`: a `./` or `../` path,
+/// resolved against the file carrying the clause exactly as the loader resolves
+/// `from`, or a `<ns>:<name>[@<ver>]` identifier, stored verbatim as a
+/// [`GeneratorModule::Spec`] until the build-dependency elaborator lands. A bare
+/// relative name without `./` is rejected with the same hint `use` gives.
 fn lower_module_specifier(
     module_path: &str,
     use_decl: &UseDecl,

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -458,10 +458,9 @@ fn optional_source_string(
 
 /// Lower an inline `module: "<specifier>"` to a [`GeneratorModule`], accepting
 /// the same shapes as a regular `use … from "<source>"`: a `./` or `../` path,
-/// resolved against the file carrying the clause exactly as the loader resolves
-/// `from`, or a `<ns>:<name>[@<ver>]` identifier, stored verbatim as a
-/// [`GeneratorModule::Spec`] until the build-dependency elaborator lands. A bare
-/// relative name without `./` is rejected with the same hint `use` gives.
+/// resolved against the file carrying the clause, or a `<ns>:<name>[@<ver>]`
+/// identifier, stored verbatim as a [`GeneratorModule::Spec`]. A bare relative
+/// name without `./` is rejected with the same hint `use` gives.
 fn lower_module_specifier(
     module_path: &str,
     use_decl: &UseDecl,

--- a/wado-compiler/src/kiln/invocation.rs
+++ b/wado-compiler/src/kiln/invocation.rs
@@ -13,16 +13,10 @@ use std::fmt;
 pub struct InvocationPath(pub String);
 
 impl InvocationPath {
-    /// Normalize a raw manifest / source path into the canonical form.
-    ///
-    /// - Backslashes are turned into forward slashes (Windows inputs).
-    /// - `./` prefix is stripped.
-    /// - Trailing slashes are trimmed.
-    /// - Empty segments between separators collapse.
-    ///
-    /// Full NFC normalization of the string contents is done by
-    /// [`crate::kiln::cache`] when the path is written into a cache key; here
-    /// we only handle the structural cases that actually change identity.
+    /// Normalize a raw manifest / source path: backslashes become forward
+    /// slashes, a `./` prefix and trailing slashes go, and empty segments
+    /// collapse. Only the structural cases that change identity — full NFC
+    /// normalization happens in [`crate::kiln::cache`] at cache-key time.
     #[must_use]
     pub fn normalize(raw: &str) -> Self {
         let mut s = raw.replace('\\', "/");

--- a/wado-compiler/src/kiln/metadata.rs
+++ b/wado-compiler/src/kiln/metadata.rs
@@ -1,15 +1,8 @@
-//! Per-invocation Kiln cache file (`<output_dir>/<primary>.kiln.json`)
-//! schema, shared between `wado-cli` (which reads and writes the file via
-//! `std::fs`) and `wado-lsp` (which reads it for consume-only redirect
-//! resolution).
-//!
-//! This module is intentionally I/O-free so the compiler crate keeps its
-//! `wasm32-unknown-unknown` clean build. The native CLI host wraps it with
-//! `std::fs` reads and writes; the LSP host (which builds for both native
-//! and `wasm32-wasip2`) does its own narrow read.
-//!
-//! See [WEP: Kiln](../../../docs/wep-2026-04-12-kiln.md), section
-//! "Caching".
+//! Schema of the per-invocation Kiln cache file
+//! `<output_dir>/<primary>.kiln.json`, shared between `wado-cli`, which reads
+//! and writes it, and `wado-lsp`, which reads it for consume-only redirects.
+//! Deliberately I/O-free, keeping the compiler crate's `wasm32-unknown-unknown`
+//! build clean — each host wraps it with its own reads. See WEP 2026-04-12.
 
 use serde::{Deserialize, Serialize};
 

--- a/wado-compiler/src/kiln/options.rs
+++ b/wado-compiler/src/kiln/options.rs
@@ -1,19 +1,8 @@
-//! Typed extraction of a Kiln generator's `Options` struct.
-//!
-//! The driver calls [`extract_options_descriptor`] once per generator
-//! component, after that component's package has been type-resolved. The
-//! returned [`OptionsDescriptor`] drives both [`crate::kiln::options_check`]
-//! (typed validation of a user-supplied options table) and
-//! [`crate::kiln::cache::encode_options_canonical`] (the cache-key byte
-//! layout).
-//!
-//! See WEP 2026-04-12 §"Authoring a generator" for the full design.
-//!
-//! The extractor is deliberately strict: only shapes that round-trip cleanly
-//! through the Component-Model canonical encoder are allowed. A generator
-//! that wants to accept richer configuration should split that configuration
-//! out into auxiliary structs that are themselves made of the primitives
-//! listed here.
+//! Typed extraction of a Kiln generator's `Options` struct. The driver calls
+//! [`extract_options_descriptor`] once per generator component, once its package
+//! is type-resolved; the result drives both options validation and the cache-key
+//! byte layout. Deliberately strict — only shapes that round-trip through the
+//! Component-Model canonical encoder. See WEP 2026-04-12.
 
 use serde::{Deserialize, Serialize};
 
@@ -125,17 +114,13 @@ pub enum CanonicalValue {
     List(Vec<CanonicalValue>),
 }
 
-/// Locate `pub struct Options` in the generator's entry module and describe
-/// it as an [`OptionsDescriptor`].
-///
-/// `Options` is optional: a generator with no configuration omits it and gets
-/// an empty descriptor. `generate` is always required.
+/// Locate `pub struct Options` in the generator's entry module and describe it
+/// as an [`OptionsDescriptor`]. `Options` is optional — a generator with no
+/// configuration gets an empty descriptor — while `generate` is required.
 ///
 /// # Errors
-/// Returns `Err` when the module has no TIR or does not export `generate`.
-/// Shape-level failures inside a present `Options` come back as batched
-/// [`Code::GeneratorOptionsUnsupported`] diagnostics (a single bad field does
-/// not hide the rest).
+/// When the module has no TIR or does not export `generate`. A shape failure
+/// inside `Options` comes back batched, so one bad field hides no others.
 pub fn extract_options_descriptor(
     sem: &Semantics,
     module: &ModuleSource,

--- a/wado-compiler/src/kiln/plan.rs
+++ b/wado-compiler/src/kiln/plan.rs
@@ -107,16 +107,11 @@ fn dedup_invocations(invocations: Vec<Invocation>) -> Result<Vec<Invocation>, Pl
         .collect())
 }
 
-/// Kahn-style topological sort.
-///
-/// Edge `A -> B` exists iff any of A's declared input paths (primary, inputs,
-/// or prior-reads — passed separately) lies lexically inside B's output
-/// directory. Here we consider only `primary` + `inputs`; prior-reads are
-/// threaded in by the pipeline driver when composing the full graph.
-///
-/// The queue is FIFO (`VecDeque::pop_front`) so that, among invocations whose
-/// relative order is not pinned by edges, the declaration order is preserved.
-/// Downstream consumers (the lockfile writer) rely on this stability.
+/// Kahn-style topological sort. Edge `A -> B` exists iff one of A's declared
+/// input paths lies lexically inside B's output directory — here `primary` and
+/// `inputs` only, the driver threading prior-reads in when it composes the full
+/// graph. The FIFO queue preserves declaration order among invocations no edge
+/// pins, which the lockfile writer relies on.
 fn topo_sort(invocations: Vec<Invocation>) -> Result<Plan, PlanError> {
     use std::collections::VecDeque;
 

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -1114,16 +1114,11 @@ impl<'a> Lexer<'a> {
         TokenKind::TemplateStringLit(parts)
     }
 
-    /// Collect an interpolation, split into expression source and optional
-    /// format specifier. Called after consuming the opening `{`; consumes up to
-    /// and including the closing `}`. Returns `(expr, format, hit_eof)`; when
-    /// `hit_eof` is true the enclosing template string was truncated
-    /// mid-interpolation and an error has been recorded.
-    ///
-    /// The format specifier is the text after the first top-level `:` (`{expr:spec}`).
-    /// Nesting (parens, brackets, braces), string/template/char literals, and
-    /// `::` scope resolution are tracked here so only a `:` at the expression's
-    /// top level is treated as the separator.
+    /// Collect an interpolation, split into expression source and optional format
+    /// specifier — the text after the first top-level `:`. Called after the
+    /// opening `{` and consuming through the closing `}`. Nesting, literals and
+    /// `::` are tracked, so only a top-level `:` separates. A true `hit_eof` in
+    /// the result means the template was truncated and an error recorded.
     fn collect_interpolation_source(
         &mut self,
         start: usize,

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -12,7 +12,7 @@ use crate::compiler_host::{Code, DiagnosticSpan, Severity};
 use crate::token::{Span, TemplateTokenPart, Token, TokenKind};
 
 /// Check if a string is a valid Wado identifier.
-/// Valid identifiers match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/
+/// Valid identifiers match the pattern `/^[a-zA-Z_][a-zA-Z0-9_]*$/`
 pub fn is_valid_ident(s: &str) -> bool {
     let mut chars = s.chars();
     match chars.next() {

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -413,12 +413,6 @@ pub fn unused_diagnostics(sem: &semantics::Semantics, is_test_world: bool) -> Ve
     out
 }
 
-/// Synthesize a library [`WorldInfo`] (`--lib`) from the entry module's
-/// `export fn` signatures: one direct world export per exported function.
-///
-/// Milestone 2 is functions-only and primitives-only, so each export is a
-/// direct world function (`from_interface_fq = None`). Parameter and return
-/// types are taken straight from the AST signature.
 /// The interface FQ a `core:kiln/generator` component's synthesized world uses
 /// for `generate` and its options record (Kiln WEP revision 3). A generator's
 /// `generate` is grouped into this interface (it references the local `Options`
@@ -508,6 +502,9 @@ fn lib_type_decl_name(item: &ast::Item) -> Option<String> {
     }
 }
 
+/// Synthesize a `--lib` [`WorldInfo`] from the entry module's `export fn`
+/// signatures, one direct world export per exported function with parameter and
+/// return types taken straight from the AST.
 fn synthesize_lib_world_info(
     registry: &component_model::CmInterfaceRegistry,
     fq: &str,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -970,17 +970,11 @@ fn compile_after_load<H: CompilerHost>(
     let wasm_assets = load_result.wasm_assets.clone();
 
     // === Phases 2 + 6a + 6b: Analyze + Annotate + Lower TIR ===
-    // `semantics_with_logger` performs analyze, type resolution, and
-    // body-level TIR lowering. The resulting `Semantics` carries the
-    // `TirModule`s the batch compiler needs plus the use→def reference
-    // map LSP queries need.
-    //
-    // `semantics_with_logger` always returns a `Semantics`. For batch
-    // compilation we refuse to continue when the pipeline did not fully
-    // resolve — the downstream phases assume populated `state` /
-    // `tir_modules`. Diagnostics explaining the failure have already
-    // been emitted to the host.
-    // Batch path: build TIR (reify) for codegen.
+    // `semantics_with_logger` always returns a `Semantics`, carrying the
+    // `TirModule`s the batch compiler needs plus LSP's use→def map. Batch
+    // compilation refuses to continue on an incomplete one — the downstream
+    // phases assume populated `state` / `tir_modules` — and its diagnostics have
+    // already reached the host.
     let sem = semantics::semantics_with_logger(load_result, logger, true);
     if !sem.is_complete() {
         return Err(Bail);
@@ -1974,19 +1968,8 @@ pub async fn dump_with_host_and_world<H: CompilerHost>(
     })
 }
 
-/// Format Wado source code.
-///
-/// Returns the formatted source with canonical formatting.
-/// Preserves comments and the `__DATA__` section.
-///
-/// # Example
-/// ```
-/// let source = r#"use {println} from "core:cli";
-/// fn run() with Stdout { println("Hello!"); }
-/// "#;
-/// let formatted = wado_compiler::format(source).unwrap();
-/// assert!(formatted.contains("use { println }"));
-/// ```
+/// Format Wado source code canonically, preserving comments and the `__DATA__`
+/// section.
 pub fn format(source: &str) -> Result<String, CompileError> {
     // Formatting requires a clean parse — the first recovered lex error
     // becomes a `CompileError::Lexer`.
@@ -2081,17 +2064,11 @@ impl ParseResult {
     }
 }
 
-/// Resolve every transitive import of `parsed` and return the loaded
-/// module set.
-///
-/// Stage 2 of the compiler frontend: pair this with [`parse`] for stage 1
-/// and [`semantics::semantics_of`] for stage 3 (analyze + resolve). The
-/// convenience [`semantics::semantics`] wraps all three for callers that
-/// don't need to inspect the parsed entry between stages.
-///
-/// `invocations` redirects bare `use { … } from "<schema>"` clauses to
-/// kiln-generated entry modules. Pass [`kiln::InvocationIndex::new`] when
-/// the caller has no kiln pipeline to advertise.
+/// Resolve every transitive import of `parsed` and return the loaded module set
+/// — stage 2 of the frontend, between [`parse`] and [`semantics::semantics_of`];
+/// [`semantics::semantics`] wraps all three. `invocations` redirects bare
+/// `use { … } from "<schema>"` clauses to kiln-generated entry modules, or is
+/// [`kiln::InvocationIndex::new`] with no kiln pipeline to advertise.
 pub async fn load<H: CompilerHost>(
     parsed: ParseResult,
     filename: Option<&str>,

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -312,22 +312,10 @@ impl Default for CompilerOptions {
     }
 }
 
-/// Compile Wado source code with a `CompilerHost` for I/O operations.
-///
-/// This is the main compilation entry point. It runs the full compilation pipeline:
-/// lexer -> parser -> binder -> loader -> analyzer -> elaborator -> lower -> optimize -> `tir_to_wir`
-///
-/// # Arguments
-/// * `source` - The entry module source code
-/// * `host` - `CompilerHost` for loading imported modules and emitting diagnostics
-/// * `filename` - Optional filename for error messages
-/// * `opt_level` - Optimization level
-///
-/// # Example
-/// ```ignore
-/// let host = FilesystemCompilerHost::new(base_path);
-/// let result = compile_with_host(source, &host, Some("main.wado"), OptLevel::O1).await?;
-/// ```
+/// Compile the entry module `source`, the main entry point, running the whole
+/// pipeline: lexer → parser → binder → loader → analyzer → elaborator → lower →
+/// optimize → `tir_to_wir`. `host` loads imported modules and receives
+/// diagnostics, and `filename` labels them.
 pub async fn compile_with_host<H: CompilerHost>(
     source: &str,
     host: &H,

--- a/wado-compiler/src/link.rs
+++ b/wado-compiler/src/link.rs
@@ -1,17 +1,6 @@
-//! Link phase — transforms a per-module `Package` into a linked `FlatPackage`.
-//!
-//! The link phase sits between type erasure and monomorphization in the pipeline:
-//!
-//! ```text
-//! Package (per-module TIR)
-//!   → link
-//! FlatPackage (flat TIR)
-//!   → monomorphize → lower → optimize → wir_build → codegen
-//! ```
-//!
-//! The link phase flattens all per-module TIR data into flat lists and
-//! performs component-model planning (world exports, test exports, bundled
-//! functions).
+//! Link phase — flatten a per-module `Package` of TIR into a `FlatPackage` of
+//! flat lists, and plan the component model surface: world exports, test
+//! exports, bundled functions. Sits between type erasure and monomorphization.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -131,18 +120,11 @@ pub fn link(package: Package) -> FlatPackage {
     }
 }
 
-/// Assert that no bodyless stub shares a definition's name.
-///
-/// A name carries its subject's declaring module, so one name is one function.
-/// A stub sharing a definition's name is a call waiting to bind to nothing,
-/// which only surfaces much later as an unsatisfied trait bound at WIR build.
-/// Checking where the invariant must hold reports every violation at once, and
-/// running it at each stage boundary names the stage that introduced one.
-///
-/// Shape stubs (tuples, `Stream<u8>`) are emitted per using module by design
-/// and have no definition anywhere, so they never collide. A `core:builtin`
-/// declaration paired with its `core:rt` implementation is the intended shape
-/// of an intrinsic, not a collision.
+/// Assert that no bodyless stub shares a definition's name. A name carries its
+/// declaring module, so one name is one function, and a stub sharing one is a
+/// call bound to nothing — surfacing far later as an unsatisfied trait bound at
+/// WIR build. Running it at each stage boundary names the stage at fault. Shape
+/// stubs and `core:builtin` / `core:rt` intrinsic pairs are not collisions.
 #[cfg(debug_assertions)]
 pub(crate) fn assert_no_stub_shadowing(
     functions: &[Rc<RefCell<crate::tir::TirFunction>>],

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -445,17 +445,11 @@ pub fn wasm_asset_kind_from_attrs(
     }
 }
 
-/// Resolve a wasm asset import source against the importing module.
-///
-/// `./libm.wat` from `core:builtin`        → `core:libm.wat`
-/// `./libm.wat` from `core:prelude/x.wado` → `core:prelude/libm.wat`
-/// `./foo.wat`  from `./entry.wado`        → `./foo.wat`
-/// `./foo.wat`  from `./sub/entry.wado`    → `./sub/foo.wat`
-///
-/// Phase 1 only accepts relative paths (`./` or `../`). Absolute
-/// namespace-qualified targets like `core:libm.wat` are not supported
-/// from user code (and aren't needed by the stdlib because the prelude
-/// imports its own siblings via `./`).
+/// Resolve a wasm asset import against the importing module's directory:
+/// `./libm.wat` from `core:prelude/x.wado` gives `core:prelude/libm.wat`, from
+/// `./sub/entry.wado` gives `./sub/foo.wat`. Only relative paths are accepted —
+/// an absolute namespace-qualified target is unsupported from user code, and the
+/// stdlib does not need one, its prelude importing siblings via `./`.
 pub fn resolve_wasm_asset_path(
     from: &ModuleSource,
     import_source: &str,
@@ -493,17 +487,11 @@ pub fn resolve_wasm_asset_path(
     }
 }
 
-/// Join `relative` (which may use `./` or `../` segments) onto the
-/// directory of `base` (a slash-separated sub-namespace path like
-/// `prelude/primitive.wado` or `cli/types.wado`) and collapse `..`
-/// segments. The result has no leading namespace prefix and no leading
-/// `./`.
-///
-/// Examples:
-/// - `("builtin",                 "./libm.wat")`        → `"libm.wat"`
-/// - `("prelude/primitive.wado",  "../libm.wat")`       → `"libm.wat"`
-/// - `("prelude/primitive.wado",  "./other.wat")`       → `"prelude/other.wat"`
-/// - `("a/b/c.wado",              "../../d/e.wat")`     → `"d/e.wat"`
+/// Join `relative` onto the directory of `base` — a slash-separated
+/// sub-namespace path such as `prelude/primitive.wado` — collapsing `..`
+/// segments: `("prelude/primitive.wado", "./other.wat")` gives
+/// `"prelude/other.wat"`. The result carries neither a namespace prefix nor a
+/// leading `./`.
 fn join_namespace_relative_path(base: &str, relative: &str) -> String {
     // Start from the base's directory: drop the last `/`-segment.
     let base_dir = match base.rfind('/') {
@@ -538,22 +526,13 @@ fn wasm_core_val_type_name(ty: WasmCoreValType) -> &'static str {
     }
 }
 
-/// Synthesize a Wado source string that declares one extern `pub fn` per
-/// export of a wasm asset, each annotated with
-/// `#[canonical("<namespace>", "<export>")]` so the existing
-/// builtin/import lowering machinery picks the call up.
-///
-/// The synthesized module is fed back through the regular
-/// parse/bind pipeline. Doing it as text (rather than building
-/// an `ast::Module` programmatically) keeps `AstId` allocation,
-/// span/source-map invariants, and the LSP "AST is the source of
-/// truth" rule honoured without special cases — see
-/// `wado-compiler/CLAUDE.md`.
-///
-/// The generated identifiers are the wat-export names verbatim, so a
-/// stdlib re-exporter such as `core:libm` can write
-/// `pub use { libm_sin, libm_cos, ... } from "./libm.wat" with { type: "wat" };`
-/// and the names line up with the wat module's actual exports.
+/// Synthesize Wado source declaring one extern `pub fn` per export of a wasm
+/// asset, each carrying `#[canonical("<namespace>", "<export>")]` so the existing
+/// import lowering picks the call up. Emitted as text and fed back through the
+/// regular parse/bind pipeline, which keeps `AstId` allocation, spans, and the
+/// "AST is the source of truth" rule honoured with no special cases. The
+/// identifiers are the wat export names verbatim, so a re-exporter's
+/// `pub use { libm_sin, … }` lines up with the module's actual exports.
 fn synthesize_wasm_bindings_source(namespace: &str, exports: &[WasmExportSig]) -> String {
     use std::fmt::Write;
     let mut out = String::with_capacity(64 * exports.len().saturating_add(8));
@@ -779,19 +758,8 @@ fn parse_wasm_module_exports(
     Ok(function_exports)
 }
 
-/// Module loader
-///
-/// Loads all modules upfront before analysis and codegen.
-/// Uses a `CompilerHost` for I/O operations.
-/// Format a compiler error for a stdlib module with a source snippet and caret.
-///
-/// Emits a multi-line message shaped like:
-///
-/// ```text
-/// parser error in core:zlib at core:zlib:2365:113: expected pattern, found Semicolon
-///   2365 |         0 => return DeflateConfig { ... };
-///        |                                                                                                                 ^
-/// ```
+/// Format a compiler error for a stdlib module: the kind, module and position,
+/// then the offending source line with a caret under the column.
 fn format_stdlib_error(
     kind: &str,
     label: &str,
@@ -970,21 +938,12 @@ mod tests {
     }
 }
 
-/// Per-module lazy cache for stdlib AST.
-///
-/// Each module is parsed and bound at most once per process. The slot
-/// table (path → slot) is built eagerly on first access — that walk is
-/// just map inserts of empty [`OnceLock`]s, no parsing — and then
-/// each module's actual parse runs only when [`cached_stdlib_module`]
-/// is called for that import path.
-///
-/// Keyed by the canonical display form (`"core:foo"`, `"wasi:bar/baz.wado"`)
-/// rather than by `ModuleSource` value. The cache is process-global, but
-/// every `ModuleLoader` instance creates `ModuleSource` keys through its
-/// own private interner — using string keys here keeps the cache lookup
-/// content-addressed and avoids forcing the cache to share an interner
-/// with every loader. See [`stdlib_cache_key`] for how callers compute
-/// the lookup string from a `ModuleSource`.
+/// Per-module lazy cache for stdlib AST: each module is parsed and bound at most
+/// once per process. The slot table is built eagerly on first access — just map
+/// inserts of empty [`OnceLock`]s — and a module parses only when
+/// [`cached_stdlib_module`] asks for it. Keyed by canonical display string rather
+/// than `ModuleSource`, since every `ModuleLoader` interns through its own
+/// private interner and this cache is process-global.
 struct StdlibSlot {
     source: &'static str,
     module: std::sync::OnceLock<Module>,
@@ -1036,6 +995,8 @@ fn stdlib_cache_key(ms: &ModuleSource) -> Option<String> {
     }
 }
 
+/// Loads every module up front, before analysis and codegen, doing its I/O
+/// through a `CompilerHost`.
 pub struct ModuleLoader<'a, H: CompilerHost> {
     /// Host for I/O operations
     host: &'a H,
@@ -1928,31 +1889,13 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     }
 }
 
-/// Resolve an include path relative to the module that contains it.
-///
-/// Returns a path suitable for passing to `CompilerHost::load_source`, which
-/// joins the result with `base_path`. The logic forks on the module source's
-/// shape:
-///
-/// - **CWD-relative entry module** (path begins with `./` or `../`): the
-///   user's input path already encodes the prefix `base_path` will
-///   re-introduce, because `compile_with_options` derives `base_path` from
-///   the entry's parent directory. Prepending `dir` here would make
-///   `host.load_source`'s subsequent `base_path.join(...)` double the prefix
-///   — e.g. `wado test ./pkg/src/main.wado` resolving `#include_str("./x")`
-///   would otherwise produce `./pkg/src/./pkg/src/x`. Strip the leading
-///   `./` from `raw_path` only and let the host's join restore the prefix.
-/// - **Absolute entry module** (path begins with `/`): keep the dir-prefixed
-///   result. `Path::join` collapses absolute joins to the absolute path, so
-///   `base_path.join("/abs/dir/x")` returns `/abs/dir/x` unchanged. Test
-///   hosts (e.g. `wado-lsp/tests/definition.rs`) key on this form.
-/// - **Imported module rooted at `./` or `../`** (`./sub/helper.wado`): the
-///   `dir` is itself base_path-relative, so prepending it to `stripped`
-///   yields the right base_path-relative result for the include.
-/// - **Other shapes** (entry without leading `./` / `../` / `/`, or an
-///   import without a `./` prefix): the dir prefix is already part of the
-///   `base_path` the host will rejoin, so we strip to the bare filename
-///   like the cwd-relative entry case.
+/// Resolve an include path relative to its containing module, returning what
+/// `CompilerHost::load_source` should join onto `base_path`. Whether to keep the
+/// module's directory as a prefix is [`dir_prefix_to_keep`]'s decision: a
+/// cwd-relative entry already encodes what the host's join re-introduces, so
+/// prefixing would double it, while an absolute path collapses cleanly under
+/// `Path::join` and a `./`-rooted import needs the prefix to stay inside the
+/// importer's directory.
 fn resolve_include_path_impl(
     entry_module_source: Option<&str>,
     module_source_str: &str,
@@ -1976,25 +1919,12 @@ fn is_cwd_relative(path: &str) -> bool {
     path.starts_with("./") || path.starts_with("../")
 }
 
-/// Decide whether the include path should keep its containing module's
-/// directory as a prefix (`Some(dir)`) or collapse to the bare filename
-/// (`None`).
-///
-/// Two situations strip to the bare filename — both because re-prepending
-/// `dir` would only duplicate what `host.load_source`'s
-/// `base_path.join(...)` is already going to add:
-///
-/// 1. The cwd-relative entry module itself. Its `dir` IS `base_path`.
-/// 2. Any module whose `dir` does not look base_path-relative. Imports
-///    normalised by the loader sit under `./...`/`../...`; entries whose
-///    module-source string is a bare `pkg/src/main.wado` carry `base_path`
-///    inside the source string already, so the dir there is also part of
-///    what `base_path.join` will re-introduce.
-///
-/// The remaining cases (absolute paths, and imports rooted at `./` /
-/// `../`) keep the dir prefix. Absolute joins collapse cleanly via
-/// `Path::join`; relative-rooted imports need the prefix to stay inside
-/// the importer's directory.
+/// Whether an include path keeps its module's directory as a prefix, or collapses
+/// to the bare filename. Two cases collapse, both because re-prepending `dir`
+/// would duplicate what `base_path.join` adds: the cwd-relative entry module,
+/// whose `dir` *is* `base_path`, and any module whose `dir` does not look
+/// base_path-relative, carrying it inside the source string already. Absolute
+/// paths and `./`-rooted imports keep the prefix.
 fn dir_prefix_to_keep<'a>(
     entry_module_source: Option<&str>,
     module_source_str: &'a str,

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -447,7 +447,7 @@ pub fn wasm_asset_kind_from_attrs(
 
 /// Resolve a wasm asset import against the importing module's directory:
 /// `./libm.wat` from `core:prelude/x.wado` gives `core:prelude/libm.wat`, from
-/// `./sub/entry.wado` gives `./sub/foo.wat`. Only relative paths are accepted —
+/// `./sub/entry.wado` gives `./sub/libm.wat`. Only relative paths are accepted —
 /// an absolute namespace-qualified target is unsupported from user code, and the
 /// stdlib does not need one, its prelude importing siblings via `./`.
 pub fn resolve_wasm_asset_path(

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -529,10 +529,8 @@ fn wasm_core_val_type_name(ty: WasmCoreValType) -> &'static str {
 /// Synthesize Wado source declaring one extern `pub fn` per export of a wasm
 /// asset, each carrying `#[canonical("<namespace>", "<export>")]` so the existing
 /// import lowering picks the call up. Emitted as text and fed back through the
-/// regular parse/bind pipeline, which keeps `AstId` allocation, spans, and the
-/// "AST is the source of truth" rule honoured with no special cases. The
-/// identifiers are the wat export names verbatim, so a re-exporter's
-/// `pub use { libm_sin, … }` lines up with the module's actual exports.
+/// regular parse/bind pipeline. The identifiers are the wat export names
+/// verbatim, so a re-exporter's `pub use { libm_sin, … }` lines up.
 fn synthesize_wasm_bindings_source(namespace: &str, exports: &[WasmExportSig]) -> String {
     use std::fmt::Write;
     let mut out = String::with_capacity(64 * exports.len().saturating_add(8));
@@ -940,10 +938,9 @@ mod tests {
 
 /// Per-module lazy cache for stdlib AST: each module is parsed and bound at most
 /// once per process. The slot table is built eagerly on first access — just map
-/// inserts of empty [`OnceLock`]s — and a module parses only when
-/// [`cached_stdlib_module`] asks for it. Keyed by canonical display string rather
-/// than `ModuleSource`, since every `ModuleLoader` interns through its own
-/// private interner and this cache is process-global.
+/// inserts of empty [`OnceLock`]s. Keyed by canonical display string rather than
+/// `ModuleSource`, since every `ModuleLoader` interns through its own private
+/// interner and this cache is process-global.
 struct StdlibSlot {
     source: &'static str,
     module: std::sync::OnceLock<Module>,
@@ -1892,10 +1889,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
 /// Resolve an include path relative to its containing module, returning what
 /// `CompilerHost::load_source` should join onto `base_path`. Whether to keep the
 /// module's directory as a prefix is [`dir_prefix_to_keep`]'s decision: a
-/// cwd-relative entry already encodes what the host's join re-introduces, so
-/// prefixing would double it, while an absolute path collapses cleanly under
-/// `Path::join` and a `./`-rooted import needs the prefix to stay inside the
-/// importer's directory.
+/// cwd-relative entry already encodes what the host's join re-introduces, while
+/// a `./`-rooted import needs the prefix to stay inside its own directory.
 fn resolve_include_path_impl(
     entry_module_source: Option<&str>,
     module_source_str: &str,
@@ -1923,8 +1918,7 @@ fn is_cwd_relative(path: &str) -> bool {
 /// to the bare filename. Two cases collapse, both because re-prepending `dir`
 /// would duplicate what `base_path.join` adds: the cwd-relative entry module,
 /// whose `dir` *is* `base_path`, and any module whose `dir` does not look
-/// base_path-relative, carrying it inside the source string already. Absolute
-/// paths and `./`-rooted imports keep the prefix.
+/// base_path-relative. Absolute paths and `./`-rooted imports keep the prefix.
 fn dir_prefix_to_keep<'a>(
     entry_module_source: Option<&str>,
     module_source_str: &'a str,

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -376,7 +376,7 @@ use crate::compiler_host::LogLevel;
 
 /// Build a `kiln:` URI from a filesystem path, normalizing and percent-encoding
 /// it so the result is valid even for URI-unsafe paths (e.g. spaces);
-/// [`strip_kiln_scheme`] reverses it losslessly. The single producer — the CLI
+/// `strip_kiln_scheme` reverses it losslessly. The single producer — the CLI
 /// and LSP both call it, so their redirect URIs match.
 ///
 /// `kiln:` (not `file://`) avoids a spurious `//`, which the qualified-name

--- a/wado-compiler/src/logger.rs
+++ b/wado-compiler/src/logger.rs
@@ -1,27 +1,8 @@
-//! Logger module for structured compiler diagnostics
-//!
-//! Provides a `Logger` wrapper around `CompilerHost` that serves as the single
-//! error reporting channel for the compilation pipeline. All compilation errors
-//! are emitted immediately to the `CompilerHost` via the logger, enabling:
-//!
-//! - Real-time error reporting (for IDE/LSP)
-//! - Phase timing via host-side timestamps (compiler stays syscall-free)
-//! - Unified error counting with automatic bail at `MAX_ERRORS`
-//!
-//! # Architecture
-//!
-//! ```text
-//! Phase (Analyzer, Elaborator, ...) → Logger → CompilerHost → CLI/IDE/LSP
-//!                                     ↑
-//!                              error counting + bail
-//! ```
-//!
-//! Each phase calls `logger.error_in(module, typed_error)?` which:
-//! 1. Converts the typed error to a `Diagnostic` via `Into<Diagnostic>`
-//! 2. Stamps the module's file onto the span when it carries none
-//! 3. Emits the diagnostic to `CompilerHost::emit_diagnostic()`
-//! 4. Increments the error count
-//! 5. Returns `Err(Bail)` if the error limit is reached
+//! A `Logger` wrapping `CompilerHost` as the pipeline's single error-reporting
+//! channel: every phase's `logger.error_in(module, typed_error)?` converts the
+//! typed error to a `Diagnostic`, stamps the module's file onto a span carrying
+//! none, emits it, and bails once the count reaches `MAX_ERRORS`. Emitting
+//! immediately gives IDEs real-time errors and keeps the compiler syscall-free.
 
 use std::cell::Cell;
 
@@ -51,44 +32,11 @@ impl std::fmt::Display for Bail {
 
 impl std::error::Error for Bail {}
 
-/// Logger for the compilation pipeline
-///
-/// Wraps a `CompilerHost` and provides the unified error reporting channel.
-/// All compilation errors and informational messages go through this logger.
-///
-/// # Error Counting
-///
-/// The logger tracks how many errors have been emitted. When the count reaches
-/// `MAX_ERRORS`, `error()` returns `Err(Bail)` to stop compilation.
-///
-/// # File Attribution
-///
-/// A diagnostic's file is stamped from the module the caller holds
-/// (`error_in` / `error_at`), never from ambient logger state — so no phase
-/// can forget to set it. `error(err)` is for diagnostics that already carry
-/// their own location.
-///
-/// # Example
-///
-/// ```ignore
-/// let logger = Logger::new(&host, LogLevel::Debug);
-///
-/// // Report compilation errors attributed to a module (counted, may bail)
-/// logger.error_in(&module_source, TypeError::TypeMismatch { expected, found, span })?;
-///
-/// // Fatal errors always bail
-/// logger.fatal(TypeError::TypeMismatch { ... })?; // always Err(Bail)
-///
-/// // Informational logging (fire-and-forget, filtered by level)
-/// logger.debug("entering function");
-/// logger.info("processing 10 items");
-///
-/// // Track phase timing with RAII guard
-/// {
-///     let _span = logger.span("parse");
-///     // ... parsing happens here ...
-/// } // SpanEnd is emitted when _span is dropped
-/// ```
+/// Logger for the compilation pipeline: the unified channel every error and
+/// informational message goes through, bailing at `MAX_ERRORS`. A diagnostic's
+/// file is stamped from the module the caller holds (`error_in` / `error_at`),
+/// never from ambient state, so no phase can forget it; `error(err)` is for one
+/// that already carries its own location.
 pub struct Logger<'a, H: CompilerHost> {
     host: &'a H,
     level: LogLevel,

--- a/wado-compiler/src/lower.rs
+++ b/wado-compiler/src/lower.rs
@@ -1,21 +1,8 @@
-//! Lowering pass for Wado TIR
-//!
-//! The lower phase is a `FlatPackage` (TIR-shaped) → `NirPackage`
-//! translation, structured as planner + translator:
-//!
-//! ```text
-//! FlatPackage → lower::plan::plan(&mut flat) → lower::translate::translate(flat, plan)
-//! ```
-//!
-//! The planner ([`plan::plan`]) runs the TIR-mutating sub-passes
-//! (pattern lowering, global-initializer extraction, boxing, closure
-//! lowering, value-copy materialization, string-literal collection) and
-//! produces a [`plan::LowerPlan`] of facts the translator consumes. The
-//! translator ([`translate::translate`]) is a single fold from TIR to
-//! NIR; arms that rewrite markers (`builtin::copy_value::<T>` → helper
-//! call, `i128`/`u128` match → if-else chain) live there.
-//!
-//! See `docs/wep-2026-05-11-nir.md`.
+//! Lowering `FlatPackage` → `NirPackage` (WEP 2026-05-11), as planner then
+//! translator. [`plan::plan`] runs the TIR-mutating sub-passes — pattern
+//! lowering, global-initializer extraction, boxing, closure lowering, value-copy
+//! materialization, string-literal collection — and hands the translator a
+//! [`plan::LowerPlan`]. [`translate::translate`] is then a single fold.
 
 pub mod bare_asserts;
 pub mod plan;

--- a/wado-compiler/src/lower/bare_asserts.rs
+++ b/wado-compiler/src/lower/bare_asserts.rs
@@ -1,24 +1,8 @@
-//! Lower the `assert_failed` marker reify emits for assertion failures.
-//!
-//! `assert cond[, msg]` reifies to
-//! `if !cond { cold_path(); assert_failed(<template>) }`, where `<template>`
-//! formats the asserted operands through the whole `Formatter` / `Inspect` /
-//! `String` stack (see `elaborator::reify::reify_assert`). The reify-emitted
-//! `core:rt::assert_failed` is a distinct callee — a marker — so this
-//! lowering can treat assertion failures differently from explicit
-//! `panic(...)` calls:
-//!
-//! - default: rewrite the call back to `core:rt::panic`, so the marker
-//!   never reaches codegen and the output is identical to a direct `panic` —
-//!   no `assert_failed` wrapper frame, no codegen drift.
-//! - `-f bare-asserts` (on by default at `-Os`): replace the whole cold block
-//!   with a bare `unreachable()`. The assertion still checks and traps, but the
-//!   message-building statements and diagnostic literals are gone; the
-//!   now-unreachable formatting functions then fall out at the next DCE.
-//!
-//! It runs in `lower` *before* string-literal planning, so the dropped template
-//! literals are never collected into the data section, and before NIR
-//! conversion, so the discarded formatting is never lowered.
+//! Lower the `assert_failed` marker reify emits for an assertion failure, a
+//! distinct callee precisely so this can treat it unlike an explicit `panic`. By
+//! default it rewrites back to `core:rt::panic`, leaving no wrapper frame; under
+//! `-f bare-asserts` (default at `-Os`) the cold block becomes `unreachable()`,
+//! so the assertion still traps while its message-building falls out at DCE.
 
 use crate::flat_package::FlatPackage;
 use crate::synthesis::common::builtin_call;

--- a/wado-compiler/src/lower/plan.rs
+++ b/wado-compiler/src/lower/plan.rs
@@ -1,17 +1,8 @@
-//! Pre-fold planning. Mutations are confined to the type table,
-//! additive synthesis (`flat.{structs,functions,globals}` growth),
-//! and per-function declaration-shape edits in
-//! [`boxing::shadow_params`] / [`lift_mut`]. Every
-//! expression-shape rewrite lives in
-//! [`crate::lower::translate`].
-//!
-//! Sub-pass ordering is dictated by what the next pass reads:
-//! `boxing::prepare_types` mutates the type table before any
-//! analysis that consults resolved types; `lift_mut` runs before
-//! `value_copy::plan`'s seed walker so the lifted `Let mut`
-//! statements are visible.
-//!
-//! See `docs/wep-2026-05-11-nir.md`.
+//! Pre-fold planning (WEP 2026-05-11). Mutations stay confined to the type
+//! table, additive synthesis, and the declaration-shape edits in
+//! [`boxing::shadow_params`] / [`lift_mut`]; every expression-shape rewrite
+//! lives in [`crate::lower::translate`]. Sub-pass order follows what the next
+//! pass reads: the type table is mutated before any analysis consults it.
 
 use crate::flat_package::FlatPackage;
 use crate::logger::{Bail, ErrorSink};

--- a/wado-compiler/src/lower/plan/boxing.rs
+++ b/wado-compiler/src/lower/plan/boxing.rs
@@ -31,16 +31,11 @@ impl BoxPlan {
     }
 }
 
-/// Prepare the type table for boxing: a type-table-only pass.
-///
-/// It mints a `Box<T>` struct type for every `&primitive` / `&variant`
-/// / `&fn` reference in the program, redefines the corresponding
-/// `Ref` / `MutRef` `TypeIds` to those struct types (so composite types
-/// that transitively contain a boxed reference follow automatically),
-/// and appends the generated struct definitions to `flat.structs`.
-///
-/// It does not touch any function body — body lowering is driven
-/// separately from the returned [`BoxPlan`].
+/// Prepare the type table for boxing, touching no function body: mint a `Box<T>`
+/// struct for every `&primitive` / `&variant` / `&fn` in the program, redefine
+/// the matching `Ref` / `MutRef` `TypeId`s to it — so composites containing one
+/// follow automatically — and append the definitions to `flat.structs`. Body
+/// lowering runs separately off the returned [`BoxPlan`].
 pub fn prepare_types(flat: &mut FlatPackage) -> BoxPlan {
     let box_module_source = flat
         .type_table
@@ -288,22 +283,11 @@ impl TypeBuilder {
 
     /// Scan the type table to find which primitives need Box types.
     fn create_needed_box_types(&mut self, type_table: &mut TypeTable) {
-        // Collect base TypeIds that need boxing, plus newtypes.
-        // Boxing is required for:
-        // - Primitives (except i128/u128 which are already GC types)
-        // - Standalone enums (plain i32 discriminants — scalar-backed
-        //   exactly like primitives, so `&mut EnumType` needs the same
-        //   stable heap slot; without it a deref-assignment through the
-        //   reference is lost). A variant's payload-less case subset is
-        //   also a `ResolvedType::Enum` but carries the variant's name and
-        //   its values are GC refs into the variant hierarchy — those go
-        //   through the variant representation, not boxing.
-        // - Variant types (subtype hierarchy prevents field-by-field deref assignment)
-        // - Function types (the local holds a `ref struct` value; `&mut fn`
-        //   needs a stable heap slot for deref-assignment, and we box `&fn`
-        //   for the same shape so reference semantics stay uniform across
-        //   all `&T` / `&mut T` types — the optimizer can elide read-only
-        //   wrappers later).
+        // Collect the base TypeIds needing boxing, plus newtypes: primitives
+        // (bar the already-GC i128/u128), standalone enums (scalar-backed, so a
+        // deref-assignment needs the same stable heap slot), variants (whose
+        // subtype hierarchy blocks field-by-field assignment), and function
+        // types. A variant's case subset is GC-backed and goes elsewhere.
         let mut needs_box_base: IndexSet<TypeId> = IndexSet::default();
 
         for type_id in type_table.iter_type_ids().collect::<Vec<_>>() {

--- a/wado-compiler/src/lower/plan/closure.rs
+++ b/wado-compiler/src/lower/plan/closure.rs
@@ -222,8 +222,7 @@ struct FnParamSpecKey {
 /// method holding the transformed body, so the literal becomes a `StructLiteral`,
 /// a `Capture` becomes a field access on `self`, and a known `IndirectCall`
 /// becomes `callee.__call(args)`. Applied only to closures bound to a local and
-/// called directly; one passed as an argument goes through fn-param
-/// specialization, which generates a callee taking the functor struct instead.
+/// called directly; one passed as an argument goes through fn-param spec.
 struct ClosureLowerer {
     /// Counter for the Phase 1 walk. Each visited `Closure` has its
     /// `functor_id` populated from this — that ID is the stable index
@@ -564,13 +563,11 @@ impl ClosureLowerer {
             }
             .visit_expr(&mut transformed_body);
 
-            // Keep a block body's statements as-is so a `Return` inside
-            // survives — the inliner rewrites `Return` into `Break` only at
-            // statement level and would miss one wrapped in a Block expression.
-            // A single-expression body that reified into a Block leaves its
-            // value in the trailing `Expr` statement; for a value-returning
-            // closure that is the return value, so promote it to a `Return` or
-            // wir_build drops it as a bare statement.
+            // Keep a block body's statements as-is so a `Return` inside survives
+            // — the inliner rewrites `Return` into `Break` only at statement
+            // level. A single-expression body that reified into a Block leaves
+            // its value in the trailing `Expr` statement; promote it to a
+            // `Return` or wir_build drops it as a bare statement.
             let body_stmts = match &transformed_body.kind {
                 TirExprKind::Block(block) => {
                     let mut stmts = block.stmts.clone();
@@ -710,8 +707,7 @@ impl ClosureLowerer {
             // impls, so trait dispatch on a specialised `&__Closure_N` writes
             // the per-literal signature and unparsed source. Template expansion
             // routes fn-typed receivers through `Fn<N, Ret>^<Trait>::<method>`,
-            // which `ClosureCallSiteLowerer` retargets here. DCE removes them
-            // when neither a user call, the redirect, nor a vtable slot reaches.
+            // which `ClosureCallSiteLowerer` retargets here.
             let signature = format_closure_signature(&collected.params, return_type, type_table);
             // Recover the per-literal source body (`|x: i32| x + 1`)
             // by unparsing the captured TIR closure form. The TIR is
@@ -1415,10 +1411,8 @@ impl TirRefVisitor for LocalCollector<'_> {
 /// Phase 2 visitor deciding which closures are safe to specialise: those whose
 /// value never escapes its declaring local, every use being a direct call or a
 /// redirect-eligible trait dispatch. Anything else must travel as a
-/// `CanonicalClosure_K`, since a specialised `__Closure_N` is incompatible with
-/// a canonical fn type. Only a call's callee, receiver or func is a non-escape
-/// position; `Let { value: Closure }` is special-cased, the literal being what
-/// binds the local, and its body walked under a fresh `local_to_closure`.
+/// `CanonicalClosure_K`. Only a call's callee, receiver or func is a non-escape
+/// position; `Let { value: Closure }` is special-cased, the literal binding it.
 struct ClosureSafetyAnalyzer<'a> {
     local_to_closure: &'a mut IndexMap<u32, u32>,
     specializable: &'a mut IndexSet<u32>,
@@ -1636,13 +1630,10 @@ impl ClosureCallSiteLowerer<'_> {
     }
 
     /// Redirect a `Fn<N, Ret>^{Inspect,InspectAlt,Display,DisplayAlt}` call on a
-    /// specialised closure local to the per-functor impl. All four shapes must
-    /// be redirected: the `Display` fallbacks delegate through
-    /// `self.Inspect::inspect(f)`, which would reach the canonical-vtable stub
-    /// and trap its `ref.cast` on a `&__Closure_N`. The rewritten `FunctionRef`
-    /// takes the *functor's* module, since the impl stays where the literal was
-    /// lowered even when the body was inlined elsewhere. A receiver that does not
-    /// peel to a local in `local_to_closure` falls through to the generic stub.
+    /// specialised closure local to the per-functor impl. All four shapes must be
+    /// redirected: the `Display` fallbacks delegate through `Inspect::inspect`,
+    /// which would trap the canonical stub's `ref.cast`. The rewritten
+    /// `FunctionRef` takes the *functor's* module, where the impl was lowered.
     fn try_redirect_inspect_to_functor(&self, receiver: &mut TirExpr, func: &mut FunctionRef) {
         let info = match &func.method_info {
             Some(info) => info,
@@ -1857,9 +1848,8 @@ impl TirMutVisitor for ClosureCallSiteLowerer<'_> {
 /// In-place body transformer for the synthesised `__call` method: rewrites each
 /// `Capture` into a `self.__capture_<index>` field access and shifts every local
 /// index — reads, `Let`s, and pattern bindings alike — past the synthetic `self`.
-/// A nested `Closure` body is not recursed into, having its own index namespace
-/// and its own `__call`, but its `captures[*].outer_index` names locals in *this*
-/// scope, so those shift too or the nested functor reads one slot too early.
+/// A nested `Closure` body has its own index namespace and is not recursed into,
+/// but its `captures[*].outer_index` names locals here, so those shift too.
 struct ClosureBodyTransformer<'a> {
     captures: &'a [TirCapture],
     self_ref_type: TypeId,

--- a/wado-compiler/src/lower/plan/closure.rs
+++ b/wado-compiler/src/lower/plan/closure.rs
@@ -47,18 +47,11 @@ const CLOSURE_FORMAT_TRAITS: [(CompilerItem, FunctorFmtBody); 4] = [
     ),
 ];
 
-/// Per-local entry recording that a function parameter has been
-/// specialized to a functor type. Populated for synthesized
-/// fn-param-specialized callees. The translator uses these entries to:
-///
-/// - Retag `Local` reads of the param to the functor `&__Closure_N`
-///   type instead of the original `fn(...)` declared type.
-/// - Rewrite `IndirectCall { callee: Local(param), .. }` into
-///   a call to the functor's `__call` method.
-/// - Wrap `Local(param)` args to call slots that
-///   still expect `fn(...)` in `ExprKind::ClosureToCanonical`,
-///   converting the specialized value back to its canonical
-///   function-shaped view.
+/// Records that a parameter of a synthesized fn-param-specialized callee has
+/// been specialized to a functor type. The translator retags the param's `Local`
+/// reads to `&__Closure_N`, rewrites its `IndirectCall`s into `__call` method
+/// calls, and wraps it in `ClosureToCanonical` wherever it feeds a slot still
+/// expecting the canonical `fn(…)` shape.
 pub struct SpecializedLocal {
     pub local_index: u32,
     pub functor_id: u32,
@@ -66,16 +59,11 @@ pub struct SpecializedLocal {
     pub original_fn_type: tir::TypeId,
 }
 
-/// Result of closure planning.
-///
-/// `functor_infos` is consumed by the TIR → NIR translator to populate
-/// `NirPackage::closure_functors`. It carries per-functor metadata
-/// (struct name, `__call` method body, captures, canonical signature)
-/// that the optimizer uses for closure inlining.
-///
-/// `specialized_locals` lists, for each synthesized specialized
-/// callee, the params that were re-bound to functor types. See
-/// [`SpecializedLocal`].
+/// Result of closure planning. `functor_infos` populates
+/// `NirPackage::closure_functors` — the per-functor metadata (struct name,
+/// `__call` body, captures, canonical signature) the optimizer inlines against —
+/// and `specialized_locals` lists each synthesized callee's params re-bound to
+/// functor types. See [`SpecializedLocal`].
 pub struct ClosurePlan {
     pub functor_infos: Vec<ClosureFunctor>,
     pub specialized_locals: IndexMap<(ModuleSource, String), Vec<SpecializedLocal>>,
@@ -230,20 +218,12 @@ struct FnParamSpecKey {
     functor_types: Vec<(u32, TypeId)>,
 }
 
-/// Lowers closures to functor structs with `__call` methods.
-///
-/// For each closure, this generates:
-/// 1. A synthetic struct `__Closure_N` with fields for captured variables
-/// 2. A `__call` method containing the transformed closure body
-///
-/// Transformations (selective - only for closures stored in locals and called directly):
-/// - `Closure { params, body, captures }` → `StructLiteral { __Closure_N, capture_values }`
-/// - `Capture { index }` (in body) → `FieldAccess { self, __capture_{index} }`
-/// - `IndirectCall { callee, args }` (known closure) → `callee.__call(args)`
-///
-/// Closures passed as function arguments are transformed via fn-param specialization:
-/// - A specialized version of the callee is generated with functor struct params
-/// - The call is updated to use the specialized function with `StructLiteral` args
+/// Lowers each closure to a `__Closure_N` struct of its captures plus a `__call`
+/// method holding the transformed body, so the literal becomes a `StructLiteral`,
+/// a `Capture` becomes a field access on `self`, and a known `IndirectCall`
+/// becomes `callee.__call(args)`. Applied only to closures bound to a local and
+/// called directly; one passed as an argument goes through fn-param
+/// specialization, which generates a callee taking the functor struct instead.
 struct ClosureLowerer {
     /// Counter for the Phase 1 walk. Each visited `Closure` has its
     /// `functor_id` populated from this — that ID is the stable index
@@ -453,16 +433,11 @@ impl ClosureLowerer {
         }
     }
 
-    /// Update `locals` in a function after closure transformation
-    /// Seed `local_to_closure` for any function parameter whose declared
-    /// type is `&__Closure_N` (the result of fn-param specialisation in
-    /// `generate_fn_param_specializations`). Without this, the
-    /// inspect-redirect in `try_redirect_inspect_to_functor` would miss
-    /// specialised parameters — they aren't `let`-bound, so the safety
-    /// analyser doesn't put them in the map — and `f.Fn^Inspect::inspect`
-    /// inside a specialised function body would fall through to the
-    /// canonical-vtable dispatch on a `&__Closure_N` value, where the
-    /// `ref.cast` to `$canonical_inspectable_base` traps.
+    /// Seed `local_to_closure` for every parameter declared `&__Closure_N` by
+    /// fn-param specialisation. These are not `let`-bound, so the safety
+    /// analyser never adds them, and without this the inspect-redirect misses
+    /// them: `f.Fn^Inspect::inspect` would reach the canonical-vtable dispatch,
+    /// where `ref.cast` to `$canonical_inspectable_base` traps on a functor.
     fn seed_local_to_closure_from_params(
         &mut self,
         param_locals: &[(u32, TypeId)],
@@ -589,17 +564,13 @@ impl ClosureLowerer {
             }
             .visit_expr(&mut transformed_body);
 
-            // Block bodies: keep the inner statements as-is so that any
-            // Return inside survives. The inliner's `remap_stmt_with_label`
-            // turns Return into Break only at the statement level, so a
-            // Return wrapped inside a Block expression would be missed.
-            //
-            // A single-expression body that reified into a Block (e.g. a
-            // spread struct literal `S { ..*s, .. }`, hoisted to
-            // `{ let __base = ..; S { .. } }`) leaves the produced value in
-            // the block's trailing `Expr` statement. For a value-returning
-            // closure that tail is the return value, so promote it to a
-            // `Return`; otherwise wir_build drops it as a bare statement.
+            // Keep a block body's statements as-is so a `Return` inside
+            // survives — the inliner rewrites `Return` into `Break` only at
+            // statement level and would miss one wrapped in a Block expression.
+            // A single-expression body that reified into a Block leaves its
+            // value in the trailing `Expr` statement; for a value-returning
+            // closure that is the return value, so promote it to a `Return` or
+            // wir_build drops it as a bare statement.
             let body_stmts = match &transformed_body.kind {
                 TirExprKind::Block(block) => {
                     let mut stmts = block.stmts.clone();
@@ -735,16 +706,12 @@ impl ClosureLowerer {
                 canonical_return: return_type,
             });
 
-            // Synthesize per-functor Inspect / InspectAlt / Display /
-            // DisplayAlt impls so trait dispatch on the specialised
-            // `&__Closure_N` value writes the per-literal signature /
-            // TIR-unparsed source. Template expansion routes `{f}` / `{f:?}`
-            // / `{f:#}` / `{f:#?}` for fn-typed receivers through the
-            // `Fn<N, Ret>^<Trait>::<method>` call shape; `ClosureCallSiteLowerer`
-            // retargets each to the matching impl here. These are reachable
-            // through three routes: explicit user calls, the redirect
-            // (specialised path), and the canonical-vtable inspect slots
-            // (indirect path). Standard DCE removes them when none reach.
+            // Synthesize per-functor Inspect / InspectAlt / Display / DisplayAlt
+            // impls, so trait dispatch on a specialised `&__Closure_N` writes
+            // the per-literal signature and unparsed source. Template expansion
+            // routes fn-typed receivers through `Fn<N, Ret>^<Trait>::<method>`,
+            // which `ClosureCallSiteLowerer` retargets here. DCE removes them
+            // when neither a user call, the redirect, nor a vtable slot reaches.
             let signature = format_closure_signature(&collected.params, return_type, type_table);
             // Recover the per-literal source body (`|x: i32| x + 1`)
             // by unparsing the captured TIR closure form. The TIR is
@@ -1427,20 +1394,11 @@ impl TirRefVisitor for LocalCollector<'_> {
         self.walk_stmt(stmt);
     }
 
-    /// Pattern bindings (in `Match` arms, `IfLet`, and `LetDestructure`)
-    /// introduce locals exactly like `Let` does — the binding's
-    /// `local_index` is the slot the variant payload / destructured
-    /// field is written into. Before WEP 2026-05-11 Phase 10, pattern
-    /// lowering ran as a separate pre-pass that rewrote every such
-    /// binding into a `Let { ..., value: VariantPayload(..) }`, so
-    /// the `Let` arm above caught every body-introduced local. With
-    /// pattern lowering now folded into the TIR → NIR translator the
-    /// pre-pass is gone, and the pattern binding is the canonical
-    /// declaration site. Record it here so the closure planner's
-    /// locals vector reserves the correct type for that slot — without
-    /// this, `wir_build` falls back to the placeholder UNKNOWN /
-    /// `i32` slot and downstream code emits ref→i32 type-mismatch
-    /// Wasm.
+    /// A pattern binding introduces a local exactly as `Let` does, and since
+    /// pattern lowering moved into the TIR → NIR translator it is the canonical
+    /// declaration site. Record it so the planner's locals vector reserves the
+    /// right type for the slot; otherwise `wir_build` falls back to a
+    /// placeholder and downstream code emits ref→i32 type-mismatch Wasm.
     fn visit_pattern(&mut self, pattern: &TirPattern) {
         if let TirPattern::Binding {
             local_index,
@@ -1454,27 +1412,13 @@ impl TirRefVisitor for LocalCollector<'_> {
     }
 }
 
-/// Phase 2 visitor: decide which closures are safe to specialise.
-///
-/// A closure is **safe to specialise** when its value never escapes its
-/// declaring local: every use is either a direct call (`local(args)` /
-/// `local.method(args)`) or a redirect-eligible trait dispatch on it.
-/// Otherwise the value must travel as a `CanonicalClosure_K` so it can be
-/// stored in struct fields, passed as a function argument, returned, or
-/// assigned to globals — all positions where a specialised
-/// `__Closure_N` would be incompatible with the receiver's canonical fn
-/// type.
-///
-/// The escape decision is made by tracking `in_callee_position`: only the
-/// callee of `IndirectCall` / receiver or func of `Call` is
-/// a non-escape position. Every other slot (struct literal field, return
-/// value, global assignment, let-rebinding, …) is an escape, and finding a
-/// closure-bearing `Local` or a `Closure` literal there marks it
-/// non-specialisable.
-///
-/// `Let { value: Closure }` is special-cased: the literal is what binds
-/// the local, not an escape. Its body is walked under a fresh
-/// `local_to_closure` (closure bodies have their own local-index namespace).
+/// Phase 2 visitor deciding which closures are safe to specialise: those whose
+/// value never escapes its declaring local, every use being a direct call or a
+/// redirect-eligible trait dispatch. Anything else must travel as a
+/// `CanonicalClosure_K`, since a specialised `__Closure_N` is incompatible with
+/// a canonical fn type. Only a call's callee, receiver or func is a non-escape
+/// position; `Let { value: Closure }` is special-cased, the literal being what
+/// binds the local, and its body walked under a fresh `local_to_closure`.
 struct ClosureSafetyAnalyzer<'a> {
     local_to_closure: &'a mut IndexMap<u32, u32>,
     specializable: &'a mut IndexSet<u32>,
@@ -1691,35 +1635,14 @@ impl ClosureCallSiteLowerer<'_> {
         };
     }
 
-    /// When a method call resolves to `Fn<N, Ret>^Inspect`,
-    /// `^InspectAlt`, `^Display`, or `^DisplayAlt` with a receiver that
-    /// is a specialised closure local — either let-bound by the closure
-    /// safety analyser, or a fn-param specialised parameter
-    /// (`generate_fn_param_specializations` rewrites the param type to
-    /// `&__Closure_N`) — redirect the call to the per-functor
-    /// `__Closure_N^Inspect / InspectAlt` impl. `Display` / `DisplayAlt`
-    /// auto-derived fallbacks delegate to `Inspect` / `InspectAlt`
-    /// respectively, so all four trait-method shapes terminate at the
-    /// per-functor impl on the specialised path. Skipping the redirect
-    /// for `Display`/`DisplayAlt` would let the value reach the
-    /// canonical-vtable dispatch stub through the fallback's
-    /// `self.Inspect::inspect(f)` body, where `ref.cast self to
-    /// $canonical_inspectable_base` traps because the receiver is a
-    /// specialised `&__Closure_N`, not a canonical struct.
-    ///
-    /// Cross-module note: when the closure was defined in module A and
-    /// the redirect fires inside a body that was inlined / specialised
-    /// into module B, the per-functor impl still lives in module A
-    /// (where the closure literal was lowered). The rewritten
-    /// `FunctionRef` uses the functor's `module_source`, not the
-    /// surrounding body's module.
-    ///
-    /// Detection: `local_to_closure` is seeded by the safety analyser
-    /// for let-bound closures and by `seed_local_to_closure_from_params`
-    /// at body-walk start for fn-param specialised parameters. A
-    /// receiver that doesn't peel down to a local (or peels to one not
-    /// in the map, i.e. a canonicalised value) falls through to the
-    /// generic dispatch stub.
+    /// Redirect a `Fn<N, Ret>^{Inspect,InspectAlt,Display,DisplayAlt}` call on a
+    /// specialised closure local to the per-functor impl. All four shapes must
+    /// be redirected: the `Display` fallbacks delegate through
+    /// `self.Inspect::inspect(f)`, which would reach the canonical-vtable stub
+    /// and trap its `ref.cast` on a `&__Closure_N`. The rewritten `FunctionRef`
+    /// takes the *functor's* module, since the impl stays where the literal was
+    /// lowered even when the body was inlined elsewhere. A receiver that does not
+    /// peel to a local in `local_to_closure` falls through to the generic stub.
     fn try_redirect_inspect_to_functor(&self, receiver: &mut TirExpr, func: &mut FunctionRef) {
         let info = match &func.method_info {
             Some(info) => info,
@@ -1931,19 +1854,12 @@ impl TirMutVisitor for ClosureCallSiteLowerer<'_> {
     }
 }
 
-/// Phase 1.5 in-place body transformer for the synthesised `__call` method.
-///
-/// Operates on a clone of the original closure body and rewrites:
-/// - `Capture { index }` → `FieldAccess { self.__capture_<index> }`
-/// - `Local { index }` → `Local { index + 1 }` (shift past the synthetic `self`)
-/// - `Let { local_index }` → `Let { local_index + 1 }`
-/// - `Binding { local_index }` (in patterns) → shifted by +1
-///
-/// A nested `Closure` node's body is NOT recursed into: it lives in a
-/// separate local-index namespace and gets its own `__call` method generated
-/// at the same level. Its `captures[*].outer_index` does name locals in *this*
-/// scope, though — the enclosing closure's — so those shift by +1 with
-/// everything else, or the nested functor reads the local one slot too early.
+/// In-place body transformer for the synthesised `__call` method: rewrites each
+/// `Capture` into a `self.__capture_<index>` field access and shifts every local
+/// index — reads, `Let`s, and pattern bindings alike — past the synthetic `self`.
+/// A nested `Closure` body is not recursed into, having its own index namespace
+/// and its own `__call`, but its `captures[*].outer_index` names locals in *this*
+/// scope, so those shift too or the nested functor reads one slot too early.
 struct ClosureBodyTransformer<'a> {
     captures: &'a [TirCapture],
     self_ref_type: TypeId,

--- a/wado-compiler/src/lower/plan/globals.rs
+++ b/wado-compiler/src/lower/plan/globals.rs
@@ -143,17 +143,10 @@ fn default_value_for_type(type_id: TypeId, type_table: &TypeTable, span: Span) -
 }
 
 /// Extract non-constant global initializers into a per-module
-/// `__initialize_module` function (one per source module; the
-/// functions share a name and are disambiguated by their
-/// `module_source` field). For each lazy-init global the original
-/// initializer is replaced with a default value, and the original
-/// expression is moved into the module's `__initialize_module` body.
-///
-/// Must run before `boxing` because the extracted initializer code
-/// may contain `&primitive` / closure expressions that boxing /
-/// closure rewrite. The top-level `__initialize_modules` aggregator
-/// that calls each module's `__initialize_module` is built later by
-/// [`build_initialize_modules`].
+/// `__initialize_module` function, the globals keeping a default value in their
+/// place. Must run before `boxing`, the extracted code being able to contain the
+/// `&primitive` and closure expressions boxing rewrites; the top-level
+/// aggregator calling each one is built later by [`build_initialize_modules`].
 pub fn extract(flat: &mut FlatPackage, errors: &dyn ErrorSink) -> Result<(), Bail> {
     let type_table = flat.type_table.borrow();
 

--- a/wado-compiler/src/lower/plan/value_copy.rs
+++ b/wado-compiler/src/lower/plan/value_copy.rs
@@ -1,9 +1,8 @@
 //! Plan Wado's value-copy semantics: [`analyze::collect_seed_types`] names the
 //! types the fold wraps in `$value_copy$T(…)` and
 //! [`synthesize::synthesize_helpers`] generates a helper apiece. A wrap is
-//! emitted only where the ownership analyses — last-use liveness, freshness,
-//! confinement, read-only sharing — cannot prove a move, share or fresh value,
-//! so every copy is necessary and nothing elides them later.
+//! emitted only where the ownership analyses cannot prove a move, share or fresh
+//! value, so every copy is necessary and nothing elides them later.
 
 pub mod analyze;
 pub mod callgraph;

--- a/wado-compiler/src/lower/plan/value_copy.rs
+++ b/wado-compiler/src/lower/plan/value_copy.rs
@@ -1,15 +1,9 @@
-//! Plan Wado's value-copy semantics.
-//!
-//! [`analyze::collect_seed_types`] returns the set of `TypeId`s the
-//! fold will wrap in `$value_copy$T(...)`;
-//! [`synthesize::synthesize_helpers`] generates a per-type helper for
-//! the seed plus its transitive closure of nested value-typed fields.
-//! The fold (`lower::translate`) emits wrap calls directly using
-//! [`ValueCopyPlan::name_for_type`], but only at consumption sites the ownership
-//! analysis cannot prove a move, share, or fresh value: last-use liveness
-//! ([`last_use`]), interprocedural freshness ([`ownership`]), per-parameter
-//! confinement ([`confine`]), and the read-only-share refinement. There is no
-//! later elision pass — every emitted copy is necessary by construction.
+//! Plan Wado's value-copy semantics: [`analyze::collect_seed_types`] names the
+//! types the fold wraps in `$value_copy$T(…)` and
+//! [`synthesize::synthesize_helpers`] generates a helper apiece. A wrap is
+//! emitted only where the ownership analyses — last-use liveness, freshness,
+//! confinement, read-only sharing — cannot prove a move, share or fresh value,
+//! so every copy is necessary and there is no later elision pass.
 
 pub mod analyze;
 pub mod callgraph;

--- a/wado-compiler/src/lower/plan/value_copy.rs
+++ b/wado-compiler/src/lower/plan/value_copy.rs
@@ -3,7 +3,7 @@
 //! [`synthesize::synthesize_helpers`] generates a helper apiece. A wrap is
 //! emitted only where the ownership analyses — last-use liveness, freshness,
 //! confinement, read-only sharing — cannot prove a move, share or fresh value,
-//! so every copy is necessary and there is no later elision pass.
+//! so every copy is necessary and nothing elides them later.
 
 pub mod analyze;
 pub mod callgraph;

--- a/wado-compiler/src/lower/plan/value_copy/funcset.rs
+++ b/wado-compiler/src/lower/plan/value_copy/funcset.rs
@@ -1,16 +1,8 @@
-//! Borrow-keyed function-identity containers for the value-copy analyses.
-//!
-//! A function is identified by `(module_source, name)` — the same pair
-//! `ownership::func_key` folds into a `FunctionId`. Keying an `IndexMap` /
-//! `IndexSet` by `FunctionId` forces every lookup to first *build* that key:
-//! clone the `ModuleSource` and heap-allocate `name.to_string()`. In the
-//! interprocedural fixpoints and the per-call fold walk that lookup runs on
-//! every call node, so the allocation dominates.
-//!
-//! Splitting the key into a two-level `module -> name -> _` map lets a lookup
-//! borrow both halves (`ModuleSource` by reference, `name` as `&str` via
-//! `String: Borrow<str>`), so membership tests allocate nothing while staying
-//! byte-for-byte equivalent to the `FunctionId`-keyed map.
+//! Borrow-keyed function-identity containers for the value-copy analyses. A
+//! `FunctionId`-keyed map makes every lookup *build* its key first, cloning a
+//! `ModuleSource` and allocating a `String` — on every call node of the
+//! interprocedural fixpoints, where that dominates. A two-level
+//! `module -> name -> _` map lets a lookup borrow both halves instead.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;

--- a/wado-compiler/src/lower/plan/value_copy/last_use.rs
+++ b/wado-compiler/src/lower/plan/value_copy/last_use.rs
@@ -12,8 +12,7 @@
 //!
 //! A function containing a closure, effect handler, or `resume` is skipped
 //! wholesale, since either can re-observe a local this pass does not model.
-//! Soundness rests on `live` over-approximating everywhere: an unknown control
-//! target keeps every local live, so at worst a copy is kept.
+//! `live` over-approximates everywhere, so at worst a copy is kept.
 
 use super::analyze::is_owned_value;
 use super::funcset::FuncKeySet;
@@ -179,26 +178,11 @@ pub fn compute_move_eligible(
     a.walk_block(body, &mut live, true);
     a.resolve_pending_mut_aliases();
 
-    // Structural freshness: the locals that *hold* an owned (unaliased) value,
-    // regardless of how many times they are read. A least fixpoint — start with
-    // every sourced local and drop those whose source is not owned given the
-    // rest. `is_owned_value` resolves a `Local` reference through this set, so a
-    // deserialize temporary read twice (the `?` tag-test + payload-extract, or a
-    // re-wrapped `Err` arm) still counts, propagating freshness up the chain to
-    // the field that is finally moved.
-    // By-value (non-reference) parameters are owned storage the function holds
-    // exclusively: the caller either deep-copied the argument in, or move-elided
-    // a fresh-and-dead one (whose source is then dead), so nothing live aliases
-    // the parameter. Consuming it at its final use is therefore a move — a
-    // `build(self) -> Self { return self }` returns its receiver without a copy.
-    // Multi-use or borrow-escaping parameters are still held back by `non_final`
-    // / `borrow_escaped`, so this only frees genuinely final consumptions.
-    // Reference parameters (`&self`) borrow the caller's storage and are never
-    // seeded. The interprocedural return convention (`ownership.rs`) seeds
-    // by-value params the same way and for the same reason: a returned parameter
-    // is never confined, so the caller always deep-copies it in, and returning it
-    // (a stored-then-returned parameter's store copied it too, since it is live at
-    // the return) yields a value that aliases only the callee's own copy.
+    // Structural freshness: the locals *holding* an owned value, however often
+    // read. A least fixpoint — seed every sourced local, drop those whose source
+    // is not owned given the rest. By-value params are seeded too, the caller
+    // having deep-copied or move-elided the argument; reference params borrow
+    // the caller's storage and never are.
     let mut fresh: IndexSet<u32> = a
         .let_sources
         .keys()
@@ -829,16 +813,10 @@ impl Analyzer<'_> {
     }
 
     /// The positions an indirect (functor) callee may store, from its functor
-    /// type's declared `stores` clause. `None` is conservative: every position
-    /// may be stored.
-    ///
-    /// Only a call through a functor *parameter* is trusted. A parameter's
-    /// declared `stores` is a sound upper bound of every value bound to it: the
-    /// frontend checks each call argument (closure / function) against the
-    /// parameter's `stores`, rejecting one that would store more. A functor
-    /// value from any other source (a `let`-bound closure whose synthesized type
-    /// records no `stores`, a returned functor) carries no such guarantee, so it
-    /// stays conservative and its `&`/`&mut` arguments keep their copies.
+    /// type's declared `stores` clause; `None` means every position may be.
+    /// Only a call through a functor *parameter* is trusted, the frontend having
+    /// checked each argument against that parameter's `stores`. A functor from
+    /// any other source carries no such guarantee and keeps its copies.
     fn functor_stores(&self, callee: &TirExpr) -> Option<IndexSet<u32>> {
         let TirExprKind::Local { index, .. } = &callee.kind else {
             return None;

--- a/wado-compiler/src/lower/plan/value_copy/last_use.rs
+++ b/wado-compiler/src/lower/plan/value_copy/last_use.rs
@@ -1,8 +1,9 @@
-//! TIR-level move-eligibility for the value-copy fold (WEP 2026-05-21), over the
-//! *synthesized* bodies the source-level pass cannot see. One backward liveness
-//! pass yields both facts a move needs: every read is a final use, and nothing
-//! the value derives from is still live at the binding. A function containing a
-//! closure, handler or `resume` is skipped, either being able to re-observe.
+//! TIR-level move-eligibility for the value-copy fold (WEP 2026-05-21), run over
+//! every body and unioned with the source-level pass's `moved_local_spans`. One
+//! backward liveness pass yields both facts a move needs: every read is a final
+//! use, and nothing the value derives from is still live at the binding. A
+//! function containing a closure, handler or `resume` is skipped, either being
+//! able to re-observe.
 
 use super::analyze::is_owned_value;
 use super::funcset::FuncKeySet;

--- a/wado-compiler/src/lower/plan/value_copy/last_use.rs
+++ b/wado-compiler/src/lower/plan/value_copy/last_use.rs
@@ -2,16 +2,13 @@
 //! may be *moved* rather than copied when that is provably unobservable: every
 //! read is a final use, and its storage traces back — through locals themselves
 //! dead at the hand-off — to a fresh allocation nothing else references. This
-//! reaches the *synthesized* bodies the source-level last-use pass cannot see,
-//! whose temporaries are the fold's remaining hot copies; the two sets are
-//! unioned there.
+//! reaches the *synthesized* bodies the source-level last-use pass cannot see.
 //!
 //! One backward liveness pass yields both facts. A *final read* is one after
-//! which the local is dead on every live path — divergent `match` arms
-//! contribute to live-in but not live-out, and a loop body reaches a fixpoint. *No
-//! live alias* means nothing the value derives from is still live at the binding,
-//! checked against live-out, so a once-consumed temporary passes while a re-read
-//! scrutinee does not. Owned storage is then a least fixpoint over the two.
+//! which the local is dead on every live path. *No live alias* means nothing the
+//! value derives from is still live at the binding, so a once-consumed temporary
+//! passes while a re-read scrutinee does not. Owned storage is then a least
+//! fixpoint over the two.
 //!
 //! A function containing a closure, effect handler, or `resume` is skipped
 //! wholesale, since either can re-observe a local this pass does not model.

--- a/wado-compiler/src/lower/plan/value_copy/last_use.rs
+++ b/wado-compiler/src/lower/plan/value_copy/last_use.rs
@@ -1,18 +1,8 @@
-//! TIR-level move-eligibility for the value-copy fold (WEP 2026-05-21). A local
-//! may be *moved* rather than copied when that is provably unobservable: every
-//! read is a final use, and its storage traces back — through locals themselves
-//! dead at the hand-off — to a fresh allocation nothing else references. This
-//! reaches the *synthesized* bodies the source-level last-use pass cannot see.
-//!
-//! One backward liveness pass yields both facts. A *final read* is one after
-//! which the local is dead on every live path. *No live alias* means nothing the
-//! value derives from is still live at the binding, so a once-consumed temporary
-//! passes while a re-read scrutinee does not. Owned storage is then a least
-//! fixpoint over the two.
-//!
-//! A function containing a closure, effect handler, or `resume` is skipped
-//! wholesale, since either can re-observe a local this pass does not model.
-//! `live` over-approximates everywhere, so at worst a copy is kept.
+//! TIR-level move-eligibility for the value-copy fold (WEP 2026-05-21), over the
+//! *synthesized* bodies the source-level pass cannot see. One backward liveness
+//! pass yields both facts a move needs: every read is a final use, and nothing
+//! the value derives from is still live at the binding. A function containing a
+//! closure, handler or `resume` is skipped, either being able to re-observe.
 
 use super::analyze::is_owned_value;
 use super::funcset::FuncKeySet;

--- a/wado-compiler/src/lower/plan/value_copy/last_use.rs
+++ b/wado-compiler/src/lower/plan/value_copy/last_use.rs
@@ -1,42 +1,22 @@
-//! TIR-level move-eligibility for the value-copy fold (WEP 2026-05-21).
+//! TIR-level move-eligibility for the value-copy fold (WEP 2026-05-21). A local
+//! may be *moved* rather than copied when that is provably unobservable: every
+//! read is a final use, and its storage traces back — through locals themselves
+//! dead at the hand-off — to a fresh allocation nothing else references. This
+//! reaches the *synthesized* bodies the source-level last-use pass cannot see,
+//! whose temporaries are the fold's remaining hot copies; the two sets are
+//! unioned there.
 //!
-//! A local qualifies to be *moved* rather than copied when moving its storage
-//! is provably unobservable: every read of it is a final use, and its storage
-//! traces back — through other locals that are themselves dead at the hand-off
-//! — to a fresh allocation (an owned call, a construction, a literal) that
-//! nothing else still references. This reaches *synthesized* function bodies —
-//! serde `deserialize`, `Default` / `Clone` derives — which have no AST and are
-//! invisible to the source-level last-use pass (`elaborator::liveness`) that
-//! feeds `moved_local_spans`. Their temporaries (a field parsed into a local,
-//! carried through an `Ok`-binding into the returned struct) are the fold's
-//! remaining hot copies. The two are unioned at the fold.
+//! One backward liveness pass yields both facts. A *final read* is one after
+//! which the local is dead on every live path — divergent `match` arms
+//! contribute to live-in but not live-out, and a loop body reaches a fixpoint. *No
+//! live alias* means nothing the value derives from is still live at the binding,
+//! checked against live-out, so a once-consumed temporary passes while a re-read
+//! scrutinee does not. Owned storage is then a least fixpoint over the two.
 //!
-//! # Two facts, one backward liveness pass
-//!
-//! - *final read* — a read after which the local is dead on every live path. A
-//!   local all of whose reads are final can be moved at each without a later
-//!   observation. Backward liveness computes this precisely: divergent `match`
-//!   arms (`… => return Err(e)`) contribute to a local's live-*in* but not its
-//!   live-*out*, and a loop body reaches a fixpoint, so a value produced and
-//!   consumed within one iteration is dead across the back-edge.
-//! - *no live alias* — at the point a local is bound, none of the locals its
-//!   value derives from are still live. A match-arm binding
-//!   (`if let Some(s) = opt`) aliases its scrutinee's interior; if `opt` is
-//!   read again, moving `s` would corrupt it, so the de-aliasing copy must
-//!   stay. Checked against the live set *after* the binding (live-out), which
-//!   excludes reads that only happen on divergent arms — so a once-consumed
-//!   deserialize temporary passes while a re-read `opt` does not.
-//!
-//! Owned storage is then a least fixpoint: a local exclusively owns fresh
-//! storage when it has no live alias and every source is owned given the locals
-//! proven so far (`is_owned_value` resolves a `Local` reference through that
-//! set). A function containing a closure, effect handler, or `resume` is
-//! skipped wholesale — a captured local or a resumed continuation can
-//! re-observe a local this pass does not model.
-//!
-//! Soundness rests on `live` being an over-approximation of the true live set
-//! everywhere: an unknown control target keeps every local live (never a spurious
-//! final read), so at worst a copy is kept.
+//! A function containing a closure, effect handler, or `resume` is skipped
+//! wholesale, since either can re-observe a local this pass does not model.
+//! Soundness rests on `live` over-approximating everywhere: an unknown control
+//! target keeps every local live, so at worst a copy is kept.
 
 use super::analyze::is_owned_value;
 use super::funcset::FuncKeySet;
@@ -1511,12 +1491,6 @@ impl Analyzer<'_> {
     }
 }
 
-/// The local whose storage this expression's *result* shares, if any. A
-/// whole-value `Local` or a projection of one (`.field`, `[i]`, `*ref`, a
-/// transparent cast) aliases that root local; a fresh allocation — a call, a
-/// construction, a literal, an arithmetic result — aliases nothing observable,
-/// so returns `None`. Errs toward `Some` for unmodelled projection-like nodes
-/// (over-flagging only keeps a copy).
 /// The top-level field a borrow place reaches off its root local: `Some(f)` for a
 /// clean projection `local.f…`, `None` for a whole-local (`local`) or an
 /// imprecise place (through an index / deref / cast / variant payload), which
@@ -1538,6 +1512,11 @@ fn borrow_top_field(place: &TirExpr) -> Option<u32> {
     }
 }
 
+/// The local whose storage this expression's *result* shares, if any: a
+/// whole-value `Local` or a projection of one aliases that root, while a fresh
+/// allocation — a call, a construction, a literal, an arithmetic result —
+/// aliases nothing observable and gives `None`. Errs toward `Some` for an
+/// unmodelled projection-like node, where over-flagging only keeps a copy.
 pub(crate) fn alias_root(expr: &TirExpr) -> Option<u32> {
     match &expr.kind {
         TirExprKind::Local { index, .. } => Some(*index),

--- a/wado-compiler/src/lower/plan/value_copy/last_use.rs
+++ b/wado-compiler/src/lower/plan/value_copy/last_use.rs
@@ -1013,20 +1013,11 @@ impl Analyzer<'_> {
         }
     }
 
-    /// Record place-level move candidates at a struct/tuple literal or a `let`
-    /// binding. A direct child that materializes a whole value / clean field of
-    /// an aggregate root `base` aliases it out of the aggregate instead of
-    /// deep-copying, when:
-    ///
-    /// - `base` is dead after the literal (`!live_out.contains(base)`);
-    /// - the materialization sites of `base` are non-overlapping owners (one
-    ///   whole move, or field moves with distinct top-level fields); and
-    /// - no *other* use of `base` in the literal mutates or moves its storage
-    ///   (`conflict`). Read-only borrows (`&self` method, field read) and
-    ///   independent deep copies are harmless because `base` dies right after.
-    ///
-    /// The owned-storage guards (fresh / no live alias / no escaped borrow) are
-    /// applied later, once the fixpoint is known.
+    /// Record place-level move candidates at a struct/tuple literal or `let`. A
+    /// direct child materializing a whole value or clean field of an aggregate
+    /// root aliases it out instead of deep-copying, provided the root is dead
+    /// after the literal, its materialization sites are non-overlapping owners,
+    /// and no other use in the literal mutates or moves its storage.
     fn collect_place_moves(&mut self, children: &[&TirExpr], live_out: &IndexSet<u32>) {
         let mut mats: IndexMap<u32, Vec<(Option<u32>, crate::token::Span)>> = IndexMap::default();
         let mut conflict: IndexSet<u32> = IndexSet::default();

--- a/wado-compiler/src/lower/plan/value_copy/last_use.rs
+++ b/wado-compiler/src/lower/plan/value_copy/last_use.rs
@@ -1533,7 +1533,7 @@ fn as_materialize(expr: &TirExpr) -> Option<(u32, Option<u32>)> {
 /// A newtype shares its base type's runtime representation (WEP 2026-01-29), so
 /// `bytes as ByteArray` hands over the same storage the local holds — it is the
 /// same materialization, not a new value. Freshness already reads through a cast
-/// ([`super::analyze::is_owned_value`]); the move side has to agree, or a
+/// (`super::analyze::is_owned_value`); the move side has to agree, or a
 /// conversion as thin as `String { repr: bytes as ByteArray, used: len }` forces
 /// a deep copy of what the caller just built.
 pub fn strip_casts(mut expr: &TirExpr) -> &TirExpr {

--- a/wado-compiler/src/lower/plan/value_copy/ownership.rs
+++ b/wado-compiler/src/lower/plan/value_copy/ownership.rs
@@ -1,22 +1,12 @@
-//! Return-convention (ownership) analysis over monomorphized TIR
-//! (WEP 2026-05-21, value-copy client).
+//! Return-convention (ownership) analysis over monomorphized TIR (WEP
+//! 2026-05-21). A function *returns owned* when every value it can return is
+//! freshly materialized rather than a borrowed projection of a `&`/global
+//! parameter, so the value-copy fold can consume its result as a move.
 //!
-//! A function *returns owned* when every value it can return is a freshly
-//! materialized value — a literal, a construction, a copy clone, a moved local,
-//! or the owned result of another call — rather than a *borrowed projection* of
-//! a `&`/global parameter (an accessor like `index_value(self: &List, i) -> T {
-//! return self.repr[i] }`). The value-copy fold consults this so a call whose
-//! callee returns owned is treated as fresh: consuming its result into an owner
-//! is a move, no defensive copy needed.
-//!
-//! This is the caller-side, single-phase replacement for the old
-//! `optimize::escape` `returns_fresh` fixpoint. It runs at insertion time
-//! (`lower::plan::value_copy`) so the fold inserts copies precisely, rather than
-//! copying every call result and recovering it in a later `optimize` pass. It is
-//! caller-side by design: the fold only materializes at owner-entry sites, so a
-//! mutable-place accessor (`arr[i].field.push(x)`) is never a materialization
-//! and its element stays aliased — which the callee-side copy-on-extract model
-//! cannot achieve.
+//! Runs caller-side at insertion time, so copies are placed precisely instead
+//! of copying every call result and recovering it later. That is deliberate: the
+//! fold materializes only at owner-entry sites, leaving a mutable-place accessor
+//! like `arr[i].field.push(x)` aliased, which copy-on-extract cannot do.
 
 use super::callgraph::CallGraph;
 use super::funcset::FuncKeySet;
@@ -234,16 +224,10 @@ pub fn compute_return_conventions(project: &FlatPackage) -> ReturnConventions {
 }
 
 /// Return types for which *every* possible indirect-call target returns owned.
-///
-/// `lower::plan::closure` rewrites every callable value — a closure literal and
-/// a bare `FuncRef` alike — into a functor whose `__call` is an ordinary
-/// function in `project.functions`, so those `__call`s are the complete set of
-/// indirect-call targets. An indirect call is type-checked against its callee's
-/// signature, so only targets returning the same type can be reached: a return
-/// type all of whose `__call`s return owned makes every such call owned.
-///
-/// Derived from `returns_owned`, so it is computed after that fixpoint settles
-/// and never feeds back into it.
+/// `lower::plan::closure` turns every callable value into a functor whose
+/// `__call` is an ordinary function, so those are the complete target set, and
+/// an indirect call reaches only targets of its own return type. Derived from
+/// `returns_owned` after that fixpoint settles, never feeding back into it.
 pub fn compute_indirect_owned_returns(
     project: &FlatPackage,
     returns_owned: &FuncKeySet,

--- a/wado-compiler/src/lower/plan/value_copy/stores.rs
+++ b/wado-compiler/src/lower/plan/value_copy/stores.rs
@@ -1,19 +1,8 @@
 //! Interprocedural reference-storage analysis: which reference-parameter
-//! *positions* a function may persist beyond its call.
-//!
-//! A reference escapes only when a *reference-typed* value derived from a
-//! parameter reaches a persistence sink — returned, placed in an aggregate /
-//! global, stored through a reference, or passed to a callee at a position that
-//! callee stores. A value read (`*p`, a value-typed `p.field`) copies data, not
-//! the reference, so it never escapes. The result is a least fixpoint over the
-//! call graph, seeded conservatively: a bodyless callee (extern / builtin / CM
-//! import) cannot retain a guest reference across its boundary, so it stores its
-//! declared positions only.
-//!
-//! Soundness rests on `carries` being an over-approximation of "this expression
-//! is a reference into a parameter": every unmodelled reference-producing shape
-//! falls to the conservative `_ => {}` only when the expression is *not*
-//! reference-typed, so a genuinely reference-typed derivation is always tracked.
+//! *positions* a function may persist beyond its call. A reference escapes only
+//! when a reference-typed value derived from a parameter reaches a persistence
+//! sink; a value read copies data, not the reference. A least fixpoint over the
+//! call graph, sound as long as `carries` over-approximates.
 
 use super::callgraph::CallGraph;
 use super::funcset::FuncKeyMap;

--- a/wado-compiler/src/lower/plan/value_copy/synthesize.rs
+++ b/wado-compiler/src/lower/plan/value_copy/synthesize.rs
@@ -1,24 +1,8 @@
-//! Generate `$value_copy$` helper functions for every type that the
-//! fold needs at a wrap site, plus the transitive closure of nested
-//! value-typed fields. The seed comes from [`super::analyze::collect_seed_types`];
-//! the loop in [`synthesize_helpers`] iterates until no new types appear
-//! in newly-generated helper bodies.
-//!
-//! For struct types the body is a `StructLiteral` with field-by-field
-//! shallow projections, plus `builtin::array_clone::<T>` for raw
-//! `Array<T>` fields (`array_clone_prefix` for the `List<T>` / `String`
-//! backing, right-sized to `used`). For variant types it is a `match`
-//! re-constructing the matched case with a copied payload. Fall-through
-//! types (references, resources) keep `return v;` (identity). Nested
-//! copies are calls to the nested type's own helper, so the helpers are
-//! mutually recursive.
-//!
-//! Synthesized helper bodies contain `builtin::copy_value::<NestedT>(x)`
-//! markers for nested value-typed fields. The translator rewrites those
-//! markers via [`crate::lower::translate`]'s `convert_call` arm. User
-//! function bodies, in contrast, get the wrap call emitted directly by
-//! the fold — they carry no markers after Phase A of WEP 2026-05-11
-//! Step 5.
+//! Generate a `$value_copy$` helper per type the fold wraps, closed over nested
+//! value-typed fields until [`synthesize_helpers`] finds no new ones. A struct
+//! becomes a field-by-field `StructLiteral`, a variant a `match` rebuilding the
+//! matched case, a reference or resource the identity. Nested copies appear as
+//! `builtin::copy_value::<NestedT>(x)` markers the translator rewrites.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -424,16 +408,11 @@ fn build_copy_return_expr(
             right_size_backing,
         ));
     }
-    // `GenericInstance` whose monomorphized struct didn't get
-    // materialised in `project.structs` is an unresolved-at-WIR-level
-    // shape — its `type_id` resolves to `AbstractRef(Struct)` rather
-    // than a concrete `WirType::Ref`, which the WIR-build
-    // `StructLiteral` arm rejects with a hard panic. Falling through
-    // here without a non-identity body keeps every reachable
-    // `array_clone::<T>` generation safe even when a stray reachable
-    // type in the closure happens to be a non-monomorphized template
-    // wrapper. The shape that *does* need a non-identity copy
-    // (List<T> / tuple) is recovered by the explicit checks below.
+    // A `GenericInstance` whose monomorphized struct never reached
+    // `project.structs` resolves to `AbstractRef(Struct)`, which the WIR-build
+    // `StructLiteral` arm rejects with a hard panic. Falling through to identity
+    // keeps a stray non-monomorphized template wrapper safe; the shapes that do
+    // need a real copy (`List<T>`, tuples) are recovered by the checks below.
     let list_name = type_table
         .borrow()
         .compiler_struct_name(crate::compiler_item::CompilerItem::List)
@@ -498,17 +477,11 @@ fn lookup_struct<'a>(
     }
 }
 
-/// `List<T>`'s wrapper-struct deep-copy emits a `StructLiteral`
-/// whose `type_id` is `List<T>`. WIR-level resolution of that
-/// `type_id` becomes `AbstractRef(Struct)` whenever `T` is a shape
-/// that the WIR struct registry never materialises a concrete entry
-/// for — resources, function/closure types, and unmaterialised
-/// generic instances. The downstream `StructLiteral` translation
-/// only knows how to handle a concrete `WirType::Ref`, so we skip
-/// the non-identity body and fall through to identity for those `T`s.
-/// Built-in primitives, ordinary structs, variants, and known wrapper
-/// shapes (`List<T>`, `String`, tuples) all have concrete WIR
-/// registrations and are passed through.
+/// `List<T>`'s deep-copy emits a `StructLiteral` typed `List<T>`, which resolves
+/// to `AbstractRef(Struct)` whenever `T` is a shape the WIR struct registry
+/// never materialises — a resource, a function type, an unmaterialised generic
+/// instance. Downstream only handles a concrete `WirType::Ref`, so those `T`s
+/// fall through to identity; everything with a WIR registration is copied.
 fn is_synth_safe_element(
     elem_type: TypeId,
     type_table: &Rc<RefCell<TypeTable>>,

--- a/wado-compiler/src/lower/translate.rs
+++ b/wado-compiler/src/lower/translate.rs
@@ -1184,7 +1184,7 @@ impl FunctionTranslator<'_, '_> {
             TirExprKind::CharLiteral(c) => Some(ValueKind::Char(*c)),
             // Pure constants whose WIR depends only on type/bytes (read back
             // from the pool by the extractor): `Null` → `None`/`ref.null`,
-            // string → `translate_string_literal`, unit → no runtime value.
+            // string → `seq_literal`, unit → no runtime value.
             TirExprKind::Null => Some(ValueKind::Null),
             // String / bytes literals are no longer atomic pool values; they
             // lower to a `StructLiteral` over a packed `Array<u8>` repr in

--- a/wado-compiler/src/lower/translate.rs
+++ b/wado-compiler/src/lower/translate.rs
@@ -829,17 +829,10 @@ impl FunctionTranslator<'_, '_> {
         };
 
         // The referent must be an in-place aggregate, so `*ref = v` writes each
-        // field of the shared handle. Replace-on-assign referents (variant /
-        // enum / fn) are boxed and were filtered by the `box_type_ids` check
-        // above. Three in-place shapes reach here:
-        //   - a plain `struct` (`String`, monomorphized generics): fields from
-        //     `struct_fields_map`.
-        //   - `List<T>`: an in-place `GenericInstance` never monomorphized into
-        //     its own struct, so its canonical `{repr, used}` layout comes from
-        //     `SeqField` with the concrete element type.
-        //   - a tuple (`[A, B, …]`): also an in-place `GenericInstance`, with
-        //     positional fields `0..n` typed by the tuple's element types.
-        // Any other type falls through to the default single-statement lowering.
+        // field of the shared handle; replace-on-assign referents are boxed and
+        // already filtered above. Three shapes reach here: a plain struct, whose
+        // fields come from `struct_fields_map`; a `List<T>`, whose `{repr, used}`
+        // layout comes from `SeqField`; and a tuple, with positional fields.
         let inner_resolved = self.base.type_table.borrow().get(inner_type_id).clone();
         let fields: Vec<(String, u32, tir::TypeId)> = if let crate::tir::ResolvedType::Struct {
             decl_name,
@@ -2084,18 +2077,11 @@ impl FunctionTranslator<'_, '_> {
         }
     }
 
-    /// Build a `String` / `List<u8>` literal as a `StructLiteral { repr:
-    /// PackedArray(bytes), used: <len> }` over a raw packed `Array<u8>`, so the
-    /// literal flows through the generic aggregate machinery (field-projection
-    /// of `.used`, body globalization) instead of being an opaque value. The
-    /// `repr` field's raw-array type and the field indices come from the
-    /// sequence struct's definition.
-    /// The single `Array<u8>` type that every `String` / `List<u8>` literal uses
-    /// for its `repr` field. `String` and `List<u8>` share one canonical backing
-    /// type, so it is read off the always-loaded `String` struct, keyed by the
-    /// compiler-item registry's canonical name/module rather than a `"String"`
-    /// magic literal — a bytes-only program may never monomorphize `List<u8>`
-    /// into `struct_fields_map`, but `String` is guaranteed present.
+    /// The single `Array<u8>` type every `String` / `List<u8>` literal uses for
+    /// its `repr` field. The two share one canonical backing type, read off the
+    /// always-loaded `String` struct through the compiler-item registry rather
+    /// than a `"String"` literal: a bytes-only program may never monomorphize
+    /// `List<u8>` into `struct_fields_map`, but `String` is always present.
     fn seq_u8_repr_type(&self) -> tir::TypeId {
         use crate::compiler_item::{CompilerItem, SeqField};
         let (string_module, string_name) = self

--- a/wado-compiler/src/lower/translate/pattern.rs
+++ b/wado-compiler/src/lower/translate/pattern.rs
@@ -2373,26 +2373,11 @@ impl<'a> PatternLowerer<'a> {
                 body,
                 ..
             } => {
-                // Closures have their own local-index namespace — the
-                // elaborator builds each closure's `FunctionContext` with a
-                // fresh `next_local: 0`, so the body's `Local` / `Let`
-                // indices are independent of the outer function's.
-                // Pattern lowering must honour that: any temp it allocates
-                // while descending into the body has to live in the
-                // closure's namespace, otherwise the closure-functor
-                // lowering pass (`lower/closure.rs`) builds a `local_types`
-                // table where the temp's outer-scoped index collides with
-                // a real closure-scoped local, producing a closure body
-                // whose `LocalSet` targets the wrong slot.
-                //
-                // The closure carries its parameter list and the types of
-                // its body-level let-bindings (`body_locals`); the
-                // closure-scope state is their concatenation. Temps
-                // pattern lowering allocates while descending grow the
-                // local maps for the duration of the visit, then the
-                // closure-functor lowering pass re-collects them from the
-                // body's `Let`s via `collect_locals_from_block`, so we
-                // discard the updated state on the way out.
+                // A closure's `FunctionContext` starts at `next_local: 0`, so any
+                // temp allocated while descending must live in that namespace —
+                // otherwise closure lowering builds a `local_types` table where
+                // the outer index collides with a real closure local. The scope
+                // state is `params + body_locals`, discarded after the visit.
                 let saved_count = self.local_count;
                 let saved_locals = std::mem::take(&mut self.locals);
                 self.local_count = (params.len() + body_locals.len()) as u32;

--- a/wado-compiler/src/lower/translate/pattern.rs
+++ b/wado-compiler/src/lower/translate/pattern.rs
@@ -76,17 +76,11 @@ fn coerce_value_to_binding(
     }
 }
 
-/// Peel `Ref` / `MutRef` wrappers and `Box<T>` struct wrappers off
-/// `expr`, returning the unwrapped expression and its type.
-///
-/// A `Ref` / `MutRef` is peeled with a `Deref`; a `Box<T>` is peeled
-/// with a `.value` field access. `boxing::prepare_types` redefines
-/// every `Ref(boxable)` `TypeId` to its `Box<T>` struct type, so when
-/// pattern lowering runs after boxing a match scrutinee on a reference
-/// surfaces here as a `Box<T>` struct rather than a `Ref` — both
-/// shapes peel to the matched value. When pattern lowering runs before
-/// boxing the box-payload registry is empty, so this degrades to a
-/// plain `Ref` peel.
+/// Peel `Ref` / `MutRef` and `Box<T>` wrappers off `expr`, returning the
+/// unwrapped expression and its type — a `Deref` for the former, a `.value`
+/// field access for the latter. `boxing::prepare_types` redefines every
+/// `Ref(boxable)` to its `Box<T>`, so post-boxing a reference scrutinee arrives
+/// box-shaped; pre-boxing the registry is empty and this is a plain `Ref` peel.
 fn peel_refs_and_box(
     mut expr: TirExpr,
     mut type_id: TypeId,
@@ -126,18 +120,11 @@ fn peel_refs_and_box(
     }
 }
 
-/// Package-level facts pattern lowering needs, gathered once so the
-/// per-function [`Lowering::lower_function`] entry point can be called
-/// from the translator's [`convert_function`](super::Translator)
-/// per-function walk (WEP 2026-05-11 Phase 10 Step 2b).
-///
-/// Pattern lowering rewrites `LetDestructure` / `IfLet` into explicit
-/// `Let` + `Match` chains and expands or-patterns in `Match` arms. It
-/// runs after the whole `lower::plan` phase (boxing, closure,
-/// `lift_mut`, `value_copy`, …): a match scrutinee on a reference
-/// reaches it as a `Box<T>` struct and the references it synthesises
-/// for ergonomic bindings are box-shaped — [`peel_refs_and_box`] and
-/// [`coerce_value_to_binding`] handle both.
+/// Package-level facts pattern lowering needs, gathered once so
+/// [`Lowering::lower_function`] can run inside the translator's per-function
+/// walk. Lowering rewrites `LetDestructure` / `IfLet` into `Let` + `Match`
+/// chains and expands or-patterns. It runs after all of `lower::plan`, so
+/// scrutinees and synthesised references alike arrive box-shaped.
 pub struct Lowering {
     /// Map from (`variant_name`, `module_source`) to (`case_name`,
     /// `case_index`) pairs. The `module_source` axis keeps two

--- a/wado-compiler/src/lower/wide_int_literal.rs
+++ b/wado-compiler/src/lower/wide_int_literal.rs
@@ -1,27 +1,8 @@
-//! Shared TIR builders for `i128` / `u128` literal expressions.
-//!
-//! Lives at the `lower::` top level because it has two callers across
-//! the planner / translator boundary:
-//!
-//! - `lower::plan::globals` — synthesizes default values for lazy-
-//!   initialized i128 / u128 globals.
-//! - `lower::translate::wide_int` — synthesizes the literal side of
-//!   `i128^Eq::eq` / `u128^Eq::eq` calls when rewriting wide-int
-//!   `Match` arms into an if-else chain.
-//!
-//! Both callers must produce identical `Call` shapes because the
-//! optimizer and `wir_build` pattern-match on them.
-//!
-//! Values that fit `i64` / `u64` are emitted as
-//! `i128::from_i64(v)` / `u128::from_u64(v)`. Values outside that
-//! range are emitted as `i128::from_pair(lo, hi)` /
-//! `u128::from_pair(lo, hi)` so the full 128 bits round-trip — same
-//! split the elaborator uses for source-level literals (see
-//! `elaborator::util::unpack_i128`, `elaborator::coercion::build_int128_from_pair`).
-//!
-//! The struct, module source, and method names are all resolved
-//! through the `CompilerItem` registry so a stdlib rename of `i128`,
-//! `u128`, or any of their `from_*` constructors stays transparent.
+//! Shared TIR builders for `i128` / `u128` literals, at the `lower::` top level
+//! for its two callers either side of the planner / translator boundary, which
+//! must produce identical `Call` shapes for the optimizer and `wir_build` to
+//! match on. A value fitting 64 bits emits `from_i64` / `from_u64`, anything
+//! wider `from_pair(lo, hi)` — the elaborator's own split for source literals.
 
 use crate::compiler_item::CompilerItem;
 use crate::module_source::ModuleSource;

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -1,11 +1,8 @@
 //! Module identity and its interner. `ModuleSource` is the "where did this code
-//! come from" half of `symbol-coordinate = (ModuleSource, AstId)` — not a
-//! name-mangling concept; rendering one into a mangled symbol is `crate::name`'s
-//! job. It is used pervasively as a map key, so every string field is
-//! canonicalised into an `Arc<str>` through [`ModuleSourceInterner`] and `clone`
-//! / `eq` / `hash` are O(1). Well-known names live in statics the interner
-//! adopts on construction, so a zero-arg constructor needs no interner and
-//! `interner.core("prelude")` is pointer-equal to [`ModuleSource::prelude`].
+//! come from" half of `symbol-coordinate = (ModuleSource, AstId)`; rendering one
+//! into a mangled symbol is `crate::name`'s job. Every string field is
+//! canonicalised into an `Arc<str>` through [`ModuleSourceInterner`], so `clone`
+//! / `eq` / `hash` are O(1) and well-known names need no interner at all.
 
 use crate::intern::{InternedStr, StringInterner};
 use std::fmt;
@@ -92,10 +89,8 @@ fn well_known_arcs() -> Vec<Arc<str>> {
 /// Canonical `Arc<str>` payloads for every stdlib module, derived from the
 /// `crate::stdlib` module lists. Every [`ModuleSourceInterner`] adopts them, so
 /// stdlib `ModuleSource` values compare pointer-equal across independently
-/// constructed interners — what lets the stdlib TIR cache key its maps by
-/// `ModuleSource`. Each payload is the part of the import path that lands inside
-/// the variant: `Core` and `Wasi` hold theirs with the prefix stripped, `Wasm`
-/// the full canonical path, matching what the loader passes in.
+/// constructed interners — what lets the stdlib TIR cache key by `ModuleSource`.
+/// `Core` and `Wasi` store the prefix-stripped path, `Wasm` the full one.
 static STDLIB_NAME_ARCS: LazyLock<Vec<Arc<str>>> = LazyLock::new(|| {
     let mut arcs: Vec<Arc<str>> = Vec::new();
     for (path, _src) in crate::stdlib::ALL_CORE_MODULES {
@@ -259,8 +254,7 @@ impl WasmAssetKind {
 /// a well-known source comes from a zero-arg constructor
 /// ([`ModuleSource::prelude`]), anything else from [`ModuleSourceInterner`],
 /// which canonicalises identity down to `Arc::ptr_eq`. Two `EntryPoint`s compare
-/// equal regardless of `filename`, so a type defined in the entry module stays
-/// consistent across compilation phases.
+/// equal regardless of `filename`.
 #[derive(Debug, Clone)]
 pub enum ModuleSource {
     /// Core library module (e.g., `core:prelude`, `core:cli`, `core:rt`, `core:builtin`)
@@ -282,9 +276,7 @@ pub enum ModuleSource {
     /// `use { … } from "<dep>"` against `[dependencies]`. Identity is the
     /// resolved entry-module `path`, so two aliases pointing at the same package
     /// unify. Distinct from [`ModuleSource::Local`] to carry the package boundary
-    /// — only `export` items cross it — and to stop a dependency resolving the
-    /// consumer's own `[dependencies]`. Loaded exactly like `Local`: a
-    /// wado-to-wado dependency compiles into the same component.
+    /// — only `export` items cross it — though loaded exactly like it.
     Dependency { path: InternedStr },
     /// Remote module loaded via HTTP/HTTPS
     Remote {
@@ -299,8 +291,7 @@ pub enum ModuleSource {
     /// Module loaded through a Kiln invocation redirect, created when an import
     /// matches the [`crate::kiln::InvocationIndex`] and never written by user
     /// source. The `uri` is opaque to the compiler, passed verbatim to
-    /// `CompilerHost::load_source` — the CLI host reads a `file:` path, an
-    /// in-memory host uses it as a key. A URI rather than a path keeps
+    /// `CompilerHost::load_source`. A URI rather than a path keeps
     /// `wado-compiler` free of `std::path`, and so `wasm32`-friendly.
     Redirected {
         /// Absolute URI (typically `file:///abs/path/to/file.wado`).
@@ -308,10 +299,9 @@ pub enum ModuleSource {
     },
     /// Wasm asset imported via
     /// `use … from "<path>" with { type: "wat"|"wasm" }`. `path` is the canonical
-    /// identifier `resolve_import` computed — `core:libm.wat` for a bundled asset
-    /// beside a core module, an entry-relative path, or the full `core:` / `wasi:`
-    /// path when the importer is one. Loaded as raw bytes; the resulting Wado
-    /// module exposes one extern fn per requested export.
+    /// identifier `resolve_import` computed — `core:libm.wat` for a bundled
+    /// asset, else an entry-relative path. Loaded as raw bytes; the resulting
+    /// Wado module exposes one extern fn per requested export.
     Wasm {
         /// Canonical path identifier (used as the unique module key and
         /// as the namespace component of the synthesized
@@ -643,8 +633,7 @@ impl ModuleSource {
     /// qualifier ([`Self::to_path`]), keeping the entry point's full compile path
     /// rather than its base name. Read where a real path must resolve a sibling
     /// file (`#include_str`) and as the filename in diagnostics. Empty for an
-    /// entry point with no real filename, such as `<stdin>`, so
-    /// `Logger::apply_file_context` can supply one from its own context.
+    /// entry point with no real filename, such as `<stdin>`.
     #[must_use]
     pub fn source_path(&self) -> String {
         match self {

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -1,23 +1,11 @@
-//! Module identity (`ModuleSource`) and its interner.
-//!
-//! `ModuleSource` is the canonical identity for a Wado module — the
-//! "where did this code come from" half of `symbol-coordinate = (ModuleSource,
-//! AstId)`. It is **not** a name-mangling concept: rendering it into a
-//! mangled symbol is the job of `crate::name`.
-//!
-//! # Pointer-identity interning
-//!
-//! `ModuleSource` is used pervasively as an `IndexMap` key during
-//! monomorphization and elaborator lookups. To make `clone` / `eq` /
-//! `hash` all O(1), every string field is canonicalised into an
-//! `Arc<str>` shared via [`ModuleSourceInterner`], which wraps the
-//! generic [`StringInterner`] from [`crate::intern`].
-//!
-//! Well-known names (the targets of zero-arg constructors like
-//! [`ModuleSource::prelude`]) live in `LazyLock<Arc<str>>` statics so
-//! they can be constructed without an interner reference. The interner
-//! adopts these statics on construction, ensuring that
-//! `interner.core("prelude") == ModuleSource::prelude()` (ptr-equal).
+//! Module identity and its interner. `ModuleSource` is the "where did this code
+//! come from" half of `symbol-coordinate = (ModuleSource, AstId)` — not a
+//! name-mangling concept; rendering one into a mangled symbol is `crate::name`'s
+//! job. It is used pervasively as a map key, so every string field is
+//! canonicalised into an `Arc<str>` through [`ModuleSourceInterner`] and `clone`
+//! / `eq` / `hash` are O(1). Well-known names live in statics the interner
+//! adopts on construction, so a zero-arg constructor needs no interner and
+//! `interner.core("prelude")` is pointer-equal to [`ModuleSource::prelude`].
 
 use crate::intern::{InternedStr, StringInterner};
 use std::fmt;
@@ -101,28 +89,13 @@ fn well_known_arcs() -> Vec<Arc<str>> {
     arcs
 }
 
-/// Canonical `Arc<str>` values for every stdlib module's `ModuleSource`
-/// payload.
-///
-/// Derived from [`crate::stdlib::ALL_CORE_MODULES`],
-/// [`crate::stdlib::ALL_WASI_MODULES`] and
-/// [`crate::stdlib::ALL_CORE_WASM_ASSETS`] — the single source of truth
-/// for the stdlib module set.  Every [`ModuleSourceInterner`] adopts
-/// these, so `ModuleSource` values for stdlib modules compare
-/// pointer-equal across independently constructed interners. This is
-/// the foundation that lets the stdlib TIR cache key its `IndexMaps` by
-/// `ModuleSource`.
-///
-/// For each variant, the interned payload is the portion of the
-/// import path that lands inside the `ModuleSource` variant:
-///
-/// * [`ModuleSource::Core`] holds the path stripped of its `core:`
-///   prefix (e.g. `"prelude"`, `"prelude/types.wado"`).
-/// * [`ModuleSource::Wasi`] holds the path stripped of its `wasi:`
-///   prefix.
-/// * [`ModuleSource::Wasm`] holds the full canonical path including
-///   the `core:` prefix (matching what the loader passes to
-///   [`ModuleSourceInterner::wasm`]).
+/// Canonical `Arc<str>` payloads for every stdlib module, derived from the
+/// `crate::stdlib` module lists. Every [`ModuleSourceInterner`] adopts them, so
+/// stdlib `ModuleSource` values compare pointer-equal across independently
+/// constructed interners — what lets the stdlib TIR cache key its maps by
+/// `ModuleSource`. Each payload is the part of the import path that lands inside
+/// the variant: `Core` and `Wasi` hold theirs with the prefix stripped, `Wasm`
+/// the full canonical path, matching what the loader passes in.
 static STDLIB_NAME_ARCS: LazyLock<Vec<Arc<str>>> = LazyLock::new(|| {
     let mut arcs: Vec<Arc<str>> = Vec::new();
     for (path, _src) in crate::stdlib::ALL_CORE_MODULES {
@@ -282,33 +255,12 @@ impl WasmAssetKind {
     }
 }
 
-/// Source location of a module.
-///
-/// This enum provides a structured representation of module paths,
-/// replacing raw `Vec<String>` for better type safety and clearer semantics.
-///
-/// String payloads are [`InternedStr`]; construct values via the
-/// well-known zero-arg constructors (e.g. [`ModuleSource::prelude`])
-/// or through [`ModuleSourceInterner`].
-///
-/// # Examples
-///
-/// ```ignore
-/// // Well-known sources need no interner.
-/// let prelude = ModuleSource::prelude();           // core:prelude
-/// let cli     = ModuleSource::cli();               // core:cli
-/// let wasi    = ModuleSource::wasi_cli();          // wasi:cli
-///
-/// // Arbitrary content goes through the interner so identity is
-/// // canonicalised (`Arc::ptr_eq` on the inner string).
-/// let mut interner = ModuleSourceInterner::new();
-/// let local  = interner.local("./geometry.wado");
-/// let wasi_x = interner.wasi("io");
-/// ```
-///
-/// Note: Two `EntryPoint` variants are considered equal regardless of their
-/// `filename` field. This ensures that types defined in the entry module
-/// are consistent across different compilation phases.
+/// Structured source location of a module. String payloads are [`InternedStr`]:
+/// a well-known source comes from a zero-arg constructor
+/// ([`ModuleSource::prelude`]), anything else from [`ModuleSourceInterner`],
+/// which canonicalises identity down to `Arc::ptr_eq`. Two `EntryPoint`s compare
+/// equal regardless of `filename`, so a type defined in the entry module stays
+/// consistent across compilation phases.
 #[derive(Debug, Clone)]
 pub enum ModuleSource {
     /// Core library module (e.g., `core:prelude`, `core:cli`, `core:rt`, `core:builtin`)
@@ -326,19 +278,13 @@ pub enum ModuleSource {
         /// Relative path (e.g., "./geometry.wado", "./utils/helper.wado")
         path: InternedStr,
     },
-    /// A module belonging to a dependency package, resolved from a bare-name
-    /// `use { … } from "<dep>"` clause against `[dependencies]`.
-    ///
-    /// Identity is the resolved entry-module `path` — within a compilation
-    /// the same resolved path is the same file, hence the same package, so
-    /// two `[dependencies]` aliases that point at the same package unify.
-    /// The variant is distinct from [`ModuleSource::Local`] to carry the
-    /// package boundary (only `export` items are visible across it) and to
-    /// keep dependency modules from resolving the consumer's `[dependencies]`.
-    /// `path` is loaded by the host exactly like `Local` — wado-to-wado
-    /// source dependencies compile into the same component (the CM boundary
-    /// is skipped), so dependency modules are ordinary Wado source once
-    /// loaded.
+    /// A module of a dependency package, resolved from a bare-name
+    /// `use { … } from "<dep>"` against `[dependencies]`. Identity is the
+    /// resolved entry-module `path`, so two aliases pointing at the same package
+    /// unify. Distinct from [`ModuleSource::Local`] to carry the package boundary
+    /// — only `export` items cross it — and to stop a dependency resolving the
+    /// consumer's own `[dependencies]`. Loaded exactly like `Local`: a
+    /// wado-to-wado dependency compiles into the same component.
     Dependency { path: InternedStr },
     /// Remote module loaded via HTTP/HTTPS
     Remote {
@@ -350,34 +296,22 @@ pub enum ModuleSource {
         /// Filename of the entry point (e.g., "hello.wado", "<stdin>", "<entry>")
         filename: InternedStr,
     },
-    /// Module loaded through a Kiln invocation redirect.
-    ///
-    /// The contained `uri` is opaque to most of the compiler — it is
-    /// passed verbatim to `CompilerHost::load_source`, which decides
-    /// how to interpret it. The CLI's `FilesystemCompilerHost` accepts
-    /// `file:` URIs and reads the absolute path; in-memory hosts use
-    /// the URI as a key. Using a URI keeps `wado-compiler` free of
-    /// `std::path` (and therefore `wasm32-unknown-unknown`-friendly).
-    ///
-    /// Created by [`crate::loader::ModuleLoader::resolve_import`] when
-    /// an import target matches an entry in the
-    /// [`crate::kiln::InvocationIndex`]; never written by user source.
+    /// Module loaded through a Kiln invocation redirect, created when an import
+    /// matches the [`crate::kiln::InvocationIndex`] and never written by user
+    /// source. The `uri` is opaque to the compiler, passed verbatim to
+    /// `CompilerHost::load_source` — the CLI host reads a `file:` path, an
+    /// in-memory host uses it as a key. A URI rather than a path keeps
+    /// `wado-compiler` free of `std::path`, and so `wasm32`-friendly.
     Redirected {
         /// Absolute URI (typically `file:///abs/path/to/file.wado`).
         uri: InternedStr,
     },
-    /// Wasm asset imported via `use ... from "<path>" with { type: "wat"|"wasm" }`.
-    ///
-    /// `path` is the canonical identifier for the asset, computed by
-    /// [`crate::loader::ModuleLoader::resolve_import`]:
-    /// - `core:libm.wat` for stdlib-bundled wat next to a core module.
-    /// - `./geometry.wat` (or normalized form) for entry-relative imports.
-    /// - The full `wasi:` / `core:` path with `.wat`/`.wasm` extension when
-    ///   the importing module is a core/wasi module.
-    ///
-    /// The asset is loaded as raw bytes and parsed by the wasm-import
-    /// loader path; the resulting Wado module exposes one extern fn per
-    /// requested export. See `docs/wep-2026-01-10-wasm-import.md`.
+    /// Wasm asset imported via
+    /// `use … from "<path>" with { type: "wat"|"wasm" }`. `path` is the canonical
+    /// identifier `resolve_import` computed — `core:libm.wat` for a bundled asset
+    /// beside a core module, an entry-relative path, or the full `core:` / `wasi:`
+    /// path when the importer is one. Loaded as raw bytes; the resulting Wado
+    /// module exposes one extern fn per requested export.
     Wasm {
         /// Canonical path identifier (used as the unique module key and
         /// as the namespace component of the synthesized
@@ -705,18 +639,12 @@ impl ModuleSource {
         format!("{self}//{name}")
     }
 
-    /// The module's real source location.
-    ///
-    /// This is the counterpart to the portable qualifier ([`Self::to_path`] /
-    /// [`Display`]): it keeps the entry point's full compile path (absolute
-    /// under the test harness, relative on the CLI) rather than its base name.
-    /// Consumed both where a real path is needed to resolve sibling files
-    /// (`#include_str` / `#include_bytes`) and as the filename shown in
-    /// diagnostics.
-    ///
-    /// Returns an empty string for entry points without real filenames
-    /// (e.g., `<stdin>`, `<entry>`) so that `Logger::apply_file_context`
-    /// can fill in the correct file from the logger's current file context.
+    /// The module's real source location — the counterpart to the portable
+    /// qualifier ([`Self::to_path`]), keeping the entry point's full compile path
+    /// rather than its base name. Read where a real path must resolve a sibling
+    /// file (`#include_str`) and as the filename in diagnostics. Empty for an
+    /// entry point with no real filename, such as `<stdin>`, so
+    /// `Logger::apply_file_context` can supply one from its own context.
     #[must_use]
     pub fn source_path(&self) -> String {
         match self {

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -299,8 +299,9 @@ pub enum ModuleSource {
     },
     /// Wasm asset imported via
     /// `use … from "<path>" with { type: "wat"|"wasm" }`. `path` is the canonical
-    /// identifier `resolve_import` computed — `core:libm.wat` for a bundled
-    /// asset, else an entry-relative path. Loaded as raw bytes; the resulting
+    /// identifier `resolve_import` computed — `core:` / `wasi:`-prefixed for a
+    /// stdlib importer, else relative to the importing module. Loaded as raw
+    /// bytes; the resulting
     /// Wado module exposes one extern fn per requested export.
     Wasm {
         /// Canonical path identifier (used as the unique module key and

--- a/wado-compiler/src/module_source.rs
+++ b/wado-compiler/src/module_source.rs
@@ -285,7 +285,7 @@ pub enum ModuleSource {
     },
     /// Entry point module (the main file being compiled)
     EntryPoint {
-        /// Filename of the entry point (e.g., "hello.wado", "<stdin>", "<entry>")
+        /// Filename of the entry point (e.g., `"hello.wado"`, `"<stdin>"`, `"<entry>"`)
         filename: InternedStr,
     },
     /// Module loaded through a Kiln invocation redirect, created when an import

--- a/wado-compiler/src/monomorphize.rs
+++ b/wado-compiler/src/monomorphize.rs
@@ -1,14 +1,7 @@
-//! Monomorphization pass for Wado TIR
-//!
-//! This phase instantiates generic structs and functions with concrete types.
-//! Monomorphization is a separate compilation phase that runs after type resolution
-//! and before the lower phase.
-//!
-//! The monomorphization process:
-//! 1. Collect all generic struct and function definitions
-//! 2. Find instantiation sites (`GenericInstance` types, generic function calls)
-//! 3. Generate concrete struct and function definitions
-//! 4. Rewrite types and function calls to use monomorphized names
+//! Monomorphization for Wado TIR, between type resolution and lowering: collect
+//! the generic struct and function definitions, find their instantiation sites,
+//! generate a concrete definition per site, and rewrite types and calls onto the
+//! monomorphized names.
 
 mod call_rewrite;
 mod func_inst;
@@ -128,16 +121,11 @@ pub fn monomorphize(flat: &mut FlatPackage) {
     flat.structs = temp_module.structs;
     flat.globals = temp_module.globals;
 
-    // `module_source` is the canonical namespace, so the
-    // `(module_source, name)` pair must be unique across the entire post-mono
-    // function set. Two functions sharing a key would silently overwrite
-    // each other in the `(module, name)`-keyed registries downstream
-    // (`FreeFunctionName`, wasm function naming, `wir_build::func_map`),
-    // and the surviving body / signature would then drive codegen for both
-    // call sites — producing wasm whose validation typically fails several
-    // phases later with a confusing `expected (ref $type), found (ref $type)`
-    // message. Detect the collision here so the responsible synthesis or
-    // monomorphization path surfaces at its first observable point.
+    // `(module_source, name)` must be unique across the post-mono function set:
+    // two functions sharing a key overwrite each other in the `(module, name)`
+    // registries downstream, and the survivor then drives codegen for both call
+    // sites — surfacing several phases later as a confusing
+    // `expected (ref $type), found (ref $type)`. Catch it at its origin.
     let mut seen_functions: IndexMap<(ModuleSource, String), ()> = IndexMap::default();
     for func_rc in &flat.functions {
         let f = func_rc.borrow();
@@ -392,71 +380,20 @@ impl Monomorphizer {
         loop {
             let mut made_progress = false;
 
-            // Batch one round of function instantiations before draining the
-            // struct pending. The ordering inside each outer iteration is
-            //
-            //     instantiate all pending functions
-            //     → drain struct pending to fixpoint (once)
-            //     → rewrite each new function's body through the now-stable
-            //       `GenericInstance → Struct` substitutions
-            //     → collect each new function's call sites
-            //
-            // and is the load-bearing piece of `function_id_for` injectivity
-            // over `project.functions`:
-            //
-            // 1. `instantiate_function` substitutes the function body; for any
-            //    `GenericInstance` whose monomorphised `Struct` is not yet
-            //    interned, `substitute_type` creates a fresh `GenericInstance`
-            //    in the type table (see `substitute.rs`'s `make_generic_instance`
-            //    fallback). The body therefore points at `GenericInstance`
-            //    `TypeId`s for not-yet-monomorphised types.
-            //
-            // 2. Drain `self.structs.pending` (after instantiating the whole
-            //    batch of functions) to fixpoint — struct monomorphisation
-            //    of the new `GenericInstance`s plus any recursively triggered
-            //    structs. After this step `self.structs.type_substitutions`
-            //    covers every `GenericInstance → Struct` pair reachable from
-            //    any body in the batch.
-            //
-            // 3. `rewrite_types_in_function` rewrites every `TypeId` in each
-            //    new body — including a call's `type_args` —
-            //    through `type_substitutions`, so the body is in canonical
-            //    `Struct` form.
-            //
-            // 4. `collect_function_instantiation_sites` finally walks the
-            //    canonicalised body. Every queued `InstantiationKey` carries
-            //    `Struct`-form `TypeId`s, matching the form receiver-driven
-            //    queue paths use. The two paths produce identical
-            //    `Hash`/`Eq` keys, so `try_queue_function`'s dedupe folds
-            //    them by construction and `function_id_for` is injective.
-            //
-            // The previous interleaving (drain all functions while also
-            // collecting their calls, then all structs) ran step 4 before
-            // step 2, so any function call whose argument types referenced a
-            // not-yet-monomorphised `GenericInstance` queued under the
-            // `GenericInstance` form; later siblings of the same call (after
-            // struct mono caught up) queued under the `Struct` form,
-            // producing two `TirFunction`s with the same `function_id_for`.
-            //
-            // Batching (instead of running the struct drain per function)
-            // keeps `collect_instantiation_sites` — an `O(|type_table|)` scan
-            // — at one call per outer iteration rather than one per function,
-            // which is what the previous design's cost profile relied on.
+            // Each outer iteration instantiates every pending function, drains
+            // the struct pending to fixpoint, rewrites the new bodies through
+            // the now-stable `GenericInstance → Struct` substitutions, and only
+            // then collects call sites — collecting earlier would queue under
+            // `GenericInstance` form and break `function_id_for` injectivity.
 
             // Step 1: instantiate every pending function. Defer
             // rewrite/collect to steps 3/4 once the struct drain has run.
             let mut batch: Vec<TirFunction> = Vec::new();
             while let Some(key) = self.functions.pending.pop() {
                 let concrete = {
-                    // Issue #1110 (1)(2): every producer sets
-                    // `FunctionRef::module_source` to the body's home
-                    // module — `elaborator::method_call::resolve_method_call`,
-                    // `synthesis::traits` (via `resolve_impl_module_via_env`),
-                    // `synthesis::template::trait_impl_module`, and
-                    // `monomorphize/func_inst::resolve_method_call_substitution`
-                    // (which re-queries `TraitEnv` after newtype peeling)
-                    // all route through `TraitEnv`. The literal
-                    // `(module_source, name)` lookup is therefore total: a
+                    // Every producer routes through `TraitEnv` and so sets
+                    // `FunctionRef::module_source` to the body's home module,
+                    // making the literal `(module_source, name)` lookup total: a
                     // miss is a producer bug, surfaced as the panic below.
                     let lookup_key = (key.module_source.clone(), key.name.clone());
                     let generic_func = generic_functions.get(&lookup_key);

--- a/wado-compiler/src/monomorphize/call_rewrite.rs
+++ b/wado-compiler/src/monomorphize/call_rewrite.rs
@@ -60,16 +60,11 @@ fn apply_instantiation(
 }
 
 impl Monomorphizer {
-    /// Try to find a queued instantiation, allowing `key.module_source` to be
-    /// an approximate hint. Mirrors `lookup_template_with_trait_fallback` in
-    /// `func_inst.rs`: when the literal `(module_source, name, ...)` key
-    /// misses, consult `TraitEnv::impl_module_for` over the listed struct
-    /// candidates to find the impl block's home, then retry the lookup with
-    /// that module. For inherent (non-trait) methods, also try the
-    /// `type_module_hint` directly — inherent impls live with their type.
-    /// Returns `(matched_key, mangled_name)` so the caller can rewrite the
-    /// call site to point at the same module the queued instantiation
-    /// landed in.
+    /// Find a queued instantiation, treating `key.module_source` as a hint.
+    /// Mirrors `lookup_template_with_trait_fallback`: on a literal-key miss,
+    /// consult `TraitEnv::impl_module_for` for the impl block's home and retry,
+    /// trying `type_module_hint` too for an inherent method. Returns
+    /// `(matched_key, mangled_name)`, so the caller rewrites to the same module.
     fn lookup_instantiation_with_trait_fallback(
         &self,
         mut key: InstantiationKey,
@@ -545,19 +540,11 @@ impl Monomorphizer {
                 }
             }
         }
-        // Also handle case where type_args is empty but receiver is a GenericInstance
-        // e.g., nums.index_value(0) where nums: Triple<i32>
-        //
-        // Skip this branch when the call carries a blanket-impl
-        // `monomorph_info` (synthesized refs like `self.data.inspect(f)` for
-        // `data: &List<i32>`). The impl_type_args derived from the
-        // receiver's GenericInstance (`[i32]`) are NOT what the blanket
-        // instantiation was queued with (`[List<i32>]`), so any match here
-        // would route the call to the inner-type's impl
-        // (`List<i32>^Inspect`) and drop the leading `&` produced by the
-        // ref blanket body. Let the dedicated blanket-fallback branch below
-        // handle these — it uses `mono.impl_type_args` which carries the
-        // full ref-inner type.
+        // Empty `type_args` over a `GenericInstance` receiver —
+        // `nums.index_value(0)` on a `Triple<i32>`. Skipped for a blanket-impl
+        // `monomorph_info`: the args derived from the receiver (`[i32]`) are not
+        // what the blanket was queued with (`[List<i32>]`), so a match here would
+        // route to the inner type's impl. The blanket branch below handles it.
         else if let Some((base_struct, impl_type_args)) =
             self.get_struct_info_from_type(receiver.type_id, type_table)
             && !impl_type_args.is_empty()

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -139,23 +139,12 @@ struct SubstitutedCall {
 }
 
 /// The impl args a pack-projecting blanket dispatch instantiates under, or
-/// `None` when this is not one.
-///
-/// `impl<T: Bound<Assoc = [..P]>, ..P> Trait for T` instantiates under
-/// `[T, T::Assoc, …]` while a call site supplies `[T]`, so without the packs
-/// appended the queueing and rewrite sides key the same instance differently.
-///
-/// One question, asked once: can this receiver supply every pack this blanket
-/// projects? Splitting it — a guard asking the blanket whether it projects
-/// packs, a helper asking the receiver whether it can supply them — let the two
-/// answer differently and key the same instance two ways.
-///
-/// The blanket is selected by the receiver, the same rule the emit side applies
-/// (`synthesis::template::blanket_dispatch_for`): a trait may carry several
-/// disjoint value blankets — the four reflection kinds each derive `Inspect`
-/// over their own `Reflect*` bound — and picking the first-registered one would
-/// ask a variant receiver for a struct's `FieldTypes` and key the instance
-/// under args the template never declared.
+/// `None`. `impl<T: Bound<Assoc = [..P]>, ..P> Trait for T` instantiates under
+/// `[T, T::Assoc, …]` where the call site supplies `[T]`, so the queueing and
+/// rewrite sides would key one instance two ways. Asked as a single question —
+/// can this receiver supply every pack? — because splitting it let the halves
+/// disagree. The blanket is picked by receiver, as the emit side picks it: a
+/// trait may carry several disjoint value blankets.
 pub(super) fn blanket_pack_dispatch_args(
     args: &[TypeId],
     trait_env: &TraitEnv,
@@ -237,26 +226,13 @@ fn blanket_receiver_satisfies(
         .is_some()
 }
 
-/// Look up a generic function template in the global map.
-///
-/// `module_hint` is the most-specific guess for the template's home —
-/// usually the call site's `FunctionRef::module_source`. If the literal
-/// `(module_hint, name)` key misses, fall back to `TraitEnv::impl_module_for`
-/// over `struct_candidates` to find a user-written cross-module trait impl
-/// (e.g. `impl<T: Inspect> Inspect for List<T>` lives in
-/// `core:prelude/format`, not in `List<T>`'s own module). For inherent
-/// methods (no trait name on the call) also try `type_module_hint` directly
-/// — inherent impls live with their receiver type.
-///
-/// Returns just `&template` (not its module); the caller decides the
-/// `InstantiationKey::module_source`, since *where* the concrete copy
-/// lands is governed by the fixture-pinned contract that pre-substitution
-/// callers (`resolve_method_call_substitution`,
-/// `substitute_types_in_expr`) already encoded into the call's
-/// `FunctionRef::module_source`. Decoupling template location from
-/// instantiation location is what lets the variadic-tuple guard and the
-/// ref-blanket dispatch both keep working under the
-/// `(ModuleSource, String)` template keying.
+/// Look up a generic function template, starting at `module_hint` — usually the
+/// call site's module — and falling back to `TraitEnv::impl_module_for` for a
+/// cross-module trait impl, or to `type_module_hint` for an inherent method,
+/// which lives with its receiver type. Returns the template alone, not its
+/// module: the caller decides where the concrete copy lands, and decoupling the
+/// two is what keeps the variadic-tuple guard and ref-blanket dispatch working
+/// under `(ModuleSource, String)` template keying.
 fn lookup_template_with_trait_fallback<'a, V>(
     generic_functions: &'a IndexMap<(ModuleSource, String), V>,
     trait_env: &TraitEnv,
@@ -447,16 +423,12 @@ impl TirMutVisitor for LocalIndexRewriter {
     }
 }
 
-/// Collects every local index introduced by a `let` statement or a pattern
-/// binding in the *current function's* local frame. Used by variadic for-of
-/// expansion to find the body locals that must be retyped / reallocated for
-/// each cloned iteration.
-///
-/// Rides the shared `TirRefVisitor` walk so no in-frame node kind can silently
-/// drop a local, but deliberately stops at `Closure` boundaries: closure bodies
-/// allocate their locals in a *separate* index namespace (`new_closure`'s
-/// `FunctionContext`), so collecting them here would let the reallocation loop
-/// corrupt unrelated closure-scoped slots.
+/// Collects every local index a `let` or pattern binding introduces in the
+/// *current function's* frame, so variadic for-of expansion knows which body
+/// locals to retype or reallocate per cloned iteration. Rides the shared
+/// `TirRefVisitor` so no node kind can silently drop one, but stops at `Closure`
+/// boundaries — those allocate in a separate index namespace, and collecting
+/// them would let the reallocation loop corrupt closure-scoped slots.
 struct LocalCollector {
     locals: Vec<u32>,
 }
@@ -555,21 +527,13 @@ fn expr_reads_local(expr: &TirExpr, index: u32) -> bool {
     finder.found
 }
 
-/// Fills in inferred method-level `type_args` on method-call nodes whose type
-/// arguments were left empty (T inferred from a `TypePack` element at resolution
-/// time, only concrete after variadic expansion). Rides the shared mutable walk
-/// so the inference reaches method calls in every in-frame position, not just
-/// the hand-enumerated few. Stops at `Closure` boundaries: a closure body is
-/// monomorphized as its own function, so its calls are inferred there, and
-/// (matching the original walker) this pass leaves them alone.
-///
-/// Two conditions gate the inference, and both are needed. The argument must
-/// read the loop binding — that is the one shape the elaborator could not pin,
-/// because the argument's type was a pack element. And the callee must actually
-/// declare a method type param: `f.write_str(&field.name())` reads the binding
-/// too, yet `write_str` takes a plain `&String`, and naming its instance after
-/// an ordinary parameter's type spells a name no call site uses. The callee's
-/// template is the authority on which is which.
+/// Fill in method-level `type_args` left empty because `T` came from a
+/// `TypePack` element and only turns concrete after variadic expansion. Stops at
+/// `Closure` boundaries, which are monomorphized as their own functions. Both
+/// gates are needed: the argument must read the loop binding — the one shape the
+/// elaborator could not pin — and the callee must declare a method type param,
+/// or the instance is named after an ordinary parameter's type and no call site
+/// spells it that way. The callee's template decides which is which.
 struct MethodTypeArgInferer<'a> {
     type_table: &'a TypeTable,
     binding_local: u32,
@@ -1120,16 +1084,13 @@ impl Monomorphizer {
                             Some((receiver.type_id, type_table)),
                         ) {
                             let generic_func = generic_func_rc.borrow();
-                            // For true ref blanket impls (e.g., impl<T> Inspect for &T),
-                            // the impl_type_args should be the full inner type of the ref,
-                            // not the inner struct's own type args.
-                            // e.g., for &List<i32>, we need [List<i32>], not [i32].
-                            //
-                            // But for specific ref impls (e.g., impl<T> IntoIterator for &List<T>),
-                            // the impl_type_args from get_struct_info_from_type are correct as-is.
-                            // Distinguish by checking the generic function's self param:
-                            //   - &T blanket: self is &&TypeParam → for-type is TypeParam
-                            //   - &List<T>:  self is &&GenericInstance → for-type is GenericInstance
+                            // A true ref blanket (`impl<T> Inspect for &T`) needs
+                            // the ref's whole inner type — `[List<i32>]` for
+                            // `&List<i32>`, not `[i32]` — while a specific ref
+                            // impl (`for &List<T>`) wants what
+                            // `get_struct_info_from_type` already gave. The self
+                            // param tells them apart: `&&TypeParam` is the
+                            // blanket, `&&GenericInstance` the specific one.
                             let effective_impl_type_args = if is_ref_blanket_impl
                                 && generic_method_name == &names_to_try[0]
                             {
@@ -1687,19 +1648,12 @@ impl Monomorphizer {
                 method_type_args: key.method_type_args.clone(),
                 is_blanket: false,
             }),
-            // Update method_info with mangled struct name including impl type args
-            // and method type args (from the method's own type params).
-            //
-            // Use `mangle_type_arg_for_generic` so the definition-side
-            // struct name matches what call-site rewrites produce via
-            // `method_instantiation_name_inner` (which also goes through
-            // `mangle_type_arg_for_generic`). Falling back to
-            // `mangle_type_name` here used to emit `Node<String>` on
-            // the function definition while the call site wrote
-            // `Node<core:prelude/string.wado/String>` — the inliner's
-            // recursive-function detection then failed to link the
-            // self-call back to its own definition, and `-O3` walked
-            // the recursive method into a stack overflow.
+            // Mangle through `mangle_type_arg_for_generic` so the definition-side
+            // struct name matches what call-site rewrites produce. With
+            // `mangle_type_name` the definition said `Node<String>` while the
+            // call site said `Node<core:prelude/string.wado/String>`, and the
+            // inliner could no longer link a self-call to its own definition —
+            // `-O3` then recursed into a stack overflow.
             method_info: generic.method_info.as_ref().map(|info| {
                 let impl_type_arg_names: Vec<FqTypeName> = key
                     .impl_type_args
@@ -2027,18 +1981,13 @@ impl Monomorphizer {
                     }
                     let new_func_name = new_info.to_mangled_name();
 
-                    // The work each branch performs is gated on its own real
-                    // precondition, not on whether the mangled name changed:
-                    //
-                    //  - A type-param receiver (`S^Trait::method`) needs its
-                    //    home module resolved and its concrete instance queued
-                    //    exactly when the receiver resolved to a concrete type.
-                    //    The mangled name is incidental — it stays `S^…` when a
-                    //    user struct is literally named `S` (so it equals the
-                    //    type-param spelling), yet the instance must still be
-                    //    queued or it is left unresolved at WIR build.
-                    //  - A non-type-param call encodes all of its type args in
-                    //    its name, so an unchanged name means nothing to rewrite.
+                    // Each branch is gated on its own precondition, not on
+                    // whether the mangled name changed. A type-param receiver
+                    // needs queueing exactly when it resolved to a concrete type
+                    // — the name stays `S^…` when a user struct is literally
+                    // named `S`, and skipping it there leaves the instance
+                    // unresolved at WIR build. A non-type-param call encodes its
+                    // type args in the name, so an unchanged name is a no-op.
                     let receiver_tid = self
                         .receiver_substitution_tid(&info, substitution)
                         .map(|tid| self.type_param_dispatch_tid(tid, &info, type_table));
@@ -2055,21 +2004,13 @@ impl Monomorphizer {
                                 .expect("receiver_is_concrete implies a resolved receiver");
                             let receiver_module =
                                 module_source_for_trait_impl(type_table, concrete_type_id);
-                            // Per the inspect_ref_array_field.wado contract, this
-                            // path must consult `concrete_impl_module_for` only —
-                            // letting a generic `impl<T> Trait for Foo<T>` leak in
-                            // would route `&List<i32>^Inspect` to List's impl in
-                            // format.wado instead of the ref blanket's, and the
-                            // leading `&` would disappear at codegen.
-                            //
-                            // If no concrete impl exists, a generic impl
-                            // on the receiver type lives in that type's
-                            // own module by convention — fall through to
-                            // `receiver_module`. Only when no per-type
-                            // impl exists at all does dispatch run
-                            // through a blanket impl
-                            // (`impl<I: Bound> Trait for I`); those live
-                            // in the blanket's own module.
+                            // Consult `concrete_impl_module_for` only: letting a
+                            // generic `impl<T> Trait for Foo<T>` in would route
+                            // `&List<i32>^Inspect` to List's impl instead of the
+                            // ref blanket's, dropping the leading `&` at codegen
+                            // (inspect_ref_array_field.wado). With no concrete
+                            // impl, a generic one lives in the receiver's own
+                            // module; only a blanket lives in its own.
                             let trait_name_for_blanket = new_info.base_trait_name();
                             let generic_or_concrete =
                                 self.functions.generic_or_concrete_impl_module(
@@ -2918,16 +2859,12 @@ impl Monomorphizer {
         true
     }
 
-    /// Resolve method call name substitution during monomorphization.
-    ///
-    /// When a generic function body contains a method call like `List<T>::len`,
-    /// this resolves it to the concrete `List<i32>::len` after type substitution.
-    /// Delegates by receiver kind:
-    /// 1. Reference type-param receiver → [`Self::try_ref_blanket_shortcut`]
-    /// 2. Type-param receiver (`T^Ord::cmp` → `i32^Ord::cmp`) →
-    ///    [`Self::resolve_type_param_dispatch`]
-    /// 3. Generic/concrete receiver (`List<T>::len` → `List<i32>::len`) →
-    ///    [`Self::resolve_generic_dispatch`]
+    /// Resolve a method call in a generic body to its concrete target after
+    /// substitution, delegating by receiver kind: a reference type-param to
+    /// [`Self::try_ref_blanket_shortcut`], a type-param (`T^Ord::cmp` →
+    /// `i32^Ord::cmp`) to [`Self::resolve_type_param_dispatch`], and a generic or
+    /// concrete one (`List<T>::len` → `List<i32>::len`) to
+    /// [`Self::resolve_generic_dispatch`].
     fn resolve_method_call_substitution(
         &self,
         method_func: &mut FunctionRef,
@@ -3129,20 +3066,12 @@ impl Monomorphizer {
             let inner = type_table.peel_refs(receiver_type_id);
             module_source_for_trait_impl(type_table, inner)
         };
-        // Per the inspect_ref_array_field.wado contract, this path must
-        // consult `concrete_impl_module_for` only — a broader
-        // `impl_module_for` fallback would route `&List<i32>^Inspect`
-        // to List's generic impl in format.wado instead of the ref
-        // blanket's, and the leading `&` would disappear at codegen.
-        //
-        // If no concrete impl exists, a generic impl on the receiver
-        // type (`impl<T> IntoIterator for List<T>`) still lives in the
-        // receiver type's own module by convention — fall through to
-        // `receiver_module` for that case (covers newtype inheritance:
-        // `FieldValue = List<u8>` reuses List's impl). Only when no
-        // per-type impl exists at all does dispatch run through a
-        // blanket impl (`impl<I: Bound> Trait for I`); the body for
-        // those lives in the blanket's module (`blanket_impls`).
+        // Consult `concrete_impl_module_for` only: a broader `impl_module_for`
+        // would route `&List<i32>^Inspect` to List's generic impl instead of the
+        // ref blanket's, dropping the leading `&` at codegen
+        // (inspect_ref_array_field.wado). With no concrete impl, a generic one
+        // lives in the receiver type's own module — which is also how newtype
+        // inheritance reuses it — and only a blanket lives in `blanket_impls`.
         let trait_name_for_blanket = new_info.base_trait_name();
         let generic_or_concrete = self
             .functions
@@ -3349,27 +3278,13 @@ impl Monomorphizer {
             method_type_args: final_method_ta,
             is_blanket: existing_is_blanket,
         });
-        // When substitution peels a newtype on the receiver
-        // (`MyBytes^InspectAlt::inspect_alt` → `List<u8>^InspectAlt::inspect_alt`),
-        // the original `module_source` (the newtype's module) no longer
-        // points at the body's home. Re-resolve through `TraitEnv` for
-        // the post-substitution struct name so the queue's lookup key
-        // matches where the template actually lives. Issue #1110 (1).
-        //
-        // `generic_or_concrete_impl_module` covers both `impl<T: Foo> Bar for List<T>`
-        // (registered under bare "List") and fully concrete impls;
-        // the producer in `synthesis::traits::resolve_impl_module_via_env`
-        // uses the same query, so the post-substitution `module_source`
-        // matches what a freshly-produced FunctionRef would have.
-        // Hint the impl-module query with the receiver's own inner-type
-        // module. Without a hint, a post-substitution struct name that
-        // falls back to a shared key — notably ref impls, which all key
-        // under "&" / "&mut" — would resolve to the *first* registered
-        // module. That picks the wrong container when several types share
-        // the key (`impl IntoIterator for &List<T>` in list.wado and
-        // `impl IntoIterator for &Array<T>` in array.wado both register
-        // under "&"), routing a `&List<i32>` call to `&Array`'s template.
-        // The receiver's module disambiguates them.
+        // Peeling a newtype on the receiver leaves `module_source` pointing at
+        // the newtype's module, not the body's home, so re-resolve through
+        // `TraitEnv` for the post-substitution name — the same query
+        // `synthesis::traits` uses, so the result matches a freshly-produced
+        // `FunctionRef`. Hint it with the receiver's inner-type module: ref impls
+        // all key under "&", so an unhinted lookup takes the first registered
+        // one and routes a `&List<i32>` call to `&Array`'s template.
         let receiver_hint = {
             let inner = type_table.peel_refs(receiver_type_id);
             super::module_source_for_trait_impl(type_table, inner)
@@ -3838,34 +3753,8 @@ impl Monomorphizer {
                 Self::rewrite_local_index_in_stmt(s, binding_local_idx, iter_binding);
             }
 
-            // Reconcile body-local types and reallocate collisions across the
-            // cloned per-iteration bodies.
-            //
-            // A `let` inside the for-of body is typed once, in the generic
-            // template, as the type-pack / tuple element type. After cloning
-            // and substituting each iteration, the *statement* type is the
-            // concrete per-element type, but the shared `locals` table entry
-            // still carries the stale generic type. Two things must happen:
-            //
-            //  1. The first iteration keeps the original local index, so its
-            //     `locals` entry must be retyped to the concrete element type —
-            //     otherwise codegen declares the slot with the generic (often
-            //     reference-shaped) type while the body stores a different
-            //     concrete value, producing an invalid Wasm local. This bites
-            //     whenever the local survives optimization, e.g. inside a
-            //     `match` arm where copy-propagation cannot fold it away.
-            //  2. Later iterations reuse the same index, so they must be
-            //     reallocated to a fresh local (also typed concretely) to avoid
-            //     sharing one slot across heterogeneous element types. This also
-            //     covers `?`-expansion temporaries (`__qm_v`, `__qm_e`).
-            //
-            // The retype in (1) must happen HERE, after reallocation, because
-            // every cloned iteration substitutes against the same shared
-            // `locals` table: retyping a slot before later iterations are moved
-            // off it (step 2) would let a later element's type clobber the type
-            // the earlier iteration still depends on. Ordinary instantiation is
-            // immune — `instantiate_function` substitutes a fresh per-function
-            // `locals` table up front, so iterations never share a slot.
+            // Must run here, after reallocation: every cloned iteration
+            // substitutes against the same shared `locals` table.
             self.reconcile_unrolled_body_locals(&mut elem_body, local_count, locals);
 
             iter_stmts.extend(elem_body.stmts);
@@ -3890,30 +3779,15 @@ impl Monomorphizer {
         )]
     }
 
-    /// Reconcile the locals of one unrolled iteration against the ones already
-    /// emitted, so heterogeneous elements never share a slot.
-    ///
-    /// A `let` inside the body is typed once, in the generic template, as the
-    /// pack element type. After cloning and substituting each iteration the
-    /// *statement* type is concrete, but the shared `locals` entry still carries
-    /// the generic one. Two things must happen:
-    ///
-    ///  1. The first iteration keeps the original index, so its `locals` entry
-    ///     is retyped to the concrete element type — otherwise codegen declares
-    ///     the slot with the generic (often reference-shaped) type while the
-    ///     body stores a different concrete value, producing an invalid Wasm
-    ///     local. This bites whenever the local survives optimization, e.g.
-    ///     inside a `match` arm where copy-propagation cannot fold it away.
-    ///  2. Later iterations reuse the same index, so they are reallocated to a
-    ///     fresh (concretely typed) local. This also covers `?`-expansion
-    ///     temporaries (`__qm_v`, `__qm_e`).
-    ///
-    /// The retype in (1) happens after reallocation because every cloned
-    /// iteration substitutes against the same shared `locals` table: retyping a
-    /// slot before later iterations are moved off it would let a later element's
-    /// type clobber the type the earlier iteration still depends on. Ordinary
-    /// instantiation is immune — `instantiate_function` substitutes a fresh
-    /// per-function `locals` table up front, so iterations never share a slot.
+    /// Reconcile one unrolled iteration's locals against those already emitted,
+    /// so heterogeneous elements never share a slot. A `let` in the body is
+    /// typed once in the generic template, so the first iteration's `locals`
+    /// entry must be retyped to the concrete element type — codegen would
+    /// otherwise declare the slot generic while the body stores something else —
+    /// and later iterations, which reuse the index, must move to fresh locals.
+    /// Retyping comes after reallocation, or a later element clobbers the type
+    /// an earlier iteration still depends on. Ordinary instantiation is immune:
+    /// `instantiate_function` substitutes a fresh `locals` table up front.
     fn reconcile_unrolled_body_locals(
         &self,
         body: &mut TirBlock,
@@ -4898,16 +4772,11 @@ fn try_lower_comparison(
 
     let resolve_module = |info: &LocalMethodName, type_mod: Option<ModuleSource>| -> ModuleSource {
         // Only concrete impls live in the module the function compiles into;
-        // generic instantiations live in the receiver's module (`type_mod`).
-        // Keyed like `FuncInstState::impl_module` so both paths agree.
-        // `type_mod` is also passed to disambiguate same-name receiver
-        // types coming from different modules.
-        //
-        // `type_mod` is guaranteed `Some` by the outer match in
-        // `try_lower_comparison`, which returns `None` for any operand
-        // type that wouldn't have a defining module (primitives, function
-        // refs, tuples). Unwrapping below is therefore total under the
-        // calling contract.
+        // generic instantiations live in the receiver's `type_mod`, which also
+        // disambiguates same-named receivers from different modules. Keyed like
+        // `FuncInstState::impl_module` so both paths agree. `try_lower_comparison`
+        // returns `None` for any operand type without a defining module, so the
+        // unwrap below is total under its contract.
         info.trait_name
             .as_ref()
             .and_then(|tn| {

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -3735,7 +3735,7 @@ impl Monomorphizer {
                 Self::rewrite_local_index_in_stmt(s, binding_local_idx, iter_binding);
             }
 
-            // Must run here, after reallocation: every cloned iteration
+            // Per iteration, after the index rewrite: every cloned iteration
             // substitutes against the same shared `locals` table.
             self.reconcile_unrolled_body_locals(&mut elem_body, local_count, locals);
 

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -1079,10 +1079,9 @@ impl Monomorphizer {
                             let generic_func = generic_func_rc.borrow();
                             // A true ref blanket (`impl<T> Inspect for &T`) needs
                             // the ref's whole inner type — `[List<i32>]` for
-                            // `&List<i32>` — while a specific ref impl (`for
-                            // &List<T>`) wants what `get_struct_info_from_type`
-                            // gave. `&&TypeParam` is the blanket, not
-                            // `&&GenericInstance`.
+                            // `&List<i32>` — while a specific ref impl wants
+                            // what `get_struct_info_from_type` gave.
+                            // `&&TypeParam` is the blanket, not `&&GenericInstance`.
                             let effective_impl_type_args = if is_ref_blanket_impl
                                 && generic_method_name == &names_to_try[0]
                             {

--- a/wado-compiler/src/monomorphize/func_inst.rs
+++ b/wado-compiler/src/monomorphize/func_inst.rs
@@ -140,11 +140,9 @@ struct SubstitutedCall {
 
 /// The impl args a pack-projecting blanket dispatch instantiates under, or
 /// `None`. `impl<T: Bound<Assoc = [..P]>, ..P> Trait for T` instantiates under
-/// `[T, T::Assoc, …]` where the call site supplies `[T]`, so the queueing and
-/// rewrite sides would key one instance two ways. Asked as a single question —
-/// can this receiver supply every pack? — because splitting it let the halves
-/// disagree. The blanket is picked by receiver, as the emit side picks it: a
-/// trait may carry several disjoint value blankets.
+/// `[T, T::Assoc, …]` where the call site supplies `[T]`, so queueing and
+/// rewrite would key one instance two ways. Answered as a single question, and
+/// by receiver as the emit side picks it — a trait may carry disjoint blankets.
 pub(super) fn blanket_pack_dispatch_args(
     args: &[TypeId],
     trait_env: &TraitEnv,
@@ -230,9 +228,7 @@ fn blanket_receiver_satisfies(
 /// call site's module — and falling back to `TraitEnv::impl_module_for` for a
 /// cross-module trait impl, or to `type_module_hint` for an inherent method,
 /// which lives with its receiver type. Returns the template alone, not its
-/// module: the caller decides where the concrete copy lands, and decoupling the
-/// two is what keeps the variadic-tuple guard and ref-blanket dispatch working
-/// under `(ModuleSource, String)` template keying.
+/// module: the caller decides where the concrete copy lands.
 fn lookup_template_with_trait_fallback<'a, V>(
     generic_functions: &'a IndexMap<(ModuleSource, String), V>,
     trait_env: &TraitEnv,
@@ -425,10 +421,9 @@ impl TirMutVisitor for LocalIndexRewriter {
 
 /// Collects every local index a `let` or pattern binding introduces in the
 /// *current function's* frame, so variadic for-of expansion knows which body
-/// locals to retype or reallocate per cloned iteration. Rides the shared
-/// `TirRefVisitor` so no node kind can silently drop one, but stops at `Closure`
-/// boundaries — those allocate in a separate index namespace, and collecting
-/// them would let the reallocation loop corrupt closure-scoped slots.
+/// locals to retype or reallocate per cloned iteration. Stops at `Closure`
+/// boundaries: those allocate in a separate index namespace, and collecting them
+/// would let the reallocation loop corrupt closure-scoped slots.
 struct LocalCollector {
     locals: Vec<u32>,
 }
@@ -528,12 +523,10 @@ fn expr_reads_local(expr: &TirExpr, index: u32) -> bool {
 }
 
 /// Fill in method-level `type_args` left empty because `T` came from a
-/// `TypePack` element and only turns concrete after variadic expansion. Stops at
-/// `Closure` boundaries, which are monomorphized as their own functions. Both
-/// gates are needed: the argument must read the loop binding — the one shape the
+/// `TypePack` element and only turns concrete after variadic expansion. Both
+/// gates matter: the argument must read the loop binding — the one shape the
 /// elaborator could not pin — and the callee must declare a method type param,
-/// or the instance is named after an ordinary parameter's type and no call site
-/// spells it that way. The callee's template decides which is which.
+/// or the instance is named after an ordinary parameter's type instead.
 struct MethodTypeArgInferer<'a> {
     type_table: &'a TypeTable,
     binding_local: u32,
@@ -1086,11 +1079,10 @@ impl Monomorphizer {
                             let generic_func = generic_func_rc.borrow();
                             // A true ref blanket (`impl<T> Inspect for &T`) needs
                             // the ref's whole inner type — `[List<i32>]` for
-                            // `&List<i32>`, not `[i32]` — while a specific ref
-                            // impl (`for &List<T>`) wants what
-                            // `get_struct_info_from_type` already gave. The self
-                            // param tells them apart: `&&TypeParam` is the
-                            // blanket, `&&GenericInstance` the specific one.
+                            // `&List<i32>` — while a specific ref impl (`for
+                            // &List<T>`) wants what `get_struct_info_from_type`
+                            // gave. `&&TypeParam` is the blanket, not
+                            // `&&GenericInstance`.
                             let effective_impl_type_args = if is_ref_blanket_impl
                                 && generic_method_name == &names_to_try[0]
                             {
@@ -1650,10 +1642,9 @@ impl Monomorphizer {
             }),
             // Mangle through `mangle_type_arg_for_generic` so the definition-side
             // struct name matches what call-site rewrites produce. With
-            // `mangle_type_name` the definition said `Node<String>` while the
-            // call site said `Node<core:prelude/string.wado/String>`, and the
-            // inliner could no longer link a self-call to its own definition —
-            // `-O3` then recursed into a stack overflow.
+            // `mangle_type_name` the definition said `Node<String>` and the call
+            // site `Node<core:prelude/string.wado/String>`; the inliner then lost
+            // the self-call link and `-O3` recursed into a stack overflow.
             method_info: generic.method_info.as_ref().map(|info| {
                 let impl_type_arg_names: Vec<FqTypeName> = key
                     .impl_type_args
@@ -1983,11 +1974,9 @@ impl Monomorphizer {
 
                     // Each branch is gated on its own precondition, not on
                     // whether the mangled name changed. A type-param receiver
-                    // needs queueing exactly when it resolved to a concrete type
-                    // — the name stays `S^…` when a user struct is literally
-                    // named `S`, and skipping it there leaves the instance
-                    // unresolved at WIR build. A non-type-param call encodes its
-                    // type args in the name, so an unchanged name is a no-op.
+                    // needs queueing exactly when it resolved concretely — the
+                    // name stays `S^…` for a user struct named `S`, and skipping
+                    // it there leaves the instance unresolved at WIR build.
                     let receiver_tid = self
                         .receiver_substitution_tid(&info, substitution)
                         .map(|tid| self.type_param_dispatch_tid(tid, &info, type_table));
@@ -2007,10 +1996,8 @@ impl Monomorphizer {
                             // Consult `concrete_impl_module_for` only: letting a
                             // generic `impl<T> Trait for Foo<T>` in would route
                             // `&List<i32>^Inspect` to List's impl instead of the
-                            // ref blanket's, dropping the leading `&` at codegen
-                            // (inspect_ref_array_field.wado). With no concrete
-                            // impl, a generic one lives in the receiver's own
-                            // module; only a blanket lives in its own.
+                            // ref blanket's, dropping the leading `&` at codegen.
+                            // A generic impl lives in the receiver's own module.
                             let trait_name_for_blanket = new_info.base_trait_name();
                             let generic_or_concrete =
                                 self.functions.generic_or_concrete_impl_module(
@@ -2862,9 +2849,8 @@ impl Monomorphizer {
     /// Resolve a method call in a generic body to its concrete target after
     /// substitution, delegating by receiver kind: a reference type-param to
     /// [`Self::try_ref_blanket_shortcut`], a type-param (`T^Ord::cmp` →
-    /// `i32^Ord::cmp`) to [`Self::resolve_type_param_dispatch`], and a generic or
-    /// concrete one (`List<T>::len` → `List<i32>::len`) to
-    /// [`Self::resolve_generic_dispatch`].
+    /// `i32^Ord::cmp`) to [`Self::resolve_type_param_dispatch`], anything else
+    /// (`List<T>::len` → `List<i32>::len`) to [`Self::resolve_generic_dispatch`].
     fn resolve_method_call_substitution(
         &self,
         method_func: &mut FunctionRef,
@@ -3068,10 +3054,9 @@ impl Monomorphizer {
         };
         // Consult `concrete_impl_module_for` only: a broader `impl_module_for`
         // would route `&List<i32>^Inspect` to List's generic impl instead of the
-        // ref blanket's, dropping the leading `&` at codegen
-        // (inspect_ref_array_field.wado). With no concrete impl, a generic one
-        // lives in the receiver type's own module — which is also how newtype
-        // inheritance reuses it — and only a blanket lives in `blanket_impls`.
+        // ref blanket's, dropping the leading `&` at codegen. With no concrete
+        // impl, a generic one lives in the receiver type's own module — how
+        // newtype inheritance reuses it — and only a blanket in `blanket_impls`.
         let trait_name_for_blanket = new_info.base_trait_name();
         let generic_or_concrete = self
             .functions
@@ -3278,13 +3263,11 @@ impl Monomorphizer {
             method_type_args: final_method_ta,
             is_blanket: existing_is_blanket,
         });
-        // Peeling a newtype on the receiver leaves `module_source` pointing at
-        // the newtype's module, not the body's home, so re-resolve through
-        // `TraitEnv` for the post-substitution name — the same query
-        // `synthesis::traits` uses, so the result matches a freshly-produced
-        // `FunctionRef`. Hint it with the receiver's inner-type module: ref impls
-        // all key under "&", so an unhinted lookup takes the first registered
-        // one and routes a `&List<i32>` call to `&Array`'s template.
+        // Peeling a newtype on the receiver leaves `module_source` at the
+        // newtype's module, so re-resolve through `TraitEnv` — the same query
+        // `synthesis::traits` uses, so the result matches a fresh `FunctionRef`.
+        // Hint with the inner-type module: ref impls all key under "&", and an
+        // unhinted lookup routes a `&List<i32>` call to `&Array`'s template.
         let receiver_hint = {
             let inner = type_table.peel_refs(receiver_type_id);
             super::module_source_for_trait_impl(type_table, inner)
@@ -3780,14 +3763,10 @@ impl Monomorphizer {
     }
 
     /// Reconcile one unrolled iteration's locals against those already emitted,
-    /// so heterogeneous elements never share a slot. A `let` in the body is
-    /// typed once in the generic template, so the first iteration's `locals`
-    /// entry must be retyped to the concrete element type — codegen would
-    /// otherwise declare the slot generic while the body stores something else —
-    /// and later iterations, which reuse the index, must move to fresh locals.
-    /// Retyping comes after reallocation, or a later element clobbers the type
-    /// an earlier iteration still depends on. Ordinary instantiation is immune:
-    /// `instantiate_function` substitutes a fresh `locals` table up front.
+    /// so heterogeneous elements never share a slot: the first iteration retypes
+    /// the template's generic `let` to the concrete element type, later ones
+    /// move to fresh locals. Retyping comes after reallocation, or a later
+    /// element clobbers the type an earlier iteration still depends on.
     fn reconcile_unrolled_body_locals(
         &self,
         body: &mut TirBlock,

--- a/wado-compiler/src/monomorphize/state.rs
+++ b/wado-compiler/src/monomorphize/state.rs
@@ -63,11 +63,8 @@ impl FuncInstState {
     /// The module owning the impl behind `info`, restricted to fully concrete
     /// impls. Mono needs this rather than the broader
     /// [`TraitEnv::impl_module_for`] because a generic impl's post-substitution
-    /// function is materialised in the *receiver's* module — the invariant
-    /// `call_rewrite`'s ref-blanket path relies on to keep
-    /// `&List<i32>^Inspect::inspect` from collapsing to `List<i32>::inspect`.
-    /// Keyed by the post-substitution `struct_name`, since a concrete impl keys
-    /// on the full type name and substitution emits the resolved concrete type.
+    /// function is materialised in the *receiver's* module. Keyed by the
+    /// post-substitution `struct_name`, which a concrete impl keys on too.
     pub fn impl_module(
         &self,
         info: &LocalMethodName,
@@ -292,12 +289,10 @@ impl Monomorphizer {
     }
 
     /// Queue a function instantiation unless already queued, deduping on the full
-    /// `InstantiationKey` alone. With faithful Ref/MutRef mangling — so `[&T]`
-    /// and `[T]` differ — and `TypeRewriter`'s post-monomorphisation rewrite of
-    /// every reachable `TypeId`, a call's `type_args` included, every site
-    /// arrives with canonicalised args. That makes `function_id_for` injective
-    /// over `project.functions` by construction, which DCE's position-based
-    /// retain asserts and depends on.
+    /// `InstantiationKey` alone. With faithful Ref/MutRef mangling and
+    /// `TypeRewriter`'s post-monomorphisation rewrite of every reachable
+    /// `TypeId`, every site arrives with canonicalised args — which makes
+    /// `function_id_for` injective, as DCE's position-based retain asserts.
     pub fn try_queue_function(
         &mut self,
         key: InstantiationKey,
@@ -313,10 +308,8 @@ impl Monomorphizer {
         // A blanket instance reaches one function from two dispatch sites whose
         // derived args can be distinct-but-equivalent `TypeId`s, so the keys
         // differ while the mangled name matches; dedup on the name, either body
-        // being complete. Only a *universal* `&T` blanket qualifies for the
-        // ref case: a `&^Trait` name that is really a newtype-peeled shape impl
-        // has no universal blanket, and deduping it would leave a for-of loop's
-        // iterator unresolved.
+        // being complete. Only a *universal* `&T` blanket qualifies for the ref
+        // case, or a newtype-peeled `&^Trait` shape impl would dedup wrongly.
         let is_ref_universal_blanket = key.impl_type_args.len() == 1
             && key.method_info.as_ref().is_some_and(|i| {
                 i.ref_receiver().is_some_and(|ref_kind| {
@@ -350,11 +343,9 @@ impl Monomorphizer {
 
     /// Generate a monomorphized struct name: `Box` + `[i32]` → `"Box<i32>"`.
     /// Mangles through `mangle_type_arg_for_generic`, so a named type argument
-    /// carries its declaring module — the same form the type-table side produces,
-    /// letting the struct registered here and the `GenericInstance` looked up by
-    /// name agree on one identity. Unqualified on one side and qualified on the
-    /// other produced two wasm-GC types for one struct and an
-    /// "expected (ref $type), found (ref $type)" ICE at validation.
+    /// carries its declaring module — the same form the type-table side produces.
+    /// Qualified on one side and not the other produced two wasm-GC types for one
+    /// struct, and an "expected (ref $type), found (ref $type)" ICE.
     pub fn instantiation_name(&self, key: &InstantiationKey, type_table: &TypeTable) -> String {
         let args: Vec<String> = key
             .impl_type_args
@@ -505,12 +496,8 @@ impl Monomorphizer {
     /// The newtype's own name when `type_id` peels to one that answers this call
     /// with its *own* impl, else `None`. Unlike
     /// [`Self::get_struct_name_from_type`], which peels newtypes transparently,
-    /// this preserves the identity — but only where the newtype overrides the
-    /// method, so the collect path queues `ByteList^Trait::method` to match what
-    /// the rewrite emits rather than the inherited base. A trait method asks for
-    /// an `impl Trait for`, an inherent one for a method of that name: answering
-    /// only the first named an inherent call after a base function that does not
-    /// exist.
+    /// this preserves the identity where the newtype overrides the method, so the
+    /// collect path queues `ByteList^Trait::method` to match the rewrite.
     pub fn newtype_own_struct_name_with_impl(
         &self,
         type_id: TypeId,
@@ -603,12 +590,8 @@ impl Monomorphizer {
     /// The ordered `(mangled_method_name, trait_name)` formats to probe when
     /// resolving a generic method call, a newtype's own impl before its base so
     /// resolution lands on `ByteList^serialize` rather than `List^serialize`.
-    /// Each candidate name yields both the inherent and trait-qualified forms,
-    /// and the newtype's own name comes back alongside so callers can seed with
-    /// it. Shared by the collect and rewrite paths, keeping them in lockstep.
-    /// The names come off the receiver's type: a template is registered under the
-    /// fq head its definition was named with, which an instantiation spelling
-    /// does not reproduce.
+    /// Each candidate name yields both the inherent and trait-qualified forms.
+    /// Shared by the collect and rewrite paths, keeping them in lockstep.
     pub fn newtype_aware_method_names(
         &self,
         receiver_type_id: TypeId,

--- a/wado-compiler/src/monomorphize/state.rs
+++ b/wado-compiler/src/monomorphize/state.rs
@@ -60,24 +60,14 @@ pub(super) struct FuncInstState {
 }
 
 impl FuncInstState {
-    /// Look up the module owning the impl that backs `info`, restricted
-    /// to fully concrete impls (no impl-level type parameters). Mono uses
-    /// this — rather than the broader [`TraitEnv::impl_module_for`] —
-    /// because a generic impl's post-substitution function is materialised
-    /// in the receiver type's module, not the impl block's module: that
-    /// invariant is what `call_rewrite`'s "ref-blanket" path relies on to
-    /// route `&List<i32>^Inspect::inspect` through the `&T`-blanket
-    /// instantiation rather than collapsing it to `List<i32>::inspect`.
-    ///
-    /// The lookup uses `info.struct_name()` (the post-substitution type
-    /// name) rather than `info.base_struct_name()`, which mirrors the
-    /// legacy `trait_method_locations.contains_key(<full mangled name>)`
-    /// semantics: a concrete impl's key is the full type name (e.g. the
-    /// `impl Ord for i32` block keys ("i32", "Ord")), and post-mono
-    /// substitution emits trait-method calls whose `struct_name` is the
-    /// resolved concrete type ("i32", not "Score"). Querying by
-    /// `base_struct_name` would miss this case for newtypes whose
-    /// `struct_name` has been resolved through the newtype.
+    /// The module owning the impl behind `info`, restricted to fully concrete
+    /// impls. Mono needs this rather than the broader
+    /// [`TraitEnv::impl_module_for`] because a generic impl's post-substitution
+    /// function is materialised in the *receiver's* module — the invariant
+    /// `call_rewrite`'s ref-blanket path relies on to keep
+    /// `&List<i32>^Inspect::inspect` from collapsing to `List<i32>::inspect`.
+    /// Keyed by the post-substitution `struct_name`, since a concrete impl keys
+    /// on the full type name and substitution emits the resolved concrete type.
     pub fn impl_module(
         &self,
         info: &LocalMethodName,
@@ -301,19 +291,13 @@ impl Monomorphizer {
         names.contains(&self.method_instantiation_name(&base_key, type_table))
     }
 
-    /// Queue a function instantiation if not already queued. Returns true
-    /// if newly queued.
-    ///
-    /// Dedupe is keyed solely on the full `InstantiationKey`. Together
-    /// with faithful Ref/MutRef mangling (so `[&T]` and `[T]` mangle to
-    /// distinct names) and `TypeRewriter`'s post-monomorphisation
-    /// type-id rewrite over **every** `TypeId` field reachable from a
-    /// `TirFunction` body — including a call's `type_args` —
-    /// every concrete instantiation site reaches `try_queue_function`
-    /// with `GenericInstance`/`Struct`-canonicalised type args. That
-    /// makes `function_id_for(func)` injective over `project.functions`
-    /// by construction — the load-bearing invariant for DCE's
-    /// position-based retain (asserted at `optimize/dce.rs:675`).
+    /// Queue a function instantiation unless already queued, deduping on the full
+    /// `InstantiationKey` alone. With faithful Ref/MutRef mangling — so `[&T]`
+    /// and `[T]` differ — and `TypeRewriter`'s post-monomorphisation rewrite of
+    /// every reachable `TypeId`, a call's `type_args` included, every site
+    /// arrives with canonicalised args. That makes `function_id_for` injective
+    /// over `project.functions` by construction, which DCE's position-based
+    /// retain asserts and depends on.
     pub fn try_queue_function(
         &mut self,
         key: InstantiationKey,
@@ -326,20 +310,13 @@ impl Monomorphizer {
         if self.concrete_impl_owns_name(&key, &mangled_name, type_table) {
             return false;
         }
-        // A blanket instance reaches the same function from two dispatch sites —
-        // a template pre-resolution and a normal method dispatch — whose derived
-        // args (`..F` tuple, or a ref blanket's pointee) can be
-        // distinct-but-equivalent `TypeId`s, so the keys differ but the mangled
-        // name is identical. Dedup those on the name to avoid the
-        // duplicate-function check; either body is complete. The struct blanket
-        // carries `[T, ..F]` (len 2); the ref/mutref blankets carry `[pointee]`
-        // (len 1) under a `&`/`&mut`-headed template name.
-        // The ref/mutref case applies only to a *universal* `&T` blanket
-        // (`impl<T: Inspect> Inspect for &T`): its template name is `&^Trait` and
-        // the template + type-param dispatch both queue it. A `&^Trait` name that
-        // is really a newtype-peeled shape impl (`&List^IntoIterator` collapsed to
-        // `&`) has no universal blanket and must NOT be deduped — dropping it
-        // would leave the for-of loop's iterator unresolved.
+        // A blanket instance reaches one function from two dispatch sites whose
+        // derived args can be distinct-but-equivalent `TypeId`s, so the keys
+        // differ while the mangled name matches; dedup on the name, either body
+        // being complete. Only a *universal* `&T` blanket qualifies for the
+        // ref case: a `&^Trait` name that is really a newtype-peeled shape impl
+        // has no universal blanket, and deduping it would leave a for-of loop's
+        // iterator unresolved.
         let is_ref_universal_blanket = key.impl_type_args.len() == 1
             && key.method_info.as_ref().is_some_and(|i| {
                 i.ref_receiver().is_some_and(|ref_kind| {
@@ -371,20 +348,13 @@ impl Monomorphizer {
         true
     }
 
-    /// Generate monomorphized struct name: `Box` + `[i32]` -> `"Box<i32>"`.
-    ///
-    /// Uses `mangle_type_arg_for_generic` so that `Variant`/`Enum`/
-    /// `Resource`/`Newtype`/`Flags` type arguments are qualified by their
-    /// declaring `ModuleSource`. This matches what the type-table-side
-    /// `get_type_name_info(GenericInstance)` produces for the same type
-    /// arg, so the struct registered here and the `GenericInstance`
-    /// looked up by mangled name in `substitute_type` agree on a single
-    /// identity. Without this, a generic instantiated over a variant
-    /// (e.g. `IterMap<ListIter<Color>, String>`) was registered with an
-    /// unqualified name from one side and looked up with a qualified
-    /// name from the other, producing two distinct wasm-GC types for the
-    /// same struct and an "expected (ref $type), found (ref $type)" ICE
-    /// at codegen-time validation.
+    /// Generate a monomorphized struct name: `Box` + `[i32]` → `"Box<i32>"`.
+    /// Mangles through `mangle_type_arg_for_generic`, so a named type argument
+    /// carries its declaring module — the same form the type-table side produces,
+    /// letting the struct registered here and the `GenericInstance` looked up by
+    /// name agree on one identity. Unqualified on one side and qualified on the
+    /// other produced two wasm-GC types for one struct and an
+    /// "expected (ref $type), found (ref $type)" ICE at validation.
     pub fn instantiation_name(&self, key: &InstantiationKey, type_table: &TypeTable) -> String {
         let args: Vec<String> = key
             .impl_type_args
@@ -532,24 +502,15 @@ impl Monomorphizer {
         }
     }
 
-    /// If `type_id` (peeling references) is a newtype that answers this call
-    /// with its OWN impl, return the newtype's own name (e.g. `"ByteList"`);
-    /// otherwise `None`.
-    ///
-    /// Unlike [`Self::get_struct_name_from_type`], which makes newtypes
-    /// transparent by peeling to the base, this preserves the newtype's identity
-    /// — but only when the newtype actually overrides the method. The collect
-    /// path tries this name first so the queued instantiation
-    /// (`ByteList^Trait::method`) matches the call the rewrite emits, not the
-    /// inherited base (`List^Trait::method`). Newtypes without their own impl
-    /// (e.g. `Meters`, simd `v128` lanes) return `None` and keep peeling to the
-    /// base, so their dispatch is unchanged.
-    ///
-    /// A trait method asks for an `impl <Trait> for`; an inherent method asks
-    /// for a method of that name. Answering only the first left
-    /// `impl MyArray<T> { fn second() }` invisible, so an inherent call on a
-    /// generic newtype was named after the base it inherits from — a function
-    /// that does not exist.
+    /// The newtype's own name when `type_id` peels to one that answers this call
+    /// with its *own* impl, else `None`. Unlike
+    /// [`Self::get_struct_name_from_type`], which peels newtypes transparently,
+    /// this preserves the identity — but only where the newtype overrides the
+    /// method, so the collect path queues `ByteList^Trait::method` to match what
+    /// the rewrite emits rather than the inherited base. A trait method asks for
+    /// an `impl Trait for`, an inherent one for a method of that name: answering
+    /// only the first named an inherent call after a base function that does not
+    /// exist.
     pub fn newtype_own_struct_name_with_impl(
         &self,
         type_id: TypeId,
@@ -639,20 +600,15 @@ impl Monomorphizer {
         own.as_ref() == Some(&info.fq_base_struct_name())
     }
 
-    /// Build the ordered list of `(mangled_method_name, trait_name)` formats to
-    /// probe when resolving a generic method call on `receiver_type_id`.
-    ///
-    /// A newtype's OWN impl is tried before its base so the resolution lands on
-    /// the newtype's own instantiation (`ByteList^serialize`) rather than the
-    /// inherited base (`List^serialize`). For each candidate struct name both
-    /// the inherent (`None`) and trait-qualified formats are emitted. Returns
-    /// the newtype's own name alongside the list so callers can also seed their
-    /// candidate set with it. Shared by the collect (`func_inst.rs`) and rewrite
-    /// (`call_rewrite.rs`) paths so the two stay in lockstep.
-    ///
-    /// The names are receivers, so they come off the receiver's type — a
-    /// template is registered under the fq head its definition was named with,
-    /// which a struct-instantiation spelling does not reproduce.
+    /// The ordered `(mangled_method_name, trait_name)` formats to probe when
+    /// resolving a generic method call, a newtype's own impl before its base so
+    /// resolution lands on `ByteList^serialize` rather than `List^serialize`.
+    /// Each candidate name yields both the inherent and trait-qualified forms,
+    /// and the newtype's own name comes back alongside so callers can seed with
+    /// it. Shared by the collect and rewrite paths, keeping them in lockstep.
+    /// The names come off the receiver's type: a template is registered under the
+    /// fq head its definition was named with, which an instantiation spelling
+    /// does not reproduce.
     pub fn newtype_aware_method_names(
         &self,
         receiver_type_id: TypeId,

--- a/wado-compiler/src/monomorphize/substitute.rs
+++ b/wado-compiler/src/monomorphize/substitute.rs
@@ -42,19 +42,11 @@ impl Monomorphizer {
         }
     }
 
-    /// Rewrite all `GenericInstance` `type_ids` in a single `TirFunction` —
-    /// the per-function dual of [`Self::rewrite_types_in_module`].
-    ///
-    /// Phase 9's inner loop calls this on every newly-instantiated function
-    /// (after struct monomorphisation has run to fixpoint over the types
-    /// reachable from its body) so that, by the time
-    /// `collect_function_instantiation_sites` walks the body, every
-    /// `TypeId` it consumes — including a call's `type_args` —
-    /// is in canonical `Struct` form. Without this, function-call queues
-    /// produced by Phase 9 carry pre-monomorphisation `GenericInstance`
-    /// `TypeId`s that mangle identically to their post-monomorphisation
-    /// `Struct` counterparts, violating `function_id_for` injectivity
-    /// over `project.functions`.
+    /// Rewrite all `GenericInstance` `type_ids` in a single `TirFunction` — the
+    /// per-function dual of [`Self::rewrite_types_in_module`]. Called on each
+    /// newly-instantiated function after struct monomorphisation reaches
+    /// fixpoint, so `collect_function_instantiation_sites` sees only canonical
+    /// `Struct` form and `function_id_for` stays injective.
     pub fn rewrite_types_in_function(
         &self,
         func: &mut crate::tir::TirFunction,
@@ -213,26 +205,11 @@ impl Monomorphizer {
         }
     }
 
-    /// Substitute type parameters in a type with concrete types.
-    ///
-    /// Walks `type_id` recursively, delegating the leaf cases (`TypeParam`,
-    /// `TypePack`, `AssocTypeProjection`, `GenericResource`) to
-    /// [`TypeTable::substitute_type_params`] and handling container /
-    /// `GenericInstance` cases inline so that a monomorphize-specific
-    /// struct-rewrite happens at every level: after recursively
-    /// substituting a `GenericInstance`'s type arguments, if an
-    /// already-monomorphized struct with the resulting mangled name exists
-    /// in the type table, the type is rewritten to that struct directly.
-    /// This keeps later phases (WIR build, variant-case registration)
-    /// looking up the same mangled name as was registered at
-    /// struct-instantiation time, including for nested references such as
-    /// `Option<&mut TreeMapNode<K>>`.
-    ///
-    /// A `GenericInstance` whose `type_args` are empty — which can occur
-    /// when e.g. `Container { .. }` inside `Container<T>::new()` is typed
-    /// as `GenericInstance` without spelling out its type arguments — is
-    /// resolved to an existing monomorphized struct using the substitution
-    /// map itself.
+    /// Substitute type parameters in a type with concrete types, delegating the
+    /// leaf cases to [`TypeTable::substitute_type_params`] and handling
+    /// containers inline so a `GenericInstance` collapses onto an
+    /// already-monomorphized struct of the same mangled name at every level.
+    /// Empty `type_args` resolve through the substitution map itself.
     pub fn substitute_type(
         &self,
         type_id: TypeId,
@@ -528,21 +505,10 @@ impl TirMutVisitor for TypeRewriter<'_> {
         expr.type_id = self.rewrite_type_id(expr.type_id);
 
         // Rewrite explicit `type_args` on a call so post-monomorphisation
-        // `InstantiationKey`s built from them use the canonical (substituted)
-        // `Struct` form rather than the elaborator-assigned `GenericInstance`
-        // form. Without this, two queue paths for the same logical
-        // instantiation — one driven by call-site `type_args` (left as
-        // `GenericInstance` by the elaborator) and another driven by
-        // receiver/struct_key paths (already rewritten to `Struct`) —
-        // would hash distinct yet mangle identically, producing two
-        // `TirFunction`s sharing one `function_id_for`.
-        //
-        // The default `walk_expr` does not descend into `type_args` (see
-        // `tir_visitor.rs`'s `Call` pattern, which only binds `args`),
-        // so rewrite them explicitly here. `Call`'s own
-        // body rewrites (param substitution, etc.) happen via
-        // `substitute_types_in_expr` at `instantiate_function` time and
-        // are independent of this whole-module rewrite.
+        // `InstantiationKey`s use canonical `Struct` form: otherwise the
+        // call-site and receiver queue paths for one instantiation hash
+        // distinctly yet mangle identically, giving two `TirFunction`s one
+        // `function_id_for`. `walk_expr` does not descend into `type_args`.
         if let TirExprKind::Call { type_args, .. } = &mut expr.kind {
             for type_arg in type_args.iter_mut() {
                 *type_arg = self.rewrite_type_id(*type_arg);

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -534,7 +534,7 @@ pub struct LocalMethodName {
     pub struct_type_args: Vec<FqTypeName>,
     /// The method name (e.g., "sum" or "fmt")
     pub method_name: String,
-    /// Method-level type args (e.g., ["i64"] for transform<i64>)
+    /// Method-level type args (e.g., `["i64"]` for `transform<i64>`)
     pub method_type_args: Vec<String>,
     /// Whether the struct name is a type parameter that should be substituted directly
     /// during monomorphization (e.g., `T^Ord::cmp` where T should become i32).
@@ -1036,7 +1036,8 @@ impl LocalMethodName {
 
     /// Create a version of this `LocalMethodName` with type args applied.
     ///
-    /// `impl_type_args` are applied to the struct name (e.g., "List" + ["i32"] → "List<i32>").
+    /// `impl_type_args` are applied to the struct name
+    /// (e.g., `"List"` + `["i32"]` → `"List<i32>"`).
     /// `method_type_args` are stored separately (not embedded in `method_name`).
     /// The base struct name and the trait are preserved (not changed by type
     /// args).
@@ -1110,7 +1111,7 @@ impl LocalMethodName {
         }
     }
 
-    /// Get the full method name including type args (e.g., "transform<i64>")
+    /// Get the full method name including type args (e.g., `"transform<i64>"`)
     #[must_use]
     pub fn full_method_name(&self) -> String {
         if self.method_type_args.is_empty() {
@@ -1597,7 +1598,7 @@ pub enum TypeNameInfo {
     Generic { name: String, args: Vec<String> },
     /// A built-in tuple `[T1, T2, …]` with element names already resolved
     Tuple(Vec<String>),
-    /// Option<T> with inner type name
+    /// `Option<T>` with inner type name
     Option(String),
     /// A function type with param count and return type name
     Function {
@@ -1606,7 +1607,7 @@ pub enum TypeNameInfo {
     },
     /// `Array<T>` (raw Wasm GC array, NOT the user-facing `List<T>` struct)
     BuiltinArray(String),
-    /// Reactive<T> with inner type name
+    /// `Reactive<T>` with inner type name
     Reactive(String),
     /// A reference type - formats as inner type (references stripped)
     Ref(String),

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1360,10 +1360,9 @@ pub fn resolve_module_path(base: &str, relative: &str) -> String {
 
 /// Canonicalize a resolved local module identity to the unique minimal form for
 /// its physical file, relative to `entry_dir`. Composing relative steps from the
-/// importer is not canonical — a path that climbs above `entry_dir` and re-enters
-/// spells the same file two ways, which lexical normalization cannot fold — so
-/// re-anchoring is what lets the loader intern each file once. Empty
-/// `entry_dir` just normalizes.
+/// importer is not canonical — a path climbing above `entry_dir` and re-entering
+/// spells the same file two ways — so re-anchoring is what lets the loader intern
+/// each file once. Empty `entry_dir` just normalizes.
 #[must_use]
 pub fn canonical_local_path(entry_dir: &str, resolved: &str) -> String {
     if entry_dir.is_empty() {
@@ -2507,11 +2506,9 @@ pub fn is_builtin_shape_name(name: &str) -> bool {
 }
 
 /// A receiver name in the form a mangled name may embed, carrying the declaring
-/// module — a bare `&str` cannot become one by accident, only a constructor
-/// below that states why its input is already fq. The mangled spelling is a
-/// rendering ([`Self::to_mangled`]), never parsed back: a `ModuleSource` may
-/// itself contain `/` and `<`, so no split is correct in general, and it cannot
-/// be rebuilt without the interner. Ask the fields instead.
+/// module — a bare `&str` cannot become one by accident. The mangled spelling is
+/// a rendering ([`Self::to_mangled`]), never parsed back: a `ModuleSource` may
+/// itself contain `/` and `<`, so no split is correct in general. Ask the fields.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FqTypeName {
     /// Outermost `&` / `&mut`, when the receiver is a reference shape.

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1,36 +1,8 @@
-//! Name mangling utilities for Wado compiler
-//!
-//! This module centralizes all naming/mangling logic for methods, effects, and other symbols.
-//!
-//! # Naming Conventions
-//!
-//! ## Method Names
-//! - Simple: `{struct_name}::{method_name}` (e.g., `Point::sum`)
-//! - Full: `{filename}/{struct_name}::{method_name}` (e.g., `./geometry.wado/Point::sum`)
-//! - With trait: `{filename}/{struct_name}^{trait_name}::{method_name}` (e.g., `./geometry.wado/Point^Display::fmt`)
-//!
-//! ## Effect Operation Names
-//! - Qualified: `{interface_name}::{operation_name}` (e.g., `Stdout::write_via_stream`)
-//!
-//! ## WASI Names
-//! - Full: `wasi:{package}/{interface}::{function}` (e.g., `wasi:cli/stdout::write-via-stream`)
-//!
-//! ## Module-Qualified Names
-//! - Function: `{module_path}/{function_name}` (e.g., `./utils.wado/helper`)
-//! - Struct: `{module_path}::{struct_name}` (e.g., `./geometry.wado::Point`)
-//!
-//! # Module Path Canonicalization
-//!
-//! Module paths are filesystem representations, not URIs: they are canonicalized
-//! by lexical normalization (`crate::path::normalize`, RFC 3986 §5.2.4
-//! dot-segment semantics) — never percent-encoded — to ensure:
-//! - Same file imported via different paths resolves to same identity
-//! - Always uses `/` separator (platform-agnostic, even on Windows)
-//! - Resolves `.` and `..` segments
-//!
-//! Canonical paths are project-root-relative:
-//! - For projects with `wado.toml`: relative to the directory containing `wado.toml`
-//! - For standalone scripts: relative to the entry point's directory
+//! Every naming and mangling decision in the compiler. A method mangles as
+//! `{module}/{struct}^{trait}::{method}` (the trait half optional), a struct as
+//! `{module}::{name}`, a WASI name as `wasi:{package}/{interface}::{function}`.
+//! Module paths are filesystem representations, not URIs: normalized lexically
+//! ([`crate::path::normalize`]), never percent-encoded, and project-root-relative.
 
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
 use std::fmt;
@@ -71,16 +43,10 @@ pub fn namespace_member_alias(namespace: &str, member: &str) -> String {
 pub const LOCAL_ITEM_ID_SEP: char = '@';
 
 /// Build the internal storage name for a local item declaration: the declared
-/// name plus the `AstId`'s module-local index, unique per declaration site so
-/// same-named local items in different functions never collide in the
-/// module-wide storage tables they're interned into.
-///
-/// Only the `local` index is encoded — never the `AstIdSpace`. The space is a
-/// process-global counter whose value depends on unrelated parse history
-/// (e.g. how many fixtures a parallel golden run compiled first), so encoding
-/// it would leak into mangled WIR names and make compiler output
-/// non-deterministic. The `local` index is dense per module and the module
-/// source already qualifies the name across modules, so it alone suffices.
+/// name plus the `AstId`'s module-local index, so same-named local items in
+/// different functions do not collide in the module-wide storage tables.
+/// Only `local` is encoded, never the `AstIdSpace` — that is a process-global
+/// counter, and encoding it would make mangled WIR names non-deterministic.
 pub fn mangle_local_item_name(name: &str, id: crate::ast::AstId) -> String {
     format!("{name}{LOCAL_ITEM_ID_SEP}{}", id.local())
 }
@@ -583,16 +549,9 @@ pub struct LocalMethodName {
     pub cm_name: Option<String>,
 }
 
-/// Derive the bare base name from a possibly-mangled type/trait name.
-///
-/// `Receiver::mangle` and friends produce names like `Stream<u8>` or
-/// `From<i32>` by appending the type-arg list to the base name; the
-/// reverse — recovering the base by truncating at the first `<` — is
-/// the canonical inverse and lives here so other components stay
-/// agnostic to name-format details (per the wado-compiler CLAUDE
-/// rules: "Use utilities in name.rs to handle name mangling and
-/// monomorphization. Other components must not know the details of
-/// name formats.").
+/// Derive the bare base name from a possibly-mangled type/trait name
+/// (`Stream<u8>` → `Stream`). The canonical inverse of appending a type-arg
+/// list, kept here so no other component has to know the name format.
 pub(crate) fn split_base_name(name: &str) -> &str {
     match name.find('<') {
         Some(i) => &name[..i],
@@ -842,16 +801,11 @@ pub fn display_type_name(mangled: &str) -> String {
     )
 }
 
-/// Decompose a local method mangle into `(receiver, trait, method)`.
-///
-/// - `Point::sum` → `("Point", None, "sum")`
-/// - `Point^Display::fmt` → `("Point", Some("Display"), "fmt")`
-/// - `Stdout::write_via_stream` → `("Stdout", None, "write_via_stream")`
-///
-/// Returns `None` when there is no `::` method separator (a bare
-/// free-function name). The receiver / trait may still carry type-argument
-/// mangling (`Box<i32>^Ord::cmp`); this splits only on the `^` and `::`
-/// separators and does not strip type args.
+/// Decompose a local method mangle into `(receiver, trait, method)`:
+/// `Point^Display::fmt` → `("Point", Some("Display"), "fmt")`. `None` when there
+/// is no `::` separator (a bare free-function name). Splits only on `^` and
+/// `::`, so a receiver or trait keeps its type-argument mangling
+/// (`Box<i32>^Ord::cmp`).
 pub fn split_local_method_name(name: &str) -> Option<(&str, Option<&str>, &str)> {
     let sep = name.find("::")?;
     let (prefix, method) = (&name[..sep], &name[sep + 2..]);
@@ -1209,16 +1163,11 @@ impl LocalMethodName {
         self.trait_name.is_some()
     }
 
-    /// Returns true if this is the synthesized `__call` method on a
-    /// `__Closure_N` functor struct.
-    ///
-    /// Closure functor `__call` methods are inherent methods syntactically
-    /// (`trait_name` is `None`), but they participate in vtable dispatch
-    /// through the `Fn<arity, ret>` canonical type whose Wasm signature is
-    /// fixed. Treating them as ordinary inherent methods (e.g. for ABI
-    /// reshaping like multi-value return) would skew the signature against
-    /// the vtable slot they're installed into, so callers that reshape
-    /// ABIs need to filter them out.
+    /// True for the synthesized `__call` on a `__Closure_N` functor struct.
+    /// Syntactically these are inherent methods, but they dispatch through the
+    /// `Fn<arity, ret>` canonical type, whose Wasm signature is fixed — so a
+    /// caller that reshapes ABIs must filter them out or the signature will no
+    /// longer match the vtable slot they are installed into.
     pub fn is_closure_call(&self) -> bool {
         self.method_name == CLOSURE_CALL_METHOD
             && self
@@ -1257,16 +1206,8 @@ impl From<MethodName> for FunctionId {
     }
 }
 
-/// A qualified struct type name.
-///
-/// Format: `{module_path}/{name}`
-///
-/// Examples:
-/// - `./geometry.wado/Point`
-/// - `core/rt/SomeType`
-///
-/// Note: When traits are added to Wado, this may need to evolve into a more
-/// general `TypeId` enum (similar to `FunctionId`) to handle trait types.
+/// A qualified struct type name, `{module_path}/{name}` — e.g.
+/// `./geometry.wado/Point`, `core/rt/SomeType`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StructName {
     /// The module where the struct is defined
@@ -1362,23 +1303,11 @@ fn has_special_prefix(path: &str) -> bool {
         || path.starts_with("http://")
 }
 
-/// Normalize a module path.
-///
-/// A module path is a filesystem representation, not a URI: it is normalized
-/// lexically via [`crate::path::normalize`] (resolve `.`/`..`, collapse
-/// duplicate slashes, unify separators to `/`) and never percent-encoded, so
-/// URI-unsafe characters such as spaces survive intact. Special prefixes
-/// (`core:` / `wasi:` / `http://` / `https://`) are opaque identifiers and are
-/// returned verbatim.
-///
-/// This function is infallible: every filesystem path normalizes.
-///
-/// Examples:
-/// - `./geometry.wado` → `./geometry.wado`
-/// - `./sub/../geometry.wado` → `./geometry.wado`
-/// - `./sub/./nested/../file.wado` → `./sub/file.wado`
-/// - `foo//bar.wado` → `foo/bar.wado`
-/// - `/home/user/My Project/x.wado` → `/home/user/My Project/x.wado`
+/// Normalize a module path lexically via [`crate::path::normalize`] — resolve
+/// `.`/`..`, collapse duplicate slashes, unify separators to `/`. Never
+/// percent-encoded, so a space survives intact. Special prefixes (`core:`,
+/// `wasi:`, `http://`, `https://`) are opaque and returned verbatim. Infallible:
+/// every filesystem path normalizes.
 pub fn normalize_module_path(path: &str) -> String {
     if has_special_prefix(path) {
         return path.to_string();
@@ -1395,16 +1324,9 @@ pub fn try_normalize_module_path(path: &str) -> Result<String, String> {
     Ok(normalize_module_path(path))
 }
 
-/// Resolve a relative module path against a base module path.
-///
-/// This function resolves import paths relative to the importing module's path,
-/// producing a canonical path from the project root.
-///
-/// Examples:
-/// - base: `./main.wado`, relative: `./geometry.wado` → `./geometry.wado`
-/// - base: `./sub/main.wado`, relative: `./utils.wado` → `./sub/utils.wado`
-/// - base: `./sub/main.wado`, relative: `../lib.wado` → `./lib.wado`
-/// - base: `./a/b/main.wado`, relative: `../../c.wado` → `./c.wado`
+/// Resolve an import path against the importing module's path, producing a path
+/// canonical from the project root — base `./sub/main.wado` with relative
+/// `../lib.wado` gives `./lib.wado`.
 pub fn resolve_module_path(base: &str, relative: &str) -> String {
     // Handle special module prefixes - they don't need resolution
     if relative.starts_with("core:")
@@ -1436,16 +1358,12 @@ pub fn resolve_module_path(base: &str, relative: &str) -> String {
     normalize_module_path(&joined)
 }
 
-/// Canonicalize a resolved local module identity to the unique minimal form
-/// for its physical file, relative to the entry directory `entry_dir`.
-///
-/// Composing relative steps from the importer ([`resolve_module_path`]) is not
-/// canonical: a path that climbs *above* `entry_dir` and re-enters spells the
-/// same file non-minimally (`../src/gen/p.wado` vs `./gen/p.wado`), which
-/// lexical normalization cannot fold. Re-anchoring under `entry_dir` gives one
-/// identity per file on every import path, so the loader interns each once
-/// (#1423). Empty `entry_dir` (no entry context) returns the input normalized
-/// and otherwise unchanged, so such callers never regress.
+/// Canonicalize a resolved local module identity to the unique minimal form for
+/// its physical file, relative to `entry_dir`. Composing relative steps from the
+/// importer is not canonical — a path that climbs above `entry_dir` and re-enters
+/// spells the same file two ways, which lexical normalization cannot fold — so
+/// re-anchoring is what lets the loader intern each file once. Empty
+/// `entry_dir` just normalizes.
 #[must_use]
 pub fn canonical_local_path(entry_dir: &str, resolved: &str) -> String {
     if entry_dir.is_empty() {
@@ -1495,16 +1413,8 @@ pub fn resolve_local_identity(entry_dir: &str, from_path: &str, import_source: &
     canonical_local_path(entry_dir, &resolve_module_path(from_path, import_source))
 }
 
-/// Resolve an import source to a `ModuleSource`.
-///
-/// This is the primary function for resolving import paths to module identifiers.
-///
-/// # Arguments
-/// * `from_module` - The `ModuleSource` of the importing module
-/// * `import_source` - The import source string (e.g., `"./geometry.wado"` or `"core:cli"`)
-///
-/// # Returns
-/// The resolved `ModuleSource`.
+/// Resolve an import source (`"./geometry.wado"`, `"core:cli"`) against the
+/// importing module.
 pub fn resolve_import(
     interner: &mut ModuleSourceInterner,
     from_module: &ModuleSource,
@@ -1514,16 +1424,10 @@ pub fn resolve_import(
 }
 
 /// Resolve an import source, consulting a Kiln [`crate::kiln::InvocationIndex`]
-/// first.
-///
-/// When the `(from_module, import_source)` pair matches a recorded invocation,
-/// the returned [`ModuleSource`] points at the invocation's generated entry
-/// module (under `build/kiln/…`). Otherwise falls back to
-/// [`resolve_import_with_entry`] unchanged.
-///
-/// Call this in place of [`resolve_import`] wherever an `InvocationIndex` is
-/// available — typically the CLI and LSP compile entry points, after the
-/// Kiln pipeline has populated the index.
+/// first: a recorded `(from_module, import_source)` pair resolves to the
+/// invocation's generated entry module under `build/kiln/…`, everything else
+/// falls through to [`resolve_import_with_entry`]. Use this in place of
+/// [`resolve_import`] wherever an index is available.
 pub fn resolve_import_with_invocations(
     interner: &mut ModuleSourceInterner,
     from_module: &ModuleSource,
@@ -1642,20 +1546,10 @@ pub fn canonicalize_entry_point(filename: &str) -> String {
     format!("./{name}")
 }
 
-/// Convert a filesystem path to a canonical module path.
-///
-/// This function:
-/// - Converts backslashes to forward slashes (Windows compatibility)
-/// - Makes the path relative to project root (removes absolute prefix)
-/// - Ensures the path starts with `./`
-///
-/// The `project_root` is the absolute path to the project root directory.
-/// The `file_path` is the absolute path to the module file.
-///
-/// Example:
-/// - `project_root`: `/home/user/project`
-/// - `file_path`: `/home/user/project/src/lib.wado`
-/// - result: `./src/lib.wado`
+/// Convert an absolute filesystem path to a canonical module path: separators
+/// unified to `/`, the absolute `project_root` prefix stripped, and a leading
+/// `./` ensured. `/home/user/project` + `/home/user/project/src/lib.wado` gives
+/// `./src/lib.wado`.
 pub fn filesystem_to_module_path(project_root: &str, file_path: &str) -> Option<String> {
     // Normalize separators to forward slashes
     let root = project_root.replace('\\', "/");
@@ -1745,16 +1639,10 @@ pub fn format_type_name(info: TypeNameInfo) -> String {
     }
 }
 
-/// Build a monomorphized type name from base name and type arguments.
-///
-/// The tuple head is spelled `[a,b]`, not `[]<a,b>` — the one spelling
+/// Build a monomorphized type name: `("Box", ["i32"])` → `"Box<i32>"`. The tuple
+/// head is spelled `[i32,i32]`, not `[]<i32,i32>` — the one spelling
 /// [`FqTypeName::to_mangled`] gives it, so an instantiated tuple receiver and a
-/// concrete tuple impl (`impl Trait for [i32, i32]`) name the same function.
-///
-/// Examples:
-/// - `mangle_generic_name("Box", &["i32"])` → `"Box<i32>"`
-/// - `mangle_generic_name("Map", &["String", "i32"])` → `"Map<String,i32>"`
-/// - `mangle_generic_name("[]", &["i32", "i32"])` → `"[i32,i32]"`
+/// concrete `impl Trait for [i32, i32]` name the same function.
 pub fn mangle_generic_name(base_name: &str, type_args: &[String]) -> String {
     if type_args.is_empty() {
         base_name.to_string()
@@ -1775,17 +1663,10 @@ pub fn mangle_tuple_type(elems: &[String]) -> String {
 pub const TUPLE_TYPE_NAME: &str = "[]";
 
 /// A name in the *declaration* namespace: what source writes, what an `impl`
-/// header spells, and what every by-name declaration lookup keys on — module
-/// scope (`struct_fields`, `enum_case`, …), the CM interface registry,
-/// go-to-definition.
-///
-/// Distinct from a mangled name, which carries the declaring module and which
-/// no declaration lookup stores. Every naming defect in WEP 2026-07-28 was one
-/// substituted for the other, and both being `String` is what let that compile.
-/// So this deliberately has no `Deref<Target = str>`, no `AsRef<str>` and no
-/// `From<String>`: it is minted by the authorities that know the namespace —
-/// [`FqTypeName`], [`Receiver`], [`crate::tir::TypeTable`] — and read back only
-/// through [`Self::as_decl_str`], which names what it is handing out.
+/// header spells, what every by-name declaration lookup keys on — as opposed to
+/// a mangled name, which carries the declaring module and which no such lookup
+/// stores. Deliberately no `Deref`, `AsRef<str>` or `From<String>`: substituting
+/// one namespace for the other is the defect this type exists to stop compiling.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct DeclName(String);
 
@@ -2097,22 +1978,11 @@ pub fn cm_wrap_async_func_name(interface_name: &str, method_name: &str) -> Strin
     format!("__cm_wrap_async__{interface_name}_{method_name}")
 }
 
-/// Convert a user-facing `test "name"` string into the snake-case segment used
-/// in the internal test function name (`__test_{index}_{snake}`).
-///
-/// Only **ASCII** alphanumerics survive verbatim (lowercased); every other
-/// character — including non-ASCII letters such as `é` or `日` — collapses to
-/// `_`. This is deliberate: the segment must downgrade losslessly into a
-/// Component Model kebab-case export name (`[a-z0-9-]+`) via
-/// `sanitize_kebab_export_name`. Using Unicode-aware `char::is_alphanumeric`
-/// here would let multibyte letters through and produce an invalid extern name,
-/// crashing Wasm validation. The original (lossless) name is preserved
-/// separately for display and filtering — see the test-name custom section.
-///
-/// Examples:
-/// - `test_name_to_snake("Hello, World!")` → `"hello__world_"`
-/// - `test_name_to_snake("café résumé")` → `"caf__r_sum_"`
-/// - `test_name_to_snake("日本語のテスト ok")` → `"________ok"`
+/// Convert a `test "name"` string into the snake-case segment of the internal
+/// test function name: `"café résumé"` → `"caf__r_sum_"`. Only ASCII
+/// alphanumerics survive — Unicode-aware `is_alphanumeric` would let multibyte
+/// letters through and produce an extern name Wasm validation rejects. The
+/// lossless name is kept separately in the test-name custom section.
 pub fn test_name_to_snake(name: &str) -> String {
     name.chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
@@ -2120,17 +1990,11 @@ pub fn test_name_to_snake(name: &str) -> String {
         .to_lowercase()
 }
 
-/// Build the exported function name for a test block. The prefix encodes the
-/// test's attributes, the index disambiguates anonymous tests, and `name` (when
-/// present) is appended as an ASCII snake-case segment via [`test_name_to_snake`].
-///
-/// - `__test_{index}` / `__test_{index}_{snake}` — plain
-/// - `__test_trap_…` — `#[expect_trap]`
-/// - `__test_todo_…` — `#[TODO]` (or module-level `#[TODO]`)
-/// - `__test_tm{ms}_…` — `#[timeout_ms(ms)]` (combines: `__test_trap_tm{ms}_…`)
-///
-/// The single source of this format: both the annotate walk and reify call here
-/// so the two never drift.
+/// Build a test block's exported name: `__test_{index}[_{snake}]`, with the
+/// prefix encoding attributes — `__test_trap_…` for `#[expect_trap]`,
+/// `__test_todo_…` for `#[TODO]`, `__test_tm{ms}_…` for `#[timeout_ms]`, and
+/// combinations such as `__test_trap_tm{ms}_…`. Both the annotate walk and reify
+/// call here, so the two cannot drift.
 pub fn test_function_name(
     meta: &crate::ast::TestMetadata,
     test_index: usize,
@@ -2642,26 +2506,12 @@ pub fn is_builtin_shape_name(name: &str) -> bool {
         )
 }
 
-/// A receiver name in the form a mangled name may embed.
-///
-/// An fq name names its subject by the module that declares it, so a receiver
-/// written into `Type::method` / `Type^Trait::method` must already carry that
-/// module. The type exists to make the rule unforgeable: a bare `&str` read off
-/// source text or off a `ResolvedType`'s `name` field cannot become a mangled
-/// name by accident — it has to pass through one of the constructors below,
-/// each of which states why its input is already fq.
-///
-/// The mangled spelling is a *rendering* ([`Self::to_mangled`]), produced on
-/// demand and never parsed back. Every question a caller used to answer by
-/// splitting the string — the declaring module, the declaration name, the type
-/// arguments — is a field access here.
-///
-/// Splitting a rendered name apart is what this type exists to prevent. A
-/// `ModuleSource` may itself contain `/` and `<`, and a type argument carries
-/// its own module path, so no split on `/`, `<` or `,` is correct in general.
-/// A rendered name is also not reversible: `ModuleSource` cannot be rebuilt
-/// without the interner, so there is deliberately no constructor from a
-/// mangled string.
+/// A receiver name in the form a mangled name may embed, carrying the declaring
+/// module — a bare `&str` cannot become one by accident, only a constructor
+/// below that states why its input is already fq. The mangled spelling is a
+/// rendering ([`Self::to_mangled`]), never parsed back: a `ModuleSource` may
+/// itself contain `/` and `<`, so no split is correct in general, and it cannot
+/// be rebuilt without the interner. Ask the fields instead.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FqTypeName {
     /// Outermost `&` / `&mut`, when the receiver is a reference shape.
@@ -2898,18 +2748,11 @@ impl std::fmt::Display for FqTypeName {
     }
 }
 
-/// The trait half of a `Type^Trait::method` mangle.
-///
-/// The receiver half already names its subject by the module that declares it;
-/// the trait half has to answer the same question or two same-named traits
-/// implemented for one type mangle to one name and one impl overwrites the
-/// other. So the head is the trait's *declaration* — never the spelling a use
-/// site wrote, which an alias or another module's import can change — and the
-/// declaring module travels with it.
-///
-/// Type arguments (`Stream<u8>`) are carried already-mangled: they make a
-/// generic trait's per-instantiation method names distinct and are never read
-/// back apart.
+/// The trait half of a `Type^Trait::method` mangle. The head is the trait's
+/// *declaration*, with its declaring module — never the spelling a use site
+/// wrote, which an alias or another module's import can change — or two
+/// same-named traits implemented for one type would mangle alike and one impl
+/// would overwrite the other. Type arguments are carried already-mangled.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FqTraitName {
     head: TypeHead,

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -1,6 +1,6 @@
 //! Every naming and mangling decision in the compiler. A method mangles as
 //! `{module}/{struct}^{trait}::{method}` (the trait half optional), a struct as
-//! `{module}::{name}`, a WASI name as `wasi:{package}/{interface}::{function}`.
+//! `{module}/{name}`, a WASI name as `wasi:{package}/{interface}::{function}`.
 //! Module paths are filesystem representations, not URIs: normalized lexically
 //! ([`crate::path::normalize`]), never percent-encoded, and project-root-relative.
 

--- a/wado-compiler/src/nir.rs
+++ b/wado-compiler/src/nir.rs
@@ -1,16 +1,8 @@
-//! Normalized Intermediate Representation (NIR) for Wado.
-//!
-//! NIR is the post-lower body IR consumed by `optimize` and `wir_build`. The
-//! body itself lives in the skeleton arena (`crate::nir_arena`); this module
-//! holds the surrounding NIR metadata — functions, globals, parameters,
-//! locals, captures, function references, and the shared leaf enums
-//! (`NirBinaryOp` / `NirUnaryOp` / `NirLiteralPattern`) the arena nodes
-//! reference.
-//!
-//! Type identity (`TypeId`, `TypeTable`, `ResolvedType`, …) and effect
-//! references (`EffectRef`) are shared with TIR.
-//!
-//! See `docs/wep-2026-05-11-nir.md` for the full rationale.
+//! Normalized Intermediate Representation (NIR): the post-lower body IR
+//! `optimize` and `wir_build` consume. Bodies live in the skeleton arena
+//! (`crate::nir_arena`); this module holds the metadata around them — functions,
+//! globals, params, locals, captures, refs, and the shared leaf enums. Type
+//! identity and `EffectRef` are shared with TIR. See WEP 2026-05-11.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -450,20 +442,11 @@ pub enum FunctionKind {
     /// `type_id`. Calls to such functions may be elided when the argument is
     /// provably fresh.
     ValueCopy { type_id: TypeId },
-    /// Auto-derived `Fn<arity, return_type>^Inspect::inspect` (or
-    /// `^InspectAlt::inspect_alt`) dispatch stub.
-    ///
-    /// The NIR body is `unreachable()` — a placeholder that exists
-    /// only so the function is registered and the call is resolvable
-    /// from templates and from user code. WIR build recognises this
-    /// kind and supplies the real body: a `call_ref` through the
-    /// matching `CanonicalClosure_K`'s `inspect` / `inspect_alt`
-    /// vtable slot. Carries `(arity, return_type)` as structured
-    /// fields so neither WIR build nor DCE has to recover them by
-    /// parsing the mangled function name.
-    ///
-    /// See WEP: Inspect (Debug Output) > Closure Inspect via Runtime
-    /// Dispatch.
+    /// Auto-derived `Fn<arity, return_type>^Inspect::inspect` dispatch stub. Its
+    /// NIR body is `unreachable()`, a placeholder making the call resolvable;
+    /// WIR build recognises the kind and supplies a `call_ref` through the
+    /// matching `CanonicalClosure_K` vtable slot. `(arity, return_type)` are
+    /// structured fields so nothing has to parse the mangled name.
     FnCanonicalDispatch {
         trait_kind: FnDispatchTrait,
         arity: usize,
@@ -596,21 +579,11 @@ impl NirFunction {
     }
 }
 
-/// A resolved local-slot entry in a function, global initializer, or
-/// closure scope, identified by its declaration / order in the surrounding
-/// local environment.
-///
-/// `FunctionContext::add_local` records every local — source-level
-/// parameters, `let` bindings, destructure bindings, and elaborator-generated
-/// temporaries — as a `NirLocal`. The single source of truth for the local
-/// namespace is `FunctionContext::locals: Vec<NirLocal>`; from there it is
-/// projected onto:
-///
-/// * `NirFunction::locals` and `NirGlobal::locals` — the function/global's
-///   absolute local table, keyed by Wasm local index.
-/// * A closure's `params + body_locals` — pattern lowering reconstructs the
-///   closure-scope local table from these while descending into a closure
-///   body (params are not duplicated in `body_locals`).
+/// A resolved local-slot entry in a function, global initializer, or closure
+/// scope, identified by its order in the surrounding local environment.
+/// `FunctionContext::locals` is the single source of truth, projected onto
+/// `NirFunction::locals` / `NirGlobal::locals` (keyed by Wasm local index) and
+/// onto a closure's `params + body_locals`, which do not overlap.
 #[derive(Debug, Clone)]
 pub struct NirLocal {
     /// Source-level name of the binding (or a synthesised `__name` for
@@ -872,16 +845,11 @@ pub struct ClosureFunctor {
     pub call_method: Rc<RefCell<NirFunction>>,
     /// Captures from the original closure
     pub captures: Vec<NirCapture>,
-    /// Canonical user-declared (name, type) pairs of the closure literal —
-    /// `[]` for `|| ...`, `[("x", i32)]` for `|x: i32| ...`. Captured at
-    /// functor creation and never mutated. `wir_build`'s
-    /// `register_closure_wrappers` uses this list to choose the wrapper's
-    /// external signature: the function-table type the closure was coerced
-    /// to is `fn(env, canonical_user_params...) -> canonical_return`,
-    /// independent of any DAE shrinkage that happens later on
-    /// `call_method.params`. Without this snapshot, dropping a "dead" param
-    /// from `__call` would also shrink the wrapper signature and
-    /// desynchronise it from the typed-fn callers.
+    /// Canonical user-declared (name, type) pairs of the closure literal,
+    /// captured at functor creation and never mutated.
+    /// `register_closure_wrappers` reads it for the wrapper's external signature
+    /// `fn(env, canonical_user_params...) -> canonical_return`, so later DAE
+    /// shrinkage on `call_method.params` cannot desynchronise typed-fn callers.
     pub canonical_user_params: Vec<(String, TypeId)>,
     /// Canonical return type of the closure literal. Same role as
     /// `canonical_user_params` — drives the wrapper external signature.

--- a/wado-compiler/src/nir.rs
+++ b/wado-compiler/src/nir.rs
@@ -217,7 +217,8 @@ pub struct NirTypeParam {
 /// Information about monomorphization origin for instantiated items
 #[derive(Debug, Clone)]
 pub struct MonomorphInfo {
-    /// Original generic name (e.g., "Box" for "Box<i32>", or "`BTreeNode`<`K,V>::insert`" for methods)
+    /// Original generic name: `"Box"` for `"Box<i32>"`, or
+    /// `"BTreeNode<K,V>::insert"` for methods.
     pub generic_name: String,
     /// Impl-level type arguments (from the struct/type, e.g. `[i32]` for `List<i32>`)
     pub impl_type_args: Vec<TypeId>,

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -1403,7 +1403,7 @@ impl Body {
     /// structural children (blocks, patterns) are not operands and are skipped.
     ///
     /// This and [`Body::for_each_child`] filter one description of the node
-    /// structure ([`Slot`]), so a variant added to the arena cannot be seen by
+    /// structure (`Slot`), so a variant added to the arena cannot be seen by
     /// one and missed by the other.
     pub fn for_each_operand(&self, node: NodeRef, mut f: impl FnMut(Operand)) {
         self.for_each_slot(node, &mut |slot| {

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -1,17 +1,8 @@
-//! NIR skeleton arena (Layer 1).
-//!
-//! A per-function arena representation of a NIR body: every node lives in a
-//! `PrimaryMap` keyed by a typed id (`ExprId` / `StmtId` / `BlockId` / `PatId`)
-//! and references its children by id. This is the substrate the worklist
-//! rewrite engine needs: stable handles that survive in-place edits.
-//!
-//! This module owns the representation, structural traversal
-//! (`for_each_child`), and structural cloning (`clone_expr` / `clone_block`).
-//! The parent map, the local use index, and the mutating edit API live on the
-//! rewrite [`crate::nir_engine::Engine`] that consumes this arena, not on
-//! `Body` itself (so they don't burden every body). `lower::translate` builds
-//! the arena directly — there is no tree representation to convert from. See
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`.
+//! NIR skeleton arena (Layer 1): a per-function body whose nodes live in
+//! `PrimaryMap`s keyed by typed ids and reference their children by id, giving
+//! the rewrite engine handles that survive in-place edits. This module owns the
+//! representation, traversal, and cloning; the parent map, use index and edit
+//! API sit on [`crate::nir_engine::Engine`]. See WEP 2026-06-05.
 
 use cranelift_entity::{EntityRef, PrimaryMap, entity_impl};
 
@@ -636,17 +627,10 @@ impl Body {
 }
 
 /// A NIR expression stored as an arena [`Body`] whose root block holds exactly
-/// one `Expr` statement. This is how single-expression NIR positions (global
-/// initializers) are represented so the optimizer engine and the arena passes
-/// can operate on them uniformly, while the wrapped expression stays directly
-/// reachable via [`ExprBody::expr`].
-///
-/// The newtype localizes the "root block = one `Expr` statement" invariant:
-/// it is established at construction (`from_body` / `wrapping`) and read
-/// through `expr()`, instead of every consumer rediscovering it via a bare
-/// `Body::sole_expr` on a plain `Body`. Passes that need to run the rewrite
-/// engine or mutate the body in place go through `body_mut()`, which keeps the
-/// single-`Expr`-statement shape (engine rules at a global are expr-local).
+/// one `Expr` statement — how a single-expression position such as a global
+/// initializer is represented, so the engine and arena passes handle it like any
+/// body. The newtype localizes that invariant: established at construction, read
+/// through `expr()`, and preserved by `body_mut()`.
 #[derive(Debug, Clone)]
 pub struct ExprBody {
     body: Body,
@@ -1232,16 +1216,11 @@ impl Body {
         counts
     }
 
-    /// Invoke `f` on every operand slot of `node`, in source order — the
-    /// mutable twin of [`Body::for_each_operand`]. Non-operand `ExprId` slots
-    /// (`Assign::target`) and structural children (blocks, patterns) are not
-    /// operands and are not visited.
-    ///
-    /// A `&mut` walk cannot be a filter over the shared [`Slot`] one, so this
-    /// match restates the operand positions. A debug assertion compares its
-    /// slot count against [`Body::for_each_operand`] on every call, so a variant
-    /// taught to one and not the other fails the first test that reaches that
-    /// node kind.
+    /// Invoke `f` on every operand slot of `node`, in source order — the mutable
+    /// twin of [`Body::for_each_operand`]. Non-operand `ExprId` slots and
+    /// structural children are skipped. A `&mut` walk cannot filter the shared
+    /// [`Slot`] one, so the match is restated here; a debug assertion compares
+    /// the two slot counts on every call.
     pub fn for_each_operand_mut(&mut self, node: NodeRef, mut f: impl FnMut(&mut Operand)) {
         #[cfg(debug_assertions)]
         let expected = {

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -1219,7 +1219,7 @@ impl Body {
     /// Invoke `f` on every operand slot of `node`, in source order — the mutable
     /// twin of [`Body::for_each_operand`]. Non-operand `ExprId` slots and
     /// structural children are skipped. A `&mut` walk cannot filter the shared
-    /// [`Slot`] one, so the match is restated here; a debug assertion compares
+    /// `Slot` one, so the match is restated here; a debug assertion compares
     /// the two slot counts on every call.
     pub fn for_each_operand_mut(&mut self, node: NodeRef, mut f: impl FnMut(&mut Operand)) {
         #[cfg(debug_assertions)]

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -2,8 +2,7 @@
 //! [`Body`] to a fixed point, visiting a node only when it might be reducible
 //! rather than re-walking the whole tree per pass. Provides the session — parent
 //! map, local use index and worklist, built once per function — the edit API
-//! that keeps both indices coherent, the [`Rule`] trait, and the `run` driver.
-//! Genuinely-local peephole passes run as rules over it. See WEP 2026-06-05.
+//! that keeps both coherent, the [`Rule`] trait, and `run`. See WEP 2026-06-05.
 
 use std::cell::OnceCell;
 use std::collections::VecDeque;
@@ -327,9 +326,7 @@ impl<'a> Engine<'a> {
     /// Re-derive `expr`'s value from its operands — the sole value source now
     /// that `value_of` is retired. Operand-determined kinds only, plus a read of
     /// a stable parameter; every other kind, and any unresolved operand, gives
-    /// `None`. Recurses through [`Engine::operand_value`], so a pure subtree over
-    /// promoted leaves resolves whole. The parameter base case is load-bearing:
-    /// without it every leaf of an unpromoted tree is `None`, so only
+    /// `None`. The parameter base case is load-bearing: without it only
     /// all-constant trees resolve and no promoted value can name a local.
     fn maintain_pure_node(&mut self, expr: ExprId) -> Option<crate::nir_value_graph::ValueId> {
         self.body.value_graph.as_ref()?;
@@ -416,10 +413,8 @@ impl<'a> Engine<'a> {
     /// Every read whose reaching value the use site can re-emit, recovered by a
     /// scratch re-walk — the same splice-point growth `inline` uses, with no live
     /// rebuild. Covers a `Local` read of anything in `forwardable`, plus a
-    /// `FieldAccess` under `include_fields`; what disqualifies a local is being
-    /// address-taken or `stores`-aliased, not being an aggregate. The re-walk
-    /// exists because SROA adds stores after the build-once graph, so those reads
-    /// carry no value. Empty when there is no graph to grow.
+    /// `FieldAccess` under `include_fields`; being address-taken or
+    /// `stores`-aliased disqualifies a local, being an aggregate does not.
     pub fn scoped_const_reads(
         &mut self,
         forwardable: &IndexSet<u32>,
@@ -785,11 +780,8 @@ impl<'a> Engine<'a> {
     /// Build the session's three indices — parent map, local use index, and
     /// post-order worklist seed — in one walk of the live tree. Not an arena
     /// scan: the arena never compacts, and an orphan still referencing a live
-    /// node would overwrite its parent edge, leaving a rule to edit the orphan
-    /// while the live tree kept the stale shape. Within the live tree two parents
-    /// is corruption, hence the panic. Parents and uses are recorded descending,
-    /// the worklist ascending, so leaves are enqueued before the contexts that
-    /// fold them.
+    /// node would overwrite its parent edge. Parents and uses are recorded
+    /// descending, the worklist ascending, so leaves fold before their contexts.
     fn build_indices(&mut self) {
         let mut stack = std::mem::take(&mut self.buf.walk_stack);
         let mut children = std::mem::take(&mut self.buf.walk_children);
@@ -981,9 +973,7 @@ impl<'a> Engine<'a> {
     /// An interned value is immutable, so only a change in which operands are
     /// reachable moves the answer. An empty census survives a removal — nothing
     /// conjures a read — and survives an attach unless something local-naming is
-    /// pending, since a node allocated detached and spliced in later can be
-    /// missed by a fill in between. A non-empty one can shrink as well as grow,
-    /// so any edit drops it.
+    /// pending. A non-empty one can shrink as well as grow, so any edit drops it.
     fn census_note_structure(&mut self) {
         if self.pending_local_naming.get()
             || self.promoted_reads.get().is_some_and(|c| !c.is_empty())
@@ -1154,10 +1144,8 @@ impl<'a> Engine<'a> {
     /// Edit API: promote `src`'s content into `dst`, leaving `src` a dead `Unit`
     /// — the arena analogue of `*dst = *src` when a rewrite collapses a wrapper
     /// onto a node it contains (`{ expr; }` → `expr`). `dst`'s former subtree is
-    /// discarded without deep-unregistering its `Local` mentions: a stale mention
-    /// only reaches `is_local_read`, where an extra dead one is conservative,
-    /// keeping a binding alive but never dropping a live one. `src`'s own mention
-    /// is moved off it so nothing dangles.
+    /// discarded without deep-unregistering its `Local` mentions: a stale one
+    /// only reaches `is_local_read`, where an extra dead mention is conservative.
     pub fn become_expr(&mut self, dst: ExprId, src: ExprId) {
         if dst == src {
             return;

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -272,7 +272,7 @@ pub struct Engine<'a> {
 impl<'a> Engine<'a> {
     /// Build a session over `body`, reusing the caller-owned `buf`: one O(n)
     /// walk populates the parent map and use index and seeds the worklist in
-    /// post-order (see [`Engine::build_indices`]). `locals` is the owning
+    /// post-order (see `Engine::build_indices`). `locals` is the owning
     /// function's local list (see [`Engine::alloc_local`]).
     pub fn new(
         body: &'a mut Body,
@@ -368,8 +368,8 @@ impl<'a> Engine<'a> {
         Some(v)
     }
 
-    /// The [`ValueId`] of an operand: the promoted value directly, or the
-    /// skeleton expr's value from the graph.
+    /// The [`ValueId`](crate::nir_value_graph::ValueId) of an operand: the
+    /// promoted value directly, or the skeleton expr's value from the graph.
     pub fn operand_value(&mut self, op: Operand) -> Option<crate::nir_value_graph::ValueId> {
         match op {
             Operand::Value(v) => Some(v),
@@ -635,7 +635,7 @@ impl<'a> Engine<'a> {
     }
 
     /// Supply the pure-builtin callee ids so the value-graph build classifies a
-    /// call's heap effect by `func_id`. See [`Engine::pure_builtin_callees`].
+    /// call's heap effect by `func_id`. See `Engine::pure_builtin_callees`.
     /// Must be set before the first value query to take effect (the graph is
     /// built once and reused).
     pub fn set_pure_builtin_callees(&mut self, ids: &'a IndexSet<crate::nir::FuncId>) {

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -304,13 +304,13 @@ impl<'a> Engine<'a> {
         engine
     }
 
-    /// The [`ValueId`] the per-function `ValueGraph` assigned to `expr`, built
+    /// The `ValueId` the per-function `ValueGraph` assigned to `expr`, built
     /// lazily; `None` for an impure, allocation-bearing or control-flow
     /// expression, and for any `ExprId` allocated after the build.
     ///
     /// The graph is built once and maintained in place, never rebuilt: engine
     /// edits keep the operands current and a query re-derives through them
-    /// ([`Engine::maintain_pure_node`]), a direct arena edit coarsens the region
+    /// (`Engine::maintain_pure_node`), a direct arena edit coarsens the region
     /// it touched, and a caller needing the reaching values regrows them into a
     /// scratch pool ([`Engine::scoped_const_reads`]).
     pub fn value(&mut self, expr: ExprId) -> Option<crate::nir_value_graph::ValueId> {
@@ -698,7 +698,7 @@ impl<'a> Engine<'a> {
     }
 
     /// Whether `local` is **single-assignment** — bound once, never written again
-    /// — which is what makes [`ValuePool::canonical_local`]'s one id per index
+    /// — which is what makes `ValuePool::canonical_local`'s one id per index
     /// denote one value. Holds per *execution* of the binding's scope, so a `let`
     /// in a loop body qualifies while naming its value across an iteration needs
     /// its own check (`materialise_point`'s refusal to place outside the loop).

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -1,19 +1,9 @@
-//! NIR rewrite engine (Phase 4).
-//!
-//! A worklist-driven engine that runs local (peephole) rewrites over one
-//! function's [`Body`] to a local fixed point — visiting a node only when it
-//! might be reducible, rather than the ~31 whole-tree passes the current
-//! optimizer runs in a global fixed point.
-//!
-//! See `docs/wep-2026-06-05-nir-optimizer-architecture.md`.
-//!
-//! The module provides the full engine: the *session* (the parent map, the
-//! local use index, and the worklist, built once per function from a `Body`),
-//! the mutating edit API (`replace_expr_kind`, `set_block_stmts`,
-//! `alloc_*`, `clone_expr`) that keeps the parent map and use index coherent,
-//! the [`Rule`] trait, and the `run` driver. Genuinely-local peephole passes
-//! (`select_lowering`, `match_to_switch`, `string_push`, `array_literal`,
-//! `elide_local`) run as rules over it.
+//! NIR rewrite engine: a worklist driving local rewrites over one function's
+//! [`Body`] to a fixed point, visiting a node only when it might be reducible
+//! rather than re-walking the whole tree per pass. Provides the session — parent
+//! map, local use index and worklist, built once per function — the edit API
+//! that keeps both indices coherent, the [`Rule`] trait, and the `run` driver.
+//! Genuinely-local peephole passes run as rules over it. See WEP 2026-06-05.
 
 use std::cell::OnceCell;
 use std::collections::VecDeque;
@@ -315,20 +305,15 @@ impl<'a> Engine<'a> {
         engine
     }
 
-    /// Return the [`ValueId`] of `expr` if the per-function `ValueGraph`
-    /// assigned one. Returns `None` for impure / allocation-bearing /
-    /// control-flow expressions and for any `ExprId` allocated after the
-    /// cache was built. Built lazily on first call.
+    /// The [`ValueId`] the per-function `ValueGraph` assigned to `expr`, built
+    /// lazily; `None` for an impure, allocation-bearing or control-flow
+    /// expression, and for any `ExprId` allocated after the build.
     ///
-    /// # Maintenance contract
-    ///
-    /// The graph is built once and maintained in place — there is no rebuild.
-    /// Edits via the engine API (`replace_expr_kind` / `redirect_expr`) keep the
-    /// operands current, and a query re-derives through them
-    /// ([`Engine::maintain_pure_node`]); a structural pass that edits the arena
-    /// directly (`inline`) coarsens the touched region, and a caller that needs
-    /// the reaching values back regrows them into a scratch pool
-    /// ([`Engine::scoped_const_reads`]).
+    /// The graph is built once and maintained in place, never rebuilt: engine
+    /// edits keep the operands current and a query re-derives through them
+    /// ([`Engine::maintain_pure_node`]), a direct arena edit coarsens the region
+    /// it touched, and a caller needing the reaching values regrows them into a
+    /// scratch pool ([`Engine::scoped_const_reads`]).
     pub fn value(&mut self, expr: ExprId) -> Option<crate::nir_value_graph::ValueId> {
         self.ensure_value_graph();
         // There is no skeleton-expr → value side-table. An expr's value comes
@@ -339,17 +324,13 @@ impl<'a> Engine<'a> {
         self.maintain_pure_node(expr)
     }
 
-    /// Re-derive `expr`'s value from its operands (the sole value source now
-    /// that `value_of` is retired). Operand-determined kinds only (`Binary`,
-    /// non-address `Unary`, `Cast`) plus a read of a stable parameter; every
-    /// other kind — and any node with an unresolved operand — yields `None`.
-    /// Recurses through [`Engine::operand_value`] so a pure subtree over promoted
-    /// leaves resolves whole. Does not cache (there is no side-table to cache
-    /// into).
-    ///
-    /// The parameter base case is load-bearing: without it every leaf of an
-    /// unpromoted tree is `None`, so only all-constant trees ever resolve and
-    /// no promoted value can name a local.
+    /// Re-derive `expr`'s value from its operands — the sole value source now
+    /// that `value_of` is retired. Operand-determined kinds only, plus a read of
+    /// a stable parameter; every other kind, and any unresolved operand, gives
+    /// `None`. Recurses through [`Engine::operand_value`], so a pure subtree over
+    /// promoted leaves resolves whole. The parameter base case is load-bearing:
+    /// without it every leaf of an unpromoted tree is `None`, so only
+    /// all-constant trees resolve and no promoted value can name a local.
     fn maintain_pure_node(&mut self, expr: ExprId) -> Option<crate::nir_value_graph::ValueId> {
         self.body.value_graph.as_ref()?;
         let kind = self.body.exprs[expr].kind.clone();
@@ -433,16 +414,12 @@ impl<'a> Engine<'a> {
     }
 
     /// Every read whose reaching value the use site can re-emit, recovered by a
-    /// scratch re-walk (the same splice-point growth `inline` uses — no live
-    /// rebuild) and without writing anything into `value_of`.
-    ///
-    /// Covers a `Local` read of any local in `forwardable`, and — when
-    /// `include_fields` — a `FieldAccess` read. What disqualifies a local is
-    /// being address-taken or `stores`-aliased, not being an aggregate.
-    ///
-    /// The re-walk exists because SROA introduces stores after the build-once
-    /// graph was built, so the new reads carry no value. Returns `(read, value)`
-    /// pairs; empty when there is no built graph to grow.
+    /// scratch re-walk — the same splice-point growth `inline` uses, with no live
+    /// rebuild. Covers a `Local` read of anything in `forwardable`, plus a
+    /// `FieldAccess` under `include_fields`; what disqualifies a local is being
+    /// address-taken or `stores`-aliased, not being an aggregate. The re-walk
+    /// exists because SROA adds stores after the build-once graph, so those reads
+    /// carry no value. Empty when there is no graph to grow.
     pub fn scoped_const_reads(
         &mut self,
         forwardable: &IndexSet<u32>,
@@ -725,29 +702,15 @@ impl<'a> Engine<'a> {
         let _ = local;
     }
 
-    /// Whether `local` is **single-assignment**: bound once and never written
-    /// again, which is what makes [`ValuePool::canonical_local`]'s one id per
-    /// index denote one value.
-    ///
-    /// A non-`mut` parameter qualifies by being entry-defined and unreassigned.
-    /// So does an ordinary binding that is never written again — and it is the
-    /// safer of the two under the anchor rule, since its `let` travels with any
-    /// copy of an operand naming it while a parameter's entry def does not.
-    ///
-    /// Single-assignment is *per execution of the binding's scope*: a `let` in a
-    /// loop body is written once in the text and once per iteration. So this
-    /// licenses naming the local within one iteration, and a consumer relocating
-    /// a value across an iteration boundary needs its own check — which is what
-    /// `materialise_point`'s refusal to place outside an enclosing loop is for.
-    ///
+    /// Whether `local` is **single-assignment** — bound once, never written again
+    /// — which is what makes [`ValuePool::canonical_local`]'s one id per index
+    /// denote one value. Holds per *execution* of the binding's scope, so a `let`
+    /// in a loop body qualifies while naming its value across an iteration needs
+    /// its own check (`materialise_point`'s refusal to place outside the loop).
     /// Read off the use index rather than `NirLocal::is_mut`, which a pass minting
-    /// a temp sets by hand while the index is maintained by the edit API. Every
-    /// half fails safe: `reads` holds every `Local` node in the arena, reachable
-    /// or not, so an assign that folded away still refuses, and refusing costs a
-    /// promotion rather than correctness.
-    ///
-    /// `extract`'s `multi_version_locals` is this predicate, so the value query
-    /// and the freeze agree by construction.
+    /// a temp sets by hand; the index holds every `Local` node whether reachable
+    /// or not, so it fails safe. `extract`'s `multi_version_locals` is this same
+    /// predicate, so the value query and the freeze agree by construction.
     pub fn local_has_one_version(&mut self, local: u32) -> bool {
         match self.local_bindings(local) {
             // No `Let`: a parameter, or a `LetDestructure` binding the use index
@@ -819,18 +782,14 @@ impl<'a> Engine<'a> {
         index
     }
 
-    /// Build the session's three indices — the parent map, the local use
-    /// index, and the post-order worklist seed — in one walk of the live tree.
-    ///
-    /// Not an arena scan: the arena never compacts, and an orphan still holding
-    /// an operand reference to a live node would overwrite that node's parent
-    /// edge, so a rule would edit the orphan while the live tree kept the stale
-    /// shape (seen as `copy_prop` stranding a read on a dropped binding).
-    /// Within the live tree two parents is corruption — an edit shared an id
-    /// instead of moving the kind (`become_expr`) — hence the panic.
-    ///
-    /// Parents and uses are recorded on the way down, the worklist on the way
-    /// up, so leaf reductions are enqueued before the contexts that fold them.
+    /// Build the session's three indices — parent map, local use index, and
+    /// post-order worklist seed — in one walk of the live tree. Not an arena
+    /// scan: the arena never compacts, and an orphan still referencing a live
+    /// node would overwrite its parent edge, leaving a rule to edit the orphan
+    /// while the live tree kept the stale shape. Within the live tree two parents
+    /// is corruption, hence the panic. Parents and uses are recorded descending,
+    /// the worklist ascending, so leaves are enqueued before the contexts that
+    /// fold them.
     fn build_indices(&mut self) {
         let mut stack = std::mem::take(&mut self.buf.walk_stack);
         let mut children = std::mem::take(&mut self.buf.walk_children);
@@ -1019,15 +978,12 @@ impl<'a> Engine<'a> {
     }
 
     /// Drop the memoized census unless this edit provably cannot have moved it.
-    ///
-    /// An interned value is immutable, so only a change to which operands are
-    /// reachable moves the answer. An empty census survives removal — nothing
-    /// can conjure a read — and survives an attach unless something local-naming
-    /// is waiting: a node allocated detached and spliced in later can be missed
-    /// by a fill in between, which is what `pending_local_naming` covers. A
-    /// non-empty census can shrink as well as grow, so any edit drops it.
-    ///
-    /// Why the empty case earns the special handling: WEP, standing invariants.
+    /// An interned value is immutable, so only a change in which operands are
+    /// reachable moves the answer. An empty census survives a removal — nothing
+    /// conjures a read — and survives an attach unless something local-naming is
+    /// pending, since a node allocated detached and spliced in later can be
+    /// missed by a fill in between. A non-empty one can shrink as well as grow,
+    /// so any edit drops it.
     fn census_note_structure(&mut self) {
         if self.pending_local_naming.get()
             || self.promoted_reads.get().is_some_and(|c| !c.is_empty())
@@ -1195,19 +1151,13 @@ impl<'a> Engine<'a> {
         true
     }
 
-    /// Edit API: promote `src`'s node content (kind + type + span) into `dst`,
-    /// leaving `src` a dead `Unit`. The arena analogue of `*dst = *src` when a
-    /// rewrite collapses a wrapper onto a nested node it contains — e.g.
-    /// `{ expr; }` → `expr`, or `label: { break label: val }` → `val`.
-    ///
-    /// `dst`'s former subtree is discarded. As with [`set_block_stmts`], this
-    /// does not deep-unregister `Local` mentions inside that discarded subtree:
-    /// the only way a stale mention matters is `is_local_read`, where an extra
-    /// (dead) mention is conservative — it can keep a binding alive, never drop
-    /// a live one. Callers use this to lift a nested node whose discarded
-    /// siblings carry no live reads (every production caller in
-    /// `const_branch_prune` promotes the sole meaningful child of a wrapper).
-    /// `src`'s own mention is moved off `src` so it is not left dangling.
+    /// Edit API: promote `src`'s content into `dst`, leaving `src` a dead `Unit`
+    /// — the arena analogue of `*dst = *src` when a rewrite collapses a wrapper
+    /// onto a node it contains (`{ expr; }` → `expr`). `dst`'s former subtree is
+    /// discarded without deep-unregistering its `Local` mentions: a stale mention
+    /// only reaches `is_local_read`, where an extra dead one is conservative,
+    /// keeping a binding alive but never dropping a live one. `src`'s own mention
+    /// is moved off it so nothing dangles.
     pub fn become_expr(&mut self, dst: ExprId, src: ExprId) {
         if dst == src {
             return;

--- a/wado-compiler/src/nir_package.rs
+++ b/wado-compiler/src/nir_package.rs
@@ -249,17 +249,11 @@ impl NirPackage {
             .collect()
     }
 
-    /// Check whether the active world declares an
-    /// `import {interface_name} { ... }` block.
-    ///
-    /// Drives world-shape decisions in codegen / lowering / DCE that used to
-    /// hinge on `target_world == "core:kiln/generator"` string matches —
-    /// `imports_interface("KilnHost")` is true for the kiln generator world and
-    /// any future world that imports the same interface, so adding a new
-    /// generator-shaped world no longer needs new branches.
-    ///
-    /// Returns `false` for the synthetic test world and for unknown worlds
-    /// (both have no entry in the registry).
+    /// Whether the active world declares an `import {interface_name} { … }`
+    /// block. Drives the world-shape decisions in codegen, lowering and DCE that
+    /// once matched on `target_world` strings, so a new generator-shaped world
+    /// needs no new branches. `false` for the synthetic test world and any
+    /// unknown one, neither having a registry entry.
     pub fn world_imports_interface(&self, interface_name: &str) -> bool {
         self.world_registry
             .get(&self.target_world)

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -1,16 +1,8 @@
-//! NIR Value Graph (Layer 2 — hash-consed pure-value DAG).
-//!
-//! Hash-consed DAG of pure values. Each value has a [`ValueId`] (newtype
-//! over `u32`); two structurally-equivalent values share one `ValueId`. CSE is
-//! pure hash-consing — there are no e-class merges, so a `ValueId` is stable
-//! once allocated. The
-//! `SkelTree` (Layer 1 — see [`crate::nir_arena`]) references pure operands by
-//! `ValueId`; pure values live exclusively here.
-//!
-//! Consumed by [`crate::nir_engine::Engine::value`] (which lazily builds the
-//! per-function graph via [`builder::build`]) and through that by the CSE
-//! and store-load-forward rules. See
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`.
+//! NIR Value Graph (Layer 2): a hash-consed DAG where structurally-equivalent
+//! values share one [`ValueId`]. CSE is pure hash-consing, with no e-class
+//! merges, so an id is stable once allocated; the `SkelTree` references pure
+//! operands by id and holds none itself. Built lazily per function by
+//! [`crate::nir_engine::Engine::value`]. See WEP 2026-06-05.
 
 pub mod builder;
 
@@ -829,18 +821,11 @@ impl ValuePool {
         }
     }
 
-    /// Remap every `OpaqueSource::Local` index through `remap` (old → new).
-    /// A pass that renumbers a body's locals must call this so a promoted
-    /// `Opaque` value (extracted as `local.get idx`) still names the right slot.
-    ///
-    /// A `None` entry marks a dropped local. The pool is append-only, so a
-    /// source naming one is the residue of a promoted read that folded away —
-    /// the caller drops a local only when no reachable operand reads it
-    /// ([`crate::optimize::arena_query::promoted_local_reads`]). Such a source
-    /// is cleared rather than remapped: the value is unreachable, and clearing
-    /// it turns any use into the "no recorded extraction source" panic at WIR
-    /// build instead of a silent read of the wrong slot. The canonical-local
-    /// cache is keyed by index, so it renumbers alongside.
+    /// Remap every `OpaqueSource::Local` index through `remap` (old → new), which
+    /// a pass renumbering a body's locals must call so a promoted `Opaque` still
+    /// names the right slot. A `None` entry marks a dropped local, whose source
+    /// is cleared rather than remapped: any use then hits the "no recorded
+    /// extraction source" panic instead of silently reading the wrong slot.
     pub fn remap_opaque_locals(&mut self, remap: &[Option<u32>]) {
         self.canonical_locals = self
             .canonical_locals
@@ -859,22 +844,11 @@ impl ValuePool {
         });
     }
 
-    /// Whether `id`'s value can be re-emitted by the extractor purely from the
-    /// graph + side-effect-free, position-independent leaves: literal constants
-    /// and `Local`-sourced opaques (a `local.get`), composed by `Binary` /
-    /// `Unary` / `Cast`. Excludes `Opaque(Expr)` (effectful / unscheduled),
-    /// `Select` / `LoopPhi` (flow merges — extraction-unsupported), `FieldAccess`,
-    /// etc.
-    ///
-    /// A `Local` opaque is only sound when the local holds **one value**: a
-    /// `local.get idx` at the frozen node's position must read what the opaque
-    /// denotes. A local written more than once fails this — its value at an
-    /// extraction point can differ from the opaque's version (`x = x*2` after a
-    /// read, a loop counter) — so the caller passes every such index in
-    /// `multi_version_locals` and they are rejected. That set comes from
-    /// `Engine::local_has_one_version`, which reads the use index rather than
-    /// the `is_mut` flag, so an untouched `let mut` is admitted and a local
-    /// written through a reference or bound twice is not.
+    /// Whether `id`'s value can be re-emitted purely from the graph and
+    /// position-independent leaves: literal constants and `Local`-sourced
+    /// opaques, composed by `Binary` / `Unary` / `Cast`. A `Local` opaque is
+    /// sound only when the local holds **one value**, so the caller rejects every
+    /// index in `multi_version_locals` (`Engine::local_has_one_version`).
     pub fn value_fully_reemittable_locally(
         &mut self,
         id: ValueId,
@@ -1026,16 +1000,10 @@ impl ValuePool {
     }
 
     /// [`ValuePool::binary`], collapsed to a literal when both operands are
-    /// already constants.
-    ///
-    /// Interning is where every producer meets — the builder, the engine's
-    /// maintenance re-derivation, and the scratch-pool reintern inlining runs —
-    /// so folding here is what holds the invariant that no node in the pool is
-    /// a foldable operation. A nested constant depends on it: the outer
-    /// operation's operand is the inner operation's node, so a node interned
-    /// raw is one no later reader can fold.
-    ///
-    /// Folding needs operand widths; without a `TypeTable` nothing folds.
+    /// already constants. Interning is where every producer meets, so folding
+    /// here is what holds the invariant that no node in the pool is a foldable
+    /// operation — a nested constant depends on it, an outer operand being the
+    /// inner node. Folding needs operand widths, so a `TypeTable` is required.
     pub fn binary_folded(
         &mut self,
         op: NirBinaryOp,

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -210,10 +210,11 @@ pub fn build(
 }
 
 /// Scoped re-valuation of one inlined block, seeded with the call site's
-/// `param → value` map and walked over a fresh heap. Returns only
-/// constant-literal entries: a scoped walk's non-constant values carry
-/// walk-local heap versions and would over-merge. Runs in `scratch`, cloned from
-/// `body.values` with ids preserved, so the shared graph is not perturbed.
+/// `param → value` map and a heap seeded from `heap_seed` — a fresh one would
+/// over-merge. Returns every caller-rooted re-emittable value (constants, plus
+/// arithmetic / field reads over the call-site args); the caller filters. Runs in
+/// `scratch`, cloned from `body.values` with ids preserved, so the shared graph
+/// is not perturbed.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_scoped(
     body: &mut Body,

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -1,33 +1,9 @@
-//! Per-function `ValueGraph` builder.
-//!
-//! Walks the `SkelTree` (`Body`) once and assigns a [`ValueId`] to every pure
-//! [`ExprId`]. Impure or allocation-bearing expressions (calls, struct/array
-//! literals, control flow, etc.) get no entry in `value_of`.
-//!
-//! Consumed lazily by [`crate::nir_engine::Engine::value`]; see the WEP at
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`.
-//!
-//! # Flow handling
-//!
-//! - Parameters seed `current_value` with a fresh `Opaque` each.
-//! - `Let` / `Assign`-to-bare-`Local` updates `current_value[local_idx]` to
-//!   the RHS's value (or `Opaque` if the RHS is impure).
-//! - `If` snapshots `current_value`, walks both branches, then merges:
-//!   diverging locals hash-cons a [`ValueKind::Select`] keyed on the
-//!   condition's value, falling back to `Opaque` if the condition is impure.
-//!   Heap state joins per arm over fall-through arms only ([`Builder::join_heap`]).
-//! - `Match` / `Switch` walk every arm and merge n-ary: if every arm agrees
-//!   on a local, that value carries; otherwise the local goes `Opaque`.
-//!   N-ary `Select` chains are not yet constructed.
-//! - `Loop` pre-scans the body for locals it may write, snapshots
-//!   `current_value` into [`ValueGraphBuild::loop_entry_values`], and
-//!   reassigns each written local to a fresh `Opaque` before walking the
-//!   body; post-loop those locals stay `Opaque`.
-//! - `LabeledBlock` marks every local written in its subtree `Opaque` on
-//!   exit, since `break` paths can carry writes the fall-through state
-//!   never observes.
-//! - Pattern bindings (`LetDestructure`, `Match` arm bindings) are seeded
-//!   with `Opaque`.
+//! Per-function `ValueGraph` builder: one walk of the `Body` assigning a
+//! [`ValueId`] to every pure [`ExprId`], leaving impure and allocation-bearing
+//! expressions out of `value_of`. Locals carry their RHS's value forward, and
+//! anything a branch, loop, or `break` path can disagree on goes `Opaque` — an
+//! `If` hash-conses a [`ValueKind::Select`] where it can. Consumed lazily by
+//! [`crate::nir_engine::Engine::value`]; see WEP 2026-06-05.
 
 use crate::const_eval;
 use crate::hashmap::IndexMap;
@@ -38,29 +14,13 @@ use crate::nir_arena::{
 
 use super::{HeapVersion, OpaqueSource, ValueId, ValueKind, ValuePool};
 
-/// Per-function heap-version tracker. The builder threads one `HeapState`
-/// through the walk; on every Skel node that may write the heap, the
-/// appropriate generation bumps to a fresh value. A read's effective
-/// version is the max of every generation that could cover it
-/// ([`HeapState::version_of`]); `field_store` keys carry that version, so a
-/// stale seed is naturally unreachable once any covering generation bumps.
-///
-/// Granularity is per-`(receiver-root, field)`:
-/// - `per_slot[(root, field)]` — bumped by a direct `root.field = …` store
-///   on a non-aliased bare-`Local` receiver, so a write to `a.f` leaves
-///   `b.f` (a different object, same `field_index`) untouched.
-/// - `per_local[root]` — bumped when every field of `root` may have changed:
-///   a call while `root` is reference-aliased (the callee can reach its
-///   object). Non-aliased locals' fields survive a call.
-/// - `field_global[field]` — bumped by a write to `field` through an
-///   aliased or non-bare-`Local` receiver (`a.b.f`, `r.f` for a reference
-///   `r`): every alias of that field is invalidated without tracking which
-///   locals alias which.
-/// - `default_version` — covers everything; [`HeapState::bump_all`] advances
-///   it for truly opaque writes (deref / index store, global set, indirect
-///   call, loop entry).
-///
-/// Branch endpoints join per arm instead of bumping ([`Builder::join_heap`]).
+/// Per-function heap-version tracker: every node that may write the heap bumps
+/// the covering generation, and a read's effective version is the max over all
+/// of them ([`HeapState::version_of`]), so a stale seed becomes unreachable.
+/// Granularity runs from `per_slot[(root, field)]` for a direct store on a
+/// non-aliased local, through `per_local` and `field_global` for aliased or
+/// projected receivers, to `default_version` for a truly opaque write. Branch
+/// endpoints join per arm instead of bumping ([`Builder::join_heap`]).
 struct HeapState {
     /// Next fresh version to hand out.
     next: HeapVersion,
@@ -219,31 +179,14 @@ pub struct ValueGraphBuild {
     pub loop_entry_values: IndexMap<BlockId, IndexMap<u32, ValueId>>,
 }
 
-/// Build the `ValueGraph` for one function body.
-///
-/// `param_locals` are the local indices of the function's parameters; each
-/// seeds `current_value` with one fresh `Opaque`, so a `Local` read returns
-/// that Opaque every time until the parameter is reassigned (which the
-/// builder picks up the same way as any other `Assign`). An unseeded local's
-/// first read mints an equivalent fallback `Opaque`, but only up-front
-/// seeding makes parameters visible in the loop-entry snapshots
-/// (`loop_entry_values`), which are taken before any in-loop read.
-///
-/// `aliased` are locals whose object is reference-aliased — address-taken,
-/// `with stores[p]`, or reference-typed (`let r = &x`, `Box`, `List`, `&T`).
-/// A write to such a local's field, or a call that may reach its object,
-/// invalidates the field through the conservative `field_global` / `per_local`
-/// generations rather than the precise `per_slot` one. `untrackable` is the
-/// `stores`-aliased subset whose fields are never seeded (their aliasing
-/// escapes entirely). A non-aliased local's object is reachable only through
-/// that local, so its `per_slot` fields survive calls and other objects'
-/// same-`field_index` writes (see [`HeapState`]).
-///
-/// `mut_escaped` is the subset of `aliased` a call may actually mutate (locals
-/// with a *mutable* escape — `&mut v`, a mut-ref argument, a `&mut self`
-/// receiver, or a `stores` stash). [`Builder::bump_call_effects`] bumps only
-/// these across a call; a reference-aliased local whose every escape is an
-/// immutable `&v` keeps its forwarded fields, since no callee can mutate it.
+/// Build the `ValueGraph` for one function body. Each parameter in
+/// `param_locals` seeds a fresh `Opaque` up front — an unseeded local's first
+/// read mints an equivalent one, but only seeding makes parameters visible in
+/// the loop-entry snapshots, taken before any in-loop read. An `aliased` local's
+/// fields are invalidated through the conservative generations rather than
+/// `per_slot`, and `untrackable` ones are never seeded at all. `mut_escaped`
+/// narrows `aliased` to what a call may actually mutate, so a local escaping
+/// only through an immutable `&v` keeps its forwarded fields.
 #[allow(clippy::too_many_arguments)]
 pub fn build(
     body: &mut Body,
@@ -272,25 +215,14 @@ pub fn build(
     ValueGraphBuild { loop_entry_values }
 }
 
-/// Scoped re-valuation of one self-contained inlined block, seeded with the
-/// call site's `param → value` map (Method A — splice-point growth). Walks only
-/// `block` after its first `skip` param-binding statements (params pre-seeded),
-/// with a fresh heap (a field read on a param is conservatively fresh), using
-/// `body`'s existing pool so produced values share ids with the graph. Returns
-/// only **constant-literal** entries: a scoped walk's non-constant values carry
-/// context local to the walk (a `FieldAccess`'s `HeapVersion` numbers from the
-/// fresh heap and would over-merge; an `Opaque` of a remapped local is
-/// walk-local), while a constant equals what a fresh build assigns. Never walks
-/// the caller's untouched remainder, so it adds no `builder::build`
-/// (`rebuilds = 0`) and parks no cache.
-///
-/// `scratch` is a pool the caller clones from `body.values` once and reuses
-/// across every inlined block of the function: the walk stamps types
-/// (`set_type`) on the values it interns, and doing that on a value the main
-/// graph shares would mutate its main-graph type and perturb the structural
-/// passes — so the walk runs in `scratch`, leaving `body.values` untouched
-/// (seeded `ValueId`s stay valid; the clone preserves ids). Only the constant
-/// *literals* are re-interned into the main pool, which is idempotent.
+/// Scoped re-valuation of one inlined block, seeded with the call site's
+/// `param → value` map and walked over a fresh heap, so it never touches the
+/// caller's remainder. Returns only constant-literal entries: a scoped walk's
+/// non-constant values carry walk-local context — a `FieldAccess`'s versions
+/// come from the fresh heap and would over-merge — while a constant equals what
+/// a fresh build assigns. The walk stamps types on what it interns, so it runs
+/// in `scratch` (cloned once from `body.values`, ids preserved) rather than
+/// perturbing the values the main graph shares.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_scoped(
     body: &mut Body,
@@ -419,19 +351,12 @@ fn reintern_const(pool: &mut ValuePool, k: ValueKind) -> ValueId {
     }
 }
 
-/// Re-intern a value computed in a [`build_scoped`] `scratch` pool into the live
-/// `live` pool, when it is rooted entirely in **caller** values — every leaf an
-/// id below `live_base` (the pool length the scratch was cloned at, so those ids
-/// are shared and valid in `live`). Such a value is a constant, or a
-/// `FieldAccess` / arithmetic / `Select` tree over the call-site argument values,
-/// and it carries the caller's heap version (from the seeded heap), so it equals
-/// what a fresh whole-function build assigns the spliced node — sound to surface.
-///
-/// Returns `None` for a walk-local `Opaque` (a remapped callee local with no seed
-/// value) or a `LoopPhi`: those have no meaning in the caller pool. The recursion
-/// is the cross-pool copy [`build_scoped`]'s constant case did, widened past
-/// constants to the re-emittable caller-rooted values (WEP: promote the spliced
-/// `FieldAccess` at its true version).
+/// Re-intern a [`build_scoped`] scratch value into `live`, when every leaf is an
+/// id below `live_base` and so already shared. Such a value is a constant or a
+/// tree over the call-site arguments, carrying the caller's heap version, so it
+/// equals what a fresh whole-function build would assign the spliced node.
+/// `None` for a walk-local `Opaque` or a `LoopPhi`, which mean nothing in the
+/// caller pool.
 fn reintern_live_rooted(
     scratch: &ValuePool,
     live: &mut ValuePool,
@@ -573,14 +498,6 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// If both operands are constant literals and `op` is a const-foldable
-    /// pure arithmetic / comparison / bitwise op, fold it exactly as niri's
-    /// CTFE would ([`crate::const_eval::eval_binary`]) and intern the resulting
-    /// literal `ValueId`. Each operand's `PrimitiveType` is read from its own
-    /// NIR type, so integer wrapping matches the runtime width and a
-    /// mixed-prim op (which niri refuses) is not folded. Returns `None` when an
-    /// operand is non-constant, a type is unavailable, or the op is not
-    /// foldable — the caller then builds the structural `Binary` node.
     /// Type of an operand during the build: from the skeleton expr, or from the
     /// build pool for a promoted constant (its source type was seeded there).
     fn operand_type(&self, op: Operand) -> crate::tir::TypeId {
@@ -593,6 +510,12 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// Fold two constant-literal operands exactly as niri's CTFE would
+    /// ([`crate::const_eval::eval_binary`]) and intern the resulting literal.
+    /// Each operand's `PrimitiveType` comes from its own NIR type, so integer
+    /// wrapping matches the runtime width and a mixed-prim op is not folded.
+    /// `None` — a non-constant operand, a missing type, or an unfoldable op —
+    /// leaves the caller to build the structural `Binary` node.
     fn fold_binary_const(
         &mut self,
         op: NirBinaryOp,
@@ -751,20 +674,12 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// A direct / method call may mutate any field of a local the callee can
-    /// reach *and* mutate — one with a mutable escape (`&mut v`, a mut-ref
-    /// argument, a `&mut self` receiver, or a `stores` stash). The callee
-    /// reaches such an object via an escaped mutable reference or a global, and
-    /// a mutable reference may have been retained, so any later call is a
-    /// potential mutation point — bump every `mut_escaped` local, not only this
-    /// call's arguments. Non-`mut_escaped` locals (non-aliased, or aliased only
-    /// through an immutable `&v`) cannot be mutated by any callee, so their
-    /// fields survive the call.
-    /// Invalidate the locals a call at `call` may mutate. A call proven to mutate
-    /// no caller local ([`BuildConfig::pure_calls`]) bumps only the `untrackable`
-    /// (stashed) locals any call can reach; otherwise every `mut_escaped` local is
-    /// bumped (conservative). Skipping the bump for a pure accessor keeps a
-    /// `mut_escaped` receiver's field version stable across it.
+    /// Invalidate the locals a call may mutate. One proven to mutate nothing
+    /// ([`BuildConfig::pure_calls`]) bumps only the `untrackable` locals any call
+    /// can reach; otherwise every `mut_escaped` local is bumped — not just this
+    /// call's arguments, since a mutable reference that escaped earlier may have
+    /// been retained. Skipping the bump for a pure accessor keeps a receiver's
+    /// field version stable across it.
     fn bump_call_effects(&mut self, call: ExprId) {
         let pure = self.pure_calls.contains(&call);
         // Iterate ascending local index, not `mut_escaped`'s insertion order:
@@ -1657,18 +1572,12 @@ impl<'a> Builder<'a> {
             .retain(|src, pointee| !writes.contains(src) && !writes.contains(pointee));
     }
 
-    /// Join the heap state at a branch endpoint: each overlay generation
-    /// keeps its pre-branch version iff every fall-through arm left it
-    /// unchanged; otherwise it bumps fresh. Non-fall-through arms (terminated
-    /// by `break` / `return` / `continue`) are excluded — their writes never
-    /// reach code after the branch. No fall-through arm ⇒ post-state is `pre`.
-    ///
-    /// Each of `per_slot` / `per_local` / `field_global` joins independently
-    /// (an absent overlay entry contributes the snapshot's `default_version`
-    /// in [`HeapState::version_of`], so the per-overlay join mirrors the
-    /// single-map case sharing the joined default). `version_of` maxes the
-    /// overlays, so a join that is too coarse only raises a read's version —
-    /// never lowers it below an arm's — keeping the join sound.
+    /// Join the heap state at a branch endpoint: a generation keeps its
+    /// pre-branch version iff every fall-through arm left it unchanged, else
+    /// bumps fresh. Arms terminated by `break` / `return` / `continue` are
+    /// excluded, their writes never reaching past the branch; with none left the
+    /// post-state is `pre`. Each overlay joins independently, and since
+    /// `version_of` maxes them, a too-coarse join only raises a read's version.
     fn join_heap(&mut self, pre: &HeapSnapshot, arms: &[(HeapSnapshot, bool)]) {
         let live: Vec<&HeapSnapshot> = arms
             .iter()
@@ -1847,16 +1756,11 @@ impl<'a> Builder<'a> {
     }
 
     /// Reassign every local the body may write to a fresh `Opaque`, and
-    /// invalidate the heap fields the body may write, before and after the
-    /// walk. The body may run 0..N times, so in-body reads must not share
-    /// `ValueId`s with pre-loop reads, and post-loop reads must not share them
-    /// with in-body reads. (Locals declared inside the loop need no pre-seed:
-    /// they get fresh `Opaque`s as the body walks.)
-    ///
-    /// Heap invalidation is selective ([`collect_loop_heap_effects`]): a field
-    /// the body never writes — directly, through a reference, or via a
-    /// non-builtin call — keeps its pre-loop version, so a `table.used = 256`
-    /// before a builtin-only loop still forwards inside and after it.
+    /// invalidate the heap fields it may write, both before and after the walk:
+    /// the body runs 0..N times, so in-body reads must share `ValueId`s with
+    /// neither pre- nor post-loop reads. Heap invalidation is selective
+    /// ([`collect_loop_heap_effects`]) — a field the body never writes keeps its
+    /// pre-loop version, so a store before a builtin-only loop still forwards.
     fn walk_loop(&mut self, body_block: crate::nir_arena::BlockId) {
         let writes = writes_of_block(self.body, body_block, &mut self.block_writes);
         let heap_effects =
@@ -1910,17 +1814,12 @@ impl<'a> Builder<'a> {
         self.apply_loop_heap_effects(&heap_effects);
     }
 
-    /// Invalidate the heap generations a loop body may write (see
-    /// [`collect_loop_heap_effects`]). A written `local.field` bumps that
-    /// local's `per_slot` (or `field_global` when the local is aliased); a
-    /// `&mut`/method/mut-arg borrow bumps the local's `per_local`; an external
-    /// write (non-builtin call, indirect call, opaque store) invalidates every
-    /// `mut_escaped` local's fields. Non-touched fields survive — and an
-    /// *immutably*-`&`-escaped local (`&config` passed to `fn process(&Config)`)
-    /// is **not** `mut_escaped`, so its fields survive the call, matching the
-    /// per-call [`Builder::bump_call_effects`] (which the loop path must agree
-    /// with — using the wider `aliased` here lost the forward for an immutable
-    /// reference field read across a loop call: `opt_licm_immut_ref`).
+    /// Invalidate the heap generations a loop body may write: a written
+    /// `local.field` bumps `per_slot`, or `field_global` when aliased; a borrow
+    /// bumps `per_local`; an external write invalidates every `mut_escaped`
+    /// local. Untouched fields survive. Keyed on `mut_escaped` to agree with the
+    /// per-call [`Builder::bump_call_effects`] — the wider `aliased` here lost
+    /// the forward for an immutable reference read across a loop call.
     fn apply_loop_heap_effects(&mut self, eff: &LoopHeapEffects) {
         for &(local, field) in &eff.written_fields {
             if self.aliased.contains(&local) {

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -1,9 +1,8 @@
 //! Per-function `ValueGraph` builder: one walk of the `Body` assigning a
 //! [`ValueId`] to every pure [`ExprId`], leaving impure and allocation-bearing
 //! expressions out of `value_of`. Locals carry their RHS's value forward, and
-//! anything a branch, loop, or `break` path can disagree on goes `Opaque` — an
-//! `If` hash-conses a [`ValueKind::Select`] where it can. Consumed lazily by
-//! [`crate::nir_engine::Engine::value`]; see WEP 2026-06-05.
+//! anything a branch, loop, or `break` path can disagree on goes `Opaque`.
+//! Consumed lazily by [`crate::nir_engine::Engine::value`]; see WEP 2026-06-05.
 
 use crate::const_eval;
 use crate::hashmap::IndexMap;
@@ -16,11 +15,9 @@ use super::{HeapVersion, OpaqueSource, ValueId, ValueKind, ValuePool};
 
 /// Per-function heap-version tracker: every node that may write the heap bumps
 /// the covering generation, and a read's effective version is the max over all
-/// of them ([`HeapState::version_of`]), so a stale seed becomes unreachable.
-/// Granularity runs from `per_slot[(root, field)]` for a direct store on a
-/// non-aliased local, through `per_local` and `field_global` for aliased or
-/// projected receivers, to `default_version` for a truly opaque write. Branch
-/// endpoints join per arm instead of bumping ([`Builder::join_heap`]).
+/// of them ([`HeapState::version_of`]). Granularity runs from
+/// `per_slot[(root, field)]` through `per_local` / `field_global` to
+/// `default_version`. Branch endpoints join instead ([`Builder::join_heap`]).
 struct HeapState {
     /// Next fresh version to hand out.
     next: HeapVersion,
@@ -180,13 +177,10 @@ pub struct ValueGraphBuild {
 }
 
 /// Build the `ValueGraph` for one function body. Each parameter in
-/// `param_locals` seeds a fresh `Opaque` up front — an unseeded local's first
-/// read mints an equivalent one, but only seeding makes parameters visible in
-/// the loop-entry snapshots, taken before any in-loop read. An `aliased` local's
-/// fields are invalidated through the conservative generations rather than
-/// `per_slot`, and `untrackable` ones are never seeded at all. `mut_escaped`
-/// narrows `aliased` to what a call may actually mutate, so a local escaping
-/// only through an immutable `&v` keeps its forwarded fields.
+/// `param_locals` seeds a fresh `Opaque` up front, which is what makes them
+/// visible in the loop-entry snapshots taken before any in-loop read. An
+/// `aliased` local invalidates through the coarse generations, `untrackable`
+/// ones are never seeded, and `mut_escaped` narrows `aliased` to real mutation.
 #[allow(clippy::too_many_arguments)]
 pub fn build(
     body: &mut Body,
@@ -216,13 +210,10 @@ pub fn build(
 }
 
 /// Scoped re-valuation of one inlined block, seeded with the call site's
-/// `param → value` map and walked over a fresh heap, so it never touches the
-/// caller's remainder. Returns only constant-literal entries: a scoped walk's
-/// non-constant values carry walk-local context — a `FieldAccess`'s versions
-/// come from the fresh heap and would over-merge — while a constant equals what
-/// a fresh build assigns. The walk stamps types on what it interns, so it runs
-/// in `scratch` (cloned once from `body.values`, ids preserved) rather than
-/// perturbing the values the main graph shares.
+/// `param → value` map and walked over a fresh heap. Returns only
+/// constant-literal entries: a scoped walk's non-constant values carry
+/// walk-local heap versions and would over-merge. Runs in `scratch`, cloned from
+/// `body.values` with ids preserved, so the shared graph is not perturbed.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_scoped(
     body: &mut Body,
@@ -353,10 +344,9 @@ fn reintern_const(pool: &mut ValuePool, k: ValueKind) -> ValueId {
 
 /// Re-intern a [`build_scoped`] scratch value into `live`, when every leaf is an
 /// id below `live_base` and so already shared. Such a value is a constant or a
-/// tree over the call-site arguments, carrying the caller's heap version, so it
-/// equals what a fresh whole-function build would assign the spliced node.
-/// `None` for a walk-local `Opaque` or a `LoopPhi`, which mean nothing in the
-/// caller pool.
+/// tree over the call-site arguments, so it equals what a fresh whole-function
+/// build would assign the spliced node. `None` for a walk-local `Opaque` or
+/// `LoopPhi`, which mean nothing in the caller pool.
 fn reintern_live_rooted(
     scratch: &ValuePool,
     live: &mut ValuePool,
@@ -514,8 +504,7 @@ impl<'a> Builder<'a> {
     /// ([`crate::const_eval::eval_binary`]) and intern the resulting literal.
     /// Each operand's `PrimitiveType` comes from its own NIR type, so integer
     /// wrapping matches the runtime width and a mixed-prim op is not folded.
-    /// `None` — a non-constant operand, a missing type, or an unfoldable op —
-    /// leaves the caller to build the structural `Binary` node.
+    /// `None` leaves the caller to build the structural `Binary` node.
     fn fold_binary_const(
         &mut self,
         op: NirBinaryOp,
@@ -678,8 +667,7 @@ impl<'a> Builder<'a> {
     /// ([`BuildConfig::pure_calls`]) bumps only the `untrackable` locals any call
     /// can reach; otherwise every `mut_escaped` local is bumped — not just this
     /// call's arguments, since a mutable reference that escaped earlier may have
-    /// been retained. Skipping the bump for a pure accessor keeps a receiver's
-    /// field version stable across it.
+    /// been retained.
     fn bump_call_effects(&mut self, call: ExprId) {
         let pure = self.pure_calls.contains(&call);
         // Iterate ascending local index, not `mut_escaped`'s insertion order:
@@ -1576,8 +1564,7 @@ impl<'a> Builder<'a> {
     /// pre-branch version iff every fall-through arm left it unchanged, else
     /// bumps fresh. Arms terminated by `break` / `return` / `continue` are
     /// excluded, their writes never reaching past the branch; with none left the
-    /// post-state is `pre`. Each overlay joins independently, and since
-    /// `version_of` maxes them, a too-coarse join only raises a read's version.
+    /// post-state is `pre`. Each overlay joins independently.
     fn join_heap(&mut self, pre: &HeapSnapshot, arms: &[(HeapSnapshot, bool)]) {
         let live: Vec<&HeapSnapshot> = arms
             .iter()
@@ -1817,9 +1804,8 @@ impl<'a> Builder<'a> {
     /// Invalidate the heap generations a loop body may write: a written
     /// `local.field` bumps `per_slot`, or `field_global` when aliased; a borrow
     /// bumps `per_local`; an external write invalidates every `mut_escaped`
-    /// local. Untouched fields survive. Keyed on `mut_escaped` to agree with the
-    /// per-call [`Builder::bump_call_effects`] — the wider `aliased` here lost
-    /// the forward for an immutable reference read across a loop call.
+    /// local. Keyed on `mut_escaped` to agree with the per-call
+    /// [`Builder::bump_call_effects`]; untouched fields survive.
     fn apply_loop_heap_effects(&mut self, eff: &LoopHeapEffects) {
         for &(local, field) in &eff.written_fields {
             if self.aliased.contains(&local) {

--- a/wado-compiler/src/niri.rs
+++ b/wado-compiler/src/niri.rs
@@ -1,24 +1,8 @@
-//! NIR Interpreter (niri).
-//!
-//! Compile-time partial evaluator over the arena `Body`: it reduces what it can
-//! and leaves a residual otherwise.
-//!
-//! Reduction is monotone and idempotent — an expression only moves toward
-//! literal form — so a literal leaf survives a no-op pass as written.
-//!
-//! Each module answers one question:
-//!
-//! - `lattice` — what an expression denotes.
-//! - `frame` — what running a body does.
-//! - `rewrite` — what becomes of an expression once its value is known.
-//! - `trackability` — which locals a walk may hold a value for.
-//! - `pattern` — whether a pattern matches a value.
-//! - `place` — what a borrow or lvalue chain names.
-//! - `region` — which blocks are self-contained enough to run as a frame.
-//! - `callee` — who a call names, and what its operands bind to.
-//!
-//! What the engine can evaluate is stated in
-//! `docs/wep-2026-04-27-nir-interpreter.md`, not here.
+//! NIR Interpreter (niri): a compile-time partial evaluator over the arena
+//! `Body`, reducing what it can and leaving a residual otherwise. Reduction is
+//! monotone and idempotent. Each submodule answers one question — `lattice`,
+//! `frame`, `rewrite`, `trackability`, `pattern`, `place`, `region`, `callee`.
+//! What it can evaluate: `docs/wep-2026-04-27-nir-interpreter.md`.
 
 use crate::const_eval::Value;
 use crate::hashmap::{IndexMap, IndexSet};
@@ -287,20 +271,10 @@ struct FrameState {
     /// Empty outside a frame.
     ctfe_clobbered: LocalSet,
     /// What this frame folded a node to, read back by
-    /// [`Interpreter::expr_to_lattice`]. Written on both backends, and
-    /// load-bearing on each for its own reason.
-    ///
-    /// On the scratch body, because [`BodySink`] promotes nothing: a fold has
-    /// nowhere else to be recorded. On a real body, because the rewrite that
-    /// commits a value consumes the node that produced it — a materialized
-    /// sequence stands where the region was — so the value is no longer
-    /// derivable from the tree, and an enclosing fold reading through this node
-    /// needs it. That is why an aggregate is memoized even when the sink takes
-    /// it: what the sink takes is a literal, what the caller needs is a value.
-    ///
-    /// The one `ExprId`-keyed memo the crate keeps (`wado-compiler/AGENTS.md`).
-    /// It holds only for the frame that wrote it and is cleared wherever the
-    /// environment restarts, so no entry outlives the flow that justified it.
+    /// [`Interpreter::expr_to_lattice`]. Load-bearing on both backends: the
+    /// scratch body promotes nothing, and on a real body the committing rewrite
+    /// consumes the node that produced the value, so an enclosing fold has
+    /// nowhere else to read it. Cleared wherever the environment restarts.
     scratch_folds: IndexMap<ExprId, Value>,
     /// Regions whose run this frame already attempted and abandoned. A seed's
     /// value is fixed for the frame's flow (a reassigned local is never
@@ -314,18 +288,11 @@ struct FrameState {
     region_misses: IndexSet<ExprId>,
 }
 
-/// What the engine knows beyond the body in front of it.
-///
-/// Every field is optional and every absence costs folds rather than
-/// correctness: without the callee map a `Call` stays [`Lattice::Unevaluated`],
-/// without the builtin map an `array_get` is an opaque call, without the global
-/// env a `GlobalVarGet` is unevaluated, and without the field env so is
-/// `GLOBAL.f`. The compiler runs the engine in two configurations — one with
-/// the program-wide view, one with only what running a call needs — so a
-/// partial one is by design, not an oversight.
-///
-/// Grouped rather than four independent knobs, so a walk that needs the
-/// program view asks for one thing and the rule above has one place to live.
+/// What the engine knows beyond the body in front of it. Every field is
+/// optional and every absence costs folds rather than correctness: no callee map
+/// leaves a `Call` [`Lattice::Unevaluated`], no global env leaves a
+/// `GlobalVarGet` so, and so on. The compiler runs the engine both with the
+/// program-wide view and with only what running a call needs.
 #[derive(Default, Clone, Copy)]
 pub(crate) struct ProgramFacts<'a> {
     pub(crate) callees: Option<&'a CalleeMap>,
@@ -552,16 +519,9 @@ impl<'a> Interpreter<'a> {
 
     /// Record a lattice value for a `let`-bound local: [`Lattice::Const`] for an
     /// immutable binding whose RHS reduced, [`Lattice::NonConst`] for `let mut`
-    /// or an RHS that did not.
-    ///
-    /// An aggregate constant is only recorded for a local
-    /// [`Self::record_aggregate_locals`] proved unreachable through any other
-    /// handle; otherwise it degrades to [`Lattice::NonConst`].
-    ///
-    /// A binding displaces a place alias the index may have held: reads must
-    /// see the binding, not project through the stale alias. The alias is not
-    /// restored when a scope ends — a read that then finds nothing abandons a
-    /// fold, which is the sound direction.
+    /// or an RHS that did not, and for an aggregate
+    /// [`Self::record_aggregate_locals`] could not prove unaliased. The binding
+    /// displaces any place alias the index held, and never restores it.
     pub fn bind_local(&mut self, index: u32, lattice: Lattice) {
         self.frame.place_aliases.swap_remove(&index);
         let unbacked_aggregate = matches!(&lattice, Lattice::Const(v) if !v.is_scalar())

--- a/wado-compiler/src/niri/frame.rs
+++ b/wado-compiler/src/niri/frame.rs
@@ -1,14 +1,9 @@
-//! The compile-time frame: running a body rather than reading it.
-//!
-//! The frame performs each statement exactly once, in order, over values the
-//! engine itself built. That is what separates it from the lattice projection,
-//! which is re-entrant and may run over the same node any number of times: a
-//! write belongs here and nowhere else, and a call that performs one is refused
-//! by the projection outright.
-//!
-//! Everything the frame cannot carry out abandons the evaluation. Stepping past
-//! an unperformed write would leave the place it targets holding a value the
-//! program never produced.
+//! The compile-time frame: running a body rather than reading it. Each statement
+//! is performed exactly once, in order, over values the engine itself built —
+//! which is what separates the frame from the re-entrant lattice projection, so
+//! a write belongs here and nowhere else. Anything the frame cannot carry out
+//! abandons the evaluation: stepping past an unperformed write would leave its
+//! target holding a value the program never produced.
 
 use crate::const_eval::Value;
 use crate::nir_arena::{
@@ -168,16 +163,11 @@ fn named_local(body: &Body, op: Operand) -> Option<u32> {
 
 /// Whether a `&mut` argument's storage is also named by another argument. Each
 /// parameter binds its own snapshot and each write-back replays whole, so a
-/// second handle on the same storage either reads a value the program never had
-/// or has its own write undone.
-///
-/// Whether the other argument could actually observe the write is not asked:
-/// after `prepare_types` a shared borrow of a primitive, plain enum, variant
-/// or fn type is the same `Box<T>` a by-value parameter carries, so no
-/// signature test tells them apart here.
-///
-/// Wado has no borrow checker, so this is ordinary source: the frame declines
-/// to run the call rather than mis-run it.
+/// second handle either reads a value the program never had or loses its own
+/// write. Whether it could actually observe the write is not asked: after
+/// `prepare_types` a shared borrow of a primitive is the same `Box<T>` a
+/// by-value parameter carries. Wado has no borrow checker, so this is ordinary
+/// source — the frame declines the call rather than mis-running it.
 fn aliased_write_targets(targets: &[(u32, u32, Vec<u32>)], places: &[(u32, Vec<u32>)]) -> bool {
     targets
         .iter()
@@ -416,16 +406,13 @@ impl Interpreter<'_> {
         }
     }
 
-    /// Update the frame's value for `root` in place, applying `update` to the
-    /// value at `path`. `None` when the frame holds no constant for the root —
-    /// which is what confines a write to values the engine itself built — or
-    /// when the path does not reach a value the update applies to.
-    ///
-    /// Written through rather than rebuilt: a rebuild copies the whole
-    /// container per write, which makes filling a sequence quadratic in its
-    /// length. A clobbered root never holds a constant here — `bind_ctfe_local`
-    /// is the only way one is recorded and it downgrades those — so writing
-    /// straight into the environment cannot revive a local a frame gave up on.
+    /// Update the frame's value for `root` in place, applying `update` at `path`.
+    /// `None` when the frame holds no constant for the root — which confines a
+    /// write to values the engine itself built — or when the path reaches
+    /// nothing the update applies to. Written through rather than rebuilt, since
+    /// a rebuild copies the container per write and makes filling a sequence
+    /// quadratic. A clobbered root never holds a constant here, so writing
+    /// straight into the environment cannot revive one the frame gave up on.
     fn update_place(
         &mut self,
         root: u32,
@@ -568,22 +555,14 @@ impl Interpreter<'_> {
         self.bind_local(index, lattice);
     }
 
-    /// The operand a `let` binds as a place rather than as a value: a borrow
-    /// names the place it is taken over, and a bare local that already names
-    /// one rebinds the same place — copying a reference copies the reference,
-    /// not its referent, so both handles must reach the same storage.
-    ///
-    /// Nothing else qualifies. A projection out of an alias reads *through*
-    /// the reference and yields a value, and `*p` is the same act spelled with
-    /// a deref — so the RHS is matched as a local written out, not through
-    /// [`place_of`], which peels a deref precisely because a write target
-    /// wants the storage behind it.
-    ///
-    /// A borrow does not always arrive spelled as one: the boxing pass rewrites
-    /// `&x` over an address-taken local into a bare read of the `Box<T>` the
-    /// local became, which is why the reference-shaped type is asked for too. A
-    /// value copy of that same local is a projection (`x.value`), so the
-    /// whole-local read is the borrow and nothing else answers here.
+    /// The operand a `let` binds as a place rather than a value: a borrow names
+    /// the place it was taken over, and a bare local already naming one rebinds
+    /// the same place, since copying a reference copies the reference. Nothing
+    /// else qualifies — a projection out of an alias reads *through* it and
+    /// yields a value, `*p` included, which is why the RHS is matched as a local
+    /// rather than through [`place_of`]. A borrow need not be spelled as one:
+    /// boxing rewrites `&x` into a bare read of the `Box<T>` the local became,
+    /// hence the reference-shaped type test.
     fn aliased_operand(&self, body: &Body, value: Operand) -> Option<Operand> {
         if let Some((_, borrowed)) = borrowed_place_operand(body, value) {
             return Some(borrowed);
@@ -627,16 +606,12 @@ impl Interpreter<'_> {
         }
     }
 
-    /// Fold a call to the value it computes. One that writes through a `&mut`
-    /// parameter is never folded here: this projection is re-entrant, and a
-    /// write applied twice is worse than one not folded at all. Those run at
-    /// statement position, where the executor applies the writes.
-    /// `Unevaluated` on any miss, so the original call — and any runtime trap
-    /// inside it — survives.
-    ///
-    /// A run this frame already made answers from the fold memo, as a region
-    /// does: re-running would re-pay the body copy and the step budget for a
-    /// value already in hand.
+    /// Fold a call to the value it computes. One writing through a `&mut`
+    /// parameter is never folded here — this projection is re-entrant, and a
+    /// write applied twice is worse than one not folded at all; those run at
+    /// statement position instead. `Unevaluated` on any miss, so the original
+    /// call and any trap inside it survive. A run this frame already made answers
+    /// from the fold memo rather than re-paying the body copy and step budget.
     pub(super) fn try_call_fold(&mut self, body: &Body, e: ExprId) -> Lattice {
         if let Some(v) = self.frame.scratch_folds.get(&e) {
             return Lattice::Const(v.clone());
@@ -662,16 +637,13 @@ impl Interpreter<'_> {
         Some((site.func_id, site.operands().map(|(_, op)| op).collect()))
     }
 
-    /// Run a call in a compile-time frame: bind the parameters, execute the
-    /// body, and report the value it returns along with what it leaves in each
-    /// `&mut` parameter. `None` when the frame cannot run it.
-    ///
-    /// `may_write` is the caller's promise to apply the write-backs. Without it
-    /// a callee taking a `&mut` parameter is refused outright, since running it
-    /// would produce writes with nowhere to go.
-    ///
-    /// The body runs on a scratch copy, so the callee's shared arena — held
-    /// under an immutable borrow — is never mutated.
+    /// Run a call in a compile-time frame: bind the parameters, execute the body,
+    /// and report both the returned value and what it leaves in each `&mut`
+    /// parameter. `None` when the frame cannot run it. `may_write` is the
+    /// caller's promise to apply the write-backs; without it a callee taking a
+    /// `&mut` parameter is refused outright, since its writes would have nowhere
+    /// to go. The body runs on a scratch copy, so the callee's shared arena is
+    /// never mutated.
     fn run_call(&mut self, body: &Body, e: ExprId, may_write: bool) -> Option<CallRun> {
         let callees = self.facts.callees?;
         let (key, args) = self.call_target(body, e)?;
@@ -760,17 +732,12 @@ impl Interpreter<'_> {
     }
 
     /// Run the scratch body already installed as the current frame, reporting
-    /// what it returned and what it left in each `&mut` parameter.
-    ///
-    /// `None` rather than an empty write list when a `&mut` parameter has no
-    /// value to write: losing it would leave the caller's place holding what
-    /// the program never produced.
-    ///
-    /// `returns_unit` discards the result — a unit callee denotes nothing, and
-    /// a value left where the call stood fails validation.
-    ///
-    /// Every fallible step of a call lives here, so the caller restores its own
-    /// frame unconditionally on return.
+    /// what it returned and what it left in each `&mut` parameter. `None` rather
+    /// than an empty write list when a `&mut` parameter has no value: losing it
+    /// would leave the caller's place holding what the program never produced.
+    /// `returns_unit` discards the result, since a value left where a unit call
+    /// stood fails validation. Every fallible step lives here, so the caller
+    /// restores its own frame unconditionally.
     fn exec_frame(
         &mut self,
         scratch: &mut Body,
@@ -801,27 +768,14 @@ impl Interpreter<'_> {
         Some(CallRun { result, writes })
     }
 
-    /// The constant a self-contained region denotes: the block runs as a frame
-    /// the engine starts from scratch, since a region that builds its value in
-    /// locals of its own and touches only those is as self-contained as a call
-    /// body. An outer local the region only reads is seeded from the walker's
-    /// environment when it holds a constant there — a value snapshot at the
-    /// region's own flow point, sound because the region cannot write it back:
-    /// [`region_free_reads`] rejects write positions and reference-typed
-    /// mentions, and a local involved in a live place alias is refused here.
-    /// `None` when the block is not such a region, or when running
-    /// it does not finish on a constant — the block survives as written, so
-    /// anything it would do at run time still happens there.
-    ///
-    /// A reference-typed region is refused before the body is copied;
-    /// `Interpreter::commit_fold` states why a reference never folds.
-    ///
-    /// Safe on the re-entrant projection path even though it executes writes:
-    /// self-containment confines every write to locals of the scratch run, so
-    /// nothing is performed twice against the program's own state. A run an
-    /// earlier visit already made answers from the fold memo, since the
-    /// scratch sink promotes nothing and the region would otherwise be re-run
-    /// at every visit.
+    /// The constant a self-contained region denotes, run as its own frame: a
+    /// region building its value in locals of its own is as self-contained as a
+    /// call body. An outer local it only reads is seeded from the walker's
+    /// environment, sound because [`region_free_reads`] rejects write positions
+    /// and reference-typed mentions. `None` when the block is not such a region
+    /// or does not finish on a constant, leaving it to run as written. Safe on
+    /// the re-entrant projection path despite executing writes: self-containment
+    /// confines every one to the scratch run. Repeat visits answer from the memo.
     pub(super) fn try_region_fold(&mut self, body: &Body, e: ExprId) -> Option<Value> {
         let (block, label) = region_shape(body, e)?;
         if let Some(value) = self.frame.scratch_folds.get(&e) {

--- a/wado-compiler/src/niri/frame.rs
+++ b/wado-compiler/src/niri/frame.rs
@@ -2,8 +2,7 @@
 //! is performed exactly once, in order, over values the engine itself built —
 //! which is what separates the frame from the re-entrant lattice projection, so
 //! a write belongs here and nowhere else. Anything the frame cannot carry out
-//! abandons the evaluation: stepping past an unperformed write would leave its
-//! target holding a value the program never produced.
+//! abandons the evaluation rather than stepping past an unperformed write.
 
 use crate::const_eval::Value;
 use crate::nir_arena::{
@@ -409,10 +408,8 @@ impl Interpreter<'_> {
     /// Update the frame's value for `root` in place, applying `update` at `path`.
     /// `None` when the frame holds no constant for the root — which confines a
     /// write to values the engine itself built — or when the path reaches
-    /// nothing the update applies to. Written through rather than rebuilt, since
-    /// a rebuild copies the container per write and makes filling a sequence
-    /// quadratic. A clobbered root never holds a constant here, so writing
-    /// straight into the environment cannot revive one the frame gave up on.
+    /// nothing the update applies to. Written through rather than rebuilt: a
+    /// rebuild copies the container per write, making a sequence fill quadratic.
     fn update_place(
         &mut self,
         root: u32,
@@ -557,12 +554,9 @@ impl Interpreter<'_> {
 
     /// The operand a `let` binds as a place rather than a value: a borrow names
     /// the place it was taken over, and a bare local already naming one rebinds
-    /// the same place, since copying a reference copies the reference. Nothing
-    /// else qualifies — a projection out of an alias reads *through* it and
-    /// yields a value, `*p` included, which is why the RHS is matched as a local
-    /// rather than through [`place_of`]. A borrow need not be spelled as one:
-    /// boxing rewrites `&x` into a bare read of the `Box<T>` the local became,
-    /// hence the reference-shaped type test.
+    /// the same place. Nothing else qualifies — a projection out of an alias
+    /// reads *through* it — hence matching the RHS as a local. Boxing rewrites
+    /// `&x` into a bare read, so the type test accepts any reference shape.
     fn aliased_operand(&self, body: &Body, value: Operand) -> Option<Operand> {
         if let Some((_, borrowed)) = borrowed_place_operand(body, value) {
             return Some(borrowed);
@@ -608,10 +602,9 @@ impl Interpreter<'_> {
 
     /// Fold a call to the value it computes. One writing through a `&mut`
     /// parameter is never folded here — this projection is re-entrant, and a
-    /// write applied twice is worse than one not folded at all; those run at
-    /// statement position instead. `Unevaluated` on any miss, so the original
-    /// call and any trap inside it survive. A run this frame already made answers
-    /// from the fold memo rather than re-paying the body copy and step budget.
+    /// write applied twice is worse than none; those run at statement position.
+    /// `Unevaluated` on any miss, so the original call and any trap inside it
+    /// survive. A repeat run answers from the fold memo.
     pub(super) fn try_call_fold(&mut self, body: &Body, e: ExprId) -> Lattice {
         if let Some(v) = self.frame.scratch_folds.get(&e) {
             return Lattice::Const(v.clone());
@@ -639,11 +632,9 @@ impl Interpreter<'_> {
 
     /// Run a call in a compile-time frame: bind the parameters, execute the body,
     /// and report both the returned value and what it leaves in each `&mut`
-    /// parameter. `None` when the frame cannot run it. `may_write` is the
-    /// caller's promise to apply the write-backs; without it a callee taking a
-    /// `&mut` parameter is refused outright, since its writes would have nowhere
-    /// to go. The body runs on a scratch copy, so the callee's shared arena is
-    /// never mutated.
+    /// parameter. `may_write` is the caller's promise to apply the write-backs;
+    /// without it a callee taking a `&mut` parameter is refused. The body runs on
+    /// a scratch copy, so the callee's shared arena is never mutated.
     fn run_call(&mut self, body: &Body, e: ExprId, may_write: bool) -> Option<CallRun> {
         let callees = self.facts.callees?;
         let (key, args) = self.call_target(body, e)?;
@@ -733,11 +724,9 @@ impl Interpreter<'_> {
 
     /// Run the scratch body already installed as the current frame, reporting
     /// what it returned and what it left in each `&mut` parameter. `None` rather
-    /// than an empty write list when a `&mut` parameter has no value: losing it
-    /// would leave the caller's place holding what the program never produced.
-    /// `returns_unit` discards the result, since a value left where a unit call
-    /// stood fails validation. Every fallible step lives here, so the caller
-    /// restores its own frame unconditionally.
+    /// than an empty write list when a `&mut` parameter has no value, or the
+    /// caller's place would hold what the program never produced. `returns_unit`
+    /// discards the result, which would otherwise fail validation.
     fn exec_frame(
         &mut self,
         scratch: &mut Body,
@@ -768,14 +757,11 @@ impl Interpreter<'_> {
         Some(CallRun { result, writes })
     }
 
-    /// The constant a self-contained region denotes, run as its own frame: a
-    /// region building its value in locals of its own is as self-contained as a
-    /// call body. An outer local it only reads is seeded from the walker's
+    /// The constant a self-contained region denotes, run as its own frame: one
+    /// building its value in locals of its own is as self-contained as a call
+    /// body. An outer local it only reads is seeded from the walker's
     /// environment, sound because [`region_free_reads`] rejects write positions
-    /// and reference-typed mentions. `None` when the block is not such a region
-    /// or does not finish on a constant, leaving it to run as written. Safe on
-    /// the re-entrant projection path despite executing writes: self-containment
-    /// confines every one to the scratch run. Repeat visits answer from the memo.
+    /// and reference-typed mentions, which also confines writes to the scratch.
     pub(super) fn try_region_fold(&mut self, body: &Body, e: ExprId) -> Option<Value> {
         let (block, label) = region_shape(body, e)?;
         if let Some(value) = self.frame.scratch_folds.get(&e) {

--- a/wado-compiler/src/niri/lattice.rs
+++ b/wado-compiler/src/niri/lattice.rs
@@ -1,15 +1,8 @@
-//! What an expression denotes.
-//!
-//! A projection reads: it answers what value an expression stands for, given
-//! what is known about its inputs, and changes nothing. Every method here takes
-//! `&self`, and that is load-bearing rather than incidental — the engine walks
-//! the same node any number of times, so anything performed here would be
-//! performed again. What has to happen once belongs to the frame.
-//!
-//! A reference denotes its referent's value: the engine has no reference
-//! values, so borrowing and dereferencing change nothing about what is denoted.
-//! Where a frame gave a local a place of its own, that holds only for reads
-//! made *through* it — see [`Interpreter::projected_lattice`].
+//! What an expression denotes. A projection only reads, and every method taking
+//! `&self` is load-bearing: the engine walks the same node any number of times,
+//! so anything performed here would be performed again — what must happen once
+//! belongs to the frame. A reference denotes its referent's value, the engine
+//! having no reference values of its own.
 
 use std::rc::Rc;
 

--- a/wado-compiler/src/niri/pattern.rs
+++ b/wado-compiler/src/niri/pattern.rs
@@ -12,17 +12,11 @@ use crate::tir::PrimitiveType;
 use super::{Interpreter, PatBindings};
 
 impl Interpreter<'_> {
-    /// Whether `value` matches `pat`, recording into `binds` the locals the
-    /// pattern binds and the sub-values they take. `binds` is only meaningful
-    /// on [`PatternMatch::Yes`]; a rejected alternative may have left entries
-    /// behind.
-    ///
-    /// An `Or` alternative preceded by an undecided one binds nothing: the
-    /// earlier alternative is tried first at run time and would bind from its
-    /// own positions.
-    ///
-    /// A tuple rest (`(a, ..)`) leaves its trailing sub-patterns without a
-    /// fixed element index, so only the exact-arity form is decided.
+    /// Whether `value` matches `pat`, recording into `binds` the locals it binds
+    /// and the sub-values they take — meaningful only on [`PatternMatch::Yes`],
+    /// a rejected alternative having possibly left entries behind. An `Or`
+    /// alternative after an undecided one binds nothing, and a tuple rest leaves
+    /// its trailing sub-patterns unindexed, so only exact arity decides.
     pub(super) fn pattern_matches(
         &self,
         body: &Body,

--- a/wado-compiler/src/niri/region.rs
+++ b/wado-compiler/src/niri/region.rs
@@ -1,17 +1,8 @@
-//! Which blocks are self-contained enough to run as a frame.
-//!
-//! A self-contained region builds a value in locals of its own, reads and
-//! writes only those locals, and yields the result as its value — as
-//! self-contained as a call body, except that the caller wrote it inline.
-//! Recognizing that shape is what lets a fully-constant string template fold
-//! to the literal the source could have written.
-//!
-//! Everything here is asked before the run, because the run copies the whole
-//! enclosing body while these only walk the block, and a codebase's blocks are
-//! overwhelmingly not regions. What is left the run decides for itself — a
-//! global it cannot read, a loop past the budget, an operation that would trap
-//! — by abandoning the evaluation, which forfeits the fold rather than
-//! dropping a write.
+//! Which blocks are self-contained enough to run as a frame: one that builds a
+//! value in locals of its own, touches only those, and yields the result — as
+//! self-contained as a call body written inline, which is what lets a constant
+//! string template fold to a literal. Asked before the run, since the run copies
+//! the whole enclosing body while this only walks the block.
 
 use crate::nir::NirUnaryOp;
 use crate::nir_arena::{
@@ -86,28 +77,16 @@ pub(super) fn region_shape(body: &Body, e: ExprId) -> Option<(BlockId, Option<&s
     }
 }
 
-/// The outer locals `block` only reads — the seeds a region frame needs —
-/// provided every call in it is one a frame could run and nothing writes a
-/// global. `None` disqualifies the region outright: an unrunnable call, a
-/// global write, an outer local in a write position — where folding the
-/// region would drop the write the program performs — or an outer local of
-/// reference type, since reading a `&mut T` value hands a callee the same
-/// write capability.
+/// The outer locals `block` only reads — the seeds a region frame needs — or
+/// `None` for anything that disqualifies it: an unrunnable call, a global write,
+/// an outer local in a write position, or a reference-typed one, reading which
+/// hands a callee the same write capability.
 ///
-/// A write position is an `Assign` target, a `&mut` borrow, or an argument —
-/// receiver included — the callee's signature takes by `&mut`. The signature
-/// is the only reliable witness: `ArenaCallArg::is_mut` marks a by-value
-/// `mut` parameter, the callee's own copy, and boxing can erase the borrow
-/// node at the call site. A write whose place no local roots also
-/// disqualifies: the executor resolves stores through the same chains, so an
-/// unrooted one is a write this scan cannot account for, not a write that
-/// will not happen.
-///
-/// Only the reachable nodes are scanned, so a mention an earlier rewrite
-/// orphaned neither disqualifies the region nor keeps it from folding. What
-/// the scan cannot see is which reachable nodes actually execute: a free local
-/// read or an unrunnable call on a statically dead path costs the fold, which
-/// is the price of answering before the body is cloned rather than after.
+/// A write position is an `Assign` target, a `&mut` borrow, or an argument the
+/// callee's signature takes by `&mut`. The signature is the only reliable
+/// witness: `is_mut` marks a by-value `mut` parameter and boxing can erase the
+/// borrow node. A write no local roots also disqualifies, being one this scan
+/// cannot account for.
 pub(super) fn region_free_reads(
     body: &Body,
     block: BlockId,

--- a/wado-compiler/src/niri/region.rs
+++ b/wado-compiler/src/niri/region.rs
@@ -79,14 +79,9 @@ pub(super) fn region_shape(body: &Body, e: ExprId) -> Option<(BlockId, Option<&s
 
 /// The outer locals `block` only reads — the seeds a region frame needs — or
 /// `None` for anything that disqualifies it: an unrunnable call, a global write,
-/// an outer local in a write position, or a reference-typed one, reading which
-/// hands a callee the same write capability.
-///
-/// A write position is an `Assign` target, a `&mut` borrow, or an argument the
-/// callee's signature takes by `&mut`. The signature is the only reliable
-/// witness: `is_mut` marks a by-value `mut` parameter and boxing can erase the
-/// borrow node. A write no local roots also disqualifies, being one this scan
-/// cannot account for.
+/// an outer local in a write position, or a reference-typed one. A write
+/// position is an `Assign` target, a `&mut` borrow, or an argument the callee's
+/// signature takes by `&mut` — the signature being the only reliable witness.
 pub(super) fn region_free_reads(
     body: &Body,
     block: BlockId,

--- a/wado-compiler/src/niri/region.rs
+++ b/wado-compiler/src/niri/region.rs
@@ -79,9 +79,10 @@ pub(super) fn region_shape(body: &Body, e: ExprId) -> Option<(BlockId, Option<&s
 
 /// The outer locals `block` only reads — the seeds a region frame needs — or
 /// `None` for anything that disqualifies it: an unrunnable call, a global write,
-/// an outer local in a write position, or a reference-typed one. A write
-/// position is an `Assign` target, a `&mut` borrow, or an argument the callee's
-/// signature takes by `&mut` — the signature being the only reliable witness.
+/// a reference-typed outer local, or a write whose place is an outer local or
+/// roots in no local at all (unaccountable, not absent). A write is an `Assign`
+/// target, a `&mut` borrow, or a `&mut` parameter per the callee's signature —
+/// the signature being the only reliable witness.
 pub(super) fn region_free_reads(
     body: &Body,
     block: BlockId,

--- a/wado-compiler/src/niri/rewrite.rs
+++ b/wado-compiler/src/niri/rewrite.rs
@@ -65,7 +65,7 @@ impl Interpreter<'_> {
     /// Reduce `e` to its flow-sensitive constant value or collapse a constant
     /// branch, committing every edit through `sink`. Both value sources — the
     /// flow-sensitive candidate and a self-contained region run — land through
-    /// [`Self::commit_fold`], so what is promoted, materialized, memoized, and
+    /// `Self::commit_fold`, so what is promoted, materialized, memoized, and
     /// refused is decided in one place.
     pub fn reduce_local<S: EditSink>(&mut self, sink: &mut S, e: ExprId) -> bool {
         if let Some(value) = self.flow_fold_candidate(sink.body(), e)

--- a/wado-compiler/src/niri/rewrite.rs
+++ b/wado-compiler/src/niri/rewrite.rs
@@ -1,14 +1,8 @@
-//! Writing a value back into the IR.
-//!
-//! The projection answers what an expression denotes; this is what becomes of
-//! the expression once it does. Every edit goes through an [`EditSink`], so the
-//! same rewrites serve two backends: the throwaway body a compile-time frame
-//! runs on, and the real one, whose maps an engine keeps coherent.
-//!
-//! Not every value has a form to be written as. A scalar promotes to a pure
-//! operand; a byte-sequence container becomes the literal the lower phase emits
-//! for a source string; every other aggregate stays inside the engine, and what
-//! reaches the IR is the scalars projected out of it.
+//! Writing a value back into the IR: what becomes of an expression once the
+//! projection says what it denotes. Every edit goes through an [`EditSink`], so
+//! the same rewrites serve the throwaway frame body and the real one. A scalar
+//! promotes to a pure operand and a byte-sequence container to the lower phase's
+//! string literal; every other aggregate reaches the IR only via its scalars.
 
 use crate::compiler_item::SeqField;
 use crate::const_eval::Value;
@@ -94,22 +88,10 @@ impl Interpreter<'_> {
     }
 
     /// Take `value` over `e`: promote a scalar, materialize a byte-sequence
-    /// container, and memoize what the sink did not take, reporting whether
-    /// the node was rewritten.
-    ///
-    /// A reference-typed node is refused whole: its value would stand as a
-    /// fresh literal where the program yields an alias, and `ref.eq` can tell
-    /// the two apart.
-    ///
-    /// A declined scalar is always memoized — the scratch backend promotes
-    /// nothing, so the memo is where its folds live.
-    ///
-    /// An aggregate is written back wherever the write buys something
-    /// ([`Self::is_worth_materializing`]), and over a shape that consumed its
-    /// source ([`consumes_its_source`]) regardless. Only the latter is
-    /// memoized: a revisit would re-run a body to recompute it, while every
-    /// other shape still derives its own value from the literal left in its
-    /// place.
+    /// container, memoize what the sink declined, and report whether the node was
+    /// rewritten. A reference-typed node is refused whole — a fresh literal where
+    /// the program yields an alias, which `ref.eq` can tell apart. An aggregate
+    /// is written where [`Self::is_worth_materializing`] agrees.
     fn commit_fold<S: EditSink>(&mut self, sink: &mut S, e: ExprId, value: Value) -> bool {
         let node_type = sink.body().exprs[e].type_id;
         if self.type_table.is_reference_shaped(node_type) {
@@ -133,17 +115,11 @@ impl Interpreter<'_> {
         committed
     }
 
-    /// Whether writing the value over `e` buys anything.
-    ///
-    /// It does everywhere but two shapes that already hold the answer. One is
-    /// the literal [`Self::materialize_seq_via`] writes — refusing it is what
-    /// makes the rewrite happen once, which the [`consumes_its_source`] shapes
-    /// get from their kinds for free.
-    ///
-    /// The other is a read of a global. Const-object globalization put the
-    /// value there so it is built once and shared; a literal in its place is
-    /// that constant copied back to every site, and the store left behind
-    /// outlives the slot the reachability census then drops.
+    /// Whether writing the value over `e` buys anything. It does everywhere but
+    /// two shapes already holding the answer: the literal
+    /// [`Self::materialize_seq_via`] writes, refusing which is what makes the
+    /// rewrite happen once, and a global read, whose value globalization put
+    /// there precisely to build once and share.
     fn is_worth_materializing(&self, body: &Body, e: ExprId) -> bool {
         !matches!(body.exprs[e].kind, ExprKind::GlobalVarGet { .. })
             && !self.is_materialized_seq_literal(body, e)
@@ -187,16 +163,9 @@ impl Interpreter<'_> {
 
     /// Write `value` back over `e` as the container literal the lower phase
     /// emits for a source string: a struct over a packed byte array and its
-    /// length.
-    ///
-    /// Only the container's first `used` bytes: capacity outruns what it holds
-    /// and is not observable. An empty one is left alone, being a reservation
-    /// rather than a result.
-    ///
-    /// The container is identified by type, never recognised by shape — any
-    /// struct over an array and an `i32` has that shape, and over
-    /// `Chunk { data, tag }` the literal would read the second field as a
-    /// length.
+    /// length. Only the first `used` bytes — capacity is not observable — and an
+    /// empty container is left alone. Identified by type, never by shape: over a
+    /// `Chunk { data, tag }` the literal would read `tag` as a length.
     fn materialize_seq_via<S: EditSink>(&self, sink: &mut S, e: ExprId, value: &Value) -> bool {
         let Value::Aggregate { type_id, .. } = value else {
             return false;

--- a/wado-compiler/src/niri/trackability.rs
+++ b/wado-compiler/src/niri/trackability.rs
@@ -224,31 +224,15 @@ enum Reach {
     Write,
 }
 
-/// Locals of `body` that may bind an aggregate constant: ones every mention
-/// only reads.
+/// Locals of `body` that may bind an aggregate constant: ones every mention only
+/// reads. The read positions are listed rather than inferred from the absence of
+/// the others, so an untaught node kind costs a fold and never a wrong one.
 ///
-/// The read positions are listed rather than inferred from the absence of the
-/// others, so a node kind nobody taught this walk about costs a fold and never
-/// a wrong one. A shared borrow and a cast are read positions that pass the
-/// read on to their operand — Wado has no interior mutability, and a cast
-/// names the same storage — which is what lets `push_str(&b)` count as a read
-/// of `b` rather than an unknown mention.
-///
-/// The two sides of the check deliberately scan different populations.
-/// Mentions and disqualifications come from the reachable body alone: an
-/// orphaned mention cannot run, so it must not disqualify anything. Two of the
-/// `value_reads` sources read the whole arena instead — the statement sweep
-/// below and [`Reached`]'s call collectors; the taught-position expression
-/// walk above stays reachable — because an in-place rewrite shares ids
-/// between a live node and the displaced parent that used to hold it, so a
-/// reachable mention's only read-position witness may sit in a statement or
-/// call no live node refers to. Narrowing those sweeps to the reachable tree
-/// disqualifies the string-building locals every Display chain folds through
-/// (measured: the `default_trait` and `display_1` goldens grew back by
-/// hundreds of lines). This is the rule's one home;
-/// `a_displaced_parent_still_vouches_for_its_mention` pins the statement
-/// witness and `a_displaced_call_still_vouches_for_its_argument` the call
-/// one.
+/// The two sides scan different populations. Mentions and disqualifications come
+/// from the reachable body alone, an orphaned mention being unable to run. Two
+/// `value_reads` sources sweep the whole arena instead: an in-place rewrite
+/// shares ids between a live node and the displaced parent that held it, so a
+/// mention's only witness may sit where nothing live refers to.
 pub(super) fn aggregate_safe_locals(body: &Body, reached: &Reached) -> LocalSet {
     fn disqualify_root(body: &Body, op: Operand, set: &mut LocalSet) {
         if let Some(index) = lvalue_root_local(body, op) {

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -1,15 +1,9 @@
-//! Optimization passes for Wado NIR.
-//!
-//! The optimizer rewrites the [`NirPackage`] in place. Each pass lives in its
-//! own module under `optimize/` and documents itself there; the sequence of
-//! [`run_pass`] calls below is the only statement of what runs and in what
-//! order, with the rationale for each position in the comment beside it.
-//!
-//! [`docs/optimizer.md`](../../../docs/optimizer.md) is the reader-facing
-//! inventory, and
-//! [`docs/wep-2026-06-05-nir-optimizer-architecture.md`](../../../docs/wep-2026-06-05-nir-optimizer-architecture.md)
-//! describes the two-tier NIR, the rewrite engine, and the gate the passes run
-//! on.
+//! Optimization passes for Wado NIR, rewriting the [`NirPackage`] in place. Each
+//! pass documents itself in its own module under `optimize/`; the sequence of
+//! [`run_pass`] calls below is the only statement of what runs in what order,
+//! with the rationale for each position beside it. `docs/optimizer.md` is the
+//! reader-facing inventory, and WEP 2026-06-05 covers the two-tier NIR, the
+//! rewrite engine, and the gate.
 
 mod alias;
 mod arena_query;
@@ -88,29 +82,11 @@ struct OptConfig {
     inline_threshold: usize,
 }
 
-/// Optimization level for the compiler.
-///
-/// All levels run DCE (Dead Code Elimination) to remove unreachable code.
-/// The levels differ in what optimization passes are run:
-/// - O0: DCE only - no optimization passes
-/// - O1: Development - fast compilation with basic optimization passes
-/// - O2: Production - full optimization passes (default)
-/// - O3: Production - aggressive optimization passes
-/// - Os: Frontend - O2 + name section stripping for smaller binaries
-///
-/// Configuration for each level:
-/// | Level | DCE | Iterations | Inline Threshold |
-/// |-------|-----|------------|------------------|
-/// | O0    | Yes | 0          | N/A              |
-/// | O1    | Yes | 2          | 4                |
-/// | O2    | Yes | 10         | 13               |
-/// | O3    | Yes | 30         | 32               |
-/// | Os    | Yes | 10         | 13               |
-///
-/// "Iterations" / "Inline Threshold" describe the fixed-point
-/// optimization loop. The post-loop rewrites the Wasm backend depends on
-/// always run, including at `O0`; only the fixed-point loop itself is
-/// skipped there.
+/// Optimization level. Every level runs DCE and the post-loop rewrites the Wasm
+/// backend depends on; what varies is the fixed-point loop, whose iteration
+/// count and inline threshold go `O0` (skipped entirely), `O1` (2 / 4),
+/// `O2` (10 / 13, the default), `O3` (30 / 32). `Os` is `O2` plus name-section
+/// stripping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum OptLevel {
     /// No optimization loop. DCE plus the always-on post-optimization
@@ -131,43 +107,13 @@ pub enum OptLevel {
     Os,
 }
 
-/// Optimize a Package by analyzing and populating its usage fields.
-///
-/// This is the main entry point for the optimizer. Based on the optimization
-/// level, it applies different optimization strategies:
-///
-/// - O0: DCE only (no optimization passes)
-/// - O1: Basic optimization passes + DCE
-/// - O2: Full optimization passes + DCE (default)
-/// - O3: Aggressive optimization passes + DCE
-/// - Os: Same as O2 plus name section stripping
-///
-/// All levels run DCE to remove unreachable functions and types, which
-/// significantly reduces codegen work.
-///
-/// For O1+, DCE runs twice: once before the optimization loop to reduce
-/// the working set (eliminating stdlib functions/types the program doesn't
-/// use), and once after to clean up code made dead by optimizations
-/// (e.g., functions inlined away).
-///
-/// The `inline_threshold` and `opt_iterations` parameters override the
-/// defaults for the given `opt_level` when provided.
-/// Maximum UTF-8 byte length for a string literal to be materialized with a
-/// constant `array.new_fixed<u8>` repr instead of a passive `array.new_data`
-/// data segment. Below it, a constant string global promotes to an eager Wasm
-/// constant; above it the compact data-segment repr is kept (and the global
-/// stays lazy). `-O3` trades a little code size for more eager string globals;
-/// the other levels (and `-Os`, which targets size) stay conservative.
-///
-/// This threshold applies to every *ordinary* string literal, including one
-/// with nothing to do with `const_object_globalization` (e.g. an `assert`
-/// diagnostic template, which `codegen_flags` tests require stay byte-scannable
-/// below this threshold). A global `const_object_globalization` hoists from an
-/// `InlineRef` candidate gets a separate, size-bounded override — see
-/// [`crate::nir::NirGlobal::prefer_fixed_string_repr`] — since such a hoist
-/// rewrites the literal's construction in place rather than moving it to
-/// `__initialize_module`, so only an eager repr lets the redundant re-assignment
-/// be recognized and dropped.
+/// Longest string literal materialized as a constant `array.new_fixed<u8>`
+/// rather than a passive data segment; above it the compact repr is kept and the
+/// global stays lazy. `-O3` trades code size for more eager string globals,
+/// while `-Os` and the rest stay conservative. Applies to every ordinary literal,
+/// an `assert` template included; a global hoisted by
+/// `const_object_globalization` overrides it via
+/// [`crate::nir::NirGlobal::prefer_fixed_string_repr`].
 fn string_inline_max_bytes(opt_level: OptLevel) -> usize {
     match opt_level {
         OptLevel::O3 => 8,
@@ -175,6 +121,11 @@ fn string_inline_max_bytes(opt_level: OptLevel) -> usize {
     }
 }
 
+/// The optimizer's entry point. Every level runs DCE, which cuts codegen work
+/// sharply; `O1` and above run it twice, before the fixed-point loop to shrink
+/// the working set and after it to sweep what the loop made dead. What runs in
+/// between is the pass sequence below, scaled by [`OptLevel`]. `inline_threshold`
+/// and `opt_iterations` override that level's defaults.
 pub fn optimize(
     mut project: NirPackage,
     opt_level: OptLevel,
@@ -236,19 +187,12 @@ pub fn optimize(
             }
         }
         OptLevel::O3 => {
-            // The iteration cap is purely defensive. Since
-            // `field_forward` was merged into `const_fold` (issue
-            // #1009), straight-line constant chains produced by
-            // inlined `List::push` and similar patterns fold in a
-            // single iteration rather than one statement per round,
-            // so even Gale parsers reach a true fixed point in well
-            // under 10 iterations. 30 leaves comfortable headroom for
-            // whatever gradient new fixtures expose.
-            //
-            // Threshold 32 sits just under a discrete size cliff at
-            // 33 on syntax-highlight (859KB -> 1049KB, crossing 1MB)
-            // where additional Gale action functions become inline
-            // candidates with no measurable speed payoff.
+            // The iteration cap is defensive: since `field_forward` merged into
+            // `const_fold`, a straight-line constant chain folds in one
+            // iteration rather than one statement per round, so even Gale
+            // parsers converge well under 10. Threshold 32 sits just under a
+            // size cliff at 33 on syntax-highlight (859KB → 1049KB), where more
+            // Gale action functions become inline candidates for no speed gain.
             let config = OptConfig {
                 iterations: opt_iterations.unwrap_or(30),
                 inline_threshold: inline_threshold.unwrap_or(32),
@@ -295,17 +239,11 @@ pub fn optimize(
         select_lowering::select_lowering(p)
     });
 
-    // Multi-value return ABI classification: marks tuple- or
-    // user-struct-returning functions whose every return site is a fresh
-    // `TupleLiteral` / `StructLiteral` and whose every call site
-    // destructures via `FieldAccess` on the bound temp. WIR build
-    // (`wir_build::translate::try_emit_multi_value_let`) reads the marker
-    // to emit the multi-value Wasm signature on the function definition
-    // and to rewrite call-site `let __tmp = Call(f)` into
-    // `MultiValueLocalBind [__tmp_0, …] = Call(f)` with subsequent
-    // `FieldAccess` reads going to the split locals directly. Runs after
-    // every other transformation so the analysis sees the final NIR
-    // shape.
+    // Multi-value return ABI classification: marks an aggregate-returning
+    // function whose every return builds a fresh literal and whose every call
+    // site destructures the bound temp, which WIR build reads to emit the
+    // multi-value signature and split the call-site binding. Runs after every
+    // other transformation, so the analysis sees the final NIR shape.
     run_pass("nir/multi_value_return", &mut project, profiler, |p| {
         multi_value_return::classify_multi_value_returns(p)
     });
@@ -579,36 +517,18 @@ fn run_optimization_passes(
                 run_pass($name, project, profiler, |p| $pass(p, &mut gate));
             }};
         }
-        // Dense-int / dense-enum `Match` → `Switch` is a codegen-friendly late
-        // lowering (see WEP 2026-05-11). It runs as `MatchToSwitchRule` inside
-        // the unified peephole session below: the pre-inline `peephole` run
-        // converts every function's `Match` to `Switch` before `inline`, so
-        // inline still sees `Switch`-shaped bodies, and the worklist reconverges
-        // on any `Match` a later rewrite plants. `container_sroa` /
-        // `value_copy_*` run before that first `peephole` and so see `Match`,
-        // which is fine — neither keys on the `Switch` shape.
-        // Container SROA must run *before* inline in each iteration: inline
-        // expands trait methods like `IndexValue::index_value` into raw
-        // `builtin::array_get` + field-access pairs, after which the
-        // method-call shape container SROA relies on is gone. Running early
-        // also means we see the `SequenceLiteralBuilder` desugaring for `[]`
-        // while its inner `Constructor` call is still a plain `Call` node,
-        // which `recognize_init` can match structurally.
+        // Container SROA must run before inline in each iteration: inline
+        // expands `IndexValue::index_value` and friends into raw
+        // `builtin::array_get` + field-access pairs, after which the method-call
+        // shape this pass keys on is gone. Running early also catches the `[]`
+        // desugaring while its inner `Constructor` is still a plain `Call`.
         gated!("nir/container_sroa", scalarize_containers);
-        // Unified peephole engine pass, pre-inline run. Folds short
-        // `push_str` literals, elides write-only locals, and (post-inline only)
-        // materializes array literals — all three rules over one shared
-        // worklist; see `optimize/peephole.rs`. Runs *before* inline so
-        // `string_push` still sees the `buf.push_str("0.")` call shape:
-        // once the inliner expands `String::push_str`'s body that node is gone
-        // and the literal-recognising rewrite can no longer match, leaving
-        // short-string formatting paths (e.g. `fpfmt.wado`) paying full
-        // per-call allocation cost. This run also hosts `const_branch_prune`
-        // (trivial-block / dead-statement cleanup); it keys only on block
-        // structure, so `copy_prop` — not pass ordering — is what folds the
-        // inliner's parameter copies. This pre-inline run also hosts
-        // `MatchToSwitchRule` (`include_match = true`), lowering every `Match` to
-        // `Switch` before `inline`.
+        // Peephole engine, pre-inline run — several rules over one worklist; see
+        // `optimize/peephole.rs`. Before inline so `string_push` still sees the
+        // `buf.push_str("0.")` shape, which the inliner's expansion would erase,
+        // leaving short-string formatting to pay full per-call allocation. Hosts
+        // `MatchToSwitchRule` (`include_match = true`), so `inline` copies
+        // `Switch`-shaped bodies, and `const_branch_prune`.
         gated!("nir/peephole", |p, g| peephole::run_peephole(p, g, true));
         // Demote deep `$value_copy$T` copies of `List<E>` to shallow spine
         // copies when the binding's elements are provably never mutated through
@@ -644,17 +564,11 @@ fn run_optimization_passes(
                 }
             }
         }
-        // Unified peephole engine pass, post-inline run. Now `array_literal`
-        // fires: it materializes `ArrayLiteral` from the `List<T> {
-        // array_new(N) } + N × List::push` builder window, which inline must
-        // expose first — the `SequenceLiteralBuilder` methods (and, for wrapper
-        // builders such as `SeqVec { items: List<T> }`, the `push_literal →
-        // self.field.push` delegation) are inlined into the raw `array_new +
-        // push` window, direct or field-rooted. Hash-consing and the later
-        // `const_fold` in this same loop then see the normalized literal. `elide_local` runs
-        // again here over inline's freshly dead bindings. No `MatchToSwitchRule`
-        // here (`include_match = false`): the pre-inline run already lowered
-        // every reachable `Match`, and `inline` copies `Switch`-shaped bodies.
+        // Peephole engine, post-inline run. `array_literal` fires only here: it
+        // needs inline to have expanded the builder methods into the raw
+        // `array_new(N) + N × push` window it matches. `elide_local` runs again
+        // over inline's freshly dead bindings. No `MatchToSwitchRule` — the
+        // pre-inline run lowered every reachable `Match` already.
         gated!("nir/peephole", |p, g| peephole::run_peephole(p, g, false));
         // `labeled_block_fusion` moved into the post-inline `nir/peephole`
         // session as `LabeledBlockFusionRule`; see `optimize/peephole.rs`.
@@ -672,26 +586,13 @@ fn run_optimization_passes(
         // elimination moved into the unified `nir/peephole` pass above.)
         gated!("nir/dae", eliminate_dead_arguments);
         gated!("nir/drve", eliminate_dead_return_values);
-        // Pure-value CSE is subsumed by hash-consing (identical values already
-        // share a ValueId), and store-load forwarding by FieldAccess promoting at
-        // its heap version, so no separate `cse` pass runs.
-        // The flow-sensitive half of constant folding; the env-free half
-        // (literal arithmetic + pure CTFE) runs in the `nir/peephole` passes.
-        // This walker handles the folds that need per-function dataflow state —
-        // env-bound locals, forwarded struct fields, immutable-global reads, and
-        // constant-branch collapse.
-        //
-        // `field_forward`'s rewrite responsibilities are absorbed by
-        // `const_fold` (see `optimize::const_folding::ConstFoldVisitor`).
-        // Both passes used to alternate one statement at a time on
-        // chained-`List::push` patterns produced by Gale-generated
-        // parsers, leaving the optimizer non-convergent at `-O3`
-        // (issue #1009). The merged const-fold walk feeds the
-        // interpreter's `field_env` from `Let` / `Assign` /
-        // `$value_copy$T(arg)` shapes and forks per branch, so a
-        // chain of pushes folds in a single iteration. The alias and
-        // value-copy-helper analyses migrated to
-        // `optimize::alias`.
+        // The flow-sensitive half of constant folding — env-bound locals,
+        // forwarded struct fields, immutable-global reads, constant-branch
+        // collapse — where the env-free half runs in `nir/peephole`. It absorbs
+        // what `field_forward` used to do: the two alternated one statement per
+        // round on Gale's chained-`push` patterns and left `-O3` non-convergent,
+        // where the merged walk folds a whole chain in one iteration. No `cse`
+        // pass: hash-consing already shares identical values.
         {
             let c = run_pass("nir/const_fold", project, profiler, |p| {
                 fold_constants(p, &mut gate, &mut const_fold_cache)

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -1,6 +1,6 @@
 //! Optimization passes for Wado NIR, rewriting the [`NirPackage`] in place. Each
 //! pass documents itself in its own module under `optimize/`; the sequence of
-//! [`run_pass`] calls below is the only statement of what runs in what order.
+//! `run_pass` calls below is the only statement of what runs in what order.
 //! `docs/optimizer.md` is the reader-facing inventory, and WEP 2026-06-05 covers
 //! the two-tier NIR, the rewrite engine, and the gate.
 

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -1,9 +1,8 @@
 //! Optimization passes for Wado NIR, rewriting the [`NirPackage`] in place. Each
 //! pass documents itself in its own module under `optimize/`; the sequence of
-//! [`run_pass`] calls below is the only statement of what runs in what order,
-//! with the rationale for each position beside it. `docs/optimizer.md` is the
-//! reader-facing inventory, and WEP 2026-06-05 covers the two-tier NIR, the
-//! rewrite engine, and the gate.
+//! [`run_pass`] calls below is the only statement of what runs in what order.
+//! `docs/optimizer.md` is the reader-facing inventory, and WEP 2026-06-05 covers
+//! the two-tier NIR, the rewrite engine, and the gate.
 
 mod alias;
 mod arena_query;
@@ -110,10 +109,8 @@ pub enum OptLevel {
 /// Longest string literal materialized as a constant `array.new_fixed<u8>`
 /// rather than a passive data segment; above it the compact repr is kept and the
 /// global stays lazy. `-O3` trades code size for more eager string globals,
-/// while `-Os` and the rest stay conservative. Applies to every ordinary literal,
-/// an `assert` template included; a global hoisted by
-/// `const_object_globalization` overrides it via
-/// [`crate::nir::NirGlobal::prefer_fixed_string_repr`].
+/// while `-Os` and the rest stay conservative. A global hoisted by
+/// `const_object_globalization` overrides it via `prefer_fixed_string_repr`.
 fn string_inline_max_bytes(opt_level: OptLevel) -> usize {
     match opt_level {
         OptLevel::O3 => 8,
@@ -188,11 +185,10 @@ pub fn optimize(
         }
         OptLevel::O3 => {
             // The iteration cap is defensive: since `field_forward` merged into
-            // `const_fold`, a straight-line constant chain folds in one
-            // iteration rather than one statement per round, so even Gale
-            // parsers converge well under 10. Threshold 32 sits just under a
-            // size cliff at 33 on syntax-highlight (859KB → 1049KB), where more
-            // Gale action functions become inline candidates for no speed gain.
+            // `const_fold`, a straight-line constant chain folds in one iteration
+            // rather than one statement per round, so even Gale parsers converge
+            // well under 10. Threshold 32 sits just under a size cliff at 33 on
+            // syntax-highlight (859KB → 1049KB), for no speed gain.
             let config = OptConfig {
                 iterations: opt_iterations.unwrap_or(30),
                 inline_threshold: inline_threshold.unwrap_or(32),
@@ -525,9 +521,8 @@ fn run_optimization_passes(
         gated!("nir/container_sroa", scalarize_containers);
         // Peephole engine, pre-inline run — several rules over one worklist; see
         // `optimize/peephole.rs`. Before inline so `string_push` still sees the
-        // `buf.push_str("0.")` shape, which the inliner's expansion would erase,
-        // leaving short-string formatting to pay full per-call allocation. Hosts
-        // `MatchToSwitchRule` (`include_match = true`), so `inline` copies
+        // `buf.push_str("0.")` shape, which the inliner's expansion would erase.
+        // Hosts `MatchToSwitchRule` (`include_match = true`), so `inline` copies
         // `Switch`-shaped bodies, and `const_branch_prune`.
         gated!("nir/peephole", |p, g| peephole::run_peephole(p, g, true));
         // Demote deep `$value_copy$T` copies of `List<E>` to shallow spine
@@ -589,10 +584,8 @@ fn run_optimization_passes(
         // The flow-sensitive half of constant folding — env-bound locals,
         // forwarded struct fields, immutable-global reads, constant-branch
         // collapse — where the env-free half runs in `nir/peephole`. It absorbs
-        // what `field_forward` used to do: the two alternated one statement per
-        // round on Gale's chained-`push` patterns and left `-O3` non-convergent,
-        // where the merged walk folds a whole chain in one iteration. No `cse`
-        // pass: hash-consing already shares identical values.
+        // `field_forward`, which used to alternate one statement per round and
+        // left `-O3` non-convergent. No `cse` pass: hash-consing already shares.
         {
             let c = run_pass("nir/const_fold", project, profiler, |p| {
                 fold_constants(p, &mut gate, &mut const_fold_cache)

--- a/wado-compiler/src/optimize/alias.rs
+++ b/wado-compiler/src/optimize/alias.rs
@@ -50,12 +50,10 @@ pub(super) struct AliasWalkResult {
 }
 
 /// Compute a body's alias annotations plus the mutable-escape walk's raw
-/// `syntactic_mut` set, sharing one traversal across three per-node collectors —
-/// none reads another's output during the walk, only in the post-processing.
+/// `syntactic_mut` set, sharing one traversal across three per-node collectors.
 /// `aliased` seeds from the function's stable annotations, which persist across
-/// iterations so a later pass erasing the syntactic markers cannot make the
-/// analysis forget an alias, then picks up whatever is visible only inside
-/// `body`. `untrackable` mirrors `stores_aliased_locals` exactly.
+/// iterations so a pass erasing the syntactic markers cannot make the analysis
+/// forget an alias. `untrackable` mirrors `stores_aliased_locals` exactly.
 pub(super) fn build_alias_info(
     body: &Body,
     locals: &[crate::nir::NirLocal],
@@ -256,10 +254,8 @@ fn build_mut_escaped(
 /// Memoised "a callee receiving this by value or immutable reference cannot
 /// mutate it" predicate. A value is mutable through a call only if it carries
 /// shared mutable state — a `&mut T`, a `Box` / `List` cell, a raw array, a
-/// resource handle, or a shape the analysis cannot see into. Anything free of
-/// those is deep-copied on pass-by-value, so no callee reaches the fields the
-/// `ValueGraph` forwards. Cross-handle mutation of a `&T` pointee is
-/// [`build_mut_escaped`]'s alias-group closure instead.
+/// resource handle, or an opaque shape. Anything else is deep-copied on
+/// pass-by-value, so no callee reaches the fields the `ValueGraph` forwards.
 pub(super) struct CallImmutability<'a> {
     type_table: &'a TypeTable,
     struct_fields: IndexMap<(String, ModuleSource), Vec<TypeId>>,
@@ -387,9 +383,8 @@ use super::arena_query::storage_root;
 /// Call exprs that mutate no caller local: a free call, or one with a `&self`
 /// receiver, whose every argument is safe — not `mut`, an immutable borrow, or a
 /// call-immutable value the callee cannot reach back through. The value graph
-/// skips the per-call bump for these, so `arr.len()` does not split
-/// `arr.used`'s version — the precondition for promoting a spliced
-/// `FieldAccess`. An unknown callee stays impure for a receiver.
+/// skips the per-call bump for these, so `arr.len()` does not split `arr.used`'s
+/// version. An unknown callee stays impure for a receiver.
 pub(super) fn pure_calls(
     body: &Body,
     type_table: &TypeTable,
@@ -710,10 +705,9 @@ fn self_derived_locals(body: &Body, p0: u32, type_table: &TypeTable) -> IndexSet
 
 /// One walk of `body` summarising param-0's receiver writes. `direct` is a
 /// fixpoint-invariant write through its projection root — an assignment, a
-/// `&mut`, a `mut` argument, or a call into a bodyless callee that mutates its
-/// receiver — and short-circuits the walk. `pending` collects the bodied callees
-/// invoked on a self projection, whose verdicts the fixpoint resolves, and is
-/// gathered only while no direct write has been seen.
+/// `&mut`, a `mut` argument, or a bodyless callee mutating its receiver — and
+/// short-circuits the walk. `pending` collects the bodied callees invoked on a
+/// self projection, whose verdicts the fixpoint resolves.
 fn summarize_receiver_writes(
     body: &Body,
     p0: u32,
@@ -780,10 +774,8 @@ fn summarize_receiver_writes(
 /// Flag the root of a call argument that hands the callee shared mutable state
 /// by value — a `Box`, `List`, `&mut T` or resource handle — which it can mutate
 /// exactly like a `&mut` place. Boxing lowers `&mut x` to a by-value `Box<x>`,
-/// clearing `is_mut`, so keying on that flag alone would forward pre-call fields
-/// across `step(&mut pos)` and miscompile. Keyed on the type rather than a
-/// per-parameter mutation analysis, which is unsound after `field_scalarize`
-/// rewrites a callee's parameter-field writes into shadow locals.
+/// clearing `is_mut`, so keying on that flag alone would miscompile
+/// `step(&mut pos)`. Keyed on the type, which survives `field_scalarize`.
 fn collect_ref_arg_escapes(
     body: &Body,
     node: NodeRef,
@@ -1013,9 +1005,8 @@ fn alias_groups_from_edges(edges: Vec<(u32, u32)>) -> IndexMap<u32, IndexSet<u32
 /// True when copying a `type_id` value between locals aliases them onto one heap
 /// object — the reference types. A value-semantic type gets a `$value_copy$T`
 /// wrapper post-loop, so treating its `let dst = src` as an edge during the loop
-/// would over-merge groups that must stay separate. `Box<T>` / `List<T>` surface
-/// either as `GenericInstance` or as monomorphized `Struct` records carrying the
-/// generic name in `base_name`.
+/// would over-merge groups. `Box<T>` / `List<T>` surface as `GenericInstance` or
+/// as monomorphized `Struct` records carrying the generic name in `base_name`.
 fn type_creates_alias(type_id: TypeId, type_table: &TypeTable) -> bool {
     let items = type_table.compiler_items();
     let box_name = items.struct_name(crate::compiler_item::CompilerItem::Box);

--- a/wado-compiler/src/optimize/alias.rs
+++ b/wado-compiler/src/optimize/alias.rs
@@ -1,22 +1,10 @@
 //! Per-function alias analysis feeding the engine [`ValueGraph`] builder.
-//!
 //! [`build_alias_info`] shares one body walk across the alias analysis and the
-//! mutable-escape scan, returning an [`AliasWalkResult`]: the finished
-//! [`AliasInfo`] (`aliased`, `untrackable`, `alias_groups`) plus
-//! the mutable-escape walk's raw `syntactic_mut` set. [`builder_alias_sets`]
-//! finishes `syntactic_mut` into `mut_escaped` via [`build_mut_escaped`], so
-//! every engine-driven pass feeds the [`ValueGraph`] the alias view it needs to
-//! bound heap-write invalidation. The walk seeds `aliased` from the function's
-//! stable `address_taken_locals` / `stores_aliased_locals` annotations plus a
-//! body scan for transient inlined-in copies, builds the union-find of
-//! reference-typed `let dst = src` aliases, and lifts `stores_aliased_locals`
-//! verbatim into `untrackable`.
-//!
-//! TODO(optimizer): plumb the callee's `stores` annotation into
-//! `AliasCollector` so a `Ref` / `MutRef` on a local that flows into a
-//! `stores`-free callee no longer marks the local aliased. The current
-//! unconditional mark over-approximates for the common
-//! `(&self).field` / `(&mut self).field = ...` single-call patterns.
+//! mutable-escape scan; [`builder_alias_sets`] finishes its `syntactic_mut` into
+//! `mut_escaped`, giving each pass the view it needs to bound heap-write
+//! invalidation. TODO(optimizer): plumb the callee's `stores` annotation in, so
+//! a reference flowing into a `stores`-free callee stops marking its local
+//! aliased — today's unconditional mark over-approximates `(&self).field`.
 //!
 //! [`ValueGraph`]: crate::nir_value_graph
 
@@ -29,21 +17,11 @@ use crate::nir_arena::{Body, ExprId, ExprKind, LocalSet, NodeRef, Operand, StmtK
 use crate::nir_package::NirPackage;
 use crate::tir::{ResolvedType, TypeId, TypeTable};
 
-/// Per-function alias / aliasing-trackability annotations.
-///
-/// Computed once per function by [`build_alias_info`] (from the function's
-/// stable `address_taken_locals` / `stores_aliased_locals` plus a body walk
-/// that catches transient inlined-in copies) and consumed by the engine
-/// [`ValueGraph`] builder ([`builder_alias_sets`]) to bound heap-write
-/// invalidation at the right granularity.
-///
-/// - `aliased`: locals reachable through some other handle (`&x`,
-///   `&mut x`, captured by a closure, struct-field-stored, etc.).
-/// - `untrackable`: locals whose aliasing escapes the analysis (e.g.
-///   stashed across a `stores`-annotated callee).
-/// - `alias_groups`: union-find groups of locals connected by
-///   reference-typed `let dst = src` copies (`Box<T>`, `List<T>`,
-///   `&T`, `&mut T`).
+/// Per-function alias annotations, computed once by [`build_alias_info`]:
+/// `aliased` are locals reachable through another handle, `untrackable` those
+/// whose aliasing escapes the analysis entirely (stashed across a `stores`
+/// callee), and `alias_groups` the union-find over reference-typed
+/// `let dst = src` copies. Bounds heap-write invalidation in the [`ValueGraph`].
 ///
 /// [`ValueGraph`]: crate::nir_value_graph
 #[derive(Default, Clone, Debug)]
@@ -71,35 +49,13 @@ pub(super) struct AliasWalkResult {
     pub(super) syntactic_mut: IndexSet<u32>,
 }
 
-/// Compute per-function alias annotations for a function body, plus the
-/// mutable-escape walk's raw `syntactic_mut` set (see [`build_mut_escaped`]).
-///
-/// Shares one body traversal across three independent per-node collectors —
-/// `collect_aliased_node`, `collect_alias_edges_node`, `collect_mut_escaped_node`
-/// — instead of walking `body` three times: none of the three reads another's
-/// output *during* the walk, only in the post-processing below, so they can
-/// run in the same pass. Populates [`AliasWalkResult::info`] as follows:
-///
-/// - `aliased`: seeds from `address_taken_locals` ∪
-///   `stores_aliased_locals`, then augmented with locals whose
-///   aliasing is visible only inside `body` (transient inlined-in
-///   copies, captures, struct-field-stores). The seeded sets persist
-///   across optimization iterations, so subsequent passes (`ref_elim`,
-///   SROA) erasing the syntactic markers can't make us forget the
-///   alias.
-/// - `untrackable`: mirrors `stores_aliased_locals` exactly. An
-///   inlined `stores`-annotated callee has stashed the reference
-///   somewhere the analyzer cannot see, so any later read may
-///   observe a mutation we never witnessed. The const-fold visitor
-///   refuses to record fields for these locals (matches the OLD
-///   WIR-level `const_forward` conservatism).
-/// - `alias_groups`: union-find over reference-typed `let dst = src`
-///   Local→Local copies in `body` (`Box<T>`, `List<T>`, `&T`,
-///   `&mut T`). Used to widen field-assignment invalidation: writing
-///   `dst.field = …` drops the same field on every alias.
-///
-/// [`AliasWalkResult::syntactic_mut`] is `stores_aliased_locals` plus every
-/// local this walk found a mutable-escape site for.
+/// Compute a body's alias annotations plus the mutable-escape walk's raw
+/// `syntactic_mut` set, sharing one traversal across three per-node collectors —
+/// none reads another's output during the walk, only in the post-processing.
+/// `aliased` seeds from the function's stable annotations, which persist across
+/// iterations so a later pass erasing the syntactic markers cannot make the
+/// analysis forget an alias, then picks up whatever is visible only inside
+/// `body`. `untrackable` mirrors `stores_aliased_locals` exactly.
 pub(super) fn build_alias_info(
     body: &Body,
     locals: &[crate::nir::NirLocal],
@@ -259,19 +215,11 @@ pub(super) fn builder_alias_sets(
     (aliased, info.untrackable.iter().collect(), mut_escaped)
 }
 
-/// Compute the per-function `mut_escaped` set subtractively from `aliased`.
-/// `syntactic_mut` is [`build_alias_info`]'s walk output: the body's syntactic
-/// mutable-escape sites ([`collect_mut_escaped_node`]) plus
-/// `stores_aliased_locals` (an inlined `stores`-annotated callee stashed the
-/// reference, mutability unknown).
-///
-/// 1. Keep every `aliased` local whose type is not provably call-immutable
-///    *or* that has a syntactic mutable escape; drop the rest (provably
-///    immutable: no callee can mutate them).
-/// 2. Close the result over `alias_groups` (the union-find
-///    [`build_alias_info`] already computed), so that mutating one member of an
-///    alias group (a `let dst = src` reference copy, or two same-pointee
-///    reference params) clobbers the whole group's fields.
+/// Compute `mut_escaped` subtractively from `aliased`: keep every local that is
+/// not provably call-immutable or that has a syntactic mutable escape, then
+/// close over `alias_groups` so mutating one member of a group clobbers the
+/// whole group's fields. `syntactic_mut` is [`build_alias_info`]'s walk output
+/// plus `stores_aliased_locals`, whose mutability is unknown.
 fn build_mut_escaped(
     locals: &[crate::nir::NirLocal],
     aliased: &IndexSet<u32>,
@@ -305,22 +253,13 @@ fn build_mut_escaped(
     esc
 }
 
-/// Transitive "a value of this type cannot be mutated by a callee that receives
-/// it by value or by immutable reference" predicate, memoised per pass.
-///
-/// A value escaping into a call is mutable through that call only if it carries
-/// *shared mutable state*: a `&mut T`, a `Box<T>` / `List<T>` cell, a raw
-/// `Array<T>`, a resource handle, a reactive cell, or a variant/generic/unknown
-/// shape we cannot see into. A type free of all of those — primitives, plain
-/// value structs of such fields (e.g. `i128 { low: i64, high: i64 }`), enums,
-/// flags, and immutable `&T` references — is deep-copied on pass-by-value and
-/// cannot be written through an immutable reference, so no callee can change
-/// the fields the `ValueGraph` forwards. (Cross-handle mutation of a `&T`
-/// pointee is handled separately by the alias-group closure in
-/// [`build_mut_escaped`].)
-///
-/// Owns a struct-field map cloned from `project.structs`, so it borrows only
-/// `type_table` for the pass's lifetime.
+/// Memoised "a callee receiving this by value or immutable reference cannot
+/// mutate it" predicate. A value is mutable through a call only if it carries
+/// shared mutable state — a `&mut T`, a `Box` / `List` cell, a raw array, a
+/// resource handle, or a shape the analysis cannot see into. Anything free of
+/// those is deep-copied on pass-by-value, so no callee reaches the fields the
+/// `ValueGraph` forwards. Cross-handle mutation of a `&T` pointee is
+/// [`build_mut_escaped`]'s alias-group closure instead.
 pub(super) struct CallImmutability<'a> {
     type_table: &'a TypeTable,
     struct_fields: IndexMap<(String, ModuleSource), Vec<TypeId>>,
@@ -445,17 +384,12 @@ impl<'a> CallImmutability<'a> {
 
 use super::arena_query::storage_root;
 
-/// Call exprs that **mutate no caller local**: a free call, or a call with a
-/// `&self` receiver, whose every argument is safe — not `mut`, an immutable `&`
-/// borrow, or a by-value value of a call-immutable type (a deep copy the callee
-/// cannot reach back through). The value graph can skip a `mut_escaped`
-/// receiver's per-call bump for these, so a field read keeps its version across a
-/// pure accessor (`arr.len()` does not split `arr.used`'s version) — the
-/// precondition for promoting a spliced `FieldAccess` (WEP: the field-bound
-/// recovery). Unknown callees stay impure for a receiver
-/// (`method_mutates_receiver`'s conservative default); a free `Call` is pure when
-/// its args are all safe, since a callee can only mutate what it is handed
-/// mutably.
+/// Call exprs that mutate no caller local: a free call, or one with a `&self`
+/// receiver, whose every argument is safe — not `mut`, an immutable borrow, or a
+/// call-immutable value the callee cannot reach back through. The value graph
+/// skips the per-call bump for these, so `arr.len()` does not split
+/// `arr.used`'s version — the precondition for promoting a spliced
+/// `FieldAccess`. An unknown callee stays impure for a receiver.
 pub(super) fn pure_calls(
     body: &Body,
     type_table: &TypeTable,
@@ -774,20 +708,12 @@ fn self_derived_locals(body: &Body, p0: u32, type_table: &TypeTable) -> IndexSet
     set
 }
 
-/// One walk of `body` extracting param-0's receiver-write summary:
-///
-/// - `direct`: a fixpoint-invariant write through param-0's projection root
-///   `p0` — `self.f = …` / `*self = …`, `&mut <self projection>`, a `mut` call
-///   argument rooted at self, or a receiver-projecting method call into a
-///   bodyless / unstamped callee that mutates its receiver (verdict fixed by the
-///   callee's declared first-param type, conservative when unknown).
-/// - `pending`: ids of bodied callees invoked on a self projection. Their verdict
-///   is `mutating[id]`, resolved by the fixpoint as the set grows. `direct`
-///   short-circuits the walk; `pending` is collected only while no direct write
-///   has been seen.
-///
-/// `projects_p0` broadens to [`roots_self`] over [`self_derived_locals`], so a
-/// mutation through a boxed self projection counts.
+/// One walk of `body` summarising param-0's receiver writes. `direct` is a
+/// fixpoint-invariant write through its projection root — an assignment, a
+/// `&mut`, a `mut` argument, or a call into a bodyless callee that mutates its
+/// receiver — and short-circuits the walk. `pending` collects the bodied callees
+/// invoked on a self projection, whose verdicts the fixpoint resolves, and is
+/// gathered only while no direct write has been seen.
 fn summarize_receiver_writes(
     body: &Body,
     p0: u32,
@@ -851,36 +777,13 @@ fn summarize_receiver_writes(
     (direct, pending)
 }
 
-/// Flag the roots of mutable-escape sites in a single node:
-///
-/// - `&mut v` — the inner place's root is mutably referenced.
-/// - `f(…, mut arg, …)` — a mut-ref call argument's root.
-/// - `recv.m(…)` where `m` takes `&mut self` (or the receiver expression is
-///   already a `&mut`), plus the method's own mut-ref arguments. Receiver
-///   mutability comes from the callee's declared first-param type
-///   (`first_param_types`); an unknown callee is treated conservatively as
-///   mutating its receiver.
-///
-/// Immutable `&v` is deliberately *not* a mutable escape: a `&self` receiver
-/// or `&T` argument cannot mutate the pointee, so the local's fields survive
-/// across the call.
-/// A call argument that passes a reference-carrying local (`Box<T>`, `List<T>`,
-/// `&mut T`, resource handle, …) by value can be mutated by the callee through
-/// that handle — exactly like a `&mut`-place (`is_mut`) argument. Boxing lowers a
-/// `&mut x` place into a by-value `Box<x>`, so `is_mut` is `false` on the lowered
-/// arg (`step(xs, &mut pos)` → `step(xs, pos)`); keying only on `is_mut` misses
-/// it and the value graph forwards the callee-mutated pre-call fields across the
-/// call (`let mut pos = 0; step(&mut pos); pos` — a miscompile).
-///
-/// Keyed on the argument's type carrying shared mutable state, not on a
-/// whole-program per-parameter mutation analysis: the latter is unsound here
-/// because this runs after `field_scalarize`, which rewrites a callee's
-/// parameter-field writes into shadow-local writes the body walk no longer sees.
-/// The type check keeps the common read-only case fully optimizable — an
-/// immutable `&T` or a deep-copied value type is `is_call_immutable` and stays
-/// unmarked, so only genuinely mutable handles (which are nearly always actually
-/// mutated) lose cross-call forwarding. Marks both the alias set (field-write
-/// granularity) and `syntactic_mut` (`build_mut_escaped` keeps it escaped).
+/// Flag the root of a call argument that hands the callee shared mutable state
+/// by value — a `Box`, `List`, `&mut T` or resource handle — which it can mutate
+/// exactly like a `&mut` place. Boxing lowers `&mut x` to a by-value `Box<x>`,
+/// clearing `is_mut`, so keying on that flag alone would forward pre-call fields
+/// across `step(&mut pos)` and miscompile. Keyed on the type rather than a
+/// per-parameter mutation analysis, which is unsound after `field_scalarize`
+/// rewrites a callee's parameter-field writes into shadow locals.
 fn collect_ref_arg_escapes(
     body: &Body,
     node: NodeRef,
@@ -1011,16 +914,6 @@ fn collect_mut_escaped_node(
 // Alias group analysis (union-find over reference-typed copies)
 // ──────────────────────────────────────────────────────────────────────────────
 
-/// Build the alias-group map. Two locals end up in the same group
-/// when they're connected by a chain of `let dst = src` Local→Local
-/// copies of a reference-typed value (`Box<T>`, `List<T>`, `&T`,
-/// `&mut T`). For value-semantic types (plain structs, variants),
-/// `let dst = src` will later be wrapped in `$value_copy$T(src)` by
-/// the value-copy synthesis pass — `dst` is then a fresh allocation
-/// and does not share storage with `src`, so we don't connect them.
-///
-/// The group is used to widen field-assignment invalidation: writing
-/// `dst.field = ...` invalidates the same field of every alias.
 /// The struct identity a reference type points at, stripping `Ref`/`MutRef`.
 /// `None` for non-reference types or references to non-struct pointees
 /// (primitives, boxed primitives) whose fields const-fold never tracks.
@@ -1117,17 +1010,12 @@ fn alias_groups_from_edges(edges: Vec<(u32, u32)>) -> IndexMap<u32, IndexSet<u32
     out
 }
 
-/// True when assigning a value of `type_id` from one local to another
-/// produces aliasing — both names refer to the same heap object. This
-/// is the case for reference types (`Box<T>`, `List<T>`, `&T`,
-/// `&mut T`). Value-semantic types (plain structs, variants) are
-/// turned into a `$value_copy$T(src)` wrapper post-loop, so during
-/// the loop a `let dst = src` edge between two value-typed locals
-/// would over-merge groups that should stay separate.
-///
-/// `Box<T>` and `List<T>` may surface either as `GenericInstance`
-/// (pre-monomorphization) or as concrete monomorphized `Struct`
-/// records carrying the original generic name in `base_name`.
+/// True when copying a `type_id` value between locals aliases them onto one heap
+/// object — the reference types. A value-semantic type gets a `$value_copy$T`
+/// wrapper post-loop, so treating its `let dst = src` as an edge during the loop
+/// would over-merge groups that must stay separate. `Box<T>` / `List<T>` surface
+/// either as `GenericInstance` or as monomorphized `Struct` records carrying the
+/// generic name in `base_name`.
 fn type_creates_alias(type_id: TypeId, type_table: &TypeTable) -> bool {
     let items = type_table.compiler_items();
     let box_name = items.struct_name(crate::compiler_item::CompilerItem::Box);

--- a/wado-compiler/src/optimize/arena_query.rs
+++ b/wado-compiler/src/optimize/arena_query.rs
@@ -187,11 +187,9 @@ pub(super) fn is_place_prefix(q: &Place, p: &Place) -> bool {
 
 /// The local whose interior storage `expr` reaches, seeing through the sharing
 /// projections — field access, indexing, variant payload, a transparent cast,
-/// and `&`/`&mut`/`*` — but not an arithmetic unary, which produces a fresh
-/// scalar. The root-only query for the escape / aliasing / mutation analyses,
-/// as against the narrower [`place_root_local`] and the path-sensitive
-/// [`place_path`]. `None` does not mean fresh: `container.index_value(i)` gives
-/// `None` yet aliases the container, so pair it with a freshness gate.
+/// and `&`/`&mut`/`*` — but not an arithmetic unary. The root-only query for the
+/// escape / aliasing / mutation analyses. `None` does not mean fresh:
+/// `container.index_value(i)` still aliases, so pair it with a freshness gate.
 pub(super) fn storage_root(body: &Body, expr: ExprId) -> Option<u32> {
     match &body.exprs[expr].kind {
         ExprKind::Local { index, .. } => Some(*index),
@@ -359,12 +357,10 @@ pub(super) fn is_pure_operand(body: &Body, op: Operand) -> bool {
 }
 
 /// True when the expression has no observable effect *and cannot trap* — the
-/// predicate for a pass that *deletes* an expression, where dropping a
-/// `100 / x` would erase a trap the program is entitled to. [`is_pure_expr`]
-/// stays trap-agnostic for reordering and CSE, which keep the expression and its
-/// trap. The trap dimension comes from the shared [`ModRef`] oracle, so the
-/// taxonomy lives in one place. With a type table a `FieldAccess` on a non-null
-/// receiver is non-trapping; pass `None` to stay conservative.
+/// predicate for a pass that *deletes* an expression, where dropping a `100 / x`
+/// would erase a trap the program is entitled to. [`is_pure_expr`] stays
+/// trap-agnostic for reordering and CSE. With a type table a `FieldAccess` on a
+/// non-null receiver is non-trapping; pass `None` to stay conservative.
 pub(super) fn is_pure_nontrapping_expr_typed(
     body: &Body,
     id: ExprId,
@@ -522,11 +518,9 @@ pub(super) fn expr_node_may_trap(body: &Body, id: ExprId) -> bool {
 
 /// Flow-insensitive `&mut`-alias map: per `&mut`-typed local, the function locals
 /// its reference may point into. Built in one walk plus a fixpoint over
-/// ref-to-ref copies — a `&mut place` definition contributes the place's root, a
-/// ref-to-ref copy propagates them, and every other shape (a call returning
-/// `&mut`, a read out of an aggregate, a pattern binding) makes the provenance
-/// unknown, so a write may hit any `borrowed` local. A mut-ref parameter aliases
-/// nothing: a caller cannot hold a reference into this frame's fresh locals.
+/// ref-to-ref copies; every other shape leaves the provenance unknown, so a write
+/// may hit any `borrowed` local. A mut-ref parameter aliases nothing — a caller
+/// cannot hold a reference into this frame's fresh locals.
 #[derive(Debug, Default)]
 pub(super) struct MutRefAliases {
     entries: crate::hashmap::IndexMap<u32, AliasEntry>,
@@ -785,12 +779,10 @@ fn is_mut_ref_typed(body: &Body, e: ExprId, type_table: &crate::tir::TypeTable) 
 }
 
 /// Report every local root the node `id` itself may mutate, the caller's walk
-/// driving traversal into children. The one shared witness→root dispatch: a
-/// single storage-chain resolution expanded through [`MutRefAliases`], and a
+/// driving traversal into children. The one shared witness→root dispatch, with a
 /// single bodyless-callee fallback. That fallback trusts the call site's declared
-/// `mut` bit, since the `&mut`-type test has false negatives for a boxed
-/// argument — `&mut scalar` arrives `Box`-typed with `is_mut` still set, the box
-/// cell being the caller-visible storage. Receivers have only the type.
+/// `mut` bit, since the `&mut`-type test misses a boxed argument: `&mut scalar`
+/// arrives `Box`-typed with `is_mut` still set.
 pub(super) fn for_each_mutated_root(
     body: &Body,
     id: ExprId,

--- a/wado-compiler/src/optimize/arena_query.rs
+++ b/wado-compiler/src/optimize/arena_query.rs
@@ -1,25 +1,12 @@
-//! Arena-side structural queries shared by the rewrite-engine rules.
+//! Arena-side structural queries shared by the rewrite-engine rules, reading the
+//! [`Body`] directly so the ported passes need no `Body ↔ tree` bridge. A new
+//! see-through node kind must be taught to `storage_root` / `strip_refs` here
+//! *and* to `niri/place.rs`, which keeps its own transparent-wrapper set.
 //!
-//! `is_local`, `expr_mentions_local`, `stmt_mentions_local`, `is_pure_expr`,
-//! `collect_reads`, … read the [`Body`] arena directly, so the ported passes
-//! need no `Body ↔ tree` bridge.
-//!
-//! `niri/place.rs` keeps its own statement of the transparent-wrapper set
-//! (`wrapped_operand`), so a new see-through node kind must be taught there
-//! as well as to `storage_root` / `strip_refs` below.
-//!
-//! ## Promoted reads
-//!
-//! After operand promotion a pure read lives in the value pool as an
-//! `Operand::Value`, not in the skeleton, so a census that walks nodes alone —
-//! [`collect_reads`], the engine's use index — cannot see it. The
-//! `promoted_*` queries here supply exactly what that walk misses, and every
-//! one of them is scoped to the *reachable* operands: the pool is append-only,
-//! so it still holds the values of reads that folded away long ago, and seeding
-//! from it would keep their locals alive forever.
-//!
-//! The walk itself lives on `Body`, since [`crate::nir_engine::Engine`]
-//! memoizes it per session and cannot reach into `optimize`.
+//! After operand promotion a pure read lives in the value pool rather than the
+//! skeleton, where a node walk cannot see it; the `promoted_*` queries supply
+//! exactly that, scoped to the *reachable* operands — the pool is append-only, so
+//! seeding from it wholesale would keep long-folded locals alive forever.
 
 use crate::hashmap::IndexSet;
 use crate::nir::{NirBinaryOp, NirUnaryOp};
@@ -198,17 +185,13 @@ pub(super) fn is_place_prefix(q: &Place, p: &Place) -> bool {
     q.0 == p.0 && q.1.len() <= p.1.len() && q.1 == p.1[..q.1.len()]
 }
 
-/// The local whose interior storage `expr` reaches, seeing through the
-/// projections that share it: field access, indexing, variant payload, a
-/// transparent cast, and `&`/`&mut`/`*`. Arithmetic unaries produce fresh
-/// scalars and do not descend. The root-only storage query for the escape /
-/// aliasing / mutation-witness analyses; distinct from [`place_root_local`]
-/// (narrower, paired with the caller's own wrapper dispatch) and the
-/// path-sensitive [`place_path`].
-///
-/// `None` does *not* mean "fresh": `container.index_value(i)` also returns
-/// `None` yet aliases the container, so callers pair this with a freshness
-/// gate (`EscapeMap::rvalue_is_fresh`) or treat `None` conservatively.
+/// The local whose interior storage `expr` reaches, seeing through the sharing
+/// projections — field access, indexing, variant payload, a transparent cast,
+/// and `&`/`&mut`/`*` — but not an arithmetic unary, which produces a fresh
+/// scalar. The root-only query for the escape / aliasing / mutation analyses,
+/// as against the narrower [`place_root_local`] and the path-sensitive
+/// [`place_path`]. `None` does not mean fresh: `container.index_value(i)` gives
+/// `None` yet aliases the container, so pair it with a freshness gate.
 pub(super) fn storage_root(body: &Body, expr: ExprId) -> Option<u32> {
     match &body.exprs[expr].kind {
         ExprKind::Local { index, .. } => Some(*index),
@@ -375,18 +358,13 @@ pub(super) fn is_pure_operand(body: &Body, op: Operand) -> bool {
     op.as_expr().is_none_or(|e| is_pure_expr(body, e))
 }
 
-/// True when the expression has no observable effect *and cannot trap*. A trap
-/// is an observable effect that must survive, so this — not [`is_pure_expr`] —
-/// is the predicate for passes that *delete* an expression (dead-argument
-/// elimination, dead-return-value elimination, write-only-local elision):
-/// dropping a `100 / x` or `arr[i]` erases a runtime trap the program is
-/// entitled to. `is_pure_expr` stays trap-agnostic for reordering/CSE, which
-/// keep the expression (its trap still fires). The trap dimension comes from the
-/// shared [`ModRef`] oracle so the taxonomy lives in one place.
-///
-/// With a type table, a `FieldAccess` on a non-null struct/ref receiver is
-/// recognised as non-trapping (dropping the dead residue of an inlined unused
-/// `&self` receiver, say); pass `None` to stay conservative.
+/// True when the expression has no observable effect *and cannot trap* — the
+/// predicate for a pass that *deletes* an expression, where dropping a
+/// `100 / x` would erase a trap the program is entitled to. [`is_pure_expr`]
+/// stays trap-agnostic for reordering and CSE, which keep the expression and its
+/// trap. The trap dimension comes from the shared [`ModRef`] oracle, so the
+/// taxonomy lives in one place. With a type table a `FieldAccess` on a non-null
+/// receiver is non-trapping; pass `None` to stay conservative.
 pub(super) fn is_pure_nontrapping_expr_typed(
     body: &Body,
     id: ExprId,
@@ -469,15 +447,10 @@ fn is_pure_block(body: &Body, block: BlockId) -> bool {
 // Per-node trap taxonomy
 // ---------------------------------------------------------------------------
 //
-// The single listing of *which operation traps*, shared by every pass that
-// reasons about trap preservation so they cannot drift apart (an earlier
-// trap-deletion P0 was exactly such a drift). It mirrors, at per-node
-// granularity, the trap dimension `mod_ref::ModRef::may_trap` accumulates
-// recursively — `mod_ref` stays the recursive trap authority (its inline
-// `Div | Mod` / `Deref` / `Cast` / heap-projection classification is the
-// reference these helpers reproduce). Consumers: `elide_box_local`'s
-// leftmost-side-effect walk (`expr_node_may_trap`) and `select_lowering`'s
-// arm-eligibility gate (`binary_op_may_trap`).
+// The single listing of which operation traps, shared so no two passes reasoning
+// about trap preservation can drift apart — an earlier trap-deletion P0 was
+// exactly that. Mirrors per node what `mod_ref::ModRef::may_trap` accumulates
+// recursively; `mod_ref` remains the recursive authority these reproduce.
 
 /// Whether a [`NirBinaryOp`] may trap at runtime, independent of its operands.
 /// Integer `Div` / `Mod` trap on a zero divisor (and `INT_MIN / -1`); every
@@ -542,41 +515,18 @@ pub(super) fn expr_node_may_trap(body: &Body, id: ExprId) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// Mutated-root queries
+// Mutated-root queries — the canonical "which locals may a subtree mutate"
+// facility. Consolidation target for the hand-rolled variants in
+// `const_folding` and `condition_implication`.
 // ---------------------------------------------------------------------------
-//
-// The canonical "which locals may a subtree mutate" facility, shared so every
-// consumer applies one witness taxonomy, one bodyless-callee fallback, and one
-// `&mut`-alias resolution. Direct consumers today: `copy_prop` (scope-stability
-// scan and usage marking). Consolidation target for the hand-rolled variants in
-// `const_folding::record_loop_write` and `condition_implication::node_modifies`.
-//
-// Receiver-wrapper caveat: at reification a `&mut self` receiver is
-// `&mut`-typed or an explicit `Unary(MutRef)` (`elaborator/method_lookup.rs`,
-// `adjust_receiver_for_self_kind_static`), but the boxing rewrite erases the
-// `&mut`/`&` wrapper distinction for boxed-scalar receivers, so at NIR a
-// mutating receiver can arrive as a bare shared `&` borrow. Mutation is
-// therefore recognized by the callee's *declared* pre-boxing bit (the oracle
-// verdict / the call site's `is_mut` bit), never by the wrapper shape alone;
-// with a mutating verdict the attribution sees through either wrapper to the
-// storage root. This is also why the bodyless fallback trusts `is_mut` rather
-// than the — boxing-erased — `&mut` type.
 
-/// Flow-insensitive `&mut`-alias map: for every `&mut`-typed local, the set of
-/// function locals its stored reference may point into.
-///
-/// Built in one walk + a fixpoint over ref-to-ref copies:
-///
-/// - `let r = &mut place` / `r = &mut place` contributes the place's root
-///   (or, when the place derefs another ref local, that local's own roots).
-/// - `let r2 = r` between ref locals copies `r`'s roots.
-/// - Every other definition shape (a call returning `&mut`, a ref read back
-///   out of an aggregate, a pattern binding, an `if` producing a ref) makes
-///   the local's provenance *unknown*: a write through it may hit any local
-///   whose `&mut` was ever taken (`borrowed`).
-///
-/// Parameters are external: a caller cannot hold a `&mut` into this frame's
-/// fresh locals, so a mut-ref parameter aliases no function local.
+/// Flow-insensitive `&mut`-alias map: per `&mut`-typed local, the function locals
+/// its reference may point into. Built in one walk plus a fixpoint over
+/// ref-to-ref copies — a `&mut place` definition contributes the place's root, a
+/// ref-to-ref copy propagates them, and every other shape (a call returning
+/// `&mut`, a read out of an aggregate, a pattern binding) makes the provenance
+/// unknown, so a write may hit any `borrowed` local. A mut-ref parameter aliases
+/// nothing: a caller cannot hold a reference into this frame's fresh locals.
 #[derive(Debug, Default)]
 pub(super) struct MutRefAliases {
     entries: crate::hashmap::IndexMap<u32, AliasEntry>,
@@ -834,18 +784,13 @@ fn is_mut_ref_typed(body: &Body, e: ExprId, type_table: &crate::tir::TypeTable) 
     )
 }
 
-/// Report every local root the expression node `id` itself may mutate (the
-/// caller's walk drives traversal into children). The single shared
-/// witness→root dispatch: one root resolution (a storage chain, expanded
-/// through [`MutRefAliases`]) and one bodyless-callee fallback.
-///
-/// Bodyless-callee fallback (`verdict: None`): trust the call site's declared
-/// `mut` bit for arguments. The `&mut`-type test used for receivers /
-/// indirect arguments has false negatives for arguments the lowering boxed
-/// (`&mut scalar` arrives `Box`-typed with `is_mut` still set, and the box
-/// cell IS the caller-visible storage), so where the declared bit exists it
-/// is the more faithful signal; where it does not (receivers, indirect call
-/// operands), the `&mut` type is all there is.
+/// Report every local root the node `id` itself may mutate, the caller's walk
+/// driving traversal into children. The one shared witness→root dispatch: a
+/// single storage-chain resolution expanded through [`MutRefAliases`], and a
+/// single bodyless-callee fallback. That fallback trusts the call site's declared
+/// `mut` bit, since the `&mut`-type test has false negatives for a boxed
+/// argument — `&mut scalar` arrives `Box`-typed with `is_mut` still set, the box
+/// cell being the caller-visible storage. Receivers have only the type.
 pub(super) fn for_each_mutated_root(
     body: &Body,
     id: ExprId,

--- a/wado-compiler/src/optimize/array_literal.rs
+++ b/wado-compiler/src/optimize/array_literal.rs
@@ -1,48 +1,13 @@
-//! Materialize `ExprKind::ArrayLiteral` from an `Array<T>` builder
-//! sequence — an `array_new(N)` allocation followed by `N` `List::push`
-//! calls.
+//! Materialize `ExprKind::ArrayLiteral` from the builder sequence an array
+//! literal lowers to — a `List<T> { repr: array_new(N), used: 0 }` struct
+//! followed by `N` `List::push` calls on it or on a field of it — rewriting the
+//! struct and dropping the pushes. They need not be contiguous: element temps
+//! sit between them, and pushes to distinct array fields may interleave.
 //!
-//! An array literal `[e0, …, eN-1] as List<T>` is lowered (via the
-//! `SequenceLiteralBuilder` coercion and inlining) to:
-//!
-//! ```text
-//! let mut __b = <init binding> List<T> { repr: array_new(N), used: 0 };
-//! PLACE.push(e0);
-//! PLACE.push(e1);
-//! …
-//! PLACE.push(eN-1);
-//! ```
-//!
-//! `PLACE` is the bound local itself for a direct `List<T>` literal, or a
-//! field of it for a custom `SequenceLiteralBuilder` whose builder wraps an
-//! `List<T>` (e.g. `SeqVec { items: List<T> }`, `Bag { keys, values }`).
-//! This pass recognizes that window — the `List<T> { repr: array_new(N),
-//! used: 0 }` struct plus its `N` trailing `List::push` calls — and rewrites
-//! the struct to `ExprKind::ArrayLiteral { elements }`, dropping the
-//! pushes. The pushes need not be contiguous: inlining `push_literal` leaves
-//! single-use element temps between them (see `pure_temp_binding`), and
-//! pushes to distinct array fields may interleave (see `try_collapse_at`).
-//!
-//! `List::push` is identified by its [`CompilerItem::ListPush`] marker, not
-//! by a canonical path, mirroring `string_push`. `array_new` is identified by
-//! its builtin identity ([`FunctionRef::builtin_name`]), anchored on the
-//! callee's `ModuleSource` rather than a bare name string.
-//!
-//! Runs *after* `inline` in the fixpoint loop: the `SequenceLiteralBuilder`
-//! `new_literal` / `push_literal` / `build` methods (and, for wrapper builders,
-//! the `push_literal → self.field.push` delegation) must be inlined first so
-//! the raw `List<T> { array_new } + List::push` window is exposed. Giving
-//! constant arrays this first-class, analyzable shape lets hash-consing,
-//! `const_fold`, bounds-check elimination, and constant globalization act on
-//! them; `wir_build` lowers `ArrayLiteral` to `array.new_fixed`.
-//!
-//! Runs on the worklist rewrite engine (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) as a block-level
-//! [`Rule`]: the builder window is a run of sibling statements, so it collapses
-//! a block's statement list (`set_block_stmts`), reusing the existing element
-//! expression ids (their statements are dropped, so the ids are moved, not
-//! cloned). Nested blocks are separate worklist nodes processed bottom-up, so
-//! an inner block collapses before its enclosing one.
+//! Runs *after* `inline`, which must expose the raw window first, and as a
+//! block-level [`Rule`], the window being a run of sibling statements. Giving
+//! constant arrays this analyzable shape lets hash-consing, `const_fold`, BCE
+//! and globalization act on them; `wir_build` emits `array.new_fixed`.
 
 use crate::compiler_item::{CompilerItem, SeqField};
 use crate::hashmap::{IndexMap, IndexSet};
@@ -306,17 +271,11 @@ impl Collapser<'_> {
     }
 }
 
-/// If `stmt` is `let temp = value`, return the local index and the bound
-/// value. Used to see through the element temps that inlining
-/// `push_literal(value)` introduces (`let v = <element>; place.push(v)`).
-///
-/// `allow_impure` is set only when the window has a single array target. With
-/// one target the materialized elements keep their original push order, so
-/// moving an impure value into its element slot preserves both evaluation
-/// count (the caller's read guards enforce single use) and order. With
-/// multiple interleaved targets (e.g. `Bag { keys, values }`) the per-field
-/// arrays materialize one after another, which would reorder side effects
-/// across fields, so only pure temps may be resolved there.
+/// If `stmt` is `let temp = value`, return the local index and the bound value —
+/// how the element temps inlining `push_literal` introduces are seen through.
+/// `allow_impure` holds only for a single-target window, where the elements keep
+/// their push order; with interleaved targets the per-field arrays materialize
+/// one after another, reordering side effects, so only pure temps resolve.
 fn temp_binding(body: &Body, stmt: StmtId, allow_impure: bool) -> Option<(u32, Operand)> {
     match &body.stmts[stmt].kind {
         StmtKind::Let {

--- a/wado-compiler/src/optimize/array_literal.rs
+++ b/wado-compiler/src/optimize/array_literal.rs
@@ -1,13 +1,8 @@
 //! Materialize `ExprKind::ArrayLiteral` from the builder sequence an array
 //! literal lowers to — a `List<T> { repr: array_new(N), used: 0 }` struct
-//! followed by `N` `List::push` calls on it or on a field of it — rewriting the
-//! struct and dropping the pushes. They need not be contiguous: element temps
-//! sit between them, and pushes to distinct array fields may interleave.
-//!
-//! Runs *after* `inline`, which must expose the raw window first, and as a
-//! block-level [`Rule`], the window being a run of sibling statements. Giving
-//! constant arrays this analyzable shape lets hash-consing, `const_fold`, BCE
-//! and globalization act on them; `wir_build` emits `array.new_fixed`.
+//! followed by `N` `List::push` calls — rewriting the struct and dropping the
+//! pushes, which need not be contiguous. Runs after `inline` exposes that
+//! window; `wir_build` then emits `array.new_fixed`.
 
 use crate::compiler_item::{CompilerItem, SeqField};
 use crate::hashmap::{IndexMap, IndexSet};

--- a/wado-compiler/src/optimize/clone_forward.rs
+++ b/wado-compiler/src/optimize/clone_forward.rs
@@ -1,31 +1,8 @@
-//! Post-inline read-only clone forwarding.
-//!
-//! Inlining an accessor that copies a projection of its receiver
-//! (`build(&self) -> List { return *self }`, finalizing a `[1, 2, 3]` builder)
-//! leaves a residual `let t = array_clone(&place)` whose result is only ever
-//! read — most visibly `array_clone(&array_clone(&place))`, the redundant
-//! double-copy of a constant into a read-only binding that later feeds another
-//! copy. The fold-time value-copy elision cannot reach it: the copy is created
-//! by `inline` + `value_copy_demote`, after the pre-inline elider has run.
-//!
-//! This pass recovers it. When `t` is a read-only binding of `array_clone(&place)`
-//! (or its shallow twin) whose sole use is the referent of *another*
-//! `array_clone(&t)`, the inner clone is redundant: the outer clone already
-//! re-materializes a fresh copy, so `t` only needs to hold `place`'s value at that
-//! one point. The pass rewrites the outer clone to read `place` directly and drops
-//! the dead binding, turning `array_clone(&array_clone(&place))` into a single
-//! `array_clone(&place)`.
-//!
-//! Soundness rests on four gates, all conservative:
-//! - `t` is read exactly once and never mutated, reassigned, or `&mut`-borrowed;
-//! - that single read is the argument of an `array_clone` call — so the outer
-//!   clone makes a fresh, independent copy at the use and `t` is dead afterward.
-//!   This is the crux: a use that instead *stored* `t` into a longer-lived
-//!   aggregate (`*r = List { repr: t }`) would keep it aliased past the use, where
-//!   a later mutation of `place` could corrupt it, so such uses are not matched;
-//! - the use is in the *same block*, after the binding, a straight-line range;
-//! - no statement in that interval mutates `place`'s root local or writes *any*
-//!   global, so `place`'s value at the use equals its value at the binding.
+//! Post-inline read-only clone forwarding: `array_clone(&array_clone(&place))`
+//! becomes one `array_clone(&place)`, recovering what an inlined accessor left
+//! past the pre-inline elider's reach. Four conservative gates: the binding is
+//! read once and never mutated; that read is another `array_clone`'s argument;
+//! the use is a straight-line successor; and nothing in between writes `place`.
 
 use super::alias::{FirstParamTypes, first_param_types, method_mutates_receiver};
 use crate::hashmap::{IndexMap, IndexSet};
@@ -297,16 +274,11 @@ fn collect_address_taken(body: &Body, out: &mut IndexSet<u32>) {
     }
 }
 
-/// The `Local { index }` node that sits as the referent of an
-/// `array_clone(&Local { index })` call in `stmt`'s subtree, if any.
-///
-/// Restricting the forwardable use to *another clone* is what keeps this sound:
-/// the outer clone re-materializes a fresh copy at the use site, so the binding's
-/// value only has to match `place` at that one point (the interval-stability
-/// check), and the binding is dead afterward. A use that instead *stored* the
-/// clone into a longer-lived aggregate (`*r = List { repr: t }`) would keep it
-/// aliased past the use, where a later mutation of `place` could corrupt it — so
-/// such uses are deliberately not matched.
+/// The `Local { index }` node sitting as the referent of an
+/// `array_clone(&Local { index })` call in `stmt`'s subtree, if any. Restricting
+/// the forwardable use to *another clone* is what keeps this sound: the outer
+/// clone re-materializes a fresh copy, so the binding need only match `place`
+/// there. A use that *stored* it would stay aliased past the use.
 fn find_clone_referent_use(
     body: &Body,
     stmt: StmtId,

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -1,40 +1,15 @@
-//! Condition Implication — eliminates bounds checks implied false by guards.
+//! Condition Implication — drives to `false` every bounds check a guard already
+//! refutes, leaving `const_branch_prune` to remove the dead branch. The
+//! recognised guards are a loop guard, a dominating `if`, a straight-line early
+//! exit, a short-circuit LHS, a bitmask range, an earlier panic-guard on the same
+//! index ([`rbce_walk`]), and a `let idx = arr.len() - k` ([`len_minus_fact`]).
 //!
-//! When a loop guard proves `i < bound`, any inner check `i >= bound` is known
-//! false and is replaced with `false`. The existing `const_branch_prune` pass
-//! then removes the dead branch on the next iteration.
-//!
-//! Recognised patterns (all **structural** and `value_of`-free):
-//!
-//! - loop guard `if !(var < bound) { break }` → checks in the body
-//!   (`structural_loop_guard`);
-//! - dominating `if (var + k) < bound { … }` → checks in the then-block
-//!   (`apply_dominating_if`);
-//! - straight-line early-exit `if (var + k) >= bound { return/break }` → checks
-//!   in the statements after it (`recognize_early_exit`);
-//! - short-circuit `(var + k) >= bound || expr` → checks in `expr`
-//!   (`ShortCircuitEliminator`);
-//! - bitmask `(x & MASK) >= BOUND`, `BOUND > MASK >= 0` (`BitmaskEliminator`);
-//! - redundant re-check: the panic-guard `arr[i]` lowers to proves `i < arr.used`,
-//!   so a later `arr[i]` (array unmodified between) is dropped — a forward walk
-//!   ([`rbce_walk`]) harvesting guard facts, needing no source-level guard;
-//! - last-element: a `let idx = arr.len() - k` (k >= 1) proves `idx < arr.len()`
-//!   ([`len_minus_fact`]), refuting the later `arr[idx]` guard — the
-//!   top-of-stack / `arr.last()` idiom, dropped if the array is resized between.
-//!
-//! Matching is **syntactic over the skeleton plus the value pool**, never the
-//! `value_of` side-table: a guard's `var` / `bound` are compared by structure
-//! ([`BoundKey`], copy temps resolved through [`Binds`]); a promoted operand
-//! (`Operand::Value`) is decomposed through `body.values` (the IR's value pool).
-//! Flow-correctness comes from a position-aware "no statement modified
-//! `var` / `bound` between the guard and the check" scan ([`stmt_modifies`] /
-//! [`node_modifies`]) rather than from `ValueId` identity. See
-//! `array_bounds_elim_oob_guard_var_mutated.wado` /
-//! `array_bounds_elim_oob_bound_shrunk.wado` for the fixtures pinning this.
-//!
-//! Runs via [`eliminate_at_root`], sharing licm's engine session (see
-//! `licm.rs`). The single rewrite point promotes a condition to constant
-//! `false` (`set_false`), replacing already-judged condition nodes only.
+//! Matching is syntactic over the skeleton plus the value pool, never the
+//! `value_of` side-table: `var` and `bound` compare by structure ([`BoundKey`]),
+//! and a promoted operand decomposes through `body.values`. Flow-correctness
+//! comes from a position-aware "nothing modified `var` / `bound` in between" scan
+//! rather than from `ValueId` identity. Runs via [`eliminate_at_root`], sharing
+//! licm's engine session.
 
 use crate::nir::{NirBinaryOp, NirUnaryOp};
 use crate::nir_arena::{BlockId, ExprId, ExprKind, NodeRef, Operand, PatId, StmtId, StmtKind};
@@ -88,16 +63,12 @@ pub(super) fn resolve_panic_ids(
         .collect()
 }
 
-/// Standalone post-`promote_fields` run of the structural BCE matcher.
-///
-/// `promote_fields` (born-as-operands) freezes invariant field reads — an array
-/// bound `arr.used` over a stable receiver — into `Operand::Value`, but it runs
-/// *after* the optimization loop, so the in-loop cond-impl never sees the
-/// promoted bound. This re-runs the matcher on the post-promotion body, where
-/// `(idx & MASK) < BOUND`'s bound is now a constant operand the structural
-/// recogniser reads through the value **pool** (no `value_of`). The caller pairs
-/// it with `const_branch_prune` to fixpoint so the now-`false` checks' panic
-/// blocks are removed.
+/// Standalone post-`promote_fields` run of the structural matcher.
+/// `promote_fields` freezes an invariant field read such as `arr.used` into an
+/// `Operand::Value`, but runs *after* the optimization loop, so the in-loop pass
+/// never sees the promoted bound. Re-running here, the recogniser reads it
+/// through the value pool. The caller pairs this with `const_branch_prune` to
+/// fixpoint so the newly-`false` checks' panic blocks go too.
 pub(super) fn eliminate_post_promote(project: &mut crate::nir_package::NirPackage) -> bool {
     use crate::nir::NirFunction;
     use crate::nir_engine::EngineBuffers;
@@ -436,17 +407,13 @@ fn struct_field_init(
         .map(|f| f.value)
 }
 
-/// The offset `c` such that `bound`'s value equals `guard_var + c`, where `bound`
-/// is an invariant struct-field read (`arr.used` over `List { used: guard_var + c }`)
-/// projected via [`struct_field_init`]. Lets a `<=` guard relate its bound to a
-/// check bound (the caller keeps only `c > cj`).
-///
-/// A bare `guard_var + c` arithmetic bound is deliberately **not** accepted: Wado
-/// add wraps, so `guard_var + c` can overflow to a value below `guard_var`,
-/// making `guard_var + cj < guard_var + c` unsound (see `wraple` repro). The
-/// struct-field form is safe because the field holds a real list length, which
-/// the runtime maintains in `[0, capacity)` with `capacity < 2^31` — so
-/// `used == guard_var + c` proves the sum did not wrap.
+/// The offset `c` for which `bound` equals `guard_var + c`, where `bound` is an
+/// invariant struct-field read projected via [`struct_field_init`] — what lets a
+/// `<=` guard relate its bound to a check bound. A bare arithmetic
+/// `guard_var + c` is deliberately refused: Wado add wraps, so it can overflow
+/// below `guard_var`. The struct-field form is safe because the field holds a
+/// real list length, which the runtime keeps in `[0, capacity)` with
+/// `capacity < 2^31`, so the equality proves the sum did not wrap.
 fn bound_offset_over(
     engine: &Engine,
     binds: &Binds,
@@ -784,21 +751,13 @@ fn structural_loop_guard(engine: &mut Engine, loop_body: BlockId, binds: &Binds)
     let Some((var, goff, bound, gop)) = parse_cmp(engine, binds, *inner) else {
         return false;
     };
-    // Walk body statements after the guard, in order. While no statement has
-    // modified `var` / `bound` since the guard, eliminate the dominated checks
-    // nested anywhere in the statement (the inlined `index_value` check is a
-    // `StmtKind::If` / `ExprKind::If` inside the statement's expression block,
-    // not a top-level statement). A statement that modifies `var` / `bound`
-    // (e.g. the `i += 1` induction update) stops the scan — the guard fact no
-    // longer holds past it.
-    //
-    // - `<` guard: surviving `var + goff < bound`; a check `var + j >= bound` is
-    //   refuted only for `j == goff` (same wrapping index, [`eliminate_checks_in_node`]).
-    // - `<=` guard (`goff == 0`, `bound` a local `gbl`): surviving `var <= gbl`,
-    //   i.e. `var < gbl + 1`; a check `var + j >= B` is refuted when `B` relates
-    //   to `gbl + c` with `c >= j + 1` ([`eliminate_le_checks_in_node`]). This is
-    //   the `arr.used == limit + 1` case.
-    // `<=` guards require a local bound; `<` accepts any. Reject other ops.
+    // Walk the statements after the guard in order, eliminating dominated checks
+    // nested anywhere inside each — an inlined `index_value` check is an `If`
+    // within the statement's expression block, not a top-level statement — and
+    // stopping at the first statement that modifies `var` / `bound`, such as the
+    // `i += 1` induction update, past which the fact no longer holds. A `<` guard
+    // refutes only the same wrapping index; a `<=` guard refutes a check whose
+    // bound relates to the guard's by a large enough offset, and needs a local.
     let le_gbl = match gop {
         NirBinaryOp::Lt => None,
         NirBinaryOp::LtEq if goff == 0 => match bound {
@@ -869,17 +828,13 @@ fn refute_panic_checks(
     changed
 }
 
-/// Drive to `false` every `if (var >= bound) { panic }` (no else) nested in
-/// `node`, matching the loop guard's `var` / `bound` structurally.
-///
-/// The guard gives `var + k < bound`; a check `var + j >= bound` is refuted only
-/// for `j == k`. Wado add wraps (i32 two's-complement), so `var + j <= var + k`
-/// does **not** hold in general: if `var + k` overflows (e.g. `var == i32::MAX`,
-/// `k == 1`) the guard passes on the wrapped-negative value while `var + j`
-/// (`j < k`) stays a large in-range positive that violates the bound. Only
-/// `j == k` computes the identical wrapping index as the guard, so `var + k <
-/// bound` refutes `var + k >= bound` regardless of wrap. See
-/// `opt_bce_wrap_guard.wado`.
+/// Drive to `false` every else-less `if (var >= bound) { panic }` nested in
+/// `node` whose `var` / `bound` match the guard structurally. The guard gives
+/// `var + k < bound`, and a check `var + j >= bound` is refuted only for
+/// `j == k`: Wado add wraps, so if `var + k` overflows the guard passes on a
+/// wrapped-negative value while a smaller `var + j` stays a large in-range
+/// positive that violates the bound. Only the identical index is safe whatever
+/// the wrap.
 fn eliminate_checks_in_node(
     engine: &mut Engine,
     node: NodeRef,
@@ -1444,18 +1399,13 @@ fn short_circuit_parts(engine: &Engine, node: NodeRef) -> Option<(Operand, Opera
     }
 }
 
-/// Forward redundant-bounds-check elimination: walk `node` in execution order
-/// maintaining a set of proven `var + off < bound` facts harvested from
-/// panic-guard checks at *unconditionally-executed* positions, and drive to
-/// `false` any later dominated check the facts already refute (e.g. `arr[i]`
-/// re-checked after an earlier `arr[i]` with the array unmodified between).
-///
-/// Facts thread by `&mut` through straight-line positions, by clone into
-/// conditional ones (an `if` branch, short-circuit RHS, or `match` arm — a
-/// branch's harvest must not escape), and afresh into loop / labeled-block
-/// bodies. [`invalidate`] drops a fact when a processed node may modify its
-/// `var` / `bound` root, so a resize between two checks keeps the later one —
-/// the same mod-tracking the straight-line early-exit elimination above uses.
+/// Forward redundant-bounds-check elimination: walk `node` in execution order,
+/// harvesting proven `var + off < bound` facts from panic-guard checks at
+/// unconditionally-executed positions and driving to `false` any later check they
+/// refute — a re-checked `arr[i]` with the array unmodified between. Facts thread
+/// by `&mut` through straight-line positions, by clone into conditional ones so a
+/// branch's harvest cannot escape, and afresh into loop bodies. [`invalidate`]
+/// drops a fact whose root a node may modify, so a resize keeps the later check.
 fn rbce_walk(engine: &mut Engine, node: NodeRef, facts: &mut Vec<ProvenLt>, binds: &Binds) -> bool {
     if let Some(cond) = panic_guard_check(engine, node) {
         if let Some((var, off, bound)) = parse_check(engine, binds, cond) {

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -7,9 +7,8 @@
 //! Matching is syntactic over the skeleton plus the value pool, never the
 //! `value_of` side-table: `var` and `bound` compare by structure ([`BoundKey`]),
 //! and a promoted operand decomposes through `body.values`. Flow-correctness
-//! comes from a position-aware "nothing modified `var` / `bound` in between" scan
-//! rather than from `ValueId` identity. Runs via [`eliminate_at_root`], sharing
-//! licm's engine session.
+//! comes from a position-aware "nothing modified `var` / `bound` in between"
+//! scan rather than from `ValueId` identity.
 
 use crate::nir::{NirBinaryOp, NirUnaryOp};
 use crate::nir_arena::{BlockId, ExprId, ExprKind, NodeRef, Operand, PatId, StmtId, StmtKind};
@@ -66,9 +65,8 @@ pub(super) fn resolve_panic_ids(
 /// Standalone post-`promote_fields` run of the structural matcher.
 /// `promote_fields` freezes an invariant field read such as `arr.used` into an
 /// `Operand::Value`, but runs *after* the optimization loop, so the in-loop pass
-/// never sees the promoted bound. Re-running here, the recogniser reads it
-/// through the value pool. The caller pairs this with `const_branch_prune` to
-/// fixpoint so the newly-`false` checks' panic blocks go too.
+/// never sees the promoted bound. The caller pairs this with `const_branch_prune`
+/// to fixpoint so the newly-`false` checks' panic blocks go too.
 pub(super) fn eliminate_post_promote(project: &mut crate::nir_package::NirPackage) -> bool {
     use crate::nir::NirFunction;
     use crate::nir_engine::EngineBuffers;
@@ -408,12 +406,10 @@ fn struct_field_init(
 }
 
 /// The offset `c` for which `bound` equals `guard_var + c`, where `bound` is an
-/// invariant struct-field read projected via [`struct_field_init`] — what lets a
-/// `<=` guard relate its bound to a check bound. A bare arithmetic
-/// `guard_var + c` is deliberately refused: Wado add wraps, so it can overflow
-/// below `guard_var`. The struct-field form is safe because the field holds a
-/// real list length, which the runtime keeps in `[0, capacity)` with
-/// `capacity < 2^31`, so the equality proves the sum did not wrap.
+/// invariant struct-field read projected via [`struct_field_init`]. A bare
+/// arithmetic `guard_var + c` is refused: Wado add wraps, so it can overflow
+/// below `guard_var`. The struct-field form holds a real list length, kept in
+/// `[0, capacity)` with `capacity < 2^31`, so the equality proves no wrap.
 fn bound_offset_over(
     engine: &Engine,
     binds: &Binds,
@@ -753,11 +749,9 @@ fn structural_loop_guard(engine: &mut Engine, loop_body: BlockId, binds: &Binds)
     };
     // Walk the statements after the guard in order, eliminating dominated checks
     // nested anywhere inside each — an inlined `index_value` check is an `If`
-    // within the statement's expression block, not a top-level statement — and
-    // stopping at the first statement that modifies `var` / `bound`, such as the
-    // `i += 1` induction update, past which the fact no longer holds. A `<` guard
-    // refutes only the same wrapping index; a `<=` guard refutes a check whose
-    // bound relates to the guard's by a large enough offset, and needs a local.
+    // within the statement's expression block — and stopping at the first
+    // statement that modifies `var` / `bound`. A `<` guard refutes only the same
+    // wrapping index; a `<=` guard also refutes an offset bound.
     let le_gbl = match gop {
         NirBinaryOp::Lt => None,
         NirBinaryOp::LtEq if goff == 0 => match bound {
@@ -832,9 +826,7 @@ fn refute_panic_checks(
 /// `node` whose `var` / `bound` match the guard structurally. The guard gives
 /// `var + k < bound`, and a check `var + j >= bound` is refuted only for
 /// `j == k`: Wado add wraps, so if `var + k` overflows the guard passes on a
-/// wrapped-negative value while a smaller `var + j` stays a large in-range
-/// positive that violates the bound. Only the identical index is safe whatever
-/// the wrap.
+/// wrapped-negative value while a smaller `var + j` stays in range.
 fn eliminate_checks_in_node(
     engine: &mut Engine,
     node: NodeRef,
@@ -1402,10 +1394,8 @@ fn short_circuit_parts(engine: &Engine, node: NodeRef) -> Option<(Operand, Opera
 /// Forward redundant-bounds-check elimination: walk `node` in execution order,
 /// harvesting proven `var + off < bound` facts from panic-guard checks at
 /// unconditionally-executed positions and driving to `false` any later check they
-/// refute — a re-checked `arr[i]` with the array unmodified between. Facts thread
-/// by `&mut` through straight-line positions, by clone into conditional ones so a
-/// branch's harvest cannot escape, and afresh into loop bodies. [`invalidate`]
-/// drops a fact whose root a node may modify, so a resize keeps the later check.
+/// refute. Facts thread by `&mut` through straight-line positions, by clone into
+/// conditional ones, and afresh into loop bodies; [`invalidate`] drops stale ones.
 fn rbce_walk(engine: &mut Engine, node: NodeRef, facts: &mut Vec<ProvenLt>, binds: &Binds) -> bool {
     if let Some(cond) = panic_guard_check(engine, node) {
         if let Some((var, off, bound)) = parse_check(engine, binds, cond) {

--- a/wado-compiler/src/optimize/condition_implication.rs
+++ b/wado-compiler/src/optimize/condition_implication.rs
@@ -1,14 +1,8 @@
 //! Condition Implication — drives to `false` every bounds check a guard already
-//! refutes, leaving `const_branch_prune` to remove the dead branch. The
-//! recognised guards are a loop guard, a dominating `if`, a straight-line early
-//! exit, a short-circuit LHS, a bitmask range, an earlier panic-guard on the same
-//! index ([`rbce_walk`]), and a `let idx = arr.len() - k` ([`len_minus_fact`]).
-//!
-//! Matching is syntactic over the skeleton plus the value pool, never the
-//! `value_of` side-table: `var` and `bound` compare by structure ([`BoundKey`]),
-//! and a promoted operand decomposes through `body.values`. Flow-correctness
-//! comes from a position-aware "nothing modified `var` / `bound` in between"
-//! scan rather than from `ValueId` identity.
+//! refutes, leaving `const_branch_prune` the dead branch. Guards recognised: a
+//! loop guard, dominating `if`, early exit, short-circuit LHS, bitmask range, an
+//! earlier panic-guard, a `len() - k`. Matching is syntactic over the skeleton
+//! and value pool, with flow-correctness from a position-aware modification scan.
 
 use crate::nir::{NirBinaryOp, NirUnaryOp};
 use crate::nir_arena::{BlockId, ExprId, ExprKind, NodeRef, Operand, PatId, StmtId, StmtKind};

--- a/wado-compiler/src/optimize/const_branch_prune.rs
+++ b/wado-compiler/src/optimize/const_branch_prune.rs
@@ -1,31 +1,8 @@
-//! Constant branch pruning for Wado NIR
-//!
-//! Simplifies trivial blocks left over after other passes:
-//! - `{ expr; }` → `expr`
-//! - `label: { break label: val; }` → `val`
-//! - Empty blocks → `()`
-//!
-//! Constant-condition `if` folding is handled by `niri` via the `const_folding`
-//! pass; this pass intentionally does *not* duplicate that logic. Copy
-//! propagation (including the in-block copies of loop-mutated locals the
-//! inliner leaves behind) is `copy_prop`'s job — this pass keys only on block
-//! and control-flow *structure*, never on labels or variable names.
-//!
-//! Runs on the worklist rewrite engine (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) as a [`Rule`]: the
-//! expression simplifications are an `apply_expr` peephole and the
-//! statement-list flattening / dead-code elimination is an `apply_block`
-//! rewrite. The break-target queries are read-only walks over the arena
-//! (`arena_query::has_break_to`). All edits go through the engine API
-//! (`become_expr`, `replace_expr_kind`, `set_block_stmts`, `alloc_stmt`) so the
-//! parent map and use index stay coherent.
-//!
-//! The in-loop run rides the unified [`super::peephole`] session
-//! (`PruneMode::Fixpoint`). Two standalone entry points keep their own engine
-//! session for the callers outside that session: [`prune_constant_branches`]
-//! (`Fixpoint`, used by the post-globalization cleanup) and
-//! [`prune_template_block_wrappers`] (`PostFixpoint`, the final `__tmpl:`
-//! flatten after the fixpoint converges).
+//! Constant branch pruning: the trivial blocks other passes leave behind —
+//! `{ expr; }`, `label: { break label: val; }`, an empty block. Keys only on
+//! block and control-flow *structure*, never on labels or names, leaving
+//! constant-condition folding to `const_folding`. The in-loop run rides the
+//! unified [`super::peephole`] session; the two standalone entries keep theirs.
 
 use crate::nir::NirFunction;
 use crate::nir_arena::{BlockId, Body, ExprId, ExprKind, NodeRef, Operand, StmtId, StmtKind};

--- a/wado-compiler/src/optimize/const_folding.rs
+++ b/wado-compiler/src/optimize/const_folding.rs
@@ -1,23 +1,8 @@
-//! Constant folding optimization for Wado NIR.
-//!
-//! Walks every function's arena [`Body`] and applies the
-//! [`niri::Interpreter`] rewrite rules at each visited node. All
-//! reduction logic (literal folding, integer cast collapsing,
-//! short-circuit identity rules, env-aware local lookup) lives in
-//! [`crate::niri`]; this module is only the visitor glue that drives
-//! `reduce_local` across function bodies and feeds the interpreter's
-//! local-variable env from `Let` / `Assign` statements.
-//!
-//! This walker tracks only scalar local lattices; reaching-def of a struct
-//! field `obj.f` is the engine [`ValueGraph`]'s job (store-load forwarding +
-//! hash-cons CSE). The local env needs no branch fork because mutable locals
-//! are recorded [`Lattice::NonConst`] up front.
-//!
-//! The visitor mutates the arena `Body` directly: the per-node rewrites
-//! (`reduce_local`) and the block-level branch splice
-//! (`reduce_local_block`) operate on arena ids. Global initializers are
-//! arena `ExprBody`s too, so the global env / global-field env are read from
-//! them via the arena interpreter path.
+//! Constant folding for Wado NIR: visitor glue driving [`niri::Interpreter`]'s
+//! `reduce_local` across every arena [`Body`] and feeding its local env from
+//! `Let` / `Assign`. All reduction logic lives in [`crate::niri`]. Only scalar
+//! local lattices are tracked — a struct field's reaching def is the engine
+//! [`ValueGraph`]'s job — and mutable locals start `NonConst`, so no fork.
 //!
 //! [`ValueGraph`]: crate::nir_value_graph
 
@@ -170,19 +155,11 @@ fn fold_function(
     visitor.visit_block(&mut engine, root)
 }
 
-/// Engine rule: environment-free constant folding.
-///
-/// Runs the [`Interpreter::const_fold_value`] subset — literal arithmetic and
-/// pure CTFE — over the worklist rewrite engine, applying each fold through the
-/// engine's edit API so the parent map and use index stay coherent. The
-/// program-wide [`CalleeMap`] is installed; the per-function `env` stays empty,
-/// so the flow-sensitive folds (env-bound locals, immutable globals,
-/// constant-branch collapse) remain with the standalone [`fold_constants`]
-/// walker that still runs once per fixed-point iteration.
-///
-/// `const_fold_value` needs `&mut Interpreter` (CTFE advances the call stack
-/// and step budget), but [`Rule::apply_expr`] is `&self`, so the interpreter
-/// lives behind a [`RefCell`].
+/// Engine rule: environment-free constant folding — the
+/// [`Interpreter::const_fold_value`] subset of literal arithmetic and pure CTFE,
+/// run over the worklist engine. The program-wide [`CalleeMap`] is installed but
+/// `env` stays empty, leaving the flow-sensitive folds to [`fold_constants`].
+/// The interpreter sits behind a [`RefCell`], `apply_expr` being `&self`.
 pub(super) struct ConstFoldRule<'a> {
     interpreter: RefCell<Interpreter<'a>>,
 }
@@ -324,18 +301,11 @@ pub(super) fn build_ctfe_builtin_map(project: &NirPackage) -> CtfeBuiltinMap {
     map
 }
 
-/// Pre-build the [`GlobalEnv`] from every global in `project`. Each
-/// non-`mut` global's initializer is reduced through a fresh
-/// [`Interpreter`] (with `callees` installed so calls in initializers
-/// fold, and with the partially-built env installed so a later global
-/// initializer can read constants computed from earlier ones).
-/// Mutable globals are recorded as `NonConst` so a parent fold like
-/// `GLOBAL_MUT + 1` correctly reports `NonConst` instead of
-/// `Unevaluated`. Globals whose initializer doesn't reduce are left
-/// out of the map (absent → `Lattice::Unevaluated` by default).
-///
-/// Global initializers are arena `ExprBody`s, so this reduces them on the
-/// arena [`Interpreter::reduce_to_lattice`] path.
+/// Pre-build the [`GlobalEnv`] from every global in `project`, reducing each
+/// non-`mut` initializer through a fresh [`Interpreter`] carrying `callees` and
+/// the partially-built env, so a later initializer reads earlier constants. A
+/// mutable global is recorded `NonConst`, making `GLOBAL_MUT + 1` report that
+/// rather than `Unevaluated`; an irreducible one is left out of the map.
 fn build_global_env(
     project: &NirPackage,
     type_table: &TypeTable,
@@ -441,17 +411,11 @@ fn const_seq_len(body: &Body, e: ExprId) -> Option<i32> {
     }
 }
 
-/// What the interpreter knows about module globals for one pass.
-///
-/// A declared initializer is only half the story: a non-trivial one never
-/// reaches the global's slot. `lower/plan`'s `globals::extract` moves it into
-/// module init, and body globalization hoists a constant read-only binding into
-/// a fresh global the same way — both leave a placeholder in the slot and the
-/// real value in an inline `GlobalVarSet`. Reading that store back is what lets
-/// such a global fold at all.
-///
-/// A store's value is function-body content, which the optimizer loop is still
-/// reducing, so this is rebuilt per pass rather than cached in [`FoldMaps`].
+/// What the interpreter knows about module globals for one pass. A declared
+/// initializer is half the story: a non-trivial one is moved into module init or
+/// hoisted, leaving a placeholder in the slot and the real value in an inline
+/// `GlobalVarSet`, so reading that store back is what lets it fold. A store's
+/// value is body content still being reduced, hence rebuilt per pass.
 struct GlobalView {
     /// What each global holds. Seeded from [`FoldMaps::declared_globals`]; a
     /// global every store of which is the same constant overrides its

--- a/wado-compiler/src/optimize/const_object_globalization.rs
+++ b/wado-compiler/src/optimize/const_object_globalization.rs
@@ -1,47 +1,17 @@
-//! Body globalization — hoist a constant, read-only aggregate `let` binding
-//! out of a function body into a shared immutable module global.
+//! Body globalization — hoist a constant, read-only aggregate `let` out of a
+//! function body into a shared module global, so Wasm 3.0 GC builds it once at
+//! instantiation instead of rebuilding it per call. The hoisted global mirrors
+//! what `lower::plan::globals::extract` produces: a Wasm-mutable slot with a
+//! `null` placeholder, assigned once inline, which
+//! [`crate::wir_optimize::const_global`] then classifies eager or lazy.
 //!
-//! A constant-shaped aggregate bound by a `let` and only ever read is rebuilt
-//! on every call (or loop iteration) — pure waste, since Wasm 3.0 GC can build
-//! it once at instantiation. This pass detects such a binding and hoists it:
-//!
-//! ```text
-//! fn f() { let xs = [10, 20, 30]; … xs.repr … }   // rebuilt per call
-//!   ⇒
-//! global __const_obj_0 = <lazy>;                   // built once
-//! fn f() { __const_obj_0 = [10, 20, 30]; … global:__const_obj_0.repr … }
-//! ```
-//!
-//! The hoisted global mirrors what `lower::plan::globals::extract` produces for
-//! a non-const user global: a Wasm-mutable, Wado-immutable slot with a `null`
-//! placeholder init, assigned once by an inline `GlobalVarSet`. The existing
-//! [`crate::wir_optimize::const_global`] pass classifies it eager/lazy.
-//!
-//! ## Soundness
-//!
-//! Two independent gates, both load-bearing:
-//!
-//! - **Closed const aggregate** ([`is_globalizable_const`]). The initializer
-//!   must be a side-effect-free constant with no free locals.
-//! - **Read-only** ([`is_readonly_body`]). Every use of the binding must be a
-//!   borrowing / reading position; any `&mut`, any `&mut self` method, any
-//!   assignment to it or a projection, and any by-value consuming use
-//!   disqualify it. See the per-arm comments in [`expr_readonly`].
-//!
-//! A constant handed to a call *by value* ([`CandidateKind::ValueArg`]) runs the
-//! read-only gate over the *callee's* parameter instead
-//! ([`Gate::callee_param_readonly`]): the value crosses into the callee
-//! uncopied — the value-copy planner skipped the copy because the literal is
-//! fresh — so the callee is the only party that could write the shared object.
-//! Being read-only is not enough there: a by-value parameter is the callee's
-//! own copy, so it may legitimately hand a *projection* of it back
-//! (`return s.data`), which the return-convention fixpoint calls owned and the
-//! caller then mutates. [`param_storage_escapes`] rules that out.
-//!
-//! A project-level pass over the arena `Body` (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`): the analysis (read-only
-//! gate, const check) is a read-only walk and the mutation (read rewrite,
-//! `let` → `GlobalVarSet`) edits the body in place.
+//! Two independent gates carry the soundness — the initializer must be a
+//! side-effect-free constant with no free locals ([`is_globalizable_const`]), and
+//! every use must be a reading position ([`is_readonly_body`]). A constant handed
+//! to a call by value runs the read-only gate over the *callee's* parameter,
+//! since the value crosses uncopied; being read-only is not enough there, because
+//! a by-value parameter may legitimately hand a projection of itself back as
+//! owned, which [`param_storage_escapes`] rules out.
 
 use cranelift_entity::EntityRef;
 use std::cell::RefCell;
@@ -999,16 +969,11 @@ impl Gate<'_> {
     }
 
     /// Whether a value of `ty` owns heap storage worth building only once.
-    ///
-    /// Hoisting is not free: it costs a global, a guard branch, and an object
-    /// that stays live for the whole program. That only pays when rebuilding
-    /// the value would re-allocate — i.e. when it (transitively) owns a GC
-    /// array, as `String` and `List` do.
-    ///
-    /// A small aggregate of scalars owns nothing: `multi_value_return` already
-    /// lifts such a return into Wasm multi-values and allocates *nothing*, so
-    /// hoisting it is strictly worse. This is the existing "skip scalars"
-    /// rationale one level up — skip whatever the backend can keep in registers.
+    /// Hoisting costs a global, a guard branch, and an object live for the whole
+    /// program, which only pays when rebuilding would re-allocate — when the
+    /// value transitively owns a GC array, as `String` and `List` do. A small
+    /// aggregate of scalars owns nothing and is strictly worse hoisted:
+    /// `multi_value_return` already lifts one into Wasm multi-values.
     fn owns_heap_storage(&self, ty: TypeId) -> bool {
         let mut seen = IndexSet::default();
         self.owns_heap_storage_inner(ty, &mut seen)
@@ -1156,20 +1121,14 @@ fn is_readonly_body(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
     block_readonly(body, body.root, idx, gate)
 }
 
-/// Whether the callee hands the *storage* of by-value parameter `idx` back out
-/// — returning `s.data`, stashing it in a global, or passing it on by value.
-///
-/// [`is_readonly_body`] does not cover this: reading a field of the parameter is
-/// a read, and a by-value parameter is the callee's own copy, so returning that
-/// field is legitimate — the return-convention fixpoint even calls it *owned*,
-/// which is what lets the caller skip a defensive copy of the result. Hoisting
-/// the argument invalidates the premise: the "owned" value handed back is the
-/// shared global's storage, and the first mutation corrupts the constant.
-/// Passing the storage on by value hands the same problem to the next callee.
-///
-/// A borrow (`&s.data`) is not an escape — the callee's own read-only gate
-/// already bounds what the borrow can do — and a scalar projection copies its
-/// value outright.
+/// Whether the callee hands the *storage* of by-value parameter `idx` back out,
+/// by returning a projection of it, stashing it, or passing it on by value.
+/// [`is_readonly_body`] does not cover this: reading a field is a read, and a
+/// by-value parameter is the callee's own copy, so returning that field is
+/// legitimate — the return-convention fixpoint even calls it owned, letting the
+/// caller skip a defensive copy. Hoisting invalidates the premise, since the
+/// "owned" value is the global's storage. A borrow is not an escape, bounded by
+/// the callee's own read-only gate, and a scalar projection copies outright.
 fn param_storage_escapes(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
     let roots = projection_alias_roots(body, idx, gate);
     let escapes = |op: Operand| delivers_projection_operand(body, op, &roots, gate);
@@ -1237,17 +1196,13 @@ fn param_storage_escapes(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
     false
 }
 
-/// `idx` plus every local *bound* from something that can yield one of their
-/// storages: a `let` (`let r = s.data;`, which LICM also produces), a
-/// destructuring `let`, or a `match` arm pattern over such a scrutinee
-/// (`match s.inner { Inner { blob } => …`). They all name the same storage, so
-/// an escape through any of them is an escape of the parameter.
-///
-/// The source only has to *contain* a reference-typed projection of a root —
-/// `let r = if c { s.a } else { s.b };` binds one of two projections, and
-/// neither the branch shape nor the pattern says which. Over-approximating a
-/// binding as an alias only makes the escape check stricter: a scalar binding
-/// can never carry a reference-typed projection of itself, so it is inert.
+/// `idx` plus every local bound from something that can yield one of their
+/// storages — a `let`, a destructuring `let`, or a `match` arm over such a
+/// scrutinee. All name the same storage, so an escape through any is an escape of
+/// the parameter. The source need only *contain* a reference-typed projection of
+/// a root: `let r = if c { s.a } else { s.b };` binds one of two and nothing says
+/// which. Over-approximating only tightens the check, and a scalar binding cannot
+/// carry such a projection at all.
 fn projection_alias_roots(body: &Body, idx: u32, gate: &Gate<'_>) -> Vec<u32> {
     let mut roots = vec![idx];
     let mut i = 0;
@@ -1803,17 +1758,11 @@ fn inline_sibling_lets(
 }
 
 /// True when `expr` cannot end as a Wasm constant instruction, so
-/// `wir_optimize::const_global` cannot delete the assignment and the
-/// candidate needs the lazy-init guard. Four shapes qualify:
-///
-/// - a call, never const-expressible;
-/// - a `PackedArray` outside the eager `array.new_fixed` bound
-///   ([`crate::wir_build::packed_array_is_eager`], the same choice
-///   `translate_packed_array` makes);
-/// - an `ArrayLiteral` past `ARRAY_NEW_FIXED_LIMIT`, whatever its elements,
-///   which `split_large_array_literals` rewrites into a build sequence;
-/// - an `ArrayLiteral` `promote_constant_arrays_to_data` will rewrite to
-///   `array.new_data` (see [`array_literal_promotes_to_data`]).
+/// `wir_optimize::const_global` cannot delete the assignment and the candidate
+/// needs a lazy-init guard. Four shapes qualify: a call, never const-expressible;
+/// a `PackedArray` outside the eager `array.new_fixed` bound; an `ArrayLiteral`
+/// past `ARRAY_NEW_FIXED_LIMIT`, which becomes a build sequence; and one
+/// `promote_constant_arrays_to_data` will rewrite to `array.new_data`.
 fn needs_lazy_guard(body: &Body, expr: ExprId, gate: &Gate<'_>, prefer_fixed: bool) -> bool {
     let mut stack = vec![NodeRef::Expr(expr)];
     while let Some(node) = stack.pop() {
@@ -1909,17 +1858,12 @@ fn stmt_needs_lazy_guard(body: &Body, stmt: StmtId, gate: &Gate<'_>, prefer_fixe
 }
 
 /// Wrap a hoisted `GlobalVarSet` in `if builtin::is_uninitialized(<global>)`.
-///
-/// The unguarded form is correct only because `wir_optimize::const_global`
-/// promotes a Wasm-const-expressible initializer into the global's eager
-/// `init` and deletes the assignment. An initializer [`needs_lazy_guard`]
-/// classes non-promotable survives — and an unguarded one re-runs on every
-/// activation, which is the opposite of hoisting.
-///
-/// The guard also pins the semantics: initialization happens at the first
-/// execution of the expression it replaced, so a callee that traps or diverges
-/// still does so, at the same point. Moving the work to module-init instead
-/// would drag both to instantiation time.
+/// The unguarded form is only correct because `wir_optimize::const_global`
+/// promotes a const-expressible initializer into the eager `init` and deletes
+/// the assignment; one [`needs_lazy_guard`] calls non-promotable survives, and
+/// unguarded would re-run on every activation. The guard also pins the
+/// semantics to the first execution of the expression it replaced, so a callee
+/// that traps still does so there rather than at instantiation.
 fn guard_set_on_uninit(
     body: &mut Body,
     set: ExprId,

--- a/wado-compiler/src/optimize/const_object_globalization.rs
+++ b/wado-compiler/src/optimize/const_object_globalization.rs
@@ -1,14 +1,8 @@
-//! Body globalization — hoist a constant, read-only aggregate `let` out of a
-//! function body into a shared module global, so Wasm 3.0 GC builds it once at
-//! instantiation instead of rebuilding it per call. The hoisted global mirrors
-//! `lower::plan::globals::extract`: a Wasm-mutable slot with a `null`
-//! placeholder, which [`crate::wir_optimize::const_global`] later classifies.
-//!
-//! Two independent gates carry the soundness — the initializer must be a
-//! side-effect-free constant with no free locals ([`is_globalizable_const`]), and
-//! every use must be a reading position ([`is_readonly_body`]). A constant handed
-//! to a call by value crosses uncopied, so the callee's parameter is gated too,
-//! with [`param_storage_escapes`] ruling out an owned projection.
+//! Body globalization — hoist a constant, read-only aggregate `let` into a
+//! shared module global, so Wasm 3.0 GC builds it once at instantiation. Two
+//! gates carry the soundness: the initializer must be a side-effect-free
+//! constant with no free locals, and every use a reading position — including
+//! the callee's parameter, a by-value constant crossing uncopied.
 
 use cranelift_entity::EntityRef;
 use std::cell::RefCell;

--- a/wado-compiler/src/optimize/const_object_globalization.rs
+++ b/wado-compiler/src/optimize/const_object_globalization.rs
@@ -1,17 +1,14 @@
 //! Body globalization — hoist a constant, read-only aggregate `let` out of a
 //! function body into a shared module global, so Wasm 3.0 GC builds it once at
 //! instantiation instead of rebuilding it per call. The hoisted global mirrors
-//! what `lower::plan::globals::extract` produces: a Wasm-mutable slot with a
-//! `null` placeholder, assigned once inline, which
-//! [`crate::wir_optimize::const_global`] then classifies eager or lazy.
+//! `lower::plan::globals::extract`: a Wasm-mutable slot with a `null`
+//! placeholder, which [`crate::wir_optimize::const_global`] later classifies.
 //!
 //! Two independent gates carry the soundness — the initializer must be a
 //! side-effect-free constant with no free locals ([`is_globalizable_const`]), and
 //! every use must be a reading position ([`is_readonly_body`]). A constant handed
-//! to a call by value runs the read-only gate over the *callee's* parameter,
-//! since the value crosses uncopied; being read-only is not enough there, because
-//! a by-value parameter may legitimately hand a projection of itself back as
-//! owned, which [`param_storage_escapes`] rules out.
+//! to a call by value crosses uncopied, so the callee's parameter is gated too,
+//! with [`param_storage_escapes`] ruling out an owned projection.
 
 use cranelift_entity::EntityRef;
 use std::cell::RefCell;
@@ -1123,12 +1120,9 @@ fn is_readonly_body(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
 
 /// Whether the callee hands the *storage* of by-value parameter `idx` back out,
 /// by returning a projection of it, stashing it, or passing it on by value.
-/// [`is_readonly_body`] does not cover this: reading a field is a read, and a
-/// by-value parameter is the callee's own copy, so returning that field is
-/// legitimate — the return-convention fixpoint even calls it owned, letting the
-/// caller skip a defensive copy. Hoisting invalidates the premise, since the
-/// "owned" value is the global's storage. A borrow is not an escape, bounded by
-/// the callee's own read-only gate, and a scalar projection copies outright.
+/// [`is_readonly_body`] does not cover this: returning a field of the callee's
+/// own copy is legitimate and even counts as owned, a premise hoisting
+/// invalidates. A borrow or a scalar projection is not an escape.
 fn param_storage_escapes(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
     let roots = projection_alias_roots(body, idx, gate);
     let escapes = |op: Operand| delivers_projection_operand(body, op, &roots, gate);
@@ -1199,10 +1193,8 @@ fn param_storage_escapes(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
 /// `idx` plus every local bound from something that can yield one of their
 /// storages — a `let`, a destructuring `let`, or a `match` arm over such a
 /// scrutinee. All name the same storage, so an escape through any is an escape of
-/// the parameter. The source need only *contain* a reference-typed projection of
-/// a root: `let r = if c { s.a } else { s.b };` binds one of two and nothing says
-/// which. Over-approximating only tightens the check, and a scalar binding cannot
-/// carry such a projection at all.
+/// the parameter. The source need only *contain* a reference-typed projection:
+/// `let r = if c { s.a } else { s.b };` binds one of two and nothing says which.
 fn projection_alias_roots(body: &Body, idx: u32, gate: &Gate<'_>) -> Vec<u32> {
     let mut roots = vec![idx];
     let mut i = 0;
@@ -1860,10 +1852,9 @@ fn stmt_needs_lazy_guard(body: &Body, stmt: StmtId, gate: &Gate<'_>, prefer_fixe
 /// Wrap a hoisted `GlobalVarSet` in `if builtin::is_uninitialized(<global>)`.
 /// The unguarded form is only correct because `wir_optimize::const_global`
 /// promotes a const-expressible initializer into the eager `init` and deletes
-/// the assignment; one [`needs_lazy_guard`] calls non-promotable survives, and
-/// unguarded would re-run on every activation. The guard also pins the
-/// semantics to the first execution of the expression it replaced, so a callee
-/// that traps still does so there rather than at instantiation.
+/// the assignment; one [`needs_lazy_guard`] calls non-promotable would re-run on
+/// every activation. The guard also pins the semantics to the first execution of
+/// the expression it replaced, so a trapping callee still traps there.
 fn guard_set_on_uninit(
     body: &mut Body,
     set: ExprId,

--- a/wado-compiler/src/optimize/container_sroa.rs
+++ b/wado-compiler/src/optimize/container_sroa.rs
@@ -2,8 +2,7 @@
 //! locals: one `List<T_k>` per field, so the per-element `struct.new` goes away.
 //! Uses are recognized by signature shape ([`ListMethodKind`]), never by method
 //! name, and an unclassified method makes the candidate escape. Runs before
-//! `inline`, which would expand those calls. TODO(optimizer): nested containers,
-//! and a `value_copy_demote` element-immutability query instead of the whitelist.
+//! `inline`, which would expand those calls.
 
 use std::cell::Cell;
 

--- a/wado-compiler/src/optimize/container_sroa.rs
+++ b/wado-compiler/src/optimize/container_sroa.rs
@@ -3,6 +3,10 @@
 //! Uses are recognized by signature shape ([`ListMethodKind`]), never by method
 //! name, and an unclassified method makes the candidate escape. Runs before
 //! `inline`, which would expand those calls.
+//!
+//! TODO(optimizer): nested-container decomposition (`List<List<T>>`), and
+//! replacing the shape whitelist with `value_copy_demote`'s element-immutability
+//! query so any element-immutable method counts as a SROA-safe use.
 
 use std::cell::Cell;
 

--- a/wado-compiler/src/optimize/container_sroa.rs
+++ b/wado-compiler/src/optimize/container_sroa.rs
@@ -1,76 +1,9 @@
-//! Container SROA (P0a) — `AoS` → `SoA` transformation for `List<Tuple<...>>` locals.
-//!
-//! This pass decomposes local variables of type `List<[T_0, T_1, ..., T_n]>` into
-//! N parallel `List<T_k>` locals, eliminating the per-element `struct.new` for
-//! tuple payloads. After decomposition, operations on the original array are
-//! rewritten as parallel operations on the new per-field arrays:
-//!
-//! ```text
-//! let mut v: List<[i32, i32]> = [];        →   let mut v_0: List<i32> = [];
-//! v.push([a, b]);                                let mut v_1: List<i32> = [];
-//! let sum = v[i].0 + v[i].1;                    v_0.push(a); v_1.push(b);
-//!                                                let sum = v_0[i] + v_1[i];
-//! ```
-//!
-//! P0a scope covers `List<Tuple<...>>` and `List<UserStruct>` locals (both have
-//! the same `WasmGC` struct representation). Nested arrays are not yet decomposed.
-//! Only method-call usage is handled; direct indexing is expected to have been
-//! desugared already into `index_value`/`index_assign` trait calls by lowering.
-//!
-//! TODO(optimizer): nested-container decomposition (`List<List<T>>`,
-//! `List<UserStruct { List<T>, ... }>`). The recursion into nested element
-//! types is a clean extension of `decompose_local`; the harder problem is the
-//! recursive element-immutability proof, which `value_copy_demote.rs` already
-//! solves and could be lifted out for reuse here.
-//!
-//! TODO(optimizer): replace the hardcoded method-shape whitelist
-//! (`ElementWriter` / `IndexReader` / `IndexWriter` / `Constructor`) with a
-//! query against `value_copy_demote`'s element-immutability analysis so any
-//! element-immutable `&self`/`&mut self` method becomes a SROA-safe use,
-//! not just `push` / `index_value` / `index_assign` / `len` / `is_empty`.
-//!
-//! # List method identification
-//!
-//! Rather than hardcoding method names (`"push"`, `"len"`, `"index_value"`, …),
-//! this pass identifies relevant List methods by **signature shape**:
-//!
-//! | Kind             | Signature                                         | stdlib method  |
-//! |------------------|---------------------------------------------------|----------------|
-//! | `ElementWriter`  | `fn(&mut List<T>, T) -> ()`                      | `push`         |
-//! | `IndexReader`    | `fn(&List<T>, i32) -> T`                         | `index_value`  |
-//! | `IndexWriter`    | `fn(&mut List<T>, i32, T) -> ()`                 | `index_assign` |
-//! | `Constructor`    | `fn(i32) -> List<T>` (static)                    | `with_capacity`|
-//! | `Query`          | `fn(&List<T>) -> i32 \| bool` (length-invariant) | `len`, `is_empty`, `capacity` |
-//!
-//! Classification happens once when the `MethodCatalog` is built, and every
-//! whitelist and rewrite decision is driven by looking up the call's classified
-//! `ListMethodKind`. Unclassified List methods cause the candidate to escape,
-//! so adding a new stdlib method that doesn't match any kind is safe by default.
-//! Adding a new method that *does* match a kind (e.g., `push_back`) is
-//! automatically handled — no optimizer change required.
-//!
-//! # Pipeline position
-//!
-//! Runs *first* in each fixed-point iteration, before `inline`. The pass
-//! relies on every `List<T>` access being a method call (`push`,
-//! `index_value`, `index_assign`, `len`, ...), but `inline` expands those
-//! thin wrappers into raw `builtin::array_get`/`array_set` + field-access
-//! pairs, after which the method-call shape is gone. Running before inline
-//! preserves the call structure that `list_method_kind` classifies.
-//!
-//! Running inside each loop iteration (rather than only once up front) also
-//! lets container SROA pick up new `List<Tuple<...>>` locals exposed by
-//! earlier-iteration inlining of helper functions.
-//!
-//! Runs on the worklist rewrite engine
-//! (`docs/wep-2026-06-05-nir-optimizer-architecture.md`) as a [`Rule`]: a
-//! per-function standalone engine session whose `apply_block` fires once at
-//! the body root and performs the whole-function rewrite in one shot. The
-//! analysis phases (candidate collection, escape / used-kinds) stay read-only
-//! walks over `engine.body`; the rewrite routes every mutation through the
-//! engine edit API (`set_block_stmts`, `replace_expr_kind`, `become_expr`,
-//! `alloc_stmt`, `alloc_expr`, `alloc_local`, `clone_expr`) so the parent map
-//! and use index stay coherent.
+//! Container SROA — `AoS` → `SoA` for `List<Tuple<…>>` / `List<UserStruct>`
+//! locals: one `List<T_k>` per field, so the per-element `struct.new` goes away.
+//! Uses are recognized by signature shape ([`ListMethodKind`]), never by method
+//! name, and an unclassified method makes the candidate escape. Runs before
+//! `inline`, which would expand those calls. TODO(optimizer): nested containers,
+//! and a `value_copy_demote` element-immutability query instead of the whitelist.
 
 use std::cell::Cell;
 
@@ -133,15 +66,10 @@ enum ListMethodKind {
     /// `List<T_k>` with the same capacity.
     Constructor,
     /// `fn(&List<T>) -> i32 | bool` — length-invariant query with no element
-    /// argument (e.g., `len`, `is_empty`, `capacity`).
-    ///
-    /// Rewrite: dispatch to field 0's corresponding method. Since push, slot
-    /// assign, and constructor-with-capacity all keep per-field arrays in
-    /// lockstep, field 0 is representative.
-    ///
-    /// We restrict the return type to `i32`/`bool` so that only true
-    /// length-invariant queries qualify — a hypothetical `hash_code() -> u64`
-    /// that depends on element contents would not match.
+    /// argument (e.g. `len`, `is_empty`, `capacity`). Rewritten to field 0's
+    /// method: every rewrite keeps the per-field arrays in lockstep. The
+    /// `i32`/`bool` return bound is what excludes a content-dependent query
+    /// such as a hypothetical `hash_code() -> u64`.
     Query,
 }
 
@@ -749,21 +677,11 @@ fn peel_value_copy(
     cur
 }
 
-/// Recognize the supported initializer form for container-SROA candidates.
-///
-/// Two equivalent shapes are accepted, both matched purely *structurally*
-/// (no hardcoded label or method names):
-///
-/// 1. A direct `Call` classified as `Constructor` by signature — e.g.
-///    `List::<T>::with_capacity(cap)` written by the user directly. The
-///    argument must be side-effect-free so it can be cloned once per field.
-/// 2. The `SequenceLiteralBuilder` desugaring for empty array literals
-///    (`[]`), which lowers to
-///    `{ let __b = <Constructor call>; break label: __b.<build>(); }`.
-///    We structurally unwrap the labeled block, look through the `Let`, and
-///    fall through to form (1) on the inner constructor call. Neither the
-///    label string nor the builder method name is inspected — only the
-///    shape of the wrapper.
+/// Recognize the supported initializer form, matched structurally: a direct
+/// `Constructor` call whose argument is side-effect-free (so it can be cloned
+/// per field), or the `SequenceLiteralBuilder` desugaring of `[]`, whose labeled
+/// block and `Let` are unwrapped down to that same constructor call. No label
+/// string or builder method name is inspected.
 fn recognize_init(
     body: &Body,
     value: ExprId,

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -236,8 +236,7 @@ struct BlockScan {
 /// mutation into all enclosing blocks at their current statement index rather
 /// than re-walking subtrees per nesting level (O(N²) on deep bodies).
 /// [`for_each_mutated_root`] decides what counts, so a read-only `x.len()`
-/// receiver does not end `x`'s stability interval while `r.f = v` through a
-/// `&mut` alias does.
+/// does not end `x`'s interval while `r.f = v` through a `&mut` alias does.
 fn scan_blocks(
     body: &Body,
     type_table: &TypeTable,

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -1,16 +1,8 @@
-//! Copy propagation optimization for Wado NIR.
-//!
-//! Eliminates trivial copy bindings like `let x = y`, `let x = &y`,
-//! `let x = &mut y`, or a copy of a promoted operand by propagating the source
-//! to all uses of the target. See `can_propagate_copy` for the safety gates.
-//!
-//! Runs on the worklist rewrite engine (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) as a [`Rule`]: a
-//! per-function standalone engine session whose `apply_block` fires once at
-//! the body root and runs the analyse/substitute fixpoint to convergence in
-//! one shot. The substitute-and-remove rewrites route through
-//! `engine.replace_expr_kind`, `engine.alloc_expr`, and
-//! `engine.set_block_stmts` so the parent map and use index stay coherent.
+//! Copy propagation for Wado NIR: eliminates a trivial `let x = y`,
+//! `let x = &y`, `let x = &mut y`, or a copy of a promoted operand by
+//! propagating the source to every use of the target. `can_propagate_copy` holds
+//! the safety gates. Runs as a [`Rule`] whose `apply_block` fires at the body
+//! root and drives the analyse/substitute fixpoint to convergence in one shot.
 
 use std::cell::Cell;
 
@@ -34,16 +26,11 @@ struct CopyBinding {
     target_local: u32,
     source: CopySource,
     type_id: TypeId,
-    /// Whether the source value is stable across the target's scope: the source
-    /// local is never *mutated* (re-assigned, field-mutated, `&mut`-borrowed,
-    /// passed as a mutable argument, or written through a `&mut` alias — see
-    /// [`MutRefAliases`]) anywhere in the binding block's statements after the
-    /// binding, and every read of the target sits after the binding (a
-    /// backward read would cross a loop iteration the interval cannot reason
-    /// about). The target's uses are confined to that scope, so a stable
-    /// source can be propagated even when the source is reassigned elsewhere
-    /// in the function (e.g. a loop counter copied inside the loop body).
-    /// Always `true` for a promoted-value source.
+    /// Whether the source value is stable across the target's scope: never
+    /// mutated — by assignment, `&mut`, or through a [`MutRefAliases`] alias —
+    /// after the binding in its block, with every read of the target after it, a
+    /// backward read crossing a loop iteration. So a source reassigned elsewhere
+    /// in the function still propagates. Always `true` for a promoted value.
     source_scope_stable: bool,
     /// Whether [`substitute_promoted_reads`] can rewrite every promoted read of
     /// the target: each fills its slot whole (`Opaque(Local target)`), and the
@@ -235,36 +222,22 @@ struct AnalysisCtx<'a> {
 }
 
 /// Per-block mutation / read positions, keyed by the block's own statement
-/// indices.
-///
-/// `mut_indices`: per-local sorted statement indices whose subtree mutates it.
-/// `.last()` is the last mutation — a binding at `k` is source-scope-stable
-/// iff its source has none after `k`. The full list additionally lets the
-/// projection-source check ask whether any mutation falls in the open
-/// interval `(binding, use]`.
-///
-/// `first_read`: per-local earliest statement index whose subtree reads it,
-/// counting the reads a promoted operand carries in the value pool.
-/// For a single-use projection temp this is its unique use, bounding the
-/// interval the projection stability check scans for root mutations; for
-/// every source kind it guards against backward (cross-iteration) reads.
+/// indices. `mut_indices` holds each local's sorted mutating statements: a
+/// binding at `k` is source-scope-stable iff its source has none after `k`, and
+/// the full list answers the projection check's open-interval question.
+/// `first_read` is the earliest read, which guards against backward reads.
 #[derive(Default)]
 struct BlockScan {
     mut_indices: IndexMap<u32, Vec<usize>>,
     first_read: IndexMap<u32, usize>,
 }
 
-/// Build every block's [`BlockScan`] in ONE top-down walk: each read /
-/// mutation event is recorded into all enclosing blocks at their current
-/// statement index, instead of re-walking full subtrees at every nesting
-/// level (O(N²) on deep bodies — #1472 follow-up).
-///
-/// A method receiver is a mutation only when the callee actually writes
-/// through it, and a write through a `&mut` alias is attributed to the
-/// aliased root too — both via [`for_each_mutated_root`], the same dispatch
-/// `analyze_expr`'s usage marking uses — so a read-only receiver (`x.len()`)
-/// does not end the scope-stability interval of `x`-sourced bindings, while
-/// `let r = &mut y; …; r.f = v` does.
+/// Build every block's [`BlockScan`] in ONE top-down walk, recording each read /
+/// mutation into all enclosing blocks at their current statement index rather
+/// than re-walking subtrees per nesting level (O(N²) on deep bodies).
+/// [`for_each_mutated_root`] decides what counts, so a read-only `x.len()`
+/// receiver does not end `x`'s stability interval while `r.f = v` through a
+/// `&mut` alias does.
 fn scan_blocks(
     body: &Body,
     type_table: &TypeTable,

--- a/wado-compiler/src/optimize/dae.rs
+++ b/wado-compiler/src/optimize/dae.rs
@@ -59,8 +59,8 @@ pub fn eliminate_dead_arguments(project: &mut NirPackage, gate: &mut FunctionGat
     true
 }
 
-/// Closure-functor methods whose receiver-position deadness is honoured and
-/// whose trait-method pin is lifted: `__Closure_N::__call` and the
+/// Closure-functor methods whose `is_closure_call` pin is lifted:
+/// `__Closure_N::__call` and the
 /// `^Inspect` / `^InspectAlt` impls. Each is reached only through a synthesised
 /// function-table wrapper, and `register_closure_wrappers` /
 /// `register_inspect_wrapper` adapt that wrapper to the shrunken signature.

--- a/wado-compiler/src/optimize/dae.rs
+++ b/wado-compiler/src/optimize/dae.rs
@@ -1,57 +1,8 @@
-//! Dead Argument Elimination for Wado NIR.
-//!
-//! Removes parameters that the callee body never reads, together with the
-//! corresponding argument expressions at every call site. The dropped
-//! arguments must be pure so removal cannot change observable behaviour.
-//!
-//! NIR analog of `wir_optimize/dae.rs`. Running at NIR exposes the freshly
-//! dead expressions to the rest of the fixed-point loop (`copy_prop` /
-//! `const_fold` / `dce`), and it shrinks signatures *before* `inline` so the
-//! inliner is not deterred by parameters that would never be read in the
-//! inlined body anyway.
-//!
-//! Pinning rules — the pass conservatively skips:
-//!
-//! - Functions without a body (imports / extern declarations).
-//! - Synthesised CM bridges (`is_cm_export`, `is_cm_binding`,
-//!   `is_dispatch_wrapper`). These sit on the world boundary; their
-//!   signatures are observed by the host runtime, not just by the
-//!   in-project call graph.
-//! - `is_ambient` functions (special call shapes — effect-handler
-//!   dispatch carries an implicit handler param the call sites assume).
-//! - Non-`Regular` `FunctionKind` entries (specialised stubs).
-//! - Builtin / wasm-asset modules (their signatures are part of the ABI).
-//! - Allocator entry points (`allocator_tag.is_some()`) — wired raw into
-//!   the canonical ABI as `realloc`, with no `is_cm_export` wrapper to
-//!   absorb a shrunken signature.
-//! - Closure `__call` functors (`is_closure_call`) — their function-table
-//!   wrapper snapshots the signature. Concrete trait-impl methods are NOT
-//!   pinned: after monomorphization they are plain functions whose call sites
-//!   all carry a resolved `func_id` (matching `sroa_param`'s relaxation), so a
-//!   dead parameter is dropped soundly. The closure-functor `^Inspect` /
-//!   `^InspectAlt` impls are the relaxed exception even among `__call`s.
-//! - Functions whose pointer is taken via `FuncRef` anywhere in the project.
-//!
-//! `is_export` is NOT a pin: every user `export fn` reaches the world
-//! boundary through a synthesised CM wrapper (`__cm_export__<name>`,
-//! `is_cm_export = true`). The wrapper is the boundary; the user
-//! function is internal — only the wrapper calls it — and the validator
-//! sees the call site, so DAE shrinks the user function safely. The
-//! wrapper's signature is held fixed by the `is_cm_export` pin above.
-//!
-//! Methods receive no special pin either. A method whose `self` is dead
-//! has the receiver dropped from `args` by `apply_dae` at every call
-//! site, leaving a free call of the same callee — mirroring what was
-//! previously implemented for closure-functor `__call` only. The
-//! `closure_call_keys` set still exists for one purpose: to lift the
-//! `trait_name` pin on the closure-functor's `^Inspect` /
-//! `^InspectAlt` impls, where the matching wrapper adapts to the
-//! shrunken signature. Everything else flows through the general path.
-//!
-//! Runs over the arena `Body` (see `docs/wep-2026-06-05-nir-optimizer-architecture.md`):
-//! the function-body work (dead-param detection, call-site validation, local
-//! renumbering, call-site rewriting) reads and mutates it directly. Global
-//! initializers are arena bodies too, so the same routines run on them.
+//! Dead Argument Elimination — drops parameters the callee never reads, along
+//! with the (pure) argument expressions at every call site. Running at NIR
+//! rather than WIR feeds the freshly dead expressions back into the fixed-point
+//! loop and shrinks signatures before `inline` sees them. [`is_dae_sroa_eligible`]
+//! holds the pinning rules; neither `is_export` nor a method receiver is pinned.
 
 use cranelift_entity::EntityRef;
 
@@ -108,27 +59,11 @@ pub fn eliminate_dead_arguments(project: &mut NirPackage, gate: &mut FunctionGat
     true
 }
 
-/// Functions whose `dead[0]` (receiver-position deadness) is honoured rather
-/// than forced to `false`, AND whose trait-method pin is lifted. These are
-/// the closure-functor methods that have a controlled dispatch path:
-///
-/// - `__Closure_N::__call` (the closure body). Reached via the
-///   synthesised `__closure_wrapper_*` (function-table dispatch) and via
-///   `lower::plan::closure`'s fn-param-specialisation `g.__call(args)`.
-///   `wir_build::register_closure_wrappers` adapts the wrapper
-///   body to the surviving `call_method.params`.
-///
-/// - `__Closure_N^Inspect::inspect` and `^InspectAlt::inspect_alt`. The
-///   only callers are the corresponding `__closure_inspect_wrapper_*` /
-///   `__closure_inspect_alt_wrapper_*` (function-table dispatch, looked
-///   up off `CanonicalClosure_K`'s `inspect` / `inspect_alt` slot). User
-///   code reaches these via `Fn<N,Ret>^Inspect::inspect(closure_ref,
-///   formatter)` / its alt twin, both of which dispatch through the
-///   canonical struct rather than the per-functor impl directly.
-///   `register_inspect_wrapper` adapts the wrapper body the same way the
-///   call wrapper does, so DAE can safely drop the `self` (env) param
-///   from the inspect impl when its synthesised body
-///   (`f.write_str("...")`) doesn't read it.
+/// Closure-functor methods whose receiver-position deadness is honoured and
+/// whose trait-method pin is lifted: `__Closure_N::__call` and the
+/// `^Inspect` / `^InspectAlt` impls. Each is reached only through a synthesised
+/// function-table wrapper, and `register_closure_wrappers` /
+/// `register_inspect_wrapper` adapt that wrapper to the shrunken signature.
 fn collect_closure_call_keys(project: &NirPackage) -> IndexSet<FnKey> {
     let mut keys: IndexSet<FnKey> = IndexSet::default();
     let functor_struct_names: IndexSet<(ModuleSource, String)> = project
@@ -142,17 +77,11 @@ fn collect_closure_call_keys(project: &NirPackage) -> IndexSet<FnKey> {
             keys.insert(id);
         }
     }
-    // Sweep the function list for synthesised
-    // `__Closure_N^{Inspect,InspectAlt}::{inspect,inspect_alt}` impls.
-    // These don't have a direct field on `ClosureFunctor`, so we
-    // discriminate by `(struct_name == __Closure_N, trait is Inspect /
-    // InspectAlt)`. The trait is matched against the canonical names in
-    // the compiler-item registry — the same source
-    // `generate_functor_format_methods` stamps into these impls'
-    // `trait_name` — so a stdlib rename of either trait flows through
-    // instead of a bare-literal `"Inspect"` match a user trait could
-    // shadow. (`base_trait_module` is left `None` on these synthesis-
-    // derived impls, so the registry name is the exact-identity anchor.)
+    // Sweep for synthesised `__Closure_N^{Inspect,InspectAlt}` impls, which have
+    // no field on `ClosureFunctor` to key off. The trait is matched against the
+    // compiler-item registry — the same source `generate_functor_format_methods`
+    // stamps into `trait_name` — so a stdlib rename flows through and no user
+    // trait named `Inspect` can shadow it.
     let type_table = project.type_table.borrow();
     let items = type_table.compiler_items();
     let inspect_name = items.trait_name(CompilerItem::Inspect);
@@ -178,26 +107,11 @@ fn collect_closure_call_keys(project: &NirPackage) -> IndexSet<FnKey> {
     keys
 }
 
-/// Shared pinning predicate for the two interprocedural signature-rewriting
-/// passes, `dae` and `sroa_param` (which calls this via `super::dae`). Both
-/// refuse the same world-boundary and ABI-fixed shapes — bodyless imports, CM
-/// bridges, non-`Regular` kinds, builtin / wasm-asset modules, and allocator
-/// entry points wired raw into the canonical ABI — and both treat a concrete
-/// trait-impl method as eligible (after monomorphization it is a plain function
-/// whose every call site carries a resolved `func_id`, so the rewrite reaches
-/// them all). They diverge only on the closure `__call` functor policy, carried
-/// by `relax_closure_call`:
-///
-/// - `false` (`sroa_param`, and `dae` for any `__call` not covered by its
-///   relaxation): a closure `__call` stays pinned — its function-table wrapper
-///   snapshots the signature.
-/// - `true` (`dae`, for the closure-functor `^Inspect` / `^InspectAlt` /
-///   `__call` impls whose wrapper adapts to the shrunken signature): the closure
-///   pin is lifted.
-///
-/// `is_export` / `is_async` are intentionally *not* pins — both describe
-/// user source-level intent, not a real call-shape constraint (see the module
-/// doc). `sroa_param` layers its one extra pin (`is_value_copy`) on top of this.
+/// Shared pinning predicate for `dae` and `sroa_param`: both refuse the same
+/// world-boundary and ABI-fixed shapes, and both accept a concrete trait-impl
+/// method (post-monomorphization every call site carries a resolved `func_id`).
+/// They diverge only on `relax_closure_call` — a closure `__call` stays pinned
+/// unless its function-table wrapper adapts to the shrunken signature.
 pub(super) fn is_dae_sroa_eligible(func: &NirFunction, relax_closure_call: bool) -> bool {
     if func.body.is_none() {
         return false;

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -94,10 +94,9 @@ pub struct DceAnalysis {
 impl DceAnalysis {
     /// Whether `s` survives the sweep — the one predicate, read both by the walk
     /// that pulls a struct's field types into the reachable set and by the retain
-    /// that drops the rest. Two spellings would keep a struct whose fields were
-    /// never walked, outliving the ids they name. A struct's stored `name`
-    /// predates newtype / flags erasure while the reachable set renders after it
-    /// (`FlagsBit<Perms>` against `FlagsBit<u32>`), so both spellings count.
+    /// that drops the rest. A struct's stored `name` predates newtype / flags
+    /// erasure while the reachable set renders after it (`FlagsBit<Perms>`
+    /// against `FlagsBit<u32>`), so both spellings count.
     fn keeps_struct(&self, s: &crate::nir::NirStruct, type_table: &TypeTable) -> bool {
         let Some(mono) = &s.monomorph_info else {
             return self
@@ -278,10 +277,8 @@ fn extend_reachable_for_optimizer_passes(
     // Keep `String::push` reachable only while a `nir/string_push` rewrite could
     // still fire — it turns a short constant `push_str` into per-byte `push`
     // calls, so the target must survive the pre-loop DCE. Gating on a surviving
-    // candidate makes the virtual edge self-limiting: present pre-loop, gone at
-    // the final DCE, where re-seeding would be pure bloat. The `$value_copy$`
-    // half below is not gated — WIR build names those helpers after the final
-    // DCE, so both invocations must seed them.
+    // candidate makes the edge self-limiting. The `$value_copy$` half is not
+    // gated: WIR build names those helpers after the final DCE.
     if let (Some((str_id, str_func_id)), Some(char_id)) = (push_str, push_char_id)
         && reachable.contains(&str_id)
         && !reachable.contains(&char_id)
@@ -656,9 +653,8 @@ pub fn filter_string_literals(project: &mut NirPackage) {
 /// Retain only the bytes literals surviving functions reference. Unlike string
 /// literals there is no per-function map, so this scans every surviving body for
 /// `ExprKind::PackedArray` nodes. String `repr`s are `PackedArray` too, making
-/// the scanned set a superset — but since it only ever drops entries, a string
-/// payload equal to an unused bytes literal costs one extra entry, which dedups
-/// into the same segment anyway.
+/// the scanned set a superset — harmless, since a shared payload dedups into the
+/// same segment anyway.
 pub fn filter_bytes_literals(project: &mut NirPackage) {
     let mut used_bytes: IndexSet<Vec<u8>> = IndexSet::default();
 
@@ -861,9 +857,8 @@ fn apply_inspect_edges(
 /// Every `(arity, return_type)` signature receiving a `Fn<…>^Inspect` or
 /// `^InspectAlt` call. Gates the per-functor root marking from
 /// `ClosureToCanonical`: with no real caller those impls cannot be invoked
-/// indirectly, so keeping them is waste. The two methods are tracked separately
-/// so a program formatting closures only with `:?` does not keep every
-/// `__Closure_N^InspectAlt` impl and its source-string constant alive.
+/// indirectly. The two methods are tracked separately, so formatting closures
+/// only with `:?` keeps no `__Closure_N^InspectAlt` impl alive.
 #[derive(Default)]
 struct InspectableSignatures {
     inspect: IndexSet<(usize, TypeId)>,
@@ -1705,10 +1700,9 @@ impl DceAnalysis {
 /// Variant declarations that outlive their uses, both for
 /// `optimize::sroa_variant_return`: `Option`, whose slots the pass mints after
 /// the early DCE, and any variant a function was scalarized *from* — scalarizing
-/// every use away is exactly what makes a declaration look unreachable, and the
-/// pass re-derives its layout to recognise its own earlier work. A kept
-/// declaration keeps its payload types too, or `register_mono_variants` panics
-/// substituting them. Keeping one costs nothing: WIR registers instances.
+/// every use away is what makes a declaration look unreachable, and the pass
+/// re-derives its layout to recognise its own earlier work. A kept declaration
+/// keeps its payload types too, or `register_mono_variants` panics.
 fn variant_decls_kept_past_use(
     project: &NirPackage,
     type_table: &TypeTable,
@@ -1743,8 +1737,7 @@ fn variant_decls_kept_past_use(
 /// reachable from any reachable function's signature, locals or expressions, or
 /// any reachable global's initializer, closed transitively over struct fields
 /// and variant payloads. Reads `analysis.functions` and `analysis.globals`, so
-/// both must be populated first, and runs pre-pruning so every DCE analysis
-/// stays in [`analyze_dce`].
+/// both must be populated first.
 fn populate_type_reachability(
     project: &NirPackage,
     descriptors: &[FunctionRef],
@@ -1814,9 +1807,8 @@ fn populate_type_reachability(
         // A reachable `__call` keeps its functor's struct / ref types live:
         // `register_closure_wrappers` reads `ref_type_id` for the wrapper's
         // `ref.cast`, and DAE can drop every other NIR-side mention by removing
-        // the env `self`, leaving the `ClosureFunctor` record as the only one.
-        // Compare by pointer identity — `functor.call_method` and the matching
-        // `project.functions[i]` are the same `Rc`.
+        // the env `self`. Compare by pointer identity — `functor.call_method`
+        // and the matching `project.functions[i]` are the same `Rc`.
         let surviving_ptrs: IndexSet<*const _> = project
             .functions
             .iter()
@@ -2245,12 +2237,9 @@ fn dead_pure_binding(
 
 /// Un-hoist a constant globalization hoisted for nobody: the folds that run
 /// after globalization can take every reader with them, leaving a global that
-/// holds its whole initializer in the binary for no observer. Two reads do not
-/// count as observing — the `is_uninitialized` guard, which decides the store
-/// rather than using it, and a read bound to a local nothing mentions — both
-/// only when the value is one this pass may delete ([`deletable_value`]), since
-/// a trap is observed like any other effect. What is left loses its guard,
-/// store, and bindings, and then has no reads for the census below to find.
+/// holds its whole initializer in the binary for no observer. The
+/// `is_uninitialized` guard and a read bound to an unmentioned local do not
+/// count as observing, provided the value is a [`deletable_value`].
 pub fn unhoist_unobserved_globals(project: &mut NirPackage) {
     let descriptors = build_callee_descriptors(project);
     let effects = super::mod_ref::compute_fn_effects(&project.functions, &project.builtin_registry);

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -2,7 +2,7 @@
 //! reachability set up front — functions, globals, types, plus the name-keyed
 //! views the type-retain predicate needs — so the downstream `remove_*` and
 //! filter passes are pure mutators over those sets, with no re-analysis. See
-//! [`crate::optimize::run_dce`]: analyze once, then mutate in dependency order.
+//! `crate::optimize::run_dce`: analyze once, then mutate in dependency order.
 
 use crate::canonical::CmCallTarget;
 use crate::hashmap::IndexSet;
@@ -2239,7 +2239,7 @@ fn dead_pure_binding(
 /// after globalization can take every reader with them, leaving a global that
 /// holds its whole initializer in the binary for no observer. The
 /// `is_uninitialized` guard and a read bound to an unmentioned local do not
-/// count as observing, provided the value is a [`deletable_value`].
+/// count as observing, provided the value is a `deletable_value`.
 pub fn unhoist_unobserved_globals(project: &mut NirPackage) {
     let descriptors = build_callee_descriptors(project);
     let effects = super::mod_ref::compute_fn_effects(&project.functions, &project.builtin_registry);

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -1,14 +1,8 @@
-//! Dead-code elimination for the NIR package.
-//!
-//! [`analyze_dce`] computes every reachability set the package needs
-//! up front (functions / globals / types, plus name-keyed views over
-//! the reachable type set for the type-retain predicate). The
-//! downstream [`remove_unreachable_functions`] / `_globals` / `_types`
-//! and the literal/closure-functor filters then become pure mutators
-//! that consume the precomputed sets; no per-pass re-analysis.
-//!
-//! See [`crate::optimize::run_dce`] for the orchestration: analyze
-//! once, mutate in dependency order.
+//! Dead-code elimination for the NIR package. [`analyze_dce`] computes every
+//! reachability set up front — functions, globals, types, plus the name-keyed
+//! views the type-retain predicate needs — so the downstream `remove_*` and
+//! filter passes are pure mutators over those sets, with no re-analysis. See
+//! [`crate::optimize::run_dce`]: analyze once, then mutate in dependency order.
 
 use crate::canonical::CmCallTarget;
 use crate::hashmap::IndexSet;
@@ -98,16 +92,12 @@ pub struct DceAnalysis {
 }
 
 impl DceAnalysis {
-    /// Whether `s` survives the sweep.
-    ///
-    /// The one predicate: the closure that pulls a struct's field types into
-    /// the reachable set reads it, and so does the retain that drops the rest.
-    /// Two spellings would let a struct be kept whose fields were never
-    /// walked, and it would outlive the ids its own fields name.
-    ///
-    /// A struct's stored `name` predates newtype / flags erasure while the
-    /// reachable set renders after it, so one type spells two ways
-    /// (`FlagsBit<Perms>` against `FlagsBit<u32>`). Both spellings count.
+    /// Whether `s` survives the sweep — the one predicate, read both by the walk
+    /// that pulls a struct's field types into the reachable set and by the retain
+    /// that drops the rest. Two spellings would keep a struct whose fields were
+    /// never walked, outliving the ids they name. A struct's stored `name`
+    /// predates newtype / flags erasure while the reachable set renders after it
+    /// (`FlagsBit<Perms>` against `FlagsBit<u32>`), so both spellings count.
     fn keeps_struct(&self, s: &crate::nir::NirStruct, type_table: &TypeTable) -> bool {
         let Some(mono) = &s.monomorph_info else {
             return self
@@ -127,17 +117,11 @@ impl DceAnalysis {
     }
 }
 
-/// Compute every DCE input from the unpruned `project` in dependency
-/// order: function reachability → global reachability → type
-/// reachability. Each downstream step (`remove_unreachable_functions`,
-/// `remove_unreachable_globals`, `remove_unreachable_types`) then
-/// becomes a pure mutator that consumes the corresponding field.
-///
-/// Splitting analysis from mutation also means the type-reachability
-/// pass can run before `remove_unreachable_globals` mutates function
-/// bodies (dropping `GlobalVarSet`s) — those mutations don't expose
-/// any new types, but the explicit ordering makes the invariant
-/// observable.
+/// Compute every DCE input from the unpruned `project` in dependency order:
+/// functions, then globals, then types. Each downstream `remove_*` is then a
+/// pure mutator over the matching field. The split also puts type reachability
+/// before `remove_unreachable_globals` mutates function bodies — those mutations
+/// expose no new types, but the ordering makes that invariant observable.
 pub fn analyze_dce(project: &mut NirPackage) -> DceAnalysis {
     // The callee descriptor for every `FuncId`, materialized once from the
     // function records (borrow-safe: a plain pass, no body walk). A call's
@@ -291,18 +275,13 @@ fn extend_reachable_for_optimizer_passes(
             _ => {}
         }
     }
-    // Keep `String::push` (`string_push_char`) reachable only while a
-    // `nir/string_push` rewrite could still fire: the rule turns a short
-    // constant `buf.push_str("abc")` into per-byte `buf.push(c)` calls, so its
-    // target must survive the DCE that runs *before* the optimization loop.
-    // The rule consumes each eligible call, so once the loop has run to
-    // fixpoint (the final DCE), no eligible candidate remains — and re-seeding
-    // `push_char` there keeps it and its callees alive as pure output bloat.
-    // Gating on a surviving candidate makes the virtual edge self-limiting:
-    // present at the pre-loop DCE (and at -O0, where the rule never runs), gone
-    // at the final DCE. The `$value_copy$` half below is *not* gated this way —
-    // its helpers are referenced by name at WIR build (after the final DCE), so
-    // both invocations must seed them.
+    // Keep `String::push` reachable only while a `nir/string_push` rewrite could
+    // still fire — it turns a short constant `push_str` into per-byte `push`
+    // calls, so the target must survive the pre-loop DCE. Gating on a surviving
+    // candidate makes the virtual edge self-limiting: present pre-loop, gone at
+    // the final DCE, where re-seeding would be pure bloat. The `$value_copy$`
+    // half below is not gated — WIR build names those helpers after the final
+    // DCE, so both invocations must seed them.
     if let (Some((str_id, str_func_id)), Some(char_id)) = (push_str, push_char_id)
         && reachable.contains(&str_id)
         && !reachable.contains(&char_id)
@@ -311,35 +290,11 @@ fn extend_reachable_for_optimizer_passes(
         reachable.extend(compute_reachable(call_graph, &char_id));
     }
 
-    // `$value_copy$` helpers synthesized by `lower::plan::value_copy`
-    // can be reached via `array_clone::<T>(arr)` for value-typed `T`: that
-    // lowers to `WirInstr::ArrayClone { element_copy_type: Some(T) }`
-    // where the helper is referenced by the element *type* at WIR codegen
-    // time, not as a NIR call edge — so the regular call graph misses it. Walk every
-    // reachable function body and seed the corresponding helper as a
-    // virtual root for each value-typed `array_clone::<T>` site.
-    //
-    // (Marking every `FunctionKind::ValueCopy` helper unconditionally — the
-    // previous shape — is correct but bloats unused monomorphisations.)
-    //
-    // TODO(optimizer): have `lower::plan::value_copy` register the
-    // synthesized helper as a real call-graph edge on the caller of
-    // `array_clone::<T>`. That folds this fixpoint into the regular
-    // reachability walk and removes the only multi-pass step in DCE.
-    // Key helpers by the copied type's canonical mangle, not its raw
-    // `TypeId`: the type table can intern the same structural type under more
-    // than one id, and `lower::plan::value_copy` synthesizes a single helper
-    // per mangle. An `array_clone::<T>` site may name a different id for that
-    // same type, so a raw-id map would miss the shared helper and DCE would
-    // drop it, panicking codegen with "references a value-copy helper ... that
-    // was not synthesized".
-    // Precompute — while the type table is borrowed — the helper map and,
-    // per function, the canonical mangles of every `array_clone::<T>`
-    // element it names. Both the helper mangles and the per-site mangles
-    // are intern-order-stable, so each is canonicalized exactly once here
-    // rather than re-derived on every fixpoint round; the borrow is then
-    // released before the loop, so `compute_reachable` never runs under a
-    // live `TypeTable` borrow.
+    // WIR codegen names a `$value_copy$` helper by `array_clone::<T>`'s element
+    // *type*, not as a NIR call edge, so seed one virtual root per value-typed
+    // site — keyed by canonical mangle, since the table can intern one type
+    // under several ids while only one helper exists per mangle.
+    // TODO(optimizer): make it a real call-graph edge in `lower::plan::value_copy`.
     let (helpers_by_mangle, candidates): (
         IndexMap<String, FunctionId>,
         Vec<(FunctionId, Vec<String>)>,
@@ -698,17 +653,12 @@ pub fn filter_string_literals(project: &mut NirPackage) {
     project.string_literals = reachable_strings.into_iter().collect();
 }
 
-/// Filter bytes literals to only include bytes referenced by surviving functions.
-///
-/// Unlike string literals (which have a `function_strings` map for per-function
-/// tracking), bytes literals are tracked only by their inline
-/// `ExprKind::PackedArray(Vec<u8>)` nodes. This scans every surviving function
-/// body for those nodes, then retains only matching entries in
-/// `project.bytes_literals`. Since string literal `repr`s are *also*
-/// `PackedArray` now, the scanned set is a superset that may include string
-/// payloads, but the `retain` only ever drops entries from `bytes_literals`, so
-/// a string payload that coincidentally equals an unused bytes literal at worst
-/// keeps that one extra entry (which dedups to the same shared segment anyway).
+/// Retain only the bytes literals surviving functions reference. Unlike string
+/// literals there is no per-function map, so this scans every surviving body for
+/// `ExprKind::PackedArray` nodes. String `repr`s are `PackedArray` too, making
+/// the scanned set a superset — but since it only ever drops entries, a string
+/// payload equal to an unused bytes literal costs one extra entry, which dedups
+/// into the same segment anyway.
 pub fn filter_bytes_literals(project: &mut NirPackage) {
     let mut used_bytes: IndexSet<Vec<u8>> = IndexSet::default();
 
@@ -908,17 +858,12 @@ fn apply_inspect_edges(
     }
 }
 
-/// Walk all NIR function bodies and collect every `(arity, return_type)`
-/// signature that is the receiver type of a `Fn<arity, ret>^Inspect` or
-/// `Fn<arity, ret>^InspectAlt` method call. Used by the DCE call-graph
-/// builder to gate the per-functor `inspect` / `inspect_alt` root
-/// marking emitted from `ClosureToCanonical` independently: without a
-/// real `Fn^Inspect[Alt]` caller, those per-functor impls cannot be
-/// invoked indirectly, so keeping them alive is purely waste.
-///
-/// The two trait methods are tracked separately so a program that only
-/// formats closures with `:?` doesn't keep every `__Closure_N^InspectAlt`
-/// impl (and its per-literal source-string constant) alive.
+/// Every `(arity, return_type)` signature receiving a `Fn<…>^Inspect` or
+/// `^InspectAlt` call. Gates the per-functor root marking from
+/// `ClosureToCanonical`: with no real caller those impls cannot be invoked
+/// indirectly, so keeping them is waste. The two methods are tracked separately
+/// so a program formatting closures only with `:?` does not keep every
+/// `__Closure_N^InspectAlt` impl and its source-string constant alive.
 #[derive(Default)]
 struct InspectableSignatures {
     inspect: IndexSet<(usize, TypeId)>,
@@ -1758,23 +1703,12 @@ impl DceAnalysis {
 }
 
 /// Variant declarations that outlive their uses, both for
-/// `optimize::sroa_variant_return`:
-///
-/// - `Option`, because the pass mints `Option<T>` slots *after* the early DCE
-///   run and `wir_build::register_mono_variants` registers the instance off the
-///   declaration.
-/// - Any variant a function was scalarized *from*. Scalarizing every use of a
-///   variant away is exactly what makes its declaration look unreachable, and
-///   the pass re-derives its layout from that declaration to recognise its own
-///   earlier work in a later iteration.
-///
-/// A kept declaration keeps its case payload types too: `register_mono_variants`
-/// substitutes the declaration's payloads against each instance's type args, so
-/// a declaration whose payload `TypeId` was pruned panics in `wir_build`. That
-/// is why the same set gates both the payload walk and the retain.
-///
-/// Keeping a declaration costs nothing: WIR registers instances, not
-/// declarations.
+/// `optimize::sroa_variant_return`: `Option`, whose slots the pass mints after
+/// the early DCE, and any variant a function was scalarized *from* — scalarizing
+/// every use away is exactly what makes a declaration look unreachable, and the
+/// pass re-derives its layout to recognise its own earlier work. A kept
+/// declaration keeps its payload types too, or `register_mono_variants` panics
+/// substituting them. Keeping one costs nothing: WIR registers instances.
 fn variant_decls_kept_past_use(
     project: &NirPackage,
     type_table: &TypeTable,
@@ -1805,17 +1739,12 @@ fn variant_decls_kept_past_use(
     kept
 }
 
-/// Populate `analysis.types` and the name-keyed type-index views.
-/// A type is reachable if it's used in any reachable function's
-/// signature, locals, or expressions, or in any reachable global's
-/// initializer (with transitive closure over struct fields, variant
-/// payloads, and per-type dependencies).
-///
-/// Reads `analysis.functions` and `analysis.globals` to filter the
-/// per-function / per-global walks — both must be populated first
-/// (see [`analyze_dce`]). Running pre-pruning, so all DCE analysis
-/// sits in `analyze_dce` and the downstream `remove_*` functions only
-/// mutate.
+/// Populate `analysis.types` and the name-keyed type-index views. A type is
+/// reachable from any reachable function's signature, locals or expressions, or
+/// any reachable global's initializer, closed transitively over struct fields
+/// and variant payloads. Reads `analysis.functions` and `analysis.globals`, so
+/// both must be populated first, and runs pre-pruning so every DCE analysis
+/// stays in [`analyze_dce`].
 fn populate_type_reachability(
     project: &NirPackage,
     descriptors: &[FunctionRef],
@@ -1882,17 +1811,12 @@ fn populate_type_reachability(
             }
         }
 
-        // When a closure functor's `__call` method is reachable, its
-        // struct / ref types must stay live: `wir_build::register_closure_wrappers`
-        // reads `ClosureFunctor::ref_type_id` to emit the wrapper's `ref.cast`,
-        // and NIR DAE can drop every other NIR-side reference (it removes the
-        // env `self` from `call_method.params[0]`), leaving the `ClosureFunctor`
-        // record itself as the only live mention. Without this insertion the
-        // type-table lookup panics with `TypeId not found`.
-        //
-        // `functor.call_method` and the matching `project.functions[i]` are the
-        // same `Rc` — compare by pointer identity to avoid cloning a
-        // `(ModuleSource, String)` key per functor.
+        // A reachable `__call` keeps its functor's struct / ref types live:
+        // `register_closure_wrappers` reads `ref_type_id` for the wrapper's
+        // `ref.cast`, and DAE can drop every other NIR-side mention by removing
+        // the env `self`, leaving the `ClosureFunctor` record as the only one.
+        // Compare by pointer identity — `functor.call_method` and the matching
+        // `project.functions[i]` are the same `Rc`.
         let surviving_ptrs: IndexSet<*const _> = project
             .functions
             .iter()
@@ -2319,27 +2243,14 @@ fn dead_pure_binding(
     super::arena_query::is_pure_nontrapping_expr_typed(body, value, Some(types)).then_some(value)
 }
 
-/// Un-hoist a constant globalization hoisted for nobody.
-///
-/// Globalization moves a constant aggregate into a shared slot and guards the
-/// store; the folds that run after it can take every reader with them. What is
-/// left computes a value nothing observes, and holds whatever the initializer
-/// builds — a reflect member walk and the strings it names — in the binary to
-/// do it.
-///
-/// Two reads do not count as observing the value:
-///
-/// - the global's own `is_uninitialized` guard, which exists to decide the
-///   store rather than to use what it holds;
-/// - a read bound to a local nothing mentions, which is what folding a member's
-///   facts out of the walk leaves behind.
-///
-/// Both are conditional on the value being one this pass may delete
-/// ([`deletable_value`]) — a trap is observed like any other effect.
-///
-/// A global with no observation left loses its guard, its store, and those
-/// bindings. It then has no reads at all, which the reachability census below
-/// already answers, and its initializer goes with it.
+/// Un-hoist a constant globalization hoisted for nobody: the folds that run
+/// after globalization can take every reader with them, leaving a global that
+/// holds its whole initializer in the binary for no observer. Two reads do not
+/// count as observing — the `is_uninitialized` guard, which decides the store
+/// rather than using it, and a read bound to a local nothing mentions — both
+/// only when the value is one this pass may delete ([`deletable_value`]), since
+/// a trap is observed like any other effect. What is left loses its guard,
+/// store, and bindings, and then has no reads for the census below to find.
 pub fn unhoist_unobserved_globals(project: &mut NirPackage) {
     let descriptors = build_callee_descriptors(project);
     let effects = super::mod_ref::compute_fn_effects(&project.functions, &project.builtin_registry);

--- a/wado-compiler/src/optimize/drve.rs
+++ b/wado-compiler/src/optimize/drve.rs
@@ -1,9 +1,8 @@
 //! Dead Return Value Elimination: a function whose return value is dropped at
 //! every call site turns void, each `Return`'s verified-pure value going away
-//! while the call sites stay structurally identical. Running at NIR, unlike the
-//! WIR analog, exposes the freshly dead expressions to the rest of the loop —
-//! after `inline` collapses a `Result<(), Error>` helper nobody reads, DCE takes
-//! the `Ok(())` constructor with it.
+//! while the call sites stay structurally identical. Running at NIR exposes the
+//! freshly dead expressions to the rest of the loop — after `inline` collapses a
+//! `Result<(), Error>` helper nobody reads, DCE takes its `Ok(())` too.
 //!
 //! Conservative: it skips DAE's pinned set, needs the body to end in an explicit
 //! `Return` with every other `Return` carrying a pure value, and needs at least

--- a/wado-compiler/src/optimize/drve.rs
+++ b/wado-compiler/src/optimize/drve.rs
@@ -1,34 +1,13 @@
-//! Dead Return Value Elimination for Wado NIR.
+//! Dead Return Value Elimination: a function whose return value is dropped at
+//! every call site turns void, each `Return`'s verified-pure value going away
+//! while the call sites stay structurally identical. Running at NIR, unlike the
+//! WIR analog, exposes the freshly dead expressions to the rest of the loop —
+//! after `inline` collapses a `Result<(), Error>` helper nobody reads, DCE takes
+//! the `Ok(())` constructor with it.
 //!
-//! Converts non-void functions whose return value is always immediately
-//! dropped at every call site into void-returning functions. Every
-//! `Return { value: Some(expr) }` becomes `Return { value: None }` once
-//! `expr` is verified pure, and call sites stay structurally identical
-//! (the call expression now produces `Unit`).
-//!
-//! NIR analog of `wir_optimize/drve.rs`. Running at NIR exposes the freshly
-//! dead expressions to the rest of the fixed-point loop. Especially useful
-//! after `inline` collapses a `Result<(), Error>`-returning helper whose
-//! callers all `_ = helper(args);`-style discard the result — DCE can then
-//! remove the (now unreferenced) `Ok(())` constructor wholesale.
-//!
-//! Conservative scope:
-//!
-//! - Skips the same pinned set as DAE.
-//! - Requires the body to end with an explicit `Return { value: Some(_) }`
-//!   so we never have to reason about an implicit trailing-value return.
-//! - Requires every other `Return` in the body to also carry a pure value.
-//! - Requires every call site to appear as a top-level statement
-//!   (`StmtKind::Expr(Call(f, ...))`); any nested or `Let`-bound use
-//!   disqualifies the candidate.
-//! - Requires at least one observed call site (otherwise DCE will delete
-//!   the function anyway and there is nothing to optimise).
-//!
-//! Runs over the arena `Body` (see `docs/wep-2026-06-05-nir-optimizer-architecture.md`):
-//! the function-body walks (purity check, call-site validation, void rewrite,
-//! call retype) read and mutate it directly. Global initializers are arena
-//! bodies too, so their use-scan (`scan_node`) and retype (`retype_calls`)
-//! reuse the same routines.
+//! Conservative: it skips DAE's pinned set, needs the body to end in an explicit
+//! `Return` with every other `Return` carrying a pure value, and needs at least
+//! one call site, each a top-level statement.
 
 use crate::hashmap::IndexSet;
 use crate::nir::{FunctionKind, NirFunction};

--- a/wado-compiler/src/optimize/elide_box_local.rs
+++ b/wado-compiler/src/optimize/elide_box_local.rs
@@ -1,42 +1,9 @@
-//! Adjacent-use single-field struct local elimination for Wado NIR.
-//!
-//! NIR analog of `wir_optimize/elide_struct.rs`'s
-//! `elide_adjacent_single_use_struct_locals`. Targets the common
-//! `Box<T>` pattern produced by [`lower::translate`]'s `wrap_in_box`
-//! and exposed by the NIR `sroa_param` pass after it strips
-//! `&primitive` parameters down to scalars:
-//!
-//! ```text
-//! let snapshot = c;                           // (1) value-copy
-//! let __v0: i32 = snapshot.value;             // (2) field extracted by sroa_param
-//! let __cond = __v0 == 0;
-//! ```
-//!
-//! When a local is exactly one `Let { StructLiteral { single field } }`
-//! and has exactly one `FieldAccess` use, this pass substitutes the
-//! single-field initializer directly at the use site and drops the
-//! `Let`. The substitution is safe when every intervening sibling
-//! statement passes [`mod_ref::can_move_past`].
-//!
-//! Why at NIR (not WIR): the NIR-level alias machinery
-//! (`address_taken_locals` / `stores_aliased_locals`) feeds the
-//! identity-escape gate directly, and the substituted expressions
-//! flow back into the same fix-point loop where `copy_prop` /
-//! `const_fold` / `dce` can fold them further. The legacy WIR
-//! variant was retired once NIR `sroa_param` made the receiver
-//! `FieldAccess`-shaped at the call site (issue #1184).
-//!
-//! ## Scope
-//!
-//! - Single-field `StructLiteral` only. Multi-field elision is left
-//!   to the existing NIR `sroa` pass.
-//! - The candidate local must be defined exactly once and read
-//!   exactly once via `FieldAccess { expr: Local(idx), field_name }`.
-//! - The use must be the leftmost evaluated sub-expression of a
-//!   subsequent sibling statement. Conditional control (`If` /
-//!   `Match` / `Switch` / `LabeledBlock` / nested `Block`) blocks
-//!   substitution — those constructs may not execute the use on
-//!   every path.
+//! Adjacent-use single-field struct local elimination, for the `Box<T>` pattern
+//! `wrap_in_box` produces and `sroa_param` exposes. A local defined once as a
+//! single-field `StructLiteral` and read once through `FieldAccess` has its
+//! initializer substituted at the use and its `Let` dropped, provided every
+//! intervening sibling passes [`mod_ref::can_move_past`] and the use is the
+//! leftmost evaluated sub-expression of a later, unconditional sibling.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::{NirBinaryOp, NirUnaryOp};
@@ -47,17 +14,11 @@ use crate::nir_engine::{Engine, Rule};
 
 use super::mod_ref::{ModRef, can_move_past};
 
-/// Adjacent-use single-field struct local elimination as a rule on the unified
-/// post-inline peephole session (combine migration; formerly the standalone
-/// `nir/elide_box_local` pass). `build_elide_box_local` computes the same
-/// whole-function read/def `stats` the standalone pass did, plus the
-/// escape-safety `blacklist` (`address_taken` + `stores_aliased` locals), once
-/// per function from the pristine body. The `stats` are read-only oracles: a
-/// peephole rewrite can only remove a read, so a stale entry can only refuse an
-/// otherwise-valid elision (safe), never enable an unsound one. Each
-/// `apply_block` performs at most one elision — substitute the single-field
-/// initializer into its one `r.field` use and drop the binding `Let` via
-/// `set_block_stmts` — then the worklist re-runs for the next.
+/// Adjacent-use single-field struct local elimination, as a rule on the unified
+/// post-inline peephole session. `build_elide_box_local` computes the
+/// whole-function read/def `stats` and the escape-safety `blacklist` once per
+/// function; a rewrite can only remove a read, so a stale entry only ever
+/// refuses a valid elision. Each `apply_block` performs at most one.
 pub(super) struct ElideBoxLocalRule {
     stats: IndexMap<u32, LocalStats>,
     blacklist: IndexSet<u32>,

--- a/wado-compiler/src/optimize/elide_box_local.rs
+++ b/wado-compiler/src/optimize/elide_box_local.rs
@@ -1,9 +1,8 @@
 //! Adjacent-use single-field struct local elimination, for the `Box<T>` pattern
 //! `wrap_in_box` produces and `sroa_param` exposes. A local defined once as a
 //! single-field `StructLiteral` and read once through `FieldAccess` has its
-//! initializer substituted at the use and its `Let` dropped, provided every
-//! intervening sibling passes [`mod_ref::can_move_past`] and the use is the
-//! leftmost evaluated sub-expression of a later, unconditional sibling.
+//! initializer substituted at the use and its `Let` dropped, if the use is the
+//! leftmost sub-expression of a later unconditional sibling it can move past.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::{NirBinaryOp, NirUnaryOp};

--- a/wado-compiler/src/optimize/elide_local.rs
+++ b/wado-compiler/src/optimize/elide_local.rs
@@ -1,14 +1,8 @@
-//! Write-only local elimination for Wado NIR.
-//!
-//! Eliminates `let x = expr;` bindings where the local `x` is never read,
-//! never has its address taken, and never escapes via closure capture or a
-//! `stores`-aliased call. When `expr` is pure the entire statement is removed;
-//! otherwise the binding is replaced by `Expr(expr)` so the side effect still
-//! runs.
-//!
-//! NIR analog of `wir_optimize/elide_local.rs`. Running at NIR exposes the
-//! freshly dead expressions to the rest of the fixed-point loop
-//! (`copy_prop` / `const_fold` / `dce`), which the WIR-level pass cannot.
+//! Write-only local elimination for Wado NIR: a `let x = expr;` whose `x` is
+//! never read, address-taken, or escaped loses its binding — the whole statement
+//! when `expr` is pure, else a bare `Expr(expr)`. The NIR analog of
+//! `wir_optimize/elide_local.rs`; running here exposes the freshly dead
+//! expressions to the rest of the fixed-point loop, which the WIR pass cannot.
 
 use crate::hashmap::IndexSet;
 use crate::nir_arena::{BlockId, ExprId, ExprKind, Operand, StmtId, StmtKind};
@@ -36,16 +30,11 @@ pub(super) struct ElideRule<'a> {
 
 impl<'a> ElideRule<'a> {
     /// Build the rule for one function. `stores_aliased` lists params whose
-    /// reference escaped via a callee's `stores` declaration: the callee may
-    /// retain that reference past its return, so writes through the local stay
-    /// observable via the alias and the local must not be elided. It is read
-    /// off the function before its body is borrowed for the engine. The other
-    /// "kept" source — every live read of a local, including `&local` /
-    /// `&mut local` and closure-capture reads — is exactly what the engine use
-    /// index records, so the rule reads it directly via `Engine::is_local_read`
-    /// rather than a separate walk. (`address_taken_locals` is intentionally
-    /// *not* a source: it is a stale static record after `inline` / `ref_elim`,
-    /// and source-1 reads already cover every live `&local`.)
+    /// reference a callee may retain past its return, keeping writes through the
+    /// local observable, so those are never elided; it is read off the function
+    /// before the engine borrows its body. Every other live read comes from
+    /// `Engine::is_local_read`, so `address_taken_locals` — stale after `inline`
+    /// / `ref_elim` — is deliberately not consulted.
     pub(super) fn new(
         stores_aliased: &'a IndexSet<u32>,
         effects: &'a [super::mod_ref::FnEffect],

--- a/wado-compiler/src/optimize/extract.rs
+++ b/wado-compiler/src/optimize/extract.rs
@@ -1,19 +1,8 @@
 //! Extraction: materialize pure values from the live `ValueGraph` back into the
-//! `SkelTree`.
-//!
-//! In the live-ValueGraph design (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) an expression's value is a
-//! hash-consed [`ValueId`]; the extractor walks the skeleton and lowers each
-//! pure operand to that value's concrete form.
-//!
-//! This is the literal case: an expression whose value is a constant (`Int` /
-//! `Float` / `Bool` / `Char`) is replaced by that literal. The share-vs-duplicate
-//! cost model for non-literal multi-use values is a later step; constants are
-//! always cheaper to rematerialize than to share, so they need no cost decision.
-//!
-//! [`extract_const`] is the shared materialization primitive, used in
-//! production by `store_load_forward`. [`ExtractLiteralRule`] (the worklist
-//! rule form) is a test-only vehicle exercising the same primitive.
+//! `SkelTree`, walking the skeleton and lowering each pure operand to its
+//! hash-consed [`ValueId`]'s concrete form. Constants are always cheaper to
+//! rematerialize than to share, so they need no cost decision.
+//! [`extract_const`] is the shared primitive, used by `store_load_forward`.
 
 use crate::nir_arena::{ExprId, ExprKind, NodeRef, StmtKind};
 use crate::nir_engine::Engine;
@@ -124,17 +113,11 @@ fn is_loop_body(e: &Engine, b: crate::nir_arena::BlockId) -> bool {
     )
 }
 
-/// The statement before which a `let _av = <value>` materialising the uses
-/// `ids` can be inserted so it **dominates all of them**: the nearest common
-/// dominator block (the deepest enclosing block common to every use) with the
-/// insertion taken at the earliest statement any use descends through there.
-///
-/// Soundness rests on structured control flow: a block runs its statements in
-/// order, so a statement at or before every use's leading statement in their
-/// common ancestor block precedes (dominates) each use. The uses share one
-/// `ValueId`, so no heap bump separates them — the field/value is constant
-/// across the span, and a load pinned at this point reproduces it for all.
-/// `None` if any use lacks a path.
+/// The statement before which a `let _av = <value>` materialising the uses `ids`
+/// can be inserted so it **dominates all of them**: their deepest common
+/// enclosing block, at the earliest statement any use descends through.
+/// Structured control flow makes that a dominator, and the shared `ValueId`
+/// means no heap bump separates the uses. `None` if any use lacks a path.
 fn materialise_point(
     e: &Engine,
     ids: &[ExprId],
@@ -473,18 +456,11 @@ fn classify_candidate(
     if engine.is_assign_target(id) || is_let_value(engine, id) {
         return None;
     }
-    // Constant-leaf promotion (early only, clean graph). A value-position
+    // Constant-leaf promotion (early only, clean graph): a value-position
     // `Local` / `FieldAccess` read whose graph value is a constant literal is
-    // frozen to that literal: context-free, width-correct (the kind carries its
-    // own `TypeId`), and — born before any pass — never re-contextualized.
-    // `is_place_read` excludes lvalue positions (`&mut x`, a `.field` / method
-    // receiver, an assign target) where the storage, not the value, is needed.
-    // The root local must not be `mut_escaped`: a write through a retained `&mut`
-    // (ref_1's `set_bool(&mut c, …)`) makes the constant point-specific in a way
-    // the build-once graph cannot keep across the structural passes (over-merge
-    // vs a fresh build). An *immutable*-`&`-escaped root (licm's `&config`) is
-    // stable — the callee cannot write through `&Config` — so its field constant
-    // freezes soundly; that is the in-loop `FieldAccess` recovery.
+    // frozen to it. `is_place_read` excludes lvalue positions, where the storage
+    // is wanted. The root must not be `mut_escaped` — a write through a retained
+    // `&mut` makes the constant point-specific — but `&`-escaped is stable.
     let leaf_root_stable = match &engine.body.exprs[id].kind {
         ExprKind::Local { index, .. } => !ctx.mut_escaped_leaf.contains(index),
         ExprKind::FieldAccess { .. } => super::arena_query::storage_root(engine.body, id)
@@ -698,14 +674,9 @@ fn worth_materialising(pool: &crate::nir_value_graph::ValuePool, v: ValueId) -> 
 
 /// Apply strategy for a non-`FieldAccess` (pure-arith / constant) representative.
 /// A value used by several slots whose leaves are all available at a common
-/// dominator is **materialised once** — a single `let _av = <value>` all uses
-/// read via `local.get _av` — at that point, the same placement
-/// [`apply_field_materialise`] uses. Every other case redirects each use to the
-/// pooled representative inline.
-///
-/// Availability says where the value *can* be computed, not that it should be:
-/// a trapping value is refused, the point is the nearest common dominator
-/// rather than entry, and a value too cheap to share stays re-emitted.
+/// dominator is **materialised once** into a `let _av = <value>`, the placement
+/// [`apply_field_materialise`] uses; everything else redirects each use inline.
+/// A trapping value is refused, and one too cheap to share stays re-emitted.
 fn apply_value_freeze(
     engine: &mut Engine,
     rep: ValueId,

--- a/wado-compiler/src/optimize/field_scalarize.rs
+++ b/wado-compiler/src/optimize/field_scalarize.rs
@@ -2645,7 +2645,7 @@ fn walk_inline_block(
 
 /// Walk a labeled block, accounting for labeled breaks that bypass the sync
 /// emitted inside it. `walk_stmt` only records each break site (committing on
-/// every one over-syncs); here the fall-through and break states are `JOINed` and
+/// every one over-syncs); here the fall-through and break states are joined and
 /// convergence sync spliced into each path whose exit diverges, so post-block
 /// code never trusts a side that is stale on some runtime path.
 fn walk_labeled_block(

--- a/wado-compiler/src/optimize/field_scalarize.rs
+++ b/wado-compiler/src/optimize/field_scalarize.rs
@@ -3,6 +3,10 @@
 //! dataflow walker tracks which side is canonical (`Both` / `ScalarOnly` /
 //! `FieldOnly`) and emits write-back / re-read sync only at transitions: calls
 //! reaching the field, branch joins, escape paths, and loop back-edges.
+//!
+//! TODO(optimizer): the "unresolved callee → all fields" fallback writes back
+//! every field on every opaque call; a "writes no field" summary propagated up
+//! the call graph would remove that cliff for thin forwarding wrappers.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::{NirBinaryOp, NirFunction, NirLocal, NirUnaryOp};

--- a/wado-compiler/src/optimize/field_scalarize.rs
+++ b/wado-compiler/src/optimize/field_scalarize.rs
@@ -1,110 +1,8 @@
-//! Hot Field Scalarization for Wado NIR
-//!
-//! Promotes a hot struct field `obj.field` (read+written inside a loop)
-//! to a mutable local `__hfs_field_N`, hoisted out of the loop. Reads
-//! and writes inside the loop become `local.get`/`local.set`; sync with
-//! the underlying GC field happens only when control leaves the
-//! scalar's domain (calls, escape paths, loop back-edges).
-//!
-//! For a field `obj.field` accessed at least `MIN_ACCESS_COUNT` times:
-//! 1. Allocate a mutable local `__hfs_field_N`.
-//! 2. Pre-load `let __hfs_field_N = obj.field;` before the loop.
-//! 3. Rewrite every `obj.field` read in the body to `__hfs_field_N`.
-//! 4. Rewrite every `obj.field = v` write in the body to
-//!    `__hfs_field_N = v`.
-//! 5. Walk the body with a dataflow lattice that tracks which side
-//!    holds the truth and emits sync only at transitions (see below).
-//!
-//! ## Sync placement (dataflow-driven)
-//!
-//! For each scalarized candidate `(L, F)` the walker tracks one of:
-//!
-//! - `Both`        — `__hfs_F == L.F` (no sync needed for either side).
-//! - `ScalarOnly`  — `__hfs_F` holds the latest value; `L.F` is stale.
-//! - `FieldOnly`   — `L.F` holds the latest value; `__hfs_F` is stale.
-//!
-//! Transitions:
-//!
-//! - Scalar write `__hfs_F = v`     → state becomes `ScalarOnly`.
-//! - `&mut T` call touching `L.F`   → pre-call: `write_back` if not
-//!   field-canonical; post-call: state becomes `FieldOnly`.
-//! - `&T` call touching `L.F`       → pre-call: `write_back` if not
-//!   field-canonical; state unchanged otherwise.
-//! - Field read `obj.field`         → re-read if not scalar-canonical;
-//!   state becomes `Both`.
-//!
-//! Sync is emitted only at canonical-side transitions:
-//! `ScalarOnly → Both/FieldOnly` writes back, `FieldOnly → Both/ScalarOnly`
-//! re-reads, `Both → *` is a relabel with no sync. Consecutive `&mut`
-//! calls therefore emit zero inter-call sync — once `FieldOnly`, every
-//! subsequent `&mut` call's pre-state is already satisfied.
-//!
-//! Sync placement is position-exact: a sync stmt may be hoisted to the
-//! enclosing statement's slot only while nothing earlier in that
-//! statement's evaluation touched any candidate's scalar or field
-//! (`WalkCtx::interior_effects`). Once something has, the sync is
-//! wrapped in place — a re-read becomes `{ __hfs_F = L.F; __hfs_F }`
-//! at the read, and a pre-call write-back wraps the call (hoisting the
-//! already-walked call inputs into temps when the args themselves
-//! transitioned state), so `let x = self.advance() + self.pos;` reads
-//! `pos` after `advance()` ran, not before the whole statement.
-//!
-//! Branch joins (`If`/`Switch`/`Match`) walk each arm with a cloned
-//! entry state and pick a per-candidate join target; convergence sync
-//! is inserted at each arm's exit. A call in one match arm cannot
-//! trigger sync that clobbers a sibling scalar-update arm (issue #1008).
-//! Joins whose paths cannot all host sync are constrained: a labeled
-//! block converges its fall-through *and every recorded `break` site*
-//! to the join target; an `&&`/`||` RHS and a match guard converge to a
-//! target reachable sync-free from the path that has no sync slot (the
-//! short-circuit / pattern-mismatch path).
-//!
-//! Loop boundaries:
-//! - The body-end of the HFS loop appends sync to drive every
-//!   candidate back to its loop-entry state, restoring the loop
-//!   back-edge invariant.
-//! - `return` / `break` to a non-enclosing target emit commit sync
-//!   inline before the control-flow stmt; `continue` converges to the
-//!   innermost loop's entry states (so a deferred candidate stays
-//!   `ScalarOnly` across a `continue` back-edge, same as fall-through).
-//! - Nested loops commit any `ScalarOnly` candidate before recursing
-//!   so inner reads see an up-to-date field, then set the outer state
-//!   to `JOIN(entry_state, body_exit_state)` per candidate.
-//!
-//! ## Field-selective sync
-//!
-//! For each call site, the walker queries a pre-computed
-//! `FieldUsageCache` to determine which scalarized fields the callee
-//! actually touches. An immutable-ref parameter elides the post-call
-//! `re_read` since the callee cannot mutate through it. Unresolved
-//! callees fall back to "all fields" conservatively.
-//!
-//! A `&`/`&mut local.field` of a scalarized field rewrites to the scalar
-//! (`&mut __hfs_F`). For a GC-typed field this is transparent: the
-//! reference is the object handle the scalar shares (the field-read
-//! rewrite re-reads first when the scalar is stale), and `*v = x`
-//! mutates the object in place — a place rebinding through a reference
-//! is inexpressible. A non-GC field ref cannot reach NIR today (the
-//! front end lowers it to a snapshot `Box` literal or rejects it), but
-//! is still handled defensively: as a call arg it makes the scalar the
-//! post-call canonical side (`SyncFields::scalar_write`); outside a
-//! call arg it disqualifies the candidate (`FnAliases::fields`).
-//!
-//! TODO(optimizer): the "unresolved callee → all fields" fallback (used
-//! by indirect / cm-raw / closure-functor invocations and by callees
-//! outside the local function set) writes back every scalarized field
-//! on every such call. Propagating an "opaque-callee transparent on
-//! fields this function never writes" summary up the call graph would
-//! eliminate the sync cliff for thin wrapper functions that only forward
-//! the receiver.
-//!
-//! ## Generated locals
-//!
-//! - `__hfs_<field>_<idx>` — the scalar holding `obj.field`.
-//! - `__hfs_call_<idx>`    — pooled per-type temps used to capture the
-//!   trailing value of a non-unit `Match` arm body / `If`/`Switch`
-//!   block when convergence sync must run after the value-producing
-//!   expression.
+//! Hot Field Scalarization: promotes a hot struct field `obj.field` accessed in
+//! a loop to a mutable local `__hfs_<field>_<idx>` hoisted out of the loop. A
+//! dataflow walker tracks which side is canonical (`Both` / `ScalarOnly` /
+//! `FieldOnly`) and emits write-back / re-read sync only at transitions: calls
+//! reaching the field, branch joins, escape paths, and loop back-edges.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::{NirBinaryOp, NirFunction, NirLocal, NirUnaryOp};
@@ -241,16 +139,11 @@ struct ParamUsageCtx<'a> {
     type_table: &'a TypeTable,
 }
 
-/// Record which fields of each struct parameter the function accesses. Only a
-/// few node shapes carry signal (`local.field` access, a whole-`param` assign
-/// or pass-to-callee); the rest descend via `for_each_child`. Patterns are not
-/// entered — a `param.field` cannot appear there.
+/// Record which fields of each struct parameter the function accesses.
 ///
-/// Every shape that reads a tracked param whole must resolve to *conservative*
-/// (all fields): a bare `Local` in value position is a ref share (`let r =
-/// param;` / `return param;` / a literal capture), through which the callee
-/// can touch any field invisibly. The precise shapes (`param.field` receivers)
-/// return before the `Local` arm can see the param.
+/// Any shape that reads a tracked param *whole* — a bare `Local` in value
+/// position — resolves to conservative "all fields": the callee can reach every
+/// field through the shared reference. Precise `param.field` shapes return first.
 fn collect_param_field_usage_node(body: &Body, node: NodeRef, cx: &mut ParamUsageCtx) {
     if let NodeRef::Expr(e) = node {
         match &body.exprs[e].kind {
@@ -664,16 +557,8 @@ fn scalarize_loop(
         pre_stmts.push(load_stmt);
     }
 
-    // Step 4: Walk the loop body with the dataflow-driven sync-placement
-    // pass. The walker tracks per-candidate canonical-side state
-    // (Scalar/Field/Both) and inserts write-back / re-read stmts only at
-    // state transitions. At escape paths (return / non-enclosing break) it
-    // commits the scalar to the field if `ScalarOnly`. At body end it
-    // forces all candidates back to `Both` to satisfy the loop's
-    // back-edge invariant (entry == exit). With this discipline the
-    // post-loop write-back is always redundant — the body and escape
-    // paths leave every candidate's field canonical — so no `post_stmts`
-    // are generated.
+    // Step 4: dataflow-driven sync placement. The body end and every escape
+    // path leave each candidate's field canonical, so no `post_stmts` arise.
     process_loop_body(
         body,
         loop_body,
@@ -819,32 +704,11 @@ struct FnAliases {
     fields: IndexSet<(u32, u32)>,
 }
 
-/// Walk the function body once and collect every GC-heap-typed local that
-/// becomes aliased anywhere in the function, so it cannot be HFS-scalarized
-/// at any loop level. Two shapes alias a local:
-///
-/// - Its address (`&local` / `&mut local`) is taken outside a direct
-///   call-argument position. Writes through the captured alias bypass the
-///   scalar.
-/// - Its whole value is bound/assigned to another local (`let other = gc;`
-///   or `other = gc;`). A GC struct is a reference, so the copy shares the
-///   heap object; a mutation through `other` (e.g. `other.push(c)`) bypasses
-///   `gc`'s scalar. The per-loop scan marks this too, but only when the
-///   alias-creating statement is walked *after* the field-access entries
-///   exist; doing it here makes the disqualification order-independent (the
-///   real-world trigger is a LICM-hoisted buffer `let _licm_buf_b = _licm_buf_a`
-///   whose copy precedes the loop's first `_licm_buf_a.field` access).
-///
-/// Also collects `&`/`&mut local.field` taken outside a call argument for a
-/// *non-GC* field (`FnAliases::fields`): such a reference would bypass the
-/// scalar entirely. A GC field's reference is the object handle the scalar
-/// shares (mutation through it is in-place, never a place rebinding), so it
-/// stays eligible; non-GC field refs are unreachable today — the front end
-/// lowers them to snapshot `Box` literals — making this purely defensive.
-///
-/// Direct call arguments are excluded from the address-taken set because the
-/// call's write-back/re-read mechanism synchronises HFS scalars around the
-/// call, bounding the alias's lifetime to that single call.
+/// Collect the locals and fields that alias, disqualifying them from HFS at any
+/// loop level: a local whose address is taken outside a call argument or whose
+/// whole value is copied into another local (a GC copy shares the heap object),
+/// and a `&`/`&mut local.field` of a non-GC field. Direct call arguments are
+/// excluded — the call's write-back/re-read bounds the alias to that call.
 fn collect_function_aliases(body: &Body, type_table: &TypeTable) -> FnAliases {
     let mut out = FnAliases {
         locals: IndexSet::default(),
@@ -1258,45 +1122,10 @@ fn mark_local_aliased(local_idx: u32, counts: &mut IndexMap<(u32, u32), FieldAcc
 // ─────────────────────────────────────────────────────────────────────────────
 // Replacement pass — dataflow-driven sync placement
 //
-// For each scalarized field `(L, F)` (with associated scalar local
-// `__hfs_F`), the walker tracks one of three canonical-side states at
-// each program point:
-//
-//   - `Both`        : `__hfs_F == L.F` (both sides agree).
-//   - `ScalarOnly`  : `__hfs_F` is the truth, `L.F` is stale.
-//   - `FieldOnly`   : `L.F` is the truth, `__hfs_F` is stale.
-//
-// Each operation has a state requirement and a state effect:
-//
-// | operation              | requires (state ∈)         | post state           |
-// | scalar read            | {Both, ScalarOnly}         | unchanged            |
-// | scalar write           | (any)                      | ScalarOnly           |
-// | call w/ `&T` arg       | {Both, FieldOnly}          | unchanged            |
-// | call w/ `&mut T` arg   | {Both, FieldOnly}          | FieldOnly            |
-//
-// When the requirement is not met, the walker inserts the cheapest sync
-// to transition the state — `re_read` (FieldOnly→Both) for scalar reads
-// and `write_back` (ScalarOnly→Both) for calls. After the operation the
-// new state is recorded.
-//
-// At branch joins (Match/If/Switch arms), each arm is walked with a
-// fresh copy of the entry state. The walker then picks a target state
-// for the join and inserts at-end-of-arm convergence sync where exit ≠
-// target.
-//
-// At escape paths (return / non-enclosing break), every `ScalarOnly`
-// candidate gets a write-back — outside the loop only the field is
-// observable.
-//
-// At loop body end, every candidate is forced back to `Both` (entry
-// state), maintaining the back-edge invariant. This makes the
-// post-loop write-back redundant in every case, so `scalarize_loop`
-// returns no `post_stmts`.
-//
-// The temp call locals introduced by non-unit call wrappers are pooled
-// per `TypeId` and reused across separate wrappers. Since each temp's
-// def and use are confined to its containing wrapper Block, reuse is
-// always sound.
+// A scalar read requires `{Both, ScalarOnly}` and a call reaching the field
+// requires `{Both, FieldOnly}`; an unmet requirement inserts the cheapest sync
+// (`re_read` / `write_back`). Temps for non-unit call wrappers are pooled per
+// `TypeId` — each temp's def and use stay inside its own wrapper block.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Per-candidate canonical-side state.
@@ -1324,17 +1153,10 @@ type ScalarStates = Vec<CanonState>;
 
 /// The per-candidate loop-entry / back-edge state.
 ///
-/// A candidate whose field the loop body never accesses through the GC
-/// reference — no call takes the local by `&`/`&mut`, and the field is never
-/// `&`/`&mut`-referenced directly — is *call-clean*: its only field
-/// interaction is the scalar write-back. For such a candidate
-/// the field can stay `ScalarOnly` across the back-edge — the per-iteration
-/// write-back the back-edge invariant would otherwise force is pure waste.
-/// Its write-back is deferred to the loop's escape points (`return`,
-/// `break`), which `commit_scalar_for_escape` already covers, so the field
-/// is canonical for any reader after the loop. Candidates that *are* read
-/// through the reference inside the loop keep the `Both` entry / body-end
-/// force so the read observes an up-to-date field.
+/// A *call-clean* candidate — one whose field the loop body never reaches
+/// through the GC reference — stays `ScalarOnly` across the back-edge, deferring
+/// its write-back to the loop's escape points instead of paying it per
+/// iteration. Every other candidate keeps the `Both` entry / body-end force.
 fn entry_states_for(candidates: &[ScalarizeCandidate], deferrable: &[bool]) -> ScalarStates {
     candidates
         .iter()
@@ -1442,18 +1264,10 @@ struct WalkCtx<'a> {
     /// constructed. Each temp's def/use are confined to one Block, so
     /// reuse across separate Blocks is sound.
     temp_pool: IndexMap<TypeId, Vec<u32>>,
-    /// Per-active-label break-site observations. `walk_labeled_block`
-    /// pushes an empty entry on enter and pops it on exit; every
-    /// `walk_stmt` `Break { label: Some(l), .. }` arm appends a
-    /// [`BreakRecord`] to the entry for `l`. The labeled-block exit
-    /// JOINs the fall-through state with every observed break-state to
-    /// derive the post-block walker state — over-approximating by entry
-    /// alone (the prior fix) wrongly dropped `FieldOnly` walker states
-    /// when entry was `ScalarOnly`, causing missed re-reads in
-    /// post-block code (#1190 regression) — and inserts per-site
-    /// convergence sync before each break whose state diverges from the
-    /// join (a sync-free `{ScalarOnly, FieldOnly}` join would leave one
-    /// runtime path's canonical side stale).
+    /// Per-active-label break-site observations, pushed and popped by
+    /// `walk_labeled_block`. The block exit JOINs the fall-through state with
+    /// every observed break-state and inserts convergence sync before each
+    /// break site that diverges from the join.
     label_breaks: IndexMap<String, Vec<BreakRecord>>,
     /// Entry states of each enclosing loop, innermost last. `continue`
     /// converges to the top entry — the state the walker assumed at the
@@ -1506,16 +1320,10 @@ impl WalkCtx<'_> {
     }
 }
 
-/// Top-level entry: walk the loop body with each candidate's state
-/// initialized to its loop-entry state, then converge body-exit back to that
-/// same entry state so the loop's back-edge invariant holds.
-///
-/// Call-clean candidates (`deferrable`) enter as `ScalarOnly` and stay
-/// `ScalarOnly` across the back-edge, so the body-end converge is a no-op
-/// for them — the per-iteration write-back is eliminated and the field is
-/// instead committed at the loop's escape points (`return` / `break`, via
-/// `commit_scalar_for_escape`). All other candidates keep the classic
-/// `Both` entry / body-end force-`Both` discipline.
+/// Walk the loop body from each candidate's loop-entry state, then converge
+/// body-exit back to it so the back-edge invariant holds. Call-clean
+/// (`deferrable`) candidates enter and stay `ScalarOnly`, making the converge a
+/// no-op; their write-back happens at the loop's escape points instead.
 #[allow(clippy::too_many_arguments)]
 fn process_loop_body(
     body: &mut Body,
@@ -1702,21 +1510,10 @@ fn insert_convergence_at_block_end(
 }
 
 /// Bind `value` so a sync sequence can run after it and still yield the same
-/// value: returns the bindings to emit before the sync, and the operand to
-/// place after it.
-///
-/// An aggregate literal binds its *operands* rather than itself. The literal is
-/// a pure construction over them, so rebuilding it after the sync evaluates
-/// exactly the same effects in exactly the same order — and it leaves no
-/// aggregate local behind. That matters downstream:
-/// [`super::multi_value_return`] flattens a return only when the return builds
-/// a fresh aggregate, so capturing the whole aggregate here costs the
-/// allocation the multi-value ABI exists to avoid.
-///
-/// Two things are re-emitted after the sync without a binding: a literal
-/// constant, and a local `assigned` says the sync leaves alone. A promoted heap
-/// read (`ValueKind::FieldAccess`) is neither — it is re-emitted at its use, and
-/// the sync may have written the field it reads.
+/// value: returns the bindings to emit before the sync and the operand to place
+/// after it. An aggregate literal binds its *operands* instead of itself, leaving
+/// no aggregate local to block [`super::multi_value_return`]. Constants and
+/// locals the sync leaves alone are re-emitted without a binding.
 fn capture_for_sync(
     body: &mut Body,
     ctx: &mut WalkCtx,
@@ -2000,20 +1797,10 @@ fn walk_stmt(
             if let Some(v) = value {
                 walk_operand(body, v, states, true, out, ctx);
             }
-            // Escape: commit every ScalarOnly candidate to the field
-            // before the return. After commit, only the field is
-            // observable outside the loop.
-            //
-            // If the return expression itself transitioned a candidate to
-            // `ScalarOnly` (e.g. an inlined `self.pos = self.pos + 1`
-            // nested under `__inline_advance: { ... break tok; }` inside
-            // the return value), a writeback emitted before the Return
-            // stmt would run with the **pre-expression** scalar value at
-            // runtime — the expression mutates `__hfs_pos` after the
-            // writeback has already syncd the old value, and the post-
-            // mutation value is then discarded by the return. Hoist the
-            // value into a temp local so the writeback can run between
-            // the expression's evaluation and the return jump.
+            // Escape: commit every ScalarOnly candidate before the return. If
+            // the return expression itself transitioned a candidate, hoist its
+            // value into a temp so the write-back runs after the expression
+            // instead of syncing the pre-expression scalar.
             if let Some(return_value) = value.filter(|_| states.contains(&CanonState::ScalarOnly)) {
                 // Build the sync first so what it assigns is read off the
                 // statements themselves, as at the other two capture sites,
@@ -2043,19 +1830,11 @@ fn walk_stmt(
             if let Some(v) = value {
                 walk_operand(body, v, states, true, out, ctx);
             }
-            // Unlabeled `break` exits the innermost loop; at the HFS-loop
-            // top level (the common case) this leaves the HFS scope, so
-            // any `ScalarOnly` candidate must be committed inline before
-            // the break — the body-end force-Both is not reached.
-            //
-            // Labeled `break <name>` exits a labeled block. Emitting an
-            // unconditional commit here ("commit-on-every-labeled-break")
-            // proved a runtime-perf disaster on gale's hot loops. Record
-            // the walker's current state and site instead so
-            // `walk_labeled_block` can JOIN every per-path exit into its
-            // post-block walker state and insert per-site convergence
-            // only where the join diverges — the precise alternative to
-            // over-syncing.
+            // Unlabeled `break` leaves the HFS scope, so `ScalarOnly`
+            // candidates must be committed inline. A labeled break is only
+            // recorded — committing on every one over-syncs gale's hot loops —
+            // so `walk_labeled_block` JOINs the sites and syncs only the ones
+            // that diverge.
             let registered_label = label
                 .as_ref()
                 .filter(|l| ctx.label_breaks.contains_key(*l))
@@ -2072,16 +1851,10 @@ fn walk_stmt(
                     .push(record);
                 out.push(sid);
             } else {
-                // An unlabeled break, or a labeled break to a label not
-                // registered during this loop-body walk (a block *enclosing*
-                // the loop): both escape the HFS scope just like a `return`.
-                // Commit `ScalarOnly` candidates so the field is canonical
-                // for readers after the loop — this is what keeps deferring
-                // the per-iteration back-edge write-back sound for breaks
-                // that exit the loop. The commit runs before the break stmt,
-                // i.e. before the break value; if that value's walk
-                // transitioned a candidate to `ScalarOnly`, hoist it into a
-                // temp (same hazard as `Return`).
+                // An unlabeled break, or one to a label enclosing the loop:
+                // both escape the HFS scope like `return`. Commit `ScalarOnly`
+                // candidates, hoisting the break value into a temp when its own
+                // walk transitioned one (same hazard as `Return`).
                 if let Some(break_value) =
                     value.filter(|_| states.contains(&CanonState::ScalarOnly))
                 {
@@ -2253,30 +2026,11 @@ fn walk_if_branches(
     *states = target;
 }
 
-/// Walk a nested loop's body and update the outer state for the
-/// post-loop point.
-///
-/// Two things must hold for the single-walk analysis to match runtime:
-///
-/// 1. **Back-edge invariant.** Iter 2+ at runtime starts with whatever
-///    state the previous iteration's body left. The walker analyzed
-///    iter 2+ assuming `entry_states`. Bridge that gap by appending
-///    sync stmts at body-end that drive `body_exit_states` back to
-///    `entry_states`. Same shape as `process_loop_body`'s body-end
-///    force-Both, but targets `entry_states`. Without this, a
-///    `read → &mut call` pattern miscompiles: walker emits no
-///    re-read at the read (state=Both), but iter 2's runtime state
-///    after iter 1's call is `FieldOnly` — scalar is stale.
-///
-/// 2. **Post-loop conservatism.** The NIR `Loop` only exits via
-///    `break`/`return`, so the post-loop state at runtime is the
-///    state at the break-point. The walker doesn't track break-paths
-///    precisely; the OLD `pick_join_target_for_candidate(entry,
-///    body_exit_pre_sync)` is a reasonable over-approximation since
-///    `body_exit_pre_sync` captures the linear-walk's belief about
-///    the body's running state, which in typical shapes coincides
-///    with break-state. Use `body_exit_pre_sync` here, NOT the
-///    post-back-edge-sync state, so the JOIN keeps that information.
+/// Walk a nested loop's body and update the outer state for the post-loop point.
+/// Body-end sync drives `body_exit_states` back to `entry_states` so iteration
+/// 2+ matches what the single walk assumed. The post-loop state JOINs
+/// `entry_states` with `body_exit_pre_sync`, whose linear-walk belief
+/// approximates the break-point state the walker does not track precisely.
 fn walk_nested_loop(
     body: &mut Body,
     block: BlockId,
@@ -2315,25 +2069,10 @@ fn walk_nested_loop(
             body.blocks[block].stmts.push(stmt);
         }
     }
-    // Post-loop state: JOIN(entry_states, body_exit_pre_sync). The
-    // outer scope sees the conservative over-approximation; subsequent
-    // scalar reads emit re-reads when break could leave `FieldOnly`.
-    //
-    // A nested loop's post-state can never soundly be `ScalarOnly`: the
-    // zero-iteration path exits at `entry_states`, which the pre-recurse
-    // commit above forced to `{Both, FieldOnly}` (field canonical, never
-    // scalar-only). Every other exit also leaves the field canonical —
-    // the body-end back-edge sync drives `body_exit` back to `entry`, and
-    // `commit_scalar_for_escape` writes the scalar back before any
-    // `break`/`return`. So if the linear `body_exit_pre_sync` pushes the
-    // JOIN to `ScalarOnly` (the `{ScalarOnly, FieldOnly}` branch-join
-    // heuristic, sound only when each arm gets convergence sync — which
-    // the un-syncable zero-iteration path does not), the scalar may in
-    // fact be stale at runtime. Demote to `FieldOnly` so the next scalar
-    // read re-reads from the canonical field instead of trusting a stale
-    // `__hfs`. (Regression: a `&mut self` push run followed by an empty
-    // inner loop, e.g. `gale dump`'s `render_follow_variants`, otherwise
-    // wrote the stale length back and dropped the pushed bytes.)
+    // Post-loop state: JOIN(entry_states, body_exit_pre_sync), demoting
+    // `ScalarOnly` to `FieldOnly`. Every exit leaves the field canonical —
+    // including the zero-iteration path, which has no slot for convergence
+    // sync — so a `ScalarOnly` join would let a later read trust a stale scalar.
     for i in 0..states.len() {
         let joined = pick_join_target_for_candidate(&[entry_states[i], body_exit_pre_sync[i]]);
         states[i] = match joined {
@@ -2904,24 +2643,11 @@ fn walk_inline_block(
     walk_block(body, block, states, ctx);
 }
 
-/// Walk a labeled block (stmt- or expr-position), accounting for
-/// labeled-break early-exits that bypass any sync the walker emits
-/// inside the block.
-///
-/// `walk_stmt`'s `Break { label: Some(l), .. }` arm does not commit
-/// unconditionally (an experiment with "commit-on-every-labeled-break"
-/// caused unacceptable over-syncing in gale's hot loops). It records a
-/// [`BreakRecord`] instead. Here we JOIN the fall-through state with
-/// every observed break-state to derive the post-block walker state,
-/// then insert convergence sync on each path — appended at the block's
-/// end for the fall-through, and spliced before each recorded break —
-/// exactly where a path's exit state diverges from the join. Without
-/// the per-path sync, a `{ScalarOnly, FieldOnly}` join resolved to
-/// `ScalarOnly` would let post-block code trust a scalar that is stale
-/// on the `FieldOnly` runtime path. Issue #1187 (the early-return +
-/// nested-loop bug) and the #1190 regression (`FieldOnly` walker exit
-/// silently weakened to `ScalarOnly` by a JOIN with `ScalarOnly`
-/// entry) both fall out of this precise per-path join.
+/// Walk a labeled block, accounting for labeled breaks that bypass the sync
+/// emitted inside it. `walk_stmt` only records each break site (committing on
+/// every one over-syncs); here the fall-through and break states are JOINed and
+/// convergence sync spliced into each path whose exit diverges, so post-block
+/// code never trusts a side that is stale on some runtime path.
 fn walk_labeled_block(
     body: &mut Body,
     label: &str,
@@ -3025,28 +2751,11 @@ fn walk_expr_branches_switch(
     *states = target;
 }
 
-/// Walk a Match expression: each `arm.body` is an expression id, not a block.
-/// The guard (if any) and the body each get their own per-expression
-/// sync wrapper so that pre-stmts emitted while walking the guard run
-/// BEFORE the guard's evaluation (not after — which would let the
-/// guard's mutations be observed before the wrap committed scalar
-/// values), and pre-stmts emitted while walking the body run BEFORE
-/// the body's value-producing expression.
-///
-/// Cross-arm guard side effects: at runtime, arm K's guard runs only
-/// after arms 1..K-1's patterns matched-and-their-guards-failed. A
-/// `&mut` call inside arm 1's guard mutates the field state before
-/// arm 2's pattern is even tested. The walker reflects this by
-/// carrying an `accumulated_pre`: the join over {entry, `arm_i_after_guard`}
-/// for each prior side-effecting guard. arm K's guard and body are
-/// then walked starting from `accumulated_pre`, matching the runtime
-/// state at the dispatch point.
-///
-/// The pattern-mismatch path (the guard never ran) has no slot for
-/// convergence sync, so the post-guard join must be reachable sync-free
-/// from the prior `accumulated_pre`; the guard-ran side converges by
-/// sync appended at the guard's end — which runs whether the guard
-/// passed or failed, so the arm body also starts from the joined state.
+/// Walk a Match expression. The guard and the body each get their own sync
+/// wrapper so pre-stmts run before the expression they belong to. Arm K's guard
+/// runs only after the earlier guards failed, so it starts from
+/// `accumulated_pre` — the join over prior side-effecting guards. The
+/// pattern-mismatch path has no sync slot, so that join must be sync-free.
 fn walk_expr_branches_match(
     body: &mut Body,
     arms: &[ArmData],

--- a/wado-compiler/src/optimize/field_scalarize.rs
+++ b/wado-compiler/src/optimize/field_scalarize.rs
@@ -2645,7 +2645,7 @@ fn walk_inline_block(
 
 /// Walk a labeled block, accounting for labeled breaks that bypass the sync
 /// emitted inside it. `walk_stmt` only records each break site (committing on
-/// every one over-syncs); here the fall-through and break states are JOINed and
+/// every one over-syncs); here the fall-through and break states are `JOINed` and
 /// convergence sync spliced into each path whose exit diverges, so post-block
 /// code never trusts a side that is stale on some runtime path.
 fn walk_labeled_block(

--- a/wado-compiler/src/optimize/gate.rs
+++ b/wado-compiler/src/optimize/gate.rs
@@ -1,43 +1,12 @@
-//! Per-function identity and dirty-set gating for the optimizer fixed-point
-//! loop (WEP: NIR Optimizer Architecture).
+//! Per-function dirty-set gating for the optimizer fixed-point loop, so a pass
+//! skips what has not changed since it last ran. Each function carries a
+//! monotonic `revision` and each pass a per-function `watermark`;
+//! [`FunctionGate::mark_changed`] bumps the revision and, conservatively, its
+//! 1-hop callers and callees. Keyed by [`FuncId`], the index in `functions`.
 //!
-//! The loop runs every pass over every function each iteration, even though
-//! after the first few rounds only a handful of functions still change. This
-//! module lets a pass skip functions that have not changed since it last
-//! processed them.
-//!
-//! # Identity
-//!
-//! The gate keys on the canonical [`FuncId`],
-//! which equals a function's index in `NirPackage::functions`: `lower` mints
-//! `id = index`, and `dce` marks dead in place without renumbering (Phase 4), so
-//! `FuncId == position` holds for the whole pipeline. The call graph reads each
-//! call node's stamped `func_id` directly — no per-edge name resolution — and the
-//! dense side-tables below index by `FuncId.index()`.
-//!
-//! # Model
-//!
-//! Each function has a monotonic `revision`. Each gated pass keeps a per-
-//! function `watermark`: it processes a function only when
-//! `revision > watermark`, then catches the watermark up. A pass that changes a
-//! function calls [`FunctionGate::mark_changed`], bumping that function's
-//! revision and — conservatively, along the 1-hop call graph — its callers and
-//! callees (a callee shrinking enables inlining / constant folding in callers; a
-//! call site appearing or vanishing changes a callee's dead-argument analysis).
-//!
-//! Every fixed-point loop pass is gate-aware, so every change is reported at
-//! function granularity: a per-function pass skips functions it has already
-//! processed at their current revision (via [`FunctionGate::run_gated`]); an
-//! interprocedural pass pulls its candidate worklist from the dirty set (via
-//! [`FunctionGate::dirty_funcs`]) and reports exactly the ones it touched (via
-//! [`FunctionGate::mark_changed`]).
-//!
-//! # Safety
-//!
-//! Every loop pass is an optimization; the IR is valid without it. So an
-//! imprecise gate can only cost optimization *quality* (a missed rewrite),
-//! never correctness. The propagation is therefore tuned conservative: when in
-//! doubt, mark dirty.
+//! Every loop pass is optional, the IR being valid without it, so an imprecise
+//! gate costs optimization quality and never correctness. When in doubt, the
+//! propagation marks dirty.
 
 use cranelift_entity::EntityRef;
 
@@ -78,21 +47,11 @@ impl GatedPass {
     const COUNT: usize = 16;
 }
 
-/// Static call graph over [`FuncId`]s, built once at loop start.
-///
-/// Each edge comes from a call node's stamped `func_id` (an unstamped in-package
-/// call falls back to name resolution). Indirect calls (`ExprKind::IndirectCall`)
-/// and calls to functions outside the package have no static edge and are simply
-/// absent — conservative for propagation, which only risks under-optimizing.
-///
-/// The graph is built once and not refreshed as bodies change. A pass that
-/// restructures calls (`inline` copies a callee body in; `container_sroa` /
-/// `value_copy_demote` retarget calls to per-field / shallow-copy callees)
-/// leaves the rewritten function's out-edges stale. That only reduces the
-/// precision of 1-hop dirty propagation — a quality knob, never correctness,
-/// since every loop pass is optional (see the module safety note) — and the
-/// rewritten function is itself reported dirty regardless. Incremental refresh
-/// could improve propagation precision but is not needed for soundness.
+/// Static call graph over [`FuncId`]s, built once at loop start from each call
+/// node's stamped `func_id`. An indirect or out-of-package call has no edge, and
+/// a pass that restructures calls leaves its out-edges stale — both only cost
+/// 1-hop propagation precision, never correctness, and the rewritten function is
+/// reported dirty regardless.
 struct CallGraph {
     callees: Vec<Vec<FuncId>>,
     callers: Vec<Vec<FuncId>>,

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -335,16 +335,11 @@ fn is_inline_eligible(
         return false;
     }
 
-    // The size threshold applies even to functions with a single call site.
-    // "One call site ⇒ inlining is always a size win" is *false* here: if the
-    // sole call site sits inside a function that is itself duplicated by
-    // threshold inlining (or nested inlining) at N sites, the large callee is
-    // copied N times instead of being shared. Bypassing the threshold for
-    // single-call-site functions measured +87% (pi_approx) / +186% (zlib) at
-    // -Os, and regressed already at -O1, so it is not a stale-DCE artifact.
-    //
-    // `#[inline]` hint raises the threshold by 5x, allowing functions up to 50
-    // expressions (at the default threshold of 10) to be inlined.
+    // The threshold applies even at a single call site: if that site sits inside
+    // a function itself duplicated at N sites, the large callee is copied N
+    // times rather than shared. Bypassing it measured +87% (pi_approx) / +186%
+    // (zlib) at -Os and regressed already at -O1. An `#[inline]` hint raises the
+    // threshold 5x.
     let effective_threshold = if func.inline_hint == InlineHint::Hint {
         inline_threshold * 5
     } else {
@@ -653,16 +648,11 @@ pub fn inline_functions(
     changed
 }
 
-/// Inline function calls in a block (arena). Each statement is processed in
-/// place (1:1); a `Let` / `Expr` / `Return` value gets a top-level inline
-/// attempt (which then re-scans the inlined body), while other statements
-/// recurse into their sub-expressions and sub-blocks.
-///
-/// `cold` marks a cold call-site context: once a `cold_path()` marker is seen,
-/// the rest of the block (and everything nested in it) is cold, mirroring
-/// [`block_cut`]. Calls at cold sites are not inlined (the callee body would
-/// bloat the hot caller with code that rarely runs) unless the callee is
-/// `#[inline(always)]`.
+/// Inline function calls in a block, each statement processed in place: a
+/// `Let` / `Expr` / `Return` value gets a top-level attempt that then re-scans
+/// the inlined body, while others recurse. `cold` marks a cold call-site
+/// context, spreading to the rest of the block once a `cold_path()` marker is
+/// seen; a cold call is inlined only when the callee is `#[inline(always)]`.
 #[allow(clippy::too_many_arguments)]
 fn inline_calls_in_block(
     body: &mut Body,

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -1,10 +1,8 @@
 //! LabeledBlock-variant fusion: eliminate the intermediate `Option` / `Result`
 //! an inlined helper leaves at a variant-discriminating consumer, as one
-//! [`Rule`] with two entry points. `apply_block` does the value-discarding
-//! fusion of `let temp = LB; if VariantTest(temp) …`, turning each `break L:`
-//! into the selected arm; `apply_expr` threads the value-producing `match LB`
-//! of `x = f()?`, rewriting it in place and yielding each arm tail through
-//! `break __thread_L:`. Post-inline only, both shapes needing the copied body.
+//! [`Rule`] with two entry points. `apply_block` fuses the value-discarding
+//! `let temp = LB; if VariantTest(temp) …`; `apply_expr` threads the
+//! value-producing `match LB` of `x = f()?`. Post-inline only.
 //!
 //! `sroa_variant_return` runs just before `inline`, so the intermediate may
 //! instead be a `[tag, slots…]` tuple. Value-discarding fusion recognises that

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -1,33 +1,14 @@
-//! LabeledBlock-variant fusion.
+//! LabeledBlock-variant fusion: eliminate the intermediate `Option` / `Result`
+//! an inlined helper leaves at a variant-discriminating consumer, as one
+//! [`Rule`] with two entry points. `apply_block` does the value-discarding
+//! fusion of `let temp = LB; if VariantTest(temp) …`, turning each `break L:`
+//! into the selected arm; `apply_expr` threads the value-producing `match LB`
+//! of `x = f()?`, rewriting it in place and yielding each arm tail through
+//! `break __thread_L:`. Post-inline only, both shapes needing the copied body.
 //!
-//! Eliminates the intermediate `Option<T>` / `Result<T, E>` an inlined helper
-//! leaves at a variant-discriminating consumer, in either shape `inline`
-//! produces — one [`Rule`] with two entry points:
-//!
-//! - `apply_block`: value-discarding fusion of `let temp = LB; if
-//!   VariantTest(temp) …` / two-arm `match temp`. Each `break L:` becomes the
-//!   selected arm; the fused block ends with a value-less `break __fused_L;`.
-//! - `apply_expr`: value-producing threading of `match LB { … }` (the `x =
-//!   f()?` shape). The `Match` is rewritten in place to the labeled block,
-//!   retyped to the match result, each `break L:` yielding its arm tail via
-//!   `break __thread_L: tail;`. Position-independent, so chained `?` resolves
-//!   bottom-up on the post-order worklist.
-//!
-//! The threading half handles guard-free `Variant` / `Wildcard` arms with a
-//! `VariantConstruct` at every exit; a `null` / value-less break (the `Option`
-//! `None`) bails, leaving Option `?` to the value-discarding half.
-//!
-//! Post-inline only: both shapes exist after `inline` copies the helper body in.
-//!
-//! # The scalarized shape
-//!
-//! `sroa_variant_return` runs just before `inline` and rewrites the same
-//! helpers' returns to `[tag, slots…]`, so the intermediate reaching the
-//! consumer is a tuple, not a variant: breaks carry a tuple literal and the
-//! consumer reads `temp.0` / `temp.k`. Value-discarding fusion recognises that
-//! shape too — [`FusedValue`] is the one axis the two differ on, and the
-//! transform is shared. Recognising only the variant form left the tuple
-//! allocated once per call, which is worse than the variant it replaced.
+//! `sroa_variant_return` runs just before `inline`, so the intermediate may
+//! instead be a `[tag, slots…]` tuple. Value-discarding fusion recognises that
+//! too — [`FusedValue`] is the only axis the two differ on.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::{NirLiteralPattern, NirLocal};
@@ -710,20 +691,11 @@ fn arm_body_operand_into_block(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Shared label-exit walk
-// ---------------------------------------------------------------------------
-//
-// One traversal drives the two full-coverage exit checks — the value-discarding
-// break check ([`BreakChecker`]) and the threading exit validator
-// ([`ExitValidator`]) — whose former hand-rolled twins diverged and caused the
-// P0 fusion miscompiles. `walk_exits` visits each exit, honouring label
-// shadowing (a nested `LabeledBlock` rebinding the label hides its exits), and
-// hands it to an [`ExitSink`] encoding the per-check policy. `walk_exit_operand`
-// accepts a promoted `Operand::Value` vacuously (`is_none_or`): it carries no
-// skeleton subtree, hence no break, so it can never invalidate a check.
-// (`find_break_case_index_for_name` deliberately stays off this walk; see its
-// note below.)
+// Shared label-exit walk: one traversal drives both exit checks, whose former
+// hand-rolled twins diverged and caused the P0 fusion miscompiles. `walk_exits`
+// visits each exit honouring label shadowing and hands it to an [`ExitSink`]
+// encoding the per-check policy. A promoted `Operand::Value` is accepted
+// vacuously, carrying no skeleton subtree and hence no break.
 
 /// Per-exit policy for the shared [`walk_exits`] traversal.
 trait ExitSink {

--- a/wado-compiler/src/optimize/let_block_flatten.rs
+++ b/wado-compiler/src/optimize/let_block_flatten.rs
@@ -1,19 +1,8 @@
-//! Flatten block-tailed `let` bindings — the value-block normal form.
-//!
-//! An inlined helper that computes intermediates before its result leaves the
-//! binding wrapped in a block, which `sroa` and other matchers — keyed on a
-//! direct `let x = <value>` — then miss:
-//!
-//! ```text
-//! let x = { let end = v.used; ArraySlice { repr: &v.repr, start: 0, end } }
-//! ⇒ let end = v.used; let x = ArraySlice { repr: &v.repr, start: 0, end }
-//! ```
-//!
-//! Only straight-line leading statements (`Let` / `Expr` / `LetDestructure`)
-//! are hoisted, so no control flow crosses the binding and the tail — already
-//! last — keeps its execution order. With the fixed-point loop this converges
-//! to the normal form: after the post-inline peephole, no `let` binds a
-//! straight-line value-position `Block`.
+//! Flatten block-tailed `let` bindings — the value-block normal form. An inlined
+//! helper computing intermediates leaves its binding wrapped in a block, which
+//! `sroa` and every other matcher keyed on a direct `let x = <value>` then miss;
+//! hoisting the leading straight-line statements out restores the shape. Only
+//! `Let` / `Expr` / `LetDestructure` move, so execution order is unchanged.
 
 use cranelift_entity::EntityRef;
 

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -1,24 +1,8 @@
-//! Loop-Invariant Code Motion (LICM) for Wado NIR
-//!
-//! This module hoists loop-invariant computations out of loops to improve performance.
-//! Two kinds of candidates move to the pre-header: field accesses on
-//! variables the loop does not modify (legality via [`ModifiedVars`]), and
-//! pure-arithmetic subtrees whose `Local` leaves are pre-header-stable
-//! (never modified in the loop), deduped by structural identity
-//! ([`ArithKey`]; see [`ArithHoist`]).
-//!
-//! Runs on the worklist rewrite engine (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) as a [`Rule`]: a
-//! per-function standalone engine session whose `apply_block` fires once at
-//! the body root and applies LICM to every loop in the function. All
-//! mutations route through the engine edit API (`alloc_expr`, `alloc_stmt`,
-//! `alloc_local`, `clone_expr`, `set_block_stmts`, `replace_expr_kind`) so
-//! the parent map and use index stay coherent.
-//!
-//! The hoist-candidate and replacement walks recurse over
-//! [`Body::for_each_child`], skipping pattern children; `collect_modified_vars`
-//! keeps its own walk because it special-cases assignments, calls, and pattern
-//! bindings.
+//! Loop-Invariant Code Motion for Wado NIR. Two kinds of candidate move to the
+//! pre-header: a field access on a variable the loop does not modify (legality
+//! via [`ModifiedVars`]), and a pure-arithmetic subtree whose `Local` leaves are
+//! pre-header-stable, deduped by structural identity ([`ArithKey`]). Runs as a
+//! [`Rule`] whose `apply_block` fires once and covers every loop in the body.
 
 use std::cell::Cell;
 
@@ -94,17 +78,10 @@ impl ModifiedVars {
     }
 
     /// True when hoisting `x.field_idx` is unsound: `x` is a reference whose
-    /// pointee's `field_idx` is written in the loop — directly via an alias, or
-    /// opaquely by a call that received the pointee by `&mut`. By-value roots
-    /// are covered by the `fully`/`fields`/alias machinery.
-    ///
-    /// The opaque-`&mut`-call case is type-keyed and restricted to plain structs:
-    /// any `&Struct`/`&mut Struct` read of a clobbered struct type is treated as
-    /// aliasing. Generic instances (`List`/`String`) are deliberately excluded
-    /// here — type-keying them would block reads of an unrelated read-only
-    /// `&List` whenever any same-typed list is mutated in the loop (e.g. a lookup
-    /// `table` while building `out`). Their cascade hazard is handled precisely
-    /// in `licm_loop` via [`Self::is_clobbered_gc_value`] on hoist locals.
+    /// pointee's field is written in the loop, directly or through a `&mut`
+    /// call. The opaque-call case is type-keyed and limited to plain structs;
+    /// keying `List` / `String` would block an unrelated read-only `&List`
+    /// whenever any same-typed list is mutated. Those go through `licm_loop`.
     fn is_reference_field_aliasing_written(
         &self,
         root_type: TypeId,
@@ -2284,30 +2261,18 @@ fn cse_operand_in_scope(
     }
 }
 
-/// Common-subexpression elimination inside a loop body under operand promotion.
+/// Common-subexpression elimination inside a loop body: hash-consing dedups a
+/// repeated pure subexpression to one `ValueId` but cannot *materialise* it, a
+/// loop-carried local's value not being reemittable at an arbitrary slot, so
+/// each occurrence is still re-emitted. This restores the one-computation
+/// `__cse_N` shape — bind a clone to a temp before the earliest top-level
+/// statement holding an occurrence, and redirect them all to read it.
 ///
-/// The value graph hash-conses a pure subexpression (`p * p` over a loop-carried
-/// `p`) to one `ValueId`, so the two occurrences in a guard and the body share
-/// an identity — but each is a distinct *skeleton* `Binary` expr the extractor
-/// can not promote to a bare `Operand::Value` (a loop-carried local's value is
-/// not reemittable at an arbitrary slot, so it stays a sourceless `Opaque`).
-/// Each is therefore re-emitted. This restores the one-computation `__cse_N`
-/// shape the standalone `cse` pass produced before hash-consing subsumed the
-/// *deduplication* (but not the materialisation): bind a clone of the
-/// subexpression to a temp placed before the earliest top-level statement that
-/// contains an occurrence, and redirect every occurrence to read the temp.
-///
-/// Soundness — placement and availability:
-/// - The temp lands before the earliest top-level statement of the loop body
-///   that holds an occurrence, so it dominates every (later or equal) occurrence
-///   in the body's linear statement list.
-/// - A value with ≥2 occurrences sharing one `ValueId` reads the *same* leaf
-///   values at each, so those leaves are in scope at all of them — hence bound
-///   before the earliest occurrence's statement (or loop-carried / a param),
-///   available where the temp is inserted. The clone re-emits the original
-///   skeleton (a `local.get` of each leaf), so it computes exactly the shared
-///   value. Trap-prone ops are excluded, so computing it once up front (possibly
-///   on an iteration a conditional occurrence would have skipped) cannot trap.
+/// That placement dominates every occurrence in the body's linear statement
+/// list, and occurrences sharing a `ValueId` read the same leaves, so those are
+/// in scope where the temp is inserted. Trap-prone ops are excluded, so
+/// computing it up front — perhaps on an iteration that would have skipped it —
+/// cannot trap.
 fn cse_loop_body(engine: &mut Engine, loop_body: BlockId, modified: &ModifiedVars) -> bool {
     let stmts = engine.body.blocks[loop_body].stmts.clone();
     // Occurrences of each materialisable arith value, keyed by a value-graph-free

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -2263,15 +2263,9 @@ fn cse_operand_in_scope(
 
 /// Common-subexpression elimination inside a loop body: hash-consing dedups a
 /// repeated pure subexpression to one `ValueId` but cannot *materialise* it, so
-/// each occurrence is still re-emitted. This restores the one-computation
-/// `__cse_N` shape — bind a clone to a temp before the earliest top-level
-/// statement holding an occurrence, and redirect them all to read it.
-///
-/// That placement dominates every occurrence in the body's linear statement
-/// list, and occurrences sharing a `ValueId` read the same leaves, so those are
-/// in scope where the temp is inserted. Trap-prone ops are excluded, so
-/// computing it up front — perhaps on an iteration that would have skipped it —
-/// cannot trap.
+/// each occurrence is still re-emitted. Binding a clone to a temp before the
+/// earliest occurrence's statement dominates them all, and their shared leaves
+/// are in scope there. Trap-prone ops are excluded, so hoisting cannot trap.
 fn cse_loop_body(engine: &mut Engine, loop_body: BlockId, modified: &ModifiedVars) -> bool {
     let stmts = engine.body.blocks[loop_body].stmts.clone();
     // Occurrences of each materialisable arith value, keyed by a value-graph-free

--- a/wado-compiler/src/optimize/licm.rs
+++ b/wado-compiler/src/optimize/licm.rs
@@ -2262,8 +2262,7 @@ fn cse_operand_in_scope(
 }
 
 /// Common-subexpression elimination inside a loop body: hash-consing dedups a
-/// repeated pure subexpression to one `ValueId` but cannot *materialise* it, a
-/// loop-carried local's value not being reemittable at an arbitrary slot, so
+/// repeated pure subexpression to one `ValueId` but cannot *materialise* it, so
 /// each occurrence is still re-emitted. This restores the one-computation
 /// `__cse_N` shape — bind a clone to a temp before the earliest top-level
 /// statement holding an occurrence, and redirect them all to read it.

--- a/wado-compiler/src/optimize/loop_version_bce.rs
+++ b/wado-compiler/src/optimize/loop_version_bce.rs
@@ -1,13 +1,8 @@
 //! Loop-versioned bounds-check elimination, for the checks
 //! `condition_implication` cannot statically prove: the loop becomes
 //! `if H < B { <clone, checks deleted> } else { <original> }`, sound by
-//! per-iteration transitivity from the guard's `i <= H`. All three locals must
-//! share one integer type, and the slow arm keeps assert timing identical.
-//!
-//! A fast arm that is exactly `a[i] = CONST; i += 1` then collapses to one
-//! `builtin::array_fill` ([`try_fill_idiom`]), the residual also proving
-//! `H + 1` cannot overflow. Runs once after the optimization loop, and only
-//! over leaf loops, so cloning never compounds.
+//! per-iteration transitivity from the guard's `i <= H`. A fast arm that is
+//! exactly `a[i] = CONST; i += 1` then collapses to one [`try_fill_idiom`].
 
 use crate::nir::{FunctionRef, NirBinaryOp, NirFunction, NirUnaryOp};
 use crate::nir_arena::{ArenaCallArg, BlockId, ExprKind, NodeRef, Operand, StmtId, StmtKind};

--- a/wado-compiler/src/optimize/loop_version_bce.rs
+++ b/wado-compiler/src/optimize/loop_version_bce.rs
@@ -1,9 +1,8 @@
 //! Loop-versioned bounds-check elimination, for the checks
 //! `condition_implication` cannot statically prove: the loop becomes
 //! `if H < B { <clone, checks deleted> } else { <original> }`, sound by
-//! per-iteration transitivity from the guard's `i <= H` and the residual's
-//! `H < B`. All three locals must share one integer type, so the comparisons
-//! agree on signedness, and the slow arm keeps assert timing bit-identical.
+//! per-iteration transitivity from the guard's `i <= H`. All three locals must
+//! share one integer type, and the slow arm keeps assert timing identical.
 //!
 //! A fast arm that is exactly `a[i] = CONST; i += 1` then collapses to one
 //! `builtin::array_fill` ([`try_fill_idiom`]), the residual also proving

--- a/wado-compiler/src/optimize/loop_version_bce.rs
+++ b/wado-compiler/src/optimize/loop_version_bce.rs
@@ -1,38 +1,14 @@
-//! Loop-versioned bounds-check elimination.
+//! Loop-versioned bounds-check elimination, for the checks
+//! `condition_implication` cannot statically prove: the loop becomes
+//! `if H < B { <clone, checks deleted> } else { <original> }`, sound by
+//! per-iteration transitivity from the guard's `i <= H` and the residual's
+//! `H < B`. All three locals must share one integer type, so the comparisons
+//! agree on signedness, and the slow arm keeps assert timing bit-identical.
 //!
-//! `condition_implication` removes a check `i < B` only when a dominating
-//! guard *statically* implies it. When a loop guard bounds `i` by an
-//! unrelated loop-invariant `H` — `for i = 0; i <= H; i += 1 { a[i] = v }`
-//! checked against `B = a.used`, with the `H`/`B` relation living at the
-//! call site — no static proof exists: the check is semantically live.
-//! This pass versions the loop on the runtime residual instead:
-//!
-//! ```text
-//! if H < B { <loop clone, checks deleted> } else { <original loop> }
-//! ```
-//!
-//! Soundness is per-iteration transitivity: the guard gives `i <= H` (`i`
-//! unmodified between guard and check, `H` loop-invariant), the residual
-//! gives `H < B` (`B` loop-invariant), hence `i < B` — the check's panic
-//! arm is dead in the fast clone. The `<` guard variant proves `i <= H-1`,
-//! so its residual is `H <= B`. All three locals must share one integer
-//! type so the comparisons agree on signedness. The slow arm is the
-//! original loop, so assert timing and message stay bit-identical when the
-//! residual fails.
-//!
-//! A versioned fast arm whose body is exactly `a[i] = CONST; i += 1` then
-//! collapses to a single `builtin::array_fill` (`try_fill_idiom`) — the
-//! bulk `array.fill` replaces per-element `array.set` bounds checks with
-//! one range check. The residual also proves `H + 1` cannot overflow,
-//! making the fill count exact. Dropped loop-local `let` temps are
-//! re-materialized with their final values, so post-loop reads (if any)
-//! observe the same state.
-//!
-//! Runs once after the optimization loop, following
-//! `cond_impl_post_promote` (so only statically-unprovable checks remain),
-//! and pairs with `BranchPruneRule` + `ElideRule` to sweep the deleted
-//! checks' residue. Only leaf loops (no nested loop) are versioned, so
-//! cloning never compounds.
+//! A fast arm that is exactly `a[i] = CONST; i += 1` then collapses to one
+//! `builtin::array_fill` ([`try_fill_idiom`]), the residual also proving
+//! `H + 1` cannot overflow. Runs once after the optimization loop, and only
+//! over leaf loops, so cloning never compounds.
 
 use crate::nir::{FunctionRef, NirBinaryOp, NirFunction, NirUnaryOp};
 use crate::nir_arena::{ArenaCallArg, BlockId, ExprKind, NodeRef, Operand, StmtId, StmtKind};
@@ -490,17 +466,11 @@ fn eliminate_checks_in_fast(engine: &mut Engine, binds: &Binds, plan: &Plan, fas
     }
 }
 
-/// If the check condition reads a `let`-bound temp (`!__cond` or `__cond`),
-/// replace that temp's initializer in the fast clone with the constant the
-/// comparison provably evaluates to there (`!c` panics ⇒ `c` is `true`;
-/// `c` panics ⇒ `c` is `false`), deleting the per-iteration compare.
-///
-/// The matched `let` is overwritten only when its initializer structurally
-/// **is** the eliminated bounds comparison over `var` ([`is_check_comparison`]).
-/// Locals are function-scoped slots, so a temp index can be re-bound; blindly
-/// constifying the first `let` for that slot would corrupt an unrelated
-/// initializer. The scan therefore skips non-comparison bindings and keeps
-/// looking for the comparison `let`.
+/// If the check condition reads a `let`-bound temp, replace that temp's
+/// initializer in the fast clone with the constant the comparison provably
+/// evaluates to (`!c` panics ⇒ `c` is `true`), deleting the per-iteration
+/// compare. Overwritten only when the initializer structurally *is* that
+/// comparison, a function-scoped slot being re-bindable.
 fn constify_check_temp(engine: &mut Engine, cond: Operand, var: u32, fast_body: BlockId) {
     let Operand::Expr(ce) = cond else {
         return;
@@ -615,25 +585,11 @@ fn subtree_redefines(engine: &Engine, block: BlockId, locals: &[u32]) -> bool {
     false
 }
 
-/// The constant-fill idiom over a cleaned fast arm:
-///
-/// ```text
-/// loop { if !(i CMP H) break; [pure lets]; array_set(A, i, CONST); i += 1 }
-/// ```
-///
-/// becomes
-///
-/// ```text
-/// if i CMP H {
-///     array_fill(A, i, CONST, <count>);
-///     [lets re-materialized with final values];
-///     i = <final>;
-/// }
-/// ```
-///
-/// where `<count>` is `H + 1 - i` for `<=` (no overflow: the fast arm's
-/// residual proves `H < B`) and `H - i` for `<`. The wrapping `if` preserves
-/// the zero-iteration case exactly (no fill, no local updates).
+/// Collapse a cleaned fast arm — `loop { if !(i CMP H) break; [pure lets];
+/// array_set(A, i, CONST); i += 1 }` — into one `array_fill` plus the lets and
+/// `i` re-materialized at their final values. The count is `H + 1 - i` for `<=`
+/// (the residual proving no overflow) and `H - i` for `<`; the wrapping `if`
+/// preserves the zero-iteration case exactly.
 fn try_fill_idiom(
     engine: &mut Engine,
     binds: &Binds,

--- a/wado-compiler/src/optimize/match_to_switch.rs
+++ b/wado-compiler/src/optimize/match_to_switch.rs
@@ -1,25 +1,8 @@
-//! Match → Switch optimization.
-//!
-//! Rewrites dense-int / dense-enum `Match` expressions into `Switch`, which
-//! lowers to a Wasm `br_table`. Faster than the generic match if-chain when
-//! the value space is dense and the match has no guards.
-//!
-//! Before WEP 2026-05-11's "Match canonical" direction, this rewrite ran
-//! during TIR → NIR lowering (`lower::translate::switch`). Moving it into
-//! the optimizer keeps `lower::translate` emitting a single canonical
-//! `Match` shape and treats `Switch` as a codegen-friendly optimised form
-//! the optimizer materialises.
-//!
-//! Runs as a [`Rule`] on the worklist rewrite engine (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) over each function's
-//! arena `Body`. The arm bodies are
-//! deep-cloned via the engine's edit API because the same arm can appear at
-//! multiple `br_table` offsets, and the arena is a tree (one parent per node).
-//! Global initializers are arena `ExprBody`s, so the same rule runs on each
-//! global's body directly. The rule is confluent under the worklist's
-//! bottom-up order: nested `Match`es in arm bodies are converted before the
-//! outer one, so the cloned bodies hold `Switch`es and re-processing them is a
-//! no-op.
+//! Match → Switch: a dense-int or dense-enum guardless `Match` becomes a
+//! `Switch`, lowering to a Wasm `br_table` rather than the generic if-chain.
+//! Kept in the optimizer rather than lowering (WEP 2026-05-11), so
+//! `lower::translate` emits one canonical `Match` shape. Arm bodies are
+//! deep-cloned, one arm being reachable at several `br_table` offsets.
 
 use crate::module_source::ModuleSource;
 use crate::nir::{FunctionRef, NirFunction, NirLiteralPattern};

--- a/wado-compiler/src/optimize/mod_ref.rs
+++ b/wado-compiler/src/optimize/mod_ref.rs
@@ -1,66 +1,8 @@
-//! Per-expression mod/ref summary for Wado NIR.
-//!
-//! A [`ModRef`] is a coarse, conservative summary of what an expression
-//! or statement (together with its sub-tree) does to machine state:
-//! which locals/globals it reads and writes, whether it touches the GC
-//! heap or linear memory, whether it may transfer control non-locally,
-//! whether it can call into arbitrary user code, and whether it may
-//! trap.
-//!
-//! Unrelated to Wado's algebraic-effect / `with`-clause machinery; this
-//! is the classical compiler-optimization notion (cf. LLVM
-//! `ModRefInfo`, GCC `mod` / `ref` sets). Lives at NIR because that's
-//! where every modref consumer in this compiler also lives (`dae`,
-//! `dce`, `copy_prop`, `store_load_forward`, `alias`, and the
-//! `elide_box_local` pass that motivated v1).
-//!
-//! ## Client API
-//!
-//! Passes consume the summary through two predicates:
-//!
-//! - [`ModRef::may_clobber`] — could the writes implied by `self`
-//!   invalidate any read implied by `other`? Wasm-semantics-accurate:
-//!   `calls` are treated as touching only globals / GC heap / linear
-//!   memory (callees cannot reach the caller's locals).
-//! - [`can_move_past`] — convenience for the common "skip an
-//!   intervening statement while erasing a candidate local" check used
-//!   by adjacent-use elision passes.
-//!
-//! ## Granularity (v1)
-//!
-//! Coarse: one R/W flag pair per heap / memory channel; calls are
-//! "everything except locals"; traps are a single boolean. The
-//! representation is private to this module — passes only call the
-//! predicates above — so refining the internals (per-`TypeId` GC heap,
-//! per-callee `stores`-aware effect summaries, `Cast`-kind precision,
-//! …) does not require call-site churn.
-//!
-//! NIR-specific assets the v1 implementation does NOT yet exploit but
-//! is designed to grow into:
-//!
-//! - `NirFunction::stores` declares which `&` / `&mut` parameters the
-//!   callee may store references through. A `Call { func }` whose
-//!   callee's `stores` is empty cannot mutate the caller's locals via
-//!   any argument, even when the argument is a reference type.
-//! - `Cast` kind: today every `Cast` is conservatively marked
-//!   `may_trap`. Refining to the actual numeric / ref-cast taxonomy
-//!   lets pure float→float / int-widening casts ride past
-//!   trap-conflicting intervening stmts.
-//!
-//! ## Discipline for extending [`ExprKind`] / [`StmtKind`]
-//!
-//! [`ModRef::accumulate_expr`] / [`ModRef::accumulate_stmt`] enumerate
-//! every effectful variant explicitly. Pure value-producing variants
-//! (constants, arithmetic, etc.) fall into terminal arms that
-//! contribute nothing of their own. When adding a new variant that
-//! introduces a new kind of effect, add it explicitly to the relevant
-//! `accumulate_*` — otherwise it silently defaults to "pure" and the
-//! soundness of downstream passes is lost.
-//!
-//! The companion test [`tests::known_effectful_variants_are_explicit`]
-//! constructs one expression / statement of each effectful shape and
-//! asserts the summary picks up the expected flag, so an accidental
-//! fall-through into a default arm surfaces as a test failure.
+//! Per-expression mod/ref summary — the classical optimization notion (LLVM's
+//! `ModRefInfo`), unrelated to Wado's algebraic effects. Passes consume it
+//! through [`ModRef::may_clobber`] and [`can_move_past`]. A new effectful
+//! [`ExprKind`] / [`StmtKind`] variant must be added to `accumulate_expr` /
+//! `accumulate_stmt` explicitly, or it silently defaults to pure.
 
 use crate::hashmap::IndexSet;
 use crate::module_source::ModuleSource;
@@ -243,18 +185,11 @@ impl ModRef {
         mr
     }
 
-    /// True iff `self`'s writes (or any call inside `self`) might
-    /// invalidate any of `other`'s reads.
+    /// True iff `self`'s writes (or any call inside `self`) might invalidate any
+    /// of `other`'s reads.
     ///
-    /// Call effects: callees can both read and mutate globals, the GC
-    /// heap, and linear memory, so a call on either side conflicts with
-    /// the other side's accesses to those channels — `self`'s call
-    /// clobbers `other`'s channel reads and `other`'s calls (whose
-    /// hidden reads `self`'s hidden writes may feed), and `other`'s
-    /// call reads whatever `self` explicitly writes. Callees CANNOT
-    /// reach the caller's Wasm locals — locals live in the calling
-    /// frame and are not addressable from another function — so a call
-    /// does not clobber a `local_reads`-only expression.
+    /// A call conflicts with the other side's globals / GC heap / linear memory,
+    /// but never with its locals — those live in the calling frame.
     pub fn may_clobber(&self, other: &ModRef) -> bool {
         let other_reads_shared =
             !other.global_reads.is_empty() || other.heap.reads || other.memory.reads;
@@ -701,33 +636,11 @@ impl ModRef {
     }
 }
 
-/// Can the expression with summary `expr_mr` be moved past an
-/// intervening statement with summary `int_mr`, while a candidate
-/// local `candidate` is being eliminated by the rewrite?
-///
-/// Soundness conditions (all must hold):
-///
-/// 1. The intervening statement transfers control linearly
-///    (`control == Linear`). `Conditional` and `NonLocal` intervenings
-///    are rejected: in the `NonLocal` case the use site may never
-///    execute; in the `Conditional` case some path through the
-///    intervening might still escape via an inner `Break`, and we
-///    over-approximate by bailing.
-/// 2. The intervening statement does not read the candidate local.
-///    With single-use candidates this is normally already guaranteed
-///    by the pass's stats check; the test is a cheap defense against
-///    future refactors.
-/// 3. The intervening and the expression do not both `may_trap`.
-///    If only one of them traps, the surviving trap fires at its own
-///    point; if both can trap, the observable trap location differs.
-///    Conservative for v1.
-/// 4. The intervening statement's writes (or any call inside it) do
-///    not clobber any of the expression's reads, AND symmetrically the
-///    expression's writes (or any call inside it) do not clobber any of
-///    the intervening statement's reads. Both directions are required:
-///    reordering the two preserves observable behaviour only when
-///    neither side's writes can be observed by the other (Bernstein's
-///    classical conditions).
+/// Can `expr_mr` move past an intervening `int_mr`, while `candidate` is being
+/// eliminated by the rewrite? All must hold: the intervening transfers control
+/// linearly, does not read `candidate`, and does not `may_trap` alongside the
+/// expression (the observable trap location would move); and neither side's
+/// writes clobber the other's reads (Bernstein's conditions).
 pub(super) fn can_move_past(expr_mr: &ModRef, int_mr: &ModRef, candidate: u32) -> bool {
     if !matches!(int_mr.control, Control::Linear) {
         return false;
@@ -752,25 +665,10 @@ pub(super) fn can_move_past(expr_mr: &ModRef, int_mr: &ModRef, candidate: u32) -
 // ---------------------------------------------------------------------------
 
 /// What a function does to machine state its caller can observe, resolved
-/// transitively across the call graph.
-///
-/// The per-expression [`ModRef`] above stops at a call boundary (`calls =
-/// true`, "callees may touch any global / heap / memory state we cannot
-/// see"). This is the callee-side refinement that module doc promises.
-///
-/// Only three channels are modelled, because only three survive a call whose
-/// arguments are freshly constructed at the call site:
-///
-/// - **globals** and **linear memory** are process-wide mutable state, so
-///   reading them makes a result depend on more than the arguments, and
-///   writing them is observable by everyone.
-/// - **I/O** (component-model calls) is observable by definition.
-///
-/// The **GC heap is deliberately absent**. A callee that mutates heap objects
-/// is still deterministic from its caller's point of view as long as the
-/// objects are ones it allocated itself or received as arguments — and a
-/// reference cannot outlive the call into caller-visible state, because
-/// `stores` (checked by the client) is what would let it escape.
+/// transitively across the call graph — the callee-side refinement of the
+/// per-expression [`ModRef`], which stops at a call boundary. Only globals,
+/// linear memory and I/O are modelled; the GC heap is deliberately absent,
+/// since `stores` (checked by the client) is what would let a reference escape.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(super) struct FnEffect {
     /// Reads process-wide mutable state (a global, or linear memory), so two

--- a/wado-compiler/src/optimize/mod_ref.rs
+++ b/wado-compiler/src/optimize/mod_ref.rs
@@ -353,10 +353,9 @@ impl ModRef {
             // VariantPayload lowers to `ref.cast` + `struct.get` on the
             // case-specific payload subtype. VariantTag and VariantTest
             // both touch the variant's discriminant field via
-            // `struct.get $variant_base discriminant`
-            // (wir_build/translate.rs:2032). All three are heap reads on
-            // a possibly-null receiver, so each carries `heap.reads`
-            // and `may_trap`.
+            // `struct.get $variant_base discriminant`. All three are heap
+            // reads on a possibly-null receiver, so each carries
+            // `heap.reads` and `may_trap`.
             ExprKind::VariantPayload { expr, .. } => {
                 self.heap.reads = true;
                 self.may_trap = true; // null receiver + case mismatch
@@ -1553,9 +1552,9 @@ mod tests {
 
     #[test]
     fn variant_tag_is_heap_read_and_may_trap() {
-        // VariantTag lowers to `struct.get $variant_base discriminant`
-        // (wir_build/translate.rs:2032) — a heap read on a possibly-null
-        // receiver. Must surface both `heap.reads` and `may_trap`.
+        // VariantTag lowers to `struct.get $variant_base discriminant` — a heap
+        // read on a possibly-null receiver. Must surface both `heap.reads` and
+        // `may_trap`.
         let mr = mr_expr(|b| {
             let l = local(b, 0);
             variant_tag(b, l)

--- a/wado-compiler/src/optimize/multi_value_return.rs
+++ b/wado-compiler/src/optimize/multi_value_return.rs
@@ -1,23 +1,8 @@
-//! Multi-value return ABI classification (NIR-level).
-//!
-//! Decides which aggregate-returning user functions should use the
-//! multi-value Wasm return ABI (each tuple element / struct field a separate
-//! Wasm result) instead of the default heap-struct ABI. The decision is
-//! recorded on [`NirFunction.return_abi`] and consumed by `wir_build`.
-//!
-//! ## Eligibility
-//!
-//! A function `f` is a candidate when its return type is a tuple or user
-//! struct of 2..=[`MAX_RESULTS`] fields (all field types eligible), every
-//! `Return` produces a fresh aggregate literal of that shape, and every call
-//! site binds it as `let __tmp = Call(f); …` — directly, or at the tail of a
-//! block that hoists the receiver first — whose only uses of `__tmp` are
-//! `FieldAccess(Local(__tmp), name)`. See the per-function comments below for
-//! the exact gates.
-//!
-//! A pure classification pass over the arena `Body` (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`): every body walk is
-//! read-only and the only mutation sets `return_abi`.
+//! Multi-value return ABI classification: which aggregate-returning functions
+//! take the multi-value Wasm ABI, one result per field, instead of a heap
+//! struct. A candidate returns a 2..=[`MAX_RESULTS`]-field tuple or struct from
+//! fresh literals, and every call site binds it as `let __tmp = Call(f)` whose
+//! only uses are field accesses. The one mutation is `return_abi`.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::{FuncId, FunctionKind, NirFunction, NirStruct, ReturnAbi};
@@ -40,19 +25,10 @@ struct CandidateInfo {
 }
 
 /// A direct call in tail position: its callee, the call's own type, and the
-/// node. Looks through a block tail, the shape `let_block_flatten` leaves when
-/// it hoists a receiver in front of the call — and hands back the statements
-/// the block runs first.
-///
-/// Those statements are ordinary code and the caller has to deal with them: a
-/// `return` validates them, `wir_build` emits them ahead of the bind. Skipping
-/// them let a whole-aggregate use in the prefix pass unseen, so its callee took
-/// the multi-value ABI while the use still read a local the split had left
-/// unassigned.
-///
-/// `wir_build::translate::try_emit_multi_value_let` shares this recogniser, so
-/// the shape this pass accepts at a `let` is by construction the shape the
-/// lowering can split.
+/// node. Looks through the block tail `let_block_flatten` leaves when it hoists
+/// a receiver, handing back the statements the block runs first — the caller
+/// must handle them, or a whole-aggregate use in the prefix passes unseen.
+/// `wir_build::translate::try_emit_multi_value_let` shares this recogniser.
 pub(crate) fn block_tail_call(
     body: &Body,
     op: Operand,
@@ -178,16 +154,10 @@ fn collect_candidates(
 }
 
 /// The candidates some call site refutes, over every function body and every
-/// global initializer — the latter carry arena bodies too, and are scanned with
-/// the same let-tracking as `dae` and `drve` do.
-///
-/// A `return g(x)` is only a pass-through when the enclosing function has the
-/// same N results to pass it through; otherwise the call has no aggregate to
-/// bind and stays an escape. That reads `tail_ok`, never this round's candidate
-/// set: a candidate can still be invalidated later in the same round, and
-/// sparing `g` on behalf of a caller that then does not take the ABI leaves the
-/// caller pushing N results through a one-ref signature. At the fixed point
-/// `tail_ok` is exactly the surviving set, so the two sides of the rule agree.
+/// global initializer. A `return g(x)` passes through only when the enclosing
+/// function has the same N results, judged against `tail_ok` rather than this
+/// round's candidate set — sparing `g` for a caller that then declines the ABI
+/// would push N results through a one-ref signature. The two agree at fixpoint.
 fn refute_candidates(
     project: &NirPackage,
     candidates: &IndexMap<usize, CandidateInfo>,

--- a/wado-compiler/src/optimize/multi_value_return.rs
+++ b/wado-compiler/src/optimize/multi_value_return.rs
@@ -725,16 +725,10 @@ fn validate_stmt(
 }
 
 /// Walk a `return`ed value, sparing a pass-through call in every tail position
-/// [`expr_returns_match`] accepts it — a block or labeled-block tail, an `If`
-/// branch tail, a `Match` arm body, a `Switch` arm tail — and recursively,
-/// since those nest. Everything the value reaches off that spine is an ordinary
-/// use.
-///
-/// The two halves have to agree: a position the return side admits but this one
-/// walks as an escape invalidates the callee, and the fix-point then withdraws
-/// the caller as well, so both keep the heap-tuple ABI. Break values are the
-/// deliberate exception — see [`ExpectedShape::tail_call_lowerable`], which
-/// refuses them on the return side too.
+/// [`expr_returns_match`] accepts — block, `If` branch, `Match` arm, `Switch`
+/// arm — and recursively, since those nest. The two halves must agree: a
+/// position one admits and the other walks as an escape invalidates the callee
+/// and, at fixpoint, the caller. Break values are refused on both sides.
 fn validate_tail_return(
     body: &Body,
     op: Operand,

--- a/wado-compiler/src/optimize/param_spec.rs
+++ b/wado-compiler/src/optimize/param_spec.rs
@@ -1,55 +1,8 @@
-//! Constant-field specialization of struct-reference parameters.
-//!
-//! Interprocedural constant propagation over struct fields, by cloning. A hot
-//! caller often threads a by-reference config struct of compile-time constants
-//! — a template's `Formatter` through `fmt_decimal` → `prepare_int_write` —
-//! into callees above the inline threshold, where `if f.sign_plus` and
-//! `if f.width > 0` then survive all the way to Wasm.
-//!
-//! For `g(…, x, …)` where `x` is a struct local (or an already specialized
-//! parameter) with constant fields, the pass clones `g`, substitutes those
-//! fields' reads, and retargets the call. It folds nothing itself: the clone's
-//! dead branches fall to `const_fold` / `const_branch_prune` next iteration,
-//! and `dce` drops the original once every call site has specialized.
-//!
-//! ## Legality
-//!
-//! A field may be substituted only if the callee never writes it — directly or
-//! through any function it forwards the reference to. [`summarize_params`]
-//! computes that write set as a fixed point over the call graph, alongside an
-//! `opaque` flag for a reference whose use the summary cannot classify.
-//!
-//! On the caller side [`collect_roots`] keeps a field only when every write to
-//! it stores the same constant and every call it is forwarded to leaves it
-//! alone. The facts are flow-insensitive — valid at every program point, so no
-//! dataflow is needed to place them.
-//!
-//! ## Profitability
-//!
-//! A field counts when the callee reads it *transitively*, so a clone that
-//! folds nothing in its own body is minted deliberately — it carries the
-//! constants along a pass-through link. That pays off when the chain ends in a
-//! fold and the clone replaces the original; it is duplication when the chain
-//! never folds and a cold path keeps the original live. Rare, but it is why
-//! Wasm grows on formatting-heavy code while whole programs shrink.
-//!
-//! TODO: require that the substituted constants can decide a branch.
-//!
-//! ## Cost
-//!
-//! Alone among the fixed-point-loop passes this one is not gate-aware: it
-//! re-summarizes every live function each iteration.
-//!
-//! TODO: gate it. Unlike a local rewrite pass, a stale summary here is a
-//! correctness surface — one taken before a callee gained a write would
-//! license an unsound substitution.
-//!
-//! ## Propagation depth
-//!
-//! Each clone records what it knows about its own parameters, so the next
-//! iteration roots on them and reaches one call deeper — the loop walks the
-//! chain one link per iteration. The clone cache keys on callee plus bindings,
-//! so a recursive call resolves to the same clone and terminates.
+//! Constant-field specialization: for `g(…, x, …)` where `x`'s struct fields are
+//! compile-time constants, clone `g`, substitute those reads, and retarget the
+//! call — `const_fold` folds the clone next iteration. Legality: no callee writes
+//! the field ([`summarize_params`]), every caller write stores the same constant
+//! ([`collect_roots`]). TODO: demand a decidable branch; TODO: make it gate-aware.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/optimize/param_spec.rs
+++ b/wado-compiler/src/optimize/param_spec.rs
@@ -2,7 +2,8 @@
 //! compile-time constants, clone `g`, substitute those reads, and retarget the
 //! call — `const_fold` folds the clone next iteration. Legality: no callee writes
 //! the field ([`summarize_params`]), every caller write stores the same constant
-//! ([`collect_roots`]). TODO: demand a decidable branch; TODO: make it gate-aware.
+//! ([`collect_roots`]). Not gate-aware: a summary taken before a callee gained a
+//! write would license an unsound substitution. TODO: demand a decidable branch.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/optimize/peephole.rs
+++ b/wado-compiler/src/optimize/peephole.rs
@@ -6,9 +6,8 @@
 //!
 //! Invoked twice per fixed-point iteration: before `inline`, where `string_push`
 //! can still see a `push_str` call, and after, where `array_literal` sees the
-//! exposed `array_new + push` window and the ref / box rules clean up what
-//! inlining left. Each rule no-ops in the run that is not its own, bailing on the
-//! first non-matching node. See WEP 2026-06-05.
+//! exposed `array_new + push` window. Each rule no-ops in the run that is not
+//! its own, bailing on the first non-matching node. See WEP 2026-06-05.
 
 use cranelift_entity::EntityRef;
 

--- a/wado-compiler/src/optimize/peephole.rs
+++ b/wado-compiler/src/optimize/peephole.rs
@@ -1,44 +1,15 @@
-//! Unified peephole engine pass.
+//! Unified peephole engine pass: every position-flexible local rewrite rule
+//! interleaved over one engine session per function — one parent map, use index
+//! and worklist — rather than a session apiece. Only the env-free half of
+//! constant folding runs here; the flow-sensitive folds need the driving
+//! visitor's per-function dataflow state and stay in `const_folding`. Likewise
+//! `select_lowering`, a terminal post-loop lowering.
 //!
-//! Runs the position-flexible local peephole rewrite rules — short `push_str`
-//! simplification (`string_push`), constant-ASCII `push` specialization
-//! (`ConstAsciiPushRule`), array-literal materialization
-//! (`array_literal`), write-only local elimination (`elide_local`), the
-//! environment-free subset of constant folding (`const_folding::ConstFoldRule`
-//! — literal arithmetic and pure CTFE), and trivial-block / dead-statement
-//! pruning (`const_branch_prune::BranchPruneRule`) — over one shared worklist
-//! per function: a single engine session (parent map, use index, post-order
-//! seed) on which all the rules interleave.
-//! See `docs/wep-2026-06-05-nir-optimizer-architecture.md`.
-//!
-//! Constant folding is only partly here. Its flow-sensitive folds — env-bound
-//! locals, forwarded struct fields, immutable-global reads, and constant-branch
-//! collapse — need the driving visitor's per-function dataflow state and stay
-//! with the standalone `const_folding::fold_constants` walker. The engine rule
-//! handles only the folds that depend on a node and its already-folded children
-//! plus the program-wide CTFE callee map, applied through the engine's edit API
-//! so the worklist and use index stay coherent.
-//!
-//! `match_to_switch` (dense `Match` → `Switch`) also runs here as a rule:
-//! folding it into the shared session means a function's `Match` lowering reuses
-//! the same engine the other rules already build, instead of a separate
-//! per-function session each iteration. Global initializer bodies are not
-//! visited by the function-level loop, so their `Match` lowering runs once via
-//! `match_to_switch_globals`, and `-O0` (loop skipped) keeps `match_to_switch_all`.
-//!
-//! `select_lowering` stays a terminal post-loop lowering (`If` → `select`) that
-//! must run after all other transformations.
-//!
-//! The pass is invoked at two points in the fixed-point loop — before `inline`
-//! (so `string_push` sees the `push_str` call before inlining expands it;
-//! `value_copy_demote` then runs after) and after `inline` (so `array_literal`
-//! sees the exposed
-//! `array_new + push` window, `RefElimRule` cleans up the ref bindings
-//! inlining exposes, `ElideBoxLocalRule` collapses the `Box<T>` shells, and
-//! `LabeledBlockFusionRule` folds inlined `Option`/`Result` allocations into
-//! the consumer's `if-let`/`match` site). `array_literal` no-ops in the first
-//! run and `string_push` no-ops in the second; both bail immediately on a
-//! non-matching node, so the wasted dispatch is negligible.
+//! Invoked twice per fixed-point iteration: before `inline`, where `string_push`
+//! can still see a `push_str` call, and after, where `array_literal` sees the
+//! exposed `array_new + push` window and the ref / box rules clean up what
+//! inlining left. Each rule no-ops in the run that is not its own, bailing on the
+//! first non-matching node. See WEP 2026-06-05.
 
 use cranelift_entity::EntityRef;
 

--- a/wado-compiler/src/optimize/peephole.rs
+++ b/wado-compiler/src/optimize/peephole.rs
@@ -1,9 +1,8 @@
 //! Unified peephole engine pass: every position-flexible local rewrite rule
 //! interleaved over one engine session per function — one parent map, use index
 //! and worklist — rather than a session apiece. Only the env-free half of
-//! constant folding runs here; the flow-sensitive folds need the driving
-//! visitor's per-function dataflow state and stay in `const_folding`. Likewise
-//! `select_lowering`, a terminal post-loop lowering.
+//! constant folding runs here; the flow-sensitive folds stay in `const_folding`,
+//! and `select_lowering` is a terminal post-loop lowering.
 //!
 //! Invoked twice per fixed-point iteration: before `inline`, where `string_push`
 //! can still see a `push_str` call, and after, where `array_literal` sees the

--- a/wado-compiler/src/optimize/peephole.rs
+++ b/wado-compiler/src/optimize/peephole.rs
@@ -1,13 +1,8 @@
-//! Unified peephole engine pass: every position-flexible local rewrite rule
-//! interleaved over one engine session per function — one parent map, use index
-//! and worklist — rather than a session apiece. Only the env-free half of
-//! constant folding runs here; the flow-sensitive folds stay in `const_folding`,
-//! and `select_lowering` is a terminal post-loop lowering.
-//!
-//! Invoked twice per fixed-point iteration: before `inline`, where `string_push`
-//! can still see a `push_str` call, and after, where `array_literal` sees the
-//! exposed `array_new + push` window. Each rule no-ops in the run that is not
-//! its own, bailing on the first non-matching node. See WEP 2026-06-05.
+//! Unified peephole engine pass (WEP 2026-06-05): every position-flexible local
+//! rewrite rule interleaved over one engine session per function rather than a
+//! session apiece, invoked twice per fixed-point iteration so `string_push` can
+//! still see a `push_str` before `inline` and `array_literal` its window after.
+//! Only the env-free half of constant folding runs here.
 
 use cranelift_entity::EntityRef;
 

--- a/wado-compiler/src/optimize/ref_elim.rs
+++ b/wado-compiler/src/optimize/ref_elim.rs
@@ -1,33 +1,8 @@
-//! Reference elimination optimization for Wado NIR.
-//!
-//! Eliminates unnecessary reference bindings introduced during function inlining.
-//! After inlining, we often have patterns like:
-//!
-//! ```text
-//! let self: &List<T> = &arr;
-//! ... self.repr ...
-//! ```
-//!
-//! This can be optimized to:
-//!
-//! ```text
-//! ... arr.repr ...
-//! ```
-//!
-//! The pass also handles bindings whose source is a field-access chain
-//! (`let r: &T = &v.f1.f2`), substituting the chain at each `r.field` use.
-//!
-//! Runs as `RefElimRule` inside the unified post-inline peephole session
-//! (see `docs/wep-2026-06-05-nir-optimizer-architecture.md`).
-//! `build_ref_elim` collects all `let r = &v` bindings and classifies every use
-//! of each `r` (field-access-only or not), plus the disjoint deref-only set, in
-//! one pristine-body analysis per function. The rule then drops eliminable
-//! bindings and substitutes uses through the engine edit API. The referent is
-//! stored as the *unresolved* source expression id and resolved during the
-//! transform — the refs map is complete, so a transitive `let r2 = &r1.field`
-//! resolves through `r1` even though `r1`'s `let` is dropped. A deref-only
-//! source is single-use, so it is moved into its one `*r` site rather than
-//! cloned.
+//! Reference elimination: drop the `let self = &arr` bindings inlining leaves
+//! behind, folding each `self.repr` back to `arr.repr`, field-access chains
+//! included. `build_ref_elim` classifies every use in one pristine-body
+//! analysis; the referent is then stored unresolved and resolved during the
+//! transform, so a transitive `let r2 = &r1.field` survives `r1`'s removal.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::NirUnaryOp;
@@ -422,17 +397,11 @@ fn extended_live_end(binding: usize, last_use: usize, loops: &[(usize, usize)]) 
     end
 }
 
-/// Whether replacement `r` invalidates ref `local`'s capture (making the
-/// `r.field → re-read referent` fold unsound). An unused ref has no live region
-/// and cannot be invalidated; a missing binding position is treated
-/// conservatively as bound at the body entry.
-///
-/// - A direct `Assign` write invalidates only when it falls strictly after the
-///   binding and within the (loop-extended) live region: `binding < pos <= end`.
-/// - A `&mut` alias (`via_borrow`) invalidates whenever it is created at or
-///   before the end of the live region (`pos <= end`), regardless of the
-///   binding: the alias stays live past its creation and can write through the
-///   referent at any later point, including one the creation position predates.
+/// Whether replacement `r` invalidates ref `local`'s capture, making the
+/// `r.field` → re-read fold unsound. An unused ref has no live region; a missing
+/// binding position is read as body entry. A direct `Assign` invalidates only
+/// within `binding < pos <= end`, while a `&mut` alias does so from anywhere
+/// `pos <= end`, staying live past its creation to write at any later point.
 fn invalidates_capture(r: &Replacement, local: u32, facts: &CaptureFacts) -> bool {
     let Some(&last_use) = facts.last_use.get(&local) else {
         return false;

--- a/wado-compiler/src/optimize/scalar_forward.rs
+++ b/wado-compiler/src/optimize/scalar_forward.rs
@@ -1,24 +1,8 @@
-//! Forward-substitute a single-use pure scalar `let` into its adjacent use.
-//!
-//! Inlining a value parameter binds it as `let p = <arg>` at the callee-block
-//! head; when the arg is a field read or a cast (`let index = self.used; let
-//! value = code as u8; array_set(&mut self.repr, index, value)`) it matches no
-//! `copy_prop` copy source and survives as a dead-weight local. This rule folds
-//! such a binding back into its one use, so the backend emits the operand
-//! directly instead of a `local.set` / `local.get` round-trip.
-//!
-//! Only a *replacement-free* fold is taken: the binding's value must be pure and
-//! scalar (a scalar copy has no aliasing or value-copy timing to preserve) and
-//! free of the reorder hazards the before-use check cannot cover — `Index` (OOB),
-//! a global read (writers invisible to the summary), and integer `/` `%` unless
-//! the divisor is a provably-safe constant. Its single use must sit in the
-//! immediately following statement, and every effect evaluated before the use's
-//! slot there must clear a `ModRef` clobber check against the value's reads — a
-//! call through a ref-typed local or a write through a captured alias has no
-//! syntactic `Assign` / `MutRef` node, so the summary, not a place scan, is the
-//! sound test. A trap-free value may also sink into a sub-block of that statement
-//! (`let t = a + b; if c { use(t) }`). Non-adjacent chains resolve through the
-//! engine fixpoint: forwarding the nearer binding makes the next one adjacent.
+//! Forward-substitute a single-use pure scalar `let` into its adjacent use, so
+//! the backend emits the operand rather than a `local.set` / `local.get` pair.
+//! The value must be pure, scalar, and free of the hazards the before-use check
+//! cannot cover — `Index`, a global read, unsafe integer `/` `%`. Its one use
+//! must be in the next statement, whose earlier effects clear a `ModRef` check.
 
 use cranelift_entity::EntityRef;
 
@@ -125,16 +109,11 @@ impl ScalarForwardRule<'_> {
         if nested && value_mr.may_trap {
             return false;
         }
-        // Reorder hazard: the value moves from `def_stmt` to `use_id`'s slot inside
-        // `use_stmt`, so it must clear every effect evaluated *before* `use_id`
-        // there. A syntactic place-overlap check is not enough — a call through a
-        // ref-typed local (`sink(advance(r), i)`) or a write through a captured
-        // alias mutates the value's reads with no `Assign` / `MutRef` node the
-        // place check sees. Summarise the strictly-earlier effects with `ModRef`
-        // and reject if any may clobber the value's reads. The outermost op's own
-        // effect (e.g. an `array_set` argument the value feeds) is sequenced after
-        // `use_id`, so it never rejects its own argument — keeping the sound scalar
-        // forwarding firing.
+        // Reorder hazard: the value moves into `use_id`'s slot, so it must clear
+        // every effect evaluated before it there. A syntactic place check is not
+        // enough — a call through a ref-typed local or a write through a captured
+        // alias has no `Assign` / `MutRef` node — so summarise with `ModRef`. The
+        // outermost op's own effect is sequenced after `use_id`.
         if clobbered_before_use(engine, &value_mr, use_id, use_stmt) {
             return false;
         }
@@ -146,17 +125,11 @@ impl ScalarForwardRule<'_> {
     }
 }
 
-/// Whether any effect evaluated strictly before `use_id` — within the top-level
-/// statement `use_stmt` — may clobber the reads summarised by `value_mr`, the
-/// pure value about to be forwarded into `use_id`'s slot. Walks up the path from
-/// `use_id` to `use_stmt`; at each parent it summarises the siblings sequenced
-/// before the path child (evaluation order, per `for_each_child`) and tests
-/// `ModRef::may_clobber`. Statements outside `use_stmt` are not visited — they
-/// run before the binding, so they are already reflected in the value. An
-/// ancestor operation's own effect is sequenced after `use_id` (its operand), so
-/// it never rejects its own argument. A `Loop` on the path is rejected: its
-/// back-edge could clobber the value between iterations, unseen by this forward
-/// walk.
+/// Whether any effect evaluated strictly before `use_id`, within the statement
+/// `use_stmt`, may clobber the reads `value_mr` summarises. Walks the path up
+/// from `use_id`, testing `ModRef::may_clobber` against each parent's earlier
+/// siblings; anything outside `use_stmt` already ran before the binding. A
+/// `Loop` on the path is rejected — its back-edge is unseen by a forward walk.
 fn clobbered_before_use(
     engine: &Engine,
     value_mr: &ModRef,

--- a/wado-compiler/src/optimize/select_lowering.rs
+++ b/wado-compiler/src/optimize/select_lowering.rs
@@ -1,17 +1,8 @@
-//! Select lowering optimization for Wado NIR.
-//!
-//! Post-optimization rewrite that converts simple `if cond { a } else { b }`
-//! expressions to `builtin::select(cond, a, b)`, which emits the branchless
-//! Wasm `select` instruction. Both branches must be pure (no side effects, no
-//! traps) since `select` evaluates both operands eagerly.
-//!
-//! Runs as a [`Rule`] on the worklist rewrite engine (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) over each function's
-//! arena `Body`. The `select` Call reuses the existing
-//! condition / arm expression ids, so the rewrite is a single
-//! `replace_expr_kind` with no node allocation. The rule is confluent — a
-//! `select` arm must be leaf-pure, so an arm can never itself be an
-//! `If` / `Call`.
+//! Select lowering: a post-optimization [`Rule`] turning `if cond { a } else
+//! { b }` into `builtin::select(cond, a, b)` and its branchless Wasm
+//! instruction. Both arms must be pure and trap-free, `select` evaluating them
+//! eagerly. The rewrite reuses the existing expression ids, so it is one
+//! `replace_expr_kind`, and leaf-purity makes the rule confluent.
 
 use crate::lower::plan::value_copy::needs_value_copy;
 use crate::module_source::ModuleSource;
@@ -139,15 +130,10 @@ fn arm_select_value(body: &Body, block: BlockId, type_table: &TypeTable) -> Opti
 }
 
 /// A promoted pure value is select-eligible under the same rule as a skeleton
-/// arm ([`is_select_eligible`]): a duplicable leaf — a scalar constant or a local
-/// read — or pure non-trapping operators over such leaves.
-///
-/// The two rules must stay in step. Which one an arm reaches depends only on
-/// whether promotion froze it, so a shape one accepts and the other refuses
-/// costs the lowering silently.
-///
-/// A [`ValueKind::Const`] aggregate stays out: materialising it in both arms
-/// allocates twice, and `select` takes scalars anyway.
+/// arm ([`is_select_eligible`]): a duplicable leaf — a scalar constant or local
+/// read — or pure non-trapping operators over such leaves. The two must stay in
+/// step, an arm reaching one or the other only by whether promotion froze it. A
+/// [`ValueKind::Const`] aggregate stays out; `select` takes scalars anyway.
 fn is_select_eligible_value(body: &Body, v: ValueId, type_table: &TypeTable) -> bool {
     let kind = body.values.kind(v);
     if kind.is_operand_constant() {
@@ -228,16 +214,10 @@ fn is_select_eligible(body: &Body, id: ExprId, type_table: &TypeTable) -> bool {
 }
 
 /// True when an `as` cast from `src` to `dst` lowers to a trapping Wasm
-/// instruction (only `f32`/`f64` → integer traps; everything else is a
-/// wrap / extend / convert / identity).
-///
-/// Intentionally finer than the shared `arena_query::expr_node_may_trap`
-/// taxonomy (which, like `mod_ref`, marks every `Cast` conservatively
-/// trap-capable): a `select` arm is a single duplicable leaf, so refining the
-/// cast test here recovers non-trapping widening / reinterpret casts that the
-/// conservative predicate would reject. Kept local because widening this
-/// refinement into the shared taxonomy would change the other consumers'
-/// classification.
+/// instruction — only float → integer; everything else wraps, extends,
+/// converts, or is the identity. Deliberately finer than the shared
+/// `arena_query::expr_node_may_trap`, which marks every `Cast` trap-capable, and
+/// kept local so the other consumers' classification is unchanged.
 fn is_trapping_cast(src: TypeId, dst: TypeId, type_table: &TypeTable) -> bool {
     matches!(
         (type_table.get(src), type_table.get(dst)),

--- a/wado-compiler/src/optimize/sroa.rs
+++ b/wado-compiler/src/optimize/sroa.rs
@@ -1,36 +1,8 @@
-//! Scalar Replacement of Aggregates (SROA) optimization for Wado NIR
-//!
-//! Eliminates struct and tuple allocations when the aggregate is only used for
-//! field access. After inlining exposes:
-//!
-//! ```text
-//! let s = MyStruct { x: expr1, y: expr2 };
-//! let a = s.x;
-//! let b = s.y;
-//! ```
-//!
-//! SROA decomposes the struct into individual scalar locals:
-//!
-//! ```text
-//! let __sroa_s_x = expr1;
-//! let __sroa_s_y = expr2;
-//! let a = __sroa_s_x;
-//! let b = __sroa_s_y;
-//! ```
-//!
-//! Copy propagation then eliminates the trivial copies.
-//!
-//! Runs on the worklist rewrite engine
-//! (`docs/wep-2026-06-05-nir-optimizer-architecture.md`) as a [`Rule`]: a
-//! per-function standalone engine session whose `apply_block` fires once at
-//! the function root and performs the whole-function decomposition in one
-//! shot. The analysis phases (candidate collection, escape / soft-escape) read
-//! `engine.body` directly; the rewrite routes every mutation through the
-//! engine edit API (`set_block_stmts`, `replace_expr_kind`, `alloc_stmt`,
-//! `alloc_expr`, `alloc_local`) so the parent map and use index stay
-//! coherent. Locals discovered to be `&local`-aliased by a decomposed field
-//! flow back into `func.stores_aliased_locals` via a `RefCell` the driver
-//! merges after `engine.run` returns.
+//! Scalar Replacement of Aggregates: a struct or tuple used only for field
+//! access — `let s = S { x: e1, y: e2 }; let a = s.x;` — is decomposed into
+//! per-field `__sroa_s_x` locals, and copy propagation then removes the trivial
+//! copies. A local found `&local`-aliased by a decomposed field flows back into
+//! `func.stores_aliased_locals` through a `RefCell` the driver merges after.
 
 use std::cell::{Cell, RefCell};
 

--- a/wado-compiler/src/optimize/sroa_param.rs
+++ b/wado-compiler/src/optimize/sroa_param.rs
@@ -1,29 +1,8 @@
-//! Single-field parameter SROA for Wado NIR.
-//!
-//! Rewrites internal functions whose parameter type is
-//! `&S` / `&mut S` for some single-field struct `S` (with `Box<T>`
-//! the canonical case) to take the inner scalar `T` directly. At call sites, the
-//! corresponding `StructLiteral S { field: val }` allocation is replaced with
-//! `val`, eliminating heap traffic.
-//!
-//! Eligibility (Phase 1): a parameter is a candidate when its type is
-//! `Ref(struct_id)` / `MutRef(struct_id)` / bare `Struct` and the referenced
-//! struct has exactly one field. The function must not be pinned. Address-taken
-//! / stores-aliased / `stores`-declared params are excluded.
-//!
-//! Validation (Phase 2): every read of the param local must be either a
-//! `FieldAccess(Local(idx), field)` (the scalar read) or an argument at a call
-//! position whose callee is ALSO a candidate at that position.
-//! Iterates to a fix-point so cascades settle.
-//!
-//! Rewrite (Phase 3): callee bodies turn `FieldAccess(Local, field)` into the
-//! scalar `Local`; call sites unwrap `StructLiteral { field: val }` to `val`
-//! (or extract via `FieldAccess`); scalarizing a receiver clears the call's
-//! `has_receiver`.
-//!
-//! The validation walk and both rewrite phases read and mutate the arena `Body`
-//! directly. Global initializers are arena bodies too, so the call-site rewrite
-//! runs on them as well.
+//! Single-field parameter SROA: an internal function taking `&S` / `&mut S` for
+//! a one-field struct — canonically `Box<T>` — is rewritten to take the inner
+//! scalar, collapsing the call site's `StructLiteral` allocation to the value.
+//! Every read of a candidate param must be the scalar `FieldAccess` or an
+//! argument to another candidate position, iterated to a fixpoint.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::ModuleSource;
@@ -238,26 +217,11 @@ fn reference_param_struct_key(
     }
 }
 
-/// Reject a reference candidate whose call-time value snapshot could be
-/// invalidated during the callee's execution — because some other access path
-/// the callee holds can mutate the pointee `*p`:
-///
-/// - `aliasing_write` — a write the walk cannot rule out: an aliasing global, or
-///   anything behind an unresolved indirect call, or
-/// - a sibling param from which a write can *reach* the wrapper. The sibling
-///   need not be the handle itself, only carry one: `f(&s.m, &mut s)` where
-///   `S { m: M }`, or `f(&x, Holder { r: &mut x })` where the `&mut` hides in a
-///   by-value struct field.
-///
-/// A genuine by-value struct candidate is already a copy, so it is never
-/// affected. A *boxed* reference is not one: `boxing::prepare_types` collapses
-/// `&T` / `&mut T` onto a by-value `Box<T>`, and `&x` of an address-taken local
-/// lowers to a read of that one box, so `f(&mut x, &x)` hands the same box to
-/// both params and the snapshot must be refused.
-///
-/// The split is load-bearing: a `fn mut()` sibling is covered only by the first
-/// clause, because the walk cannot see its captures — see
-/// [`ReachableWrites::Opaque`].
+/// Reject a reference candidate whose call-time snapshot the callee could
+/// invalidate through another access path: an `aliasing_write` the walk cannot
+/// rule out, or a sibling param a write can *reach* the wrapper through —
+/// `f(&s.m, &mut s)`, or a `&mut` hidden in a by-value field. A boxed reference
+/// counts, `&x` of an address-taken local lowering to a read of the one box.
 fn param_snapshot_unsound(
     func: &NirFunction,
     pi: usize,
@@ -934,17 +898,10 @@ fn rewrite_arg(
 // -----------------------------------------------------------------------
 
 /// Pinning rules, shared with DAE via [`super::dae::is_dae_sroa_eligible`].
-/// `relax_closure_call = false` keeps closure `__call` functors pinned (their
-/// function-table wrapper snapshots the signature); unlike DAE there is no
-/// relaxation here. `sroa_param` adds one pin the shared predicate does not
-/// carry — a `$value_copy$T` helper is never a rewrite target.
-///
-/// Concrete trait-impl methods are eligible: after monomorphization every call
-/// site carries a resolved `func_id` and `rewrite_call_sites` rewrites them all,
-/// so scalarizing a single-field-struct parameter (and its call-site
-/// allocation) is sound. This unwraps the `Box<Scalar>` that `&T` reference
-/// parameters box the value into — e.g. every scalar `serde` field / element
-/// (`SerializeStruct::field<i32>`, `SerializeSeq::element<f64>`).
+/// `relax_closure_call = false` keeps closure `__call` functors pinned, their
+/// function-table wrapper having snapshotted the signature, and one pin is added
+/// here: a `$value_copy$T` helper is never a rewrite target. A concrete
+/// trait-impl method is eligible, every post-mono call site being resolved.
 fn is_eligible(func: &NirFunction) -> bool {
     super::dae::is_dae_sroa_eligible(func, false) && !func.is_value_copy()
 }

--- a/wado-compiler/src/optimize/sroa_variant_return.rs
+++ b/wado-compiler/src/optimize/sroa_variant_return.rs
@@ -1,96 +1,8 @@
-//! Variant return scalarization for Wado NIR — the return-position dual of
-//! [`super::sroa_param`].
-//!
-//! A function returning a `variant` is rewritten to return a tuple of
-//! `[tag, payload slots…]`, so nothing downstream sees a variant in the return
-//! position:
-//!
-//! ```text
-//! fn parse(s: String) -> Result<i32, String>
-//!   ⇒ fn parse(s: String) -> [i32, i32, Option<String>]
-//!
-//! return Ok(v)                     ⇒  return [0, v, None]
-//! match parse(s) { Ok(v) => A, … }  ⇒  let t = parse(s);
-//!                                      match t.0 { 0 => { let v = t.1; A } … }
-//! ```
-//!
-//! The Wasm-level ABI needs no new machinery: [`super::multi_value_return`]
-//! already flattens a tuple return whose call sites destructure, so the variant
-//! stops being a special case. Running in the optimization loop before
-//! `nir/inline` is the point — every later pass then reasons about an integer
-//! tag and plain locals instead of one opaque boxed value.
-//!
-//! ## The slot typing rule
-//!
-//! Padding is the only part NIR cannot express directly: an unused slot needs a
-//! value of the slot's type, and NIR types carry no nullability. The rule keys
-//! on the payload's *Wasm* representation, which is what decides whether a
-//! wrapper costs anything:
-//!
-//! | payload `T`                                   | slot        | live      | pad     |
-//! | --------------------------------------------- | ----------- | --------- | ------- |
-//! | scalar (primitive / enum / flags / resource)  | `T`         | `v`       | `0`     |
-//! | already nullable (`Option<X>`, `X` a GC ref)  | `T`         | `v`       | `None`  |
-//! | any other GC ref                              | `Option<T>` | `Some(v)` | `None`  |
-//! | `Unit`                                        | (no slot)   | —         | —       |
-//!
-//! `wir_optimize::nullable_ref` lowers `Option<T>` for a non-nullable ref `T`
-//! to a bare `ref null T`, so row 3's wrapper is free. Row 2 is what stops the
-//! wrapper from ever costing a box: `Option<Option<String>>` holds a *nullable*
-//! ref, which that lowering refuses to erase.
-//!
-//! A pad is never read — every reader tests the tag first.
-//!
-//! ## Soundness does not rest on validation
-//!
-//! Validation is a snapshot of the call sites that exist when it runs, and
-//! `nir/inline` keeps planting new ones afterwards — so a callee rewritten in
-//! one iteration can acquire an unvalidated call site in the next, by which
-//! point its signature is committed. Two things close that:
-//!
-//! - The call-site rewrite runs over *everything scalarized so far*, not just
-//!   this round's candidates, so a site inlining just planted still gets the
-//!   fast path. It declines per temp ([`temp_uses_rewritable`]) rather than
-//!   assuming validation vouched for the shape.
-//! - [`rebox_stragglers`] takes what is left: any call the fast path did not
-//!   bind is wrapped back into the variant it used to return. Validation is a
-//!   profitability filter, not a correctness precondition.
-//!
-//! A rebox is sound but reinstates the allocation the pass exists to remove, so
-//! one firing in steady state means the candidate should not have been taken —
-//! it is a bug in the candidate set, not a cost to absorb. The tail-call rule
-//! in [`check_uses`] is what keeps the count at zero: a `return g(x)` is only a
-//! reason to keep `g` when the caller has a tuple to pass it through.
-//!
-//! ## Where a call's result is read
-//!
-//! [`call_sites`] is the only answer. Validation, the call-site rewrite, the
-//! repair and the invariant check all read it, so they differ in what they do
-//! with a site and never in which sites exist. Add a consumer by reading it,
-//! never by writing a fifth traversal.
-//!
-//! Each of the four used to decide for itself, and every gap between them was a
-//! defect: a binding the rewrite bound and validation refused, a call the
-//! rewrite retyped and the repair wrapped back into a variant, a `let` the
-//! assertion never looked at.
-//!
-//! ## Not yet handled
-//!
-//! The WIR widening pass this replaced is gone; only its `flatten_variant_slots`
-//! half remains, splitting a nested result slot after lowering. What this pass
-//! still declines:
-//!
-//! - A `LabeledBlock` in return-value position whose value also arrives via
-//!   `break L: v`. Those exits are rejected outright
-//!   ([`return_value_scalarizable`]) rather than half-handled.
-//! - A `v128`, `i128` or `u128` payload ([`slot_shape`]). The pad decides it:
-//!   every slot needs a zero this pass can mint as a promoted value, and
-//!   `ValueKind` has no `v128` literal, while the 128-bit types occupy two Wasm
-//!   results the slot count does not model.
-//!
-//! A case payload that is itself a variant is *not* declined — it takes a
-//! [`SlotShape::Wrapped`] slot, and `flatten_variant_slots` splits that slot
-//! further if the WIR shapes allow.
+//! Variant return scalarization — the return-position dual of
+//! [`super::sroa_param`]. A `variant` return becomes `[tag, payload slots…]`,
+//! which [`super::multi_value_return`] already flattens; slot types key on the
+//! payload's Wasm representation ([`slot_shape`]) and pads are never read.
+//! Whatever the rewrite misses, [`rebox_stragglers`] wraps back into a variant.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::nir::{FuncId, FunctionKind, NirBinaryOp, NirFunction, NirLiteralPattern, NirLocal};
@@ -249,27 +161,11 @@ pub fn scalarize_variant_returns(project: &mut NirPackage, gate: &mut FunctionGa
 // Repair: reboxing a call site the scalarized form never reached
 // -----------------------------------------------------------------------
 
-/// What makes the rewrite unconditionally sound.
-///
-/// Validation is a snapshot: it sees the call sites that exist when it runs.
-/// `nir/inline` runs later in the same iteration and keeps running in later
-/// ones, and it copies bodies wholesale — so a callee rewritten in iteration N
-/// can acquire a brand-new call site in iteration N+1 that nothing validated.
-/// The signature is already committed by then, so leaving that site alone is
-/// invalid Wasm, not a missed optimization.
-///
-/// Rather than try to forbid such sites, any call this pass's fast path did not
-/// bind is wrapped back into the variant it used to return:
-///
-/// ```text
-/// f(x)  ⇒  { let __t = f(x); match __t.0 { 0 => Ok(__t.1!), _ => Err(__t.2!) } }
-/// ```
-///
-/// The surrounding context then sees the variant-typed expression it was
-/// written against and needs no analysis at all. The rebox costs the allocation
-/// the scalarization was meant to avoid, so it is a correctness backstop, not a
-/// target — `const_fold` and `sroa` collapse most of them once the tag is
-/// known. Validation is left as what it now is: a profitability filter.
+/// Wrap every call the fast path did not bind back into the variant it used to
+/// return, so the surrounding context sees the type it was written against:
+/// `f(x)` ⇒ `{ let __t = f(x); match __t.0 { 0 => Ok(__t.1!), _ => Err(__t.2!) } }`.
+/// This is what makes the rewrite sound without validation — `nir/inline` keeps
+/// planting call sites after a callee's signature is already committed.
 fn rebox_stragglers(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
     let scalarized = scalarized_returns(project);
     if scalarized.is_empty() {
@@ -2132,17 +2028,11 @@ fn rewrite_call_sites(
         let rebind = Rebind::new(&func, &project.type_table.borrow());
         changed |= hoist_call_scrutinees(&mut body, &mut func, candidates, &rebind, span);
         let mut bound = bound_temps(&body, candidates, func.return_type);
-        // A site validated this round is known handleable; one inherited from an
-        // earlier round is not, so each temp is re-checked. A temp that fails is
-        // dropped here and reboxed instead of half-rewritten.
-        //
-        // The aliasing refusal has to be repeated here, not left to validation:
-        // this runs over everything scalarized so far, and an inline-planted
-        // site on an earlier round's callee never passed validation at all. A
-        // temp whose address is taken, or which a `stores` parameter aliases, is
-        // not a pure destructure target — retyping it to the tuple would hand a
-        // tuple to a reference cell the rebox can no longer repair, because
-        // `handled_call_sites` then reads the binding as already handled.
+        // Re-check every temp: a site inherited from an earlier round never
+        // passed validation, so the aliasing refusal is repeated here rather
+        // than left to it. An aliased temp is not a pure destructure target, and
+        // retyping it would hand a tuple to a reference cell the rebox can no
+        // longer repair. A temp that fails is dropped and reboxed instead.
         let aliased = |local: &u32| {
             func.address_taken_locals.contains(local) || func.stores_aliased_locals.contains(local)
         };

--- a/wado-compiler/src/optimize/store_load_forward.rs
+++ b/wado-compiler/src/optimize/store_load_forward.rs
@@ -1,22 +1,8 @@
-//! Store-to-Load Forwarding optimization for Wado NIR.
-//!
-//! Replace a value-position read — a `Local` read or a `FieldAccess` read —
-//! with the literal that reaches it. The engine's `ValueGraph` handles
-//! flow-sensitive reaching-defs, branch merges, loop and heap-write
-//! invalidation, and field store→load seeding, so this rule only inspects
-//! each read's `ValueKind` and substitutes when it is a literal.
-//!
-//! For `Local` reads, address-taken and `stores`-aliased locals are excluded
-//! here — the builder does not model writes through references for bare
-//! locals. For `FieldAccess` reads the alias safety is upstream: the builder
-//! seeds a field store only for a non-aliased, non-address-taken receiver, so
-//! an aliased field read never carries a literal `ValueId` to begin with.
-//! Particularly useful after SROA decomposes struct fields into scalar
-//! locals, and now also folds reads of fields whose stored value the builder
-//! forwarded (`obj.f = 5; … obj.f …` and `let x = S { f: 5 }; … x.f …`).
-//!
-//! Runs as a per-function standalone engine session whose `apply_block`
-//! fires once at the body root.
+//! Store-to-Load Forwarding: replace a value-position `Local` or `FieldAccess`
+//! read with the literal reaching it. The `ValueGraph` handles reaching-defs,
+//! branch merges, and heap-write invalidation, so this rule only inspects each
+//! read's `ValueKind`. Address-taken and `stores`-aliased locals are excluded;
+//! a field read is safe already, its store seeded only for an unaliased receiver.
 
 use std::cell::Cell;
 

--- a/wado-compiler/src/optimize/string_push.rs
+++ b/wado-compiler/src/optimize/string_push.rs
@@ -1,41 +1,8 @@
 //! Two composed string-append rewrites over the shared peephole session:
-//!
-//! * [`ShortPushStrRule`] rewrites `buf.push_str("short_constant")` (≤8 ASCII
-//!   bytes) into a sequence of `buf.push(ch)` calls — eliminating the temporary
-//!   `String` allocation that the literal would otherwise materialize at
-//!   lowering.
-//! * [`ConstAsciiPushRule`] then retargets each `buf.push(<const char < 0x80>)`
-//!   — the ones above, plus any direct constant-ASCII `push` — to
-//!   `buf.push_ascii_unchecked(<byte>)`, skipping `encode_char`'s UTF-8 width dispatch.
-//!
-//! Must run *before* `inline`: once the inliner expands `push_str`'s body
-//! the call node is replaced by a labeled block, after which the
-//! literal-recognising rewrite no longer fires.
-//!
-//! Identifies the methods via their [`crate::compiler_item::CompilerItem`]
-//! markers (`StringPushStr` / `StringPushChar` / `StringPushAscii`) so the pass
-//! does not depend on the canonical paths of `String::push_str` /
-//! `String::push` / `String::push_ascii_unchecked`.
-//!
-//! The receiver is duplicated once per output `push` call. We only rewrite
-//! when the receiver is one of the syntactically pure forms accepted by
-//! [`is_duplicable_receiver`] — anything that could allocate, trap, or
-//! observe state is left alone.
-//!
-//! ASCII-only: each output `push` is given a `CharLiteral` whose code point
-//! equals the source byte. For byte ≥ 0x80 that would push raw UTF-8
-//! continuation bytes through `push`, which expects a Unicode scalar and
-//! would re-encode them — corrupting the string. We therefore skip any
-//! literal containing a non-ASCII byte.
-//!
-//! Empty literals are also skipped: `push_str("")` is a no-op already.
-//!
-//! Runs on the worklist rewrite engine (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) as a block-level
-//! [`Rule`]: `push_str` is a `&mut self` method whose result is dropped, so it
-//! always appears as a statement, and expanding it produces N statements — a
-//! statement-list edit (`set_block_stmts`). Nested blocks are separate worklist
-//! nodes, so the rule only ever rewrites one block's direct statement list.
+//! [`ShortPushStrRule`] expands `buf.push_str("short_constant")` (≤8 ASCII bytes)
+//! into per-byte `buf.push(ch)` calls, and [`ConstAsciiPushRule`] retargets each
+//! constant-ASCII `push` to `push_ascii_unchecked`. Must run *before* `inline`,
+//! which replaces the call node the literal-recogniser matches.
 
 use crate::compiler_item::CompilerItem;
 use crate::nir::NirUnaryOp;
@@ -130,14 +97,9 @@ impl Rule for ShortPushStrRule {
 
 /// Retarget `buf.push(<const char < 0x80>)` to
 /// `buf.push_ascii_unchecked(<byte>)`, skipping `encode_char`'s UTF-8 width
-/// dispatch: a constant ASCII scalar is always a one-byte sequence. Composes
-/// with [`ShortPushStrRule`] — the per-byte `push(ch)` calls it emits for a
-/// short constant `push_str` are all ASCII, so they flow straight into this
-/// rule on the shared worklist.
-///
-/// `push` is `&mut self`-returning-unit, so its call is always a statement
-/// expression; the rewrite is an in-place call edit (swap the callee
-/// and coerce the `char` argument to its `u8` byte).
+/// dispatch: a constant ASCII scalar is always one byte. Composes with
+/// [`ShortPushStrRule`], whose per-byte output is all ASCII. The rewrite is an
+/// in-place call edit — swap the callee, coerce the `char` to its `u8`.
 pub(super) struct ConstAsciiPushRule {
     push_char_id: crate::nir::FuncId,
     push_ascii_id: crate::nir::FuncId,
@@ -287,17 +249,11 @@ fn try_split_stmt(engine: &mut Engine, stmt: StmtId, ctx: &Ctx) -> Option<Vec<St
     Some(stmts)
 }
 
-/// Receivers we are willing to clone N times. The set is intentionally
-/// narrow: anything that may allocate, trap, or be observably stateful is
-/// excluded so duplicating it cannot change semantics.
-///
-/// `String::push_str`'s `&mut self` parameter constrains what a NIR
-/// call receiver can syntactically be: it must be a place, so
-/// in practice we only ever see `Local`, an `&mut`-wrapped `Local`, or
-/// a `FieldAccess` chain rooted at a `Local`. The broader leaves
-/// (`GlobalVarGet`) are accepted defensively because they are pure reads
-/// with no observable side effects of their own — were they to appear
-/// here, cloning them would still be sound.
+/// Receivers safe to clone N times — deliberately narrow, excluding anything
+/// that may allocate, trap, or be observably stateful. `push_str`'s `&mut self`
+/// already forces a place, so in practice only a `Local`, an `&mut`-wrapped one,
+/// or a `FieldAccess` chain rooted at one appears; `GlobalVarGet` is accepted
+/// defensively, being a pure read.
 fn is_duplicable_receiver(body: &Body, id: ExprId) -> bool {
     match &body.exprs[id].kind {
         ExprKind::Local { .. } | ExprKind::GlobalVarGet { .. } => true,

--- a/wado-compiler/src/optimize/tmpl_hoist.rs
+++ b/wado-compiler/src/optimize/tmpl_hoist.rs
@@ -1,49 +1,8 @@
-//! Template String Buffer Hoisting for Loops
-//!
-//! When a template string (`__tmpl` labeled block) appears inside a loop,
-//! this pass hoists the entire `String` allocation before the loop and reuses
-//! it across iterations, resetting `used = 0` instead of creating a new struct.
-//!
-//! **Before:**
-//! ```text
-//! loop {
-//!     let s = __tmpl: {
-//!         let mut __r = String { repr: array_new(N), used: 0 };
-//!         __r.push_str(...);
-//!         break __tmpl: __r;
-//!     };
-//!     s.len();   // s only used as method receiver
-//! }
-//! ```
-//!
-//! **After:**
-//! ```text
-//! let mut __tmpl_buf_0 = String { repr: array_new(N), used: 0 };
-//! loop {
-//!     let s /* skip_value_copy */ = __tmpl: {
-//!         __tmpl_buf_0.used = 0;        // reset (no struct.new)
-//!         __tmpl_buf_0.push_str(...);      // reuse same String
-//!         break __tmpl: __tmpl_buf_0;
-//!     };
-//!     s.len();   // s aliases __tmpl_buf_0
-//! }
-//! ```
-//!
-//! Safety: The optimization reuses the same String GC struct across iterations.
-//! It is only applied when the template result does not escape the iteration:
-//! the result must be bound to a Let variable whose value never reaches an
-//! escaping position (call argument, aggregate field/element, assignment /
-//! global / return / break value) — directly, through `if`/`match`/block
-//! result tails, or through uncopied alias `let`s (see [`EscapeScan`]). The
-//! inner `__r` buffer is checked too ([`template_buf_escapes`]).
-//!
-//! Runs on the worklist rewrite engine (see
-//! `docs/wep-2026-06-05-nir-optimizer-architecture.md`) as a [`Rule`]: a
-//! per-function standalone engine session whose `apply_block` fires once at
-//! the body root and walks every loop in the function, applying the template-
-//! string buffer hoist per loop. All mutations route through the engine edit
-//! API (`alloc_expr`, `alloc_stmt`, `alloc_local`, `set_block_stmts`,
-//! `replace_expr_kind`) so the parent map and use index stay coherent.
+//! Template-string buffer hoisting: a `__tmpl` block inside a loop gets its
+//! `String` allocation lifted before the loop and reused, each iteration
+//! resetting `used = 0` instead of building a fresh struct. Sound only when
+//! neither the template result nor the inner `__r` escapes the iteration, which
+//! [`EscapeScan`] and [`template_buf_escapes`] decide. Runs as a [`Rule`].
 
 use std::cell::{Cell, RefCell};
 
@@ -306,28 +265,11 @@ fn template_buf_escapes(body: &Body, tmpl_block: BlockId, buf_local_index: u32) 
     scan.finish().contains(&buf_local_index)
 }
 
-/// Escape analysis for the template-buffer hoist.
-///
-/// A local escapes when its *value* reaches a position that may store it
-/// beyond the iteration: a non-receiver call argument, an aggregate-literal
-/// element or struct field, an assignment / global-set / return / break value.
-/// At each such position the whole value-result chain of the consumed
-/// expression is marked ([`for_each_chain_local`]): the bare local plus every
-/// local reachable as the expression's result — through `&`/`&mut`/casts,
-/// block tails, `if` branch tails, `match` arm bodies, `switch` arm tails, and
-/// labeled-block break values. A call result or a fresh aggregate literal is a
-/// new value, so the chain stops there: a value that leaves only through a
-/// `$value_copy$…` helper stays hoistable.
-///
-/// `let t = <chain containing s>` records an alias edge `t → s` instead of
-/// marking; [`Self::finish`] propagates escapes across edges to a fixpoint.
-/// This keeps precision: a tail value consumed only by non-escaping positions
-/// still hoists.
-///
-/// A `FieldAccess` base is deliberately *not* on the chain (`s.repr` as a
-/// consumed value does not mark `s`): extracted fields feed iterators and
-/// formatters consumed within the iteration, and marking them would disable
-/// the pass for every `.bytes()`-style loop.
+/// Escape analysis for the template-buffer hoist. A local escapes when its value
+/// reaches a position that may store it past the iteration, at which point the
+/// whole value-result chain is marked ([`for_each_chain_local`]); the chain stops
+/// at a call result or fresh literal. `let t = <chain>` records an alias edge
+/// instead, resolved in [`Self::finish`]. A `FieldAccess` base is not on it.
 struct EscapeScan<'a> {
     body: &'a Body,
     escaping: IndexSet<u32>,
@@ -912,16 +854,10 @@ fn transform_expr(
     }
 }
 
-/// Check if a `__tmpl` block has the expected pattern.
-///
-/// Before lowering:
-///   `let mut __r = String::with_capacity(N);`
-///
-/// After lowering (inlined):
-///   `let mut __r = String { repr: array_new<u8>(N), used: 0 };`
-///
-/// Both end with:
-///   `break __tmpl: __r;`
+/// Check if a `__tmpl` block has the expected pattern: `let mut __r =
+/// String::with_capacity(N)` before lowering, or the inlined
+/// `String { repr: array_new<u8>(N), used: 0 }` after, both closing with
+/// `break __tmpl: __r`.
 fn extract_tmpl_candidate(
     body: &Body,
     block: BlockId,
@@ -1848,17 +1784,11 @@ mod tests {
         })
     }
 
-    /// `references_local` decides whether an intermediate `let buf_inner = <e>`
-    /// binding makes `buf_inner` an *alias* of the hoisted template buffer.
-    /// When it answers yes, `extract_fmt_candidates` force-rewrites the matched
-    /// Formatter's `buf` field to `&mut <hoisted buffer>` — so a false positive
-    /// redirects the Formatter to the wrong buffer (a miscompile).
-    ///
-    /// It must therefore match only genuine alias shapes — a bare `Local` or a
-    /// `&mut` chain down to it — and reject any expression that merely *mentions*
-    /// the local (a call argument, an operand, …). Broadening it to a full
-    /// "mentions anywhere" walk (e.g. `expr_mentions_local`) reintroduces that
-    /// miscompile; these assertions exist to fail the moment someone does.
+    /// A yes from `references_local` makes `extract_fmt_candidates` rewrite the
+    /// Formatter's `buf` field to `&mut <hoisted buffer>`, so a false positive
+    /// redirects it to the wrong buffer — a miscompile. It must match only
+    /// genuine alias shapes, a bare `Local` or a `&mut` chain to one, and reject
+    /// an expression that merely *mentions* the local.
     #[test]
     fn references_local_matches_only_aliases_not_mentions() {
         const IDX: u32 = 7;

--- a/wado-compiler/src/optimize/value_copy/mutation.rs
+++ b/wado-compiler/src/optimize/value_copy/mutation.rs
@@ -1,15 +1,8 @@
-//! The mutation-witness recognizer behind copy propagation's mutation
-//! analyses (consumed via `arena_query::for_each_mutated_root`), plus the
-//! callee oracle it consults.
-//!
-//! The verdict is a callee's declared `&mut` parameter bit (`param_mut`,
-//! captured before boxing erases the `&mut`/`&` distinction) — never a
-//! body-derived "does not write" proof, which has false negatives for
-//! mutations the boxing rewrite hides (`&mut self.payload` becomes
-//! `Box { value: self.payload }`), so trusting it would strip a copy the
-//! callee then corrupts (wado-lang/wado#1544).
-//!
-//! Root resolution and the bodyless-callee default stay with each consumer.
+//! The mutation-witness recognizer behind copy propagation's mutation analyses,
+//! plus the callee oracle it consults. The verdict is the callee's declared
+//! `&mut` parameter bit, captured before boxing erases the `&mut` / `&`
+//! distinction — never a body-derived "does not write" proof, which misses the
+//! mutations boxing hides and would strip a copy the callee corrupts (#1544).
 
 use crate::hashmap::IndexMap;
 use crate::nir::{FuncId, NirUnaryOp};

--- a/wado-compiler/src/optimize/value_copy_demote.rs
+++ b/wado-compiler/src/optimize/value_copy_demote.rs
@@ -1,34 +1,13 @@
-//! `value_copy_demote` — demote a deep `$value_copy$T` of an `List<E>` to a
-//! shallow spine copy when the binding's elements are provably never mutated
-//! through it (nor through the source the copy reads from).
+//! Demote a deep `$value_copy$T` of a `List<E>` to a shallow spine copy when the
+//! binding's elements are provably never mutated through it. Such a copy is one
+//! the lower phase could not drop, its binding not being fully read-only; but a
+//! binding only *spine*-mutated (`sort`, `push`) can share the element objects,
+//! so the call is rewritten to a sibling helper using `array_clone_shallow`.
 //!
-//! A `$value_copy$T` reaching the optimizer is one the lower-phase ownership
-//! analysis could not prove unnecessary — its binding is not fully read-only, so
-//! it cannot be dropped. But when the binding is only *spine*-mutated (`sort`,
-//! `push`, …) and never mutates an element, a shallow copy is still safe: the
-//! binding gets its own `repr` spine while sharing the
-//! (immutable-through-this-handle) element objects. This pass proves the
-//! element-immutability precondition and rewrites the call to a synthesized
-//! shallow sibling helper that uses `array_clone_shallow`.
-//!
-//! The element-immutability analysis (`fn`s prefixed `analyze_`/`verify_`) is
-//! shape-compatible with what `container_sroa` needs but currently kept
-//! private to this module.
-//!
-//! TODO(optimizer): expose the element-immutability analysis so
-//! `container_sroa` can replace its hardcoded method-shape whitelist
-//! with this richer query, and so nested-`List<List<T>>` demotion can
-//! reuse the recursive immutability proof. The recursion guard at
-//! `is_element_immutable_method` returns `false` for any recursive
-//! call site, suppressing self-recursive and mutually-recursive helpers.
-//!
-//! ## Arena traversal
-//!
-//! The pass reads and mutates the arena [`Body`] directly. The two
-//! soundness-critical analyses (`ElementClean`, `ElementImmutable`) are
-//! recursive arena walks over [`Body::for_each_child`], so every nested node —
-//! including match-arm and destructure patterns, and `ConstantValue` pattern
-//! sub-expressions — is covered exactly as the canonical tree visitor was.
+//! TODO(optimizer): expose the element-immutability analysis so `container_sroa`
+//! can replace its method-shape whitelist with it, and nested `List<List<T>>`
+//! demotion can reuse the recursive proof. The recursion guard currently answers
+//! `false` at any recursive call site.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -903,22 +882,10 @@ impl ElementClean<'_, '_> {
 }
 
 /// Element-immutability proof for a `&mut self` method: whether calling it can
-/// mutate any element of `self`. Threads the analysis state as fields:
-///
-/// - `tainted` — locals that alias `self`'s storage (local 0 is `self`). The
-///   set grows in statement order: a `let x = <self-derived>` (or assignment)
-///   taints `x` for every *later* statement, so the order-sensitive update
-///   lives in the `visit_stmt` override, after the value is visited.
-/// - `visiting` — the recursion guard shared with [`Analyzer::verify`], so a
-///   self-derived `&mut self` call recurses into the callee's own proof.
-/// - `clean` — the running verdict; once falsified every visit short-circuits.
-///
-/// Only the storage-escaping shapes (`&mut` of self-derived, element
-/// field/index writes, unsafe calls on self-derived receivers/args, indirect
-/// calls of self-capturing closures) are special-cased; everything else
-/// recurses through the arena `for_each_child` walk, which descends into
-/// match-arm and destructure patterns *and* threads taint through
-/// expression-position blocks.
+/// mutate any element of `self`. `tainted` holds the locals aliasing `self`'s
+/// storage and grows in statement order, `visiting` is the recursion guard
+/// shared with [`Analyzer::verify`], and `clean` is the running verdict. Only
+/// the storage-escaping shapes are special-cased; the rest recurses.
 struct ElementImmutable<'a, 'b, 'c> {
     analyzer: &'b mut Analyzer<'a>,
     tainted: IndexSet<u32>,

--- a/wado-compiler/src/optimize/value_copy_demote.rs
+++ b/wado-compiler/src/optimize/value_copy_demote.rs
@@ -3,6 +3,10 @@
 //! the lower phase could not drop, its binding not being fully read-only; but a
 //! binding only *spine*-mutated (`sort`, `push`) can share the element objects,
 //! so the call is rewritten to a sibling helper using `array_clone_shallow`.
+//!
+//! TODO(optimizer): expose the element-immutability analysis for
+//! `container_sroa`'s whitelist and nested-`List<List<T>>` demotion. Its
+//! recursion guard reports `false` at any recursive call site.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/optimize/value_copy_demote.rs
+++ b/wado-compiler/src/optimize/value_copy_demote.rs
@@ -3,11 +3,6 @@
 //! the lower phase could not drop, its binding not being fully read-only; but a
 //! binding only *spine*-mutated (`sort`, `push`) can share the element objects,
 //! so the call is rewritten to a sibling helper using `array_clone_shallow`.
-//!
-//! TODO(optimizer): expose the element-immutability analysis so `container_sroa`
-//! can replace its method-shape whitelist with it, and nested `List<List<T>>`
-//! demotion can reuse the recursive proof. The recursion guard currently answers
-//! `false` at any recursive call site.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/param_resolution.rs
+++ b/wado-compiler/src/param_resolution.rs
@@ -2,7 +2,7 @@
 //! and monomorphize: resolve each global's override — `-D NAME=value` first,
 //! then its `from_env` variable — and replace the initializer with the converted
 //! literal. Conversion is native Rust matching `LenientFromStr`, isolated in
-//! [`convert_builtin`] so a future wasm-CTFE path replaces only that boundary.
+//! `convert_builtin` so a future wasm-CTFE path replaces only that boundary.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/param_resolution.rs
+++ b/wado-compiler/src/param_resolution.rs
@@ -1,19 +1,8 @@
-//! Compile-time parameter resolution (`#[param]`).
-//!
-//! Runs after link and before monomorphize/lower. For each `#[param]` global it
-//! resolves an override (highest priority first: `-D NAME=value`, then the
-//! `from_env` environment variable) and, on success, replaces the global's
-//! initializer with the converted literal. The rewritten global then flows
-//! through the ordinary pipeline — scalar literals are eligible for Constant
-//! Global Promotion, `String` uses the existing lazy-init path — so no new
-//! optimization is needed.
-//!
-//! v1 converts override strings to the declared type natively in Rust (after a
-//! trim), matching the built-in impls of `LenientFromStr` (radix prefixes, `_`
-//! separators, `nan`/`inf`, `1`/`0` for `bool`). v2 swaps this native path for
-//! evaluating the trait via wasm-CTFE, lifting the built-in-only restriction.
-//! The conversion is isolated in [`convert_builtin`] so only that boundary
-//! changes. See `wep-2026-04-26-compile-time-params.md`.
+//! Compile-time parameter resolution (`#[param]`, WEP 2026-04-26), between link
+//! and monomorphize: resolve each global's override — `-D NAME=value` first,
+//! then its `from_env` variable — and replace the initializer with the converted
+//! literal. Conversion is native Rust matching `LenientFromStr`, isolated in
+//! [`convert_builtin`] so a future wasm-CTFE path replaces only that boundary.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -215,16 +215,11 @@ impl Parser {
         }
     }
 
-    /// Allocate a fresh [`AstId`] for an AST node currently being constructed.
-    /// Id locals are dense in `0..next_ast_id` and assigned in parse order,
-    /// all within this parser's `ast_id_space`.
-    ///
-    /// Side effect: every comment in `self.comments` whose `span.start`
-    /// precedes the next-to-consume token's start and has not already been
-    /// attached is attached to the returned id as leading trivia. The
-    /// outermost AST node being constructed at a given source position
-    /// allocates first (DFS parse order), so the comment naturally lands
-    /// on the AST node it semantically belongs to.
+    /// Allocate a fresh [`AstId`], dense in `0..next_ast_id` and assigned in
+    /// parse order within this parser's `ast_id_space`. Also attaches every
+    /// not-yet-attached comment preceding the next token as leading trivia on
+    /// the returned id: DFS parse order means the outermost node at a source
+    /// position allocates first, so the comment lands where it belongs.
     fn alloc_ast_id(&mut self) -> crate::ast::AstId {
         let id = crate::ast::AstId::new(self.ast_id_space, self.next_ast_id);
         self.next_ast_id += 1;
@@ -265,16 +260,12 @@ impl Parser {
         trivia
     }
 
-    /// Snapshot enough parser state to roll back a speculative parse
-    /// without losing comments. `alloc_ast_id` advances `comment_cursor`
-    /// and writes leading trivia keyed by the freshly allocated id, so a
-    /// raw `self.pos = saved` style of backtrack would silently drop
-    /// every comment consumed during the discarded branch (the cursor
-    /// stays past them, the id they were attached to is never visited
-    /// by the unparser). [`Parser::restore`] also rolls back
-    /// `comment_cursor` and `next_ast_id`, and prunes any trivia entries
-    /// allocated in the discarded range, so the re-parse sees the
-    /// comment stream exactly as it was at the checkpoint.
+    /// Snapshot enough parser state to roll back a speculative parse without
+    /// losing comments. A bare `self.pos = saved` would drop every comment the
+    /// discarded branch consumed: `alloc_ast_id` left the cursor past them,
+    /// attached to an id the unparser never visits. [`Parser::restore`] rewinds
+    /// `comment_cursor` and `next_ast_id` and prunes the trivia allocated in
+    /// between, so the re-parse sees the checkpoint's comment stream.
     fn checkpoint(&self) -> ParserCheckpoint {
         ParserCheckpoint {
             pos: self.pos,
@@ -420,19 +411,12 @@ impl Parser {
         )
     }
 
-    /// True when the current token starts a type/impl declaration valid
-    /// *inside* a function body (a local `struct`/`enum`/`variant`/`flags`/
-    /// `type`/`impl`/`trait`; see `Stmt::Item`). Excludes `use`/`fn`/
-    /// `interface`/`resource`/`world`/`global` — never locally valid — and
-    /// any visibility prefix (`pub`/`internal`/`export`) — a local item is
-    /// always private, so a prefixed form is left to fall through to the
-    /// pre-existing "probably a missing `}`" recovery, same as today.
-    ///
-    /// `struct`/`enum`/`variant`/`impl`/`trait` are hard keywords, safe to
-    /// treat unconditionally. `flags`/`type` are contextual (valid as plain
-    /// identifiers, e.g. `flags = flags | 1;`), so they need one token of
-    /// lookahead: only `flags <IDENT>`/`type <IDENT>` — the declaration
-    /// name position — counts as starting a declaration.
+    /// True when the current token starts a declaration valid *inside* a
+    /// function body (`Stmt::Item`). Excludes the never-local keywords and any
+    /// visibility prefix — a local item is always private, so a prefixed form
+    /// falls through to the "probably a missing `}`" recovery. `flags` and
+    /// `type` are contextual and stay valid as plain identifiers, so they need a
+    /// token of lookahead: only `flags <IDENT>` counts.
     fn at_local_item_start(&self) -> bool {
         match self.peek_kind() {
             T::Struct | T::Enum | T::Variant | T::Impl | T::Trait => true,
@@ -722,17 +706,13 @@ impl Parser {
         start.merge(&self.tokens[self.pos - 1].span)
     }
 
-    /// Parse an expression at statement granularity, recovering on failure: the
-    /// error is reported, tokens are skipped to the next statement boundary
-    /// (see [`Parser::sync_expr_boundary`]), and an [`Expr::Error`] placeholder
-    /// spanning the skipped run is returned. This keeps the enclosing statement
-    /// (its `let` binding, `return`, expression-statement node) intact instead
-    /// of discarding it, so e.g. `let x = a + ;` still binds `x`.
-    ///
-    /// Call only from statement positions. It sets [`Parser::recovering`], which
-    /// turns on operand recovery in the binary / assignment parsers (see that
-    /// field); the `checkpoint`/`restore` speculative paths never reach those,
-    /// so a backtracking caller's error is never masked.
+    /// Parse an expression at statement granularity, recovering on failure by
+    /// reporting, skipping to the next statement boundary, and returning an
+    /// [`Expr::Error`] over the skipped run — so the enclosing statement
+    /// survives and `let x = a + ;` still binds `x`. Call only from statement
+    /// positions: it sets [`Parser::recovering`], and the speculative
+    /// `checkpoint`/`restore` paths never reach the parsers that read it, so a
+    /// backtracking caller's error is never masked.
     fn parse_expr_recovering(&mut self) -> Expr {
         let before = self.pos;
         // Enable operand-position recovery inside the binary / assignment
@@ -797,18 +777,13 @@ impl Parser {
         self.skipped_span(before)
     }
 
-    /// Parse a comma-separated list of types within angle brackets (`<T1, T2>`).
-    /// Assumes the opening `<` has already been consumed.
-    /// Handles `>>` splitting for nested generics via `pending_gt`.
-    ///
-    /// Element-locally error-recovering: a malformed argument is reported and
-    /// skipped to the next `,` or the closing `>` and replaced with a
-    /// [`Type::Error`] placeholder, so the surrounding arguments (and the
-    /// generic itself) survive. The closing `>` is still required — a list that
-    /// runs off into `)` / `]` / `;` rather than closing returns an error so the
-    /// enclosing construct recovers at its own boundary. The speculative
-    /// turbofish path (`parse_generic_static_method_call_or_backtrack`) parses
-    /// its types directly, not through here, so its backtracking is unaffected.
+    /// Parse a comma-separated type list inside angle brackets, the opening `<`
+    /// already consumed, splitting `>>` for nested generics via `pending_gt`.
+    /// Recovery is element-local: a malformed argument is reported, skipped to
+    /// the next `,` or `>`, and replaced with a [`Type::Error`], so its
+    /// neighbours survive. The closing `>` is still required — a list running off
+    /// into `)` or `;` errors, so the enclosing construct recovers at its own
+    /// boundary.
     fn parse_type_args(&mut self) -> ParseResult<Vec<Type>> {
         let mut args = Vec::new();
         loop {
@@ -2054,23 +2029,12 @@ impl Parser {
 
         let mut stmts = Vec::new();
 
-        // Stop at a hard item keyword too, so a missing `}` closes the block
-        // instead of swallowing the next item. Must be `at_hard_item_keyword`,
-        // not `at_item_start`: see its doc for why `#`/`test`/`flags`/`type` are
-        // excluded. Trade-off: a brace-less block right before a `#[attr]` item
-        // still over-reads `#` as a compile-time literal, blurring that one
-        // diagnostic — the following item still recovers.
-        //
-        // `at_local_item_start` is checked first and, when true, wins over
-        // `at_hard_item_keyword`: `struct`/`enum`/`variant`/`impl`/`trait`
-        // are members of both sets, but inside a block they are a valid
-        // local declaration (`Stmt::Item`), not a "missing `}`" signal.
-        // `at_visibility_prefixed_local_item_start` also wins, for the same
-        // reason `pub`/`internal`/`export` (also hard item keywords) are in
-        // that set: `pub struct` inside a block should reach
-        // `parse_stmt_in_block`'s dedicated "cannot be `pub`" error, not the
-        // generic "missing `}`" this loop would otherwise report by
-        // stopping here.
+        // Stop at a hard item keyword so a missing `}` closes the block instead
+        // of swallowing the next item. The two local-item checks are tried
+        // first and win: `struct` and friends belong to both sets, but inside a
+        // block they are a valid `Stmt::Item`, and a `pub struct` should reach
+        // `parse_stmt_in_block`'s "cannot be `pub`" error rather than the
+        // generic "missing `}`" this loop would report by stopping here.
         while !self.check(&TokenKind::RBrace)
             && !self.is_at_end()
             && (self.at_local_item_start()
@@ -4256,16 +4220,11 @@ impl Parser {
         })))
     }
 
-    /// Parse an effect handler installation expression:
-    /// `with E1 => h1, E2 => h2 do { body }` or `with &mut h do { body }` (bundled).
-    ///
-    /// Each binding is one of:
-    /// - `EffectName => expr` — install `expr` as the handler for `EffectName`.
-    ///   The `=>` reads as "case E is dispatched to expr", mirroring match arms;
-    ///   this is not an assignment.
-    /// - `expr` (no `=>`) — bundled handler, used for every effect `expr` implements.
-    ///
-    /// See `docs/wep-2026-04-11-effect-handler.md`.
+    /// Parse an effect handler installation:
+    /// `with E1 => h1, E2 => h2 do { body }`, or `with &mut h do { body }` for a
+    /// bundled handler used for every effect it implements. The `=>` reads as
+    /// "case E is dispatched to expr", mirroring a match arm — it is not an
+    /// assignment. See WEP 2026-04-11.
     fn parse_with_handler_expr(&mut self) -> ParseResult<Expr> {
         let start_span = self.peek().span;
         self.expect(&TokenKind::With)?;
@@ -5769,16 +5728,8 @@ impl Parser {
         }))
     }
 
-    /// Parse a trait declaration
-    /// ```wado
-    /// trait Display {
-    ///     fn display(&self) -> String;
-    /// }
-    ///
-    /// trait Ord: Eq {
-    ///     fn cmp(&self, other: &Self) -> Ordering;
-    /// }
-    /// ```
+    /// Parse a trait declaration, with or without a supertrait list
+    /// (`trait Ord: Eq { … }`).
     fn parse_trait_decl(
         &mut self,
         visibility: Visibility,
@@ -6273,17 +6224,12 @@ fn rebase_span(span: Span, origin: crate::token::Position) -> Span {
     )
 }
 
-/// Populate `Attribute::cm_boundary` based on the attribute name.
-///
-/// - `#[canonical("namespace", "name")]` becomes `CmBoundary::Canonical`.
-/// - `#[cm("ns:pkg/iface[@v][#fn]")]` becomes `CmBoundary::Import`.
-/// - `#[cm("simple-name")]` (anything that doesn't parse as a full CM path)
-///   becomes `CmBoundary::Name`.
-/// - Any other attribute returns `Ok(None)`.
-///
-/// Both `#[canonical(...)]` and `#[cm(...)]` are validated strictly: argument
-/// count and types must match the canonical form. Malformed shapes return
-/// `Err` so the caller can surface a parse-time diagnostic.
+/// Populate `Attribute::cm_boundary` from the attribute name:
+/// `#[canonical("namespace", "name")]` gives `Canonical`,
+/// `#[cm("ns:pkg/iface[@v][#fn]")]` gives `Import`, and a `#[cm(…)]` that does
+/// not parse as a full CM path gives `Name`. Anything else is `Ok(None)`. Both
+/// forms are validated strictly on argument count and type, and a malformed one
+/// returns `Err` for the caller to report.
 fn parse_cm_boundary(name: &str, args: &[AttrArg]) -> Result<Option<CmBoundary>, String> {
     if name == "canonical" {
         let [namespace, function] = args else {

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -347,8 +347,8 @@ impl Parser {
     /// Parse the token stream into a [`Module`]. Always succeeds: syntax
     /// errors are recovered and collected into `self.errors`, drained by
     /// [`Parser::take_errors`]. An unparsable item becomes an [`Item::Error`]
-    /// node (see [`Parser::recover_item`]); a broken statement inside a block
-    /// becomes a [`Stmt::Error`] placeholder (see [`Parser::error_stmt`]).
+    /// node (see `Parser::recover_item`); a broken statement inside a block
+    /// becomes a [`Stmt::Error`] placeholder (see `Parser::error_stmt`).
     pub fn parse(&mut self) -> Module {
         // `parse_inner_attributes` records each attribute as it parses, so a
         // malformed one only loses itself; the rest stay in the module.

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -414,7 +414,7 @@ impl Parser {
     /// function body (`Stmt::Item`). Excludes the never-local keywords and any
     /// visibility prefix — a local item is always private, so a prefixed form
     /// falls through to the "probably a missing `}`" recovery. `flags` and `type`
-    /// are contextual, so only `flags <IDENT>` counts.
+    /// are contextual, so only `flags <IDENT>` / `type <IDENT>` count.
     fn at_local_item_start(&self) -> bool {
         match self.peek_kind() {
             T::Struct | T::Enum | T::Variant | T::Impl | T::Trait => true,

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -262,10 +262,9 @@ impl Parser {
 
     /// Snapshot enough parser state to roll back a speculative parse without
     /// losing comments. A bare `self.pos = saved` would drop every comment the
-    /// discarded branch consumed: `alloc_ast_id` left the cursor past them,
-    /// attached to an id the unparser never visits. [`Parser::restore`] rewinds
-    /// `comment_cursor` and `next_ast_id` and prunes the trivia allocated in
-    /// between, so the re-parse sees the checkpoint's comment stream.
+    /// discarded branch consumed, attached to an id the unparser never visits.
+    /// [`Parser::restore`] rewinds `comment_cursor` and `next_ast_id` and prunes
+    /// the trivia allocated in between.
     fn checkpoint(&self) -> ParserCheckpoint {
         ParserCheckpoint {
             pos: self.pos,
@@ -414,9 +413,8 @@ impl Parser {
     /// True when the current token starts a declaration valid *inside* a
     /// function body (`Stmt::Item`). Excludes the never-local keywords and any
     /// visibility prefix — a local item is always private, so a prefixed form
-    /// falls through to the "probably a missing `}`" recovery. `flags` and
-    /// `type` are contextual and stay valid as plain identifiers, so they need a
-    /// token of lookahead: only `flags <IDENT>` counts.
+    /// falls through to the "probably a missing `}`" recovery. `flags` and `type`
+    /// are contextual, so only `flags <IDENT>` counts.
     fn at_local_item_start(&self) -> bool {
         match self.peek_kind() {
             T::Struct | T::Enum | T::Variant | T::Impl | T::Trait => true,
@@ -708,11 +706,9 @@ impl Parser {
 
     /// Parse an expression at statement granularity, recovering on failure by
     /// reporting, skipping to the next statement boundary, and returning an
-    /// [`Expr::Error`] over the skipped run — so the enclosing statement
-    /// survives and `let x = a + ;` still binds `x`. Call only from statement
-    /// positions: it sets [`Parser::recovering`], and the speculative
-    /// `checkpoint`/`restore` paths never reach the parsers that read it, so a
-    /// backtracking caller's error is never masked.
+    /// [`Expr::Error`] over the skipped run — so the enclosing statement survives
+    /// and `let x = a + ;` still binds `x`. Call only from statement positions:
+    /// it sets [`Parser::recovering`], which a backtracking caller must not.
     fn parse_expr_recovering(&mut self) -> Expr {
         let before = self.pos;
         // Enable operand-position recovery inside the binary / assignment
@@ -780,10 +776,8 @@ impl Parser {
     /// Parse a comma-separated type list inside angle brackets, the opening `<`
     /// already consumed, splitting `>>` for nested generics via `pending_gt`.
     /// Recovery is element-local: a malformed argument is reported, skipped to
-    /// the next `,` or `>`, and replaced with a [`Type::Error`], so its
-    /// neighbours survive. The closing `>` is still required — a list running off
-    /// into `)` or `;` errors, so the enclosing construct recovers at its own
-    /// boundary.
+    /// the next `,` or `>`, and replaced with a [`Type::Error`]. The closing `>`
+    /// is still required, so the enclosing construct recovers at its own boundary.
     fn parse_type_args(&mut self) -> ParseResult<Vec<Type>> {
         let mut args = Vec::new();
         loop {
@@ -2030,11 +2024,10 @@ impl Parser {
         let mut stmts = Vec::new();
 
         // Stop at a hard item keyword so a missing `}` closes the block instead
-        // of swallowing the next item. The two local-item checks are tried
-        // first and win: `struct` and friends belong to both sets, but inside a
-        // block they are a valid `Stmt::Item`, and a `pub struct` should reach
-        // `parse_stmt_in_block`'s "cannot be `pub`" error rather than the
-        // generic "missing `}`" this loop would report by stopping here.
+        // of swallowing the next item. The local-item checks win: `struct` and
+        // friends are a valid `Stmt::Item` inside a block, and a `pub struct`
+        // should reach `parse_stmt_in_block`'s "cannot be `pub`" error rather
+        // than the generic "missing `}`" this loop would report.
         while !self.check(&TokenKind::RBrace)
             && !self.is_at_end()
             && (self.at_local_item_start()
@@ -6227,9 +6220,8 @@ fn rebase_span(span: Span, origin: crate::token::Position) -> Span {
 /// Populate `Attribute::cm_boundary` from the attribute name:
 /// `#[canonical("namespace", "name")]` gives `Canonical`,
 /// `#[cm("ns:pkg/iface[@v][#fn]")]` gives `Import`, and a `#[cm(…)]` that does
-/// not parse as a full CM path gives `Name`. Anything else is `Ok(None)`. Both
-/// forms are validated strictly on argument count and type, and a malformed one
-/// returns `Err` for the caller to report.
+/// not parse as a full CM path gives `Name`. Anything else is `Ok(None)`; a
+/// malformed argument count or type returns `Err` for the caller to report.
 fn parse_cm_boundary(name: &str, args: &[AttrArg]) -> Result<Option<CmBoundary>, String> {
     if name == "canonical" {
         let [namespace, function] = args else {

--- a/wado-compiler/src/path.rs
+++ b/wado-compiler/src/path.rs
@@ -1,28 +1,14 @@
-//! Deterministic, host-independent lexical path normalization.
-//!
-//! A Wado module path is a filesystem representation, not a URI: a space stays
-//! a space and a literal `%` stays a `%`. Normalization here is purely lexical
-//! — it folds `.`/`..` and redundant separators without touching the
-//! filesystem (so it is `wasm32-unknown-unknown`-safe) and without consulting
-//! the host platform's path parser (so a module identity is byte-identical on
-//! every host). It follows the RFC 3986 §5.2.4 dot-segment semantics, extended
-//! to preserve an absolute root (POSIX `/` or a Windows drive prefix), which a
-//! `..` segment can never escape.
+//! Deterministic, host-independent lexical path normalization. A Wado module
+//! path is a filesystem representation, not a URI, so a space and a literal `%`
+//! stay as written. Folding `.`/`..` and redundant separators touches neither
+//! the filesystem nor the host's path parser, keeping it `wasm32`-safe and
+//! byte-identical everywhere. Follows RFC 3986 §5.2.4, plus an inescapable root.
 
-/// Normalize a filesystem-style path lexically.
-///
-/// - `\` is treated as `/` (Windows separators are unified).
-/// - `.` segments are dropped; `..` pops the preceding real segment.
-/// - An absolute root (`/` or `C:`) is preserved and `..` cannot escape it.
-/// - A relative path keeps its leading `./` marker and any leading `..`.
-/// - The content is never percent-encoded, decoded, or otherwise rewritten,
-///   so the round-trip back to a filesystem path is the identity function.
-///
-/// Examples:
-/// - `./sub/../geometry.wado` → `./geometry.wado`
-/// - `/abs/a/../b.wado` → `/abs/b.wado`
-/// - `/home/user/My Project/x.wado` → `/home/user/My Project/x.wado`
-/// - `C:\proj\main.wado` → `C:/proj/main.wado`
+/// Normalize a filesystem-style path lexically: `\` unifies to `/`, `.` segments
+/// drop, `..` pops the preceding real segment without escaping an absolute root
+/// (`/` or `C:`), and a relative path keeps its leading `./` and any leading
+/// `..`. Content is never percent-encoded or otherwise rewritten, so the
+/// round-trip back to a filesystem path is the identity.
 #[must_use]
 pub fn normalize(path: &str) -> String {
     let unified = path.replace('\\', "/");
@@ -89,20 +75,11 @@ fn split_root(path: &str) -> (String, &str) {
     (String::new(), path)
 }
 
-/// Express `target` as a path relative to the directory `base`, lexically.
-///
-/// Both arguments are normalized first ([`normalize`]). The result is the
-/// minimal `./`- or `../`-prefixed path that, joined with `base` and
-/// normalized, yields `target` again — the unique spelling of `target` as seen
-/// from `base`. Purely lexical (no filesystem, `wasm32`-safe).
-///
-/// `base` and `target` must share rootedness (both relative, or both absolute
-/// under the same root); a mismatch returns `normalize(target)` unchanged.
-///
-/// Examples:
-/// - base `/p/src`, target `/p/src/gen/x.wado` → `./gen/x.wado`
-/// - base `/p/src`, target `/p/shared/h.wado` → `../shared/h.wado`
-/// - base `.`, target `./x.wado` → `./x.wado`
+/// Express `target` as a path relative to the directory `base`, lexically: after
+/// [`normalize`]ing both, the minimal `./`- or `../`-prefixed path that rejoins
+/// with `base` to give `target` back. `base` and `target` must share rootedness;
+/// a mismatch returns `normalize(target)` unchanged. Base `/p/src` and target
+/// `/p/shared/h.wado` give `../shared/h.wado`.
 #[must_use]
 pub fn relative_path(base: &str, target: &str) -> String {
     let base = normalize(base);

--- a/wado-compiler/src/remarks.rs
+++ b/wado-compiler/src/remarks.rs
@@ -1,27 +1,12 @@
-//! Optimizer remarks: surface residual value-semantic copies that survive
-//! optimization. See WEP `wep-2026-06-03-optimizer-remarks.md`.
+//! Optimizer remarks (WEP 2026-06-03): surface the value-semantic copies that
+//! survive optimization and would otherwise be invisible while coding. After the
+//! NIR pipeline a survivor is a `$value_copy$T` helper call, an `array_clone` /
+//! `array_clone_shallow` spine copy, or a `copy_value`.
 //!
-//! Wado deep-copies aggregates on assignment, parameter passing, and return.
-//! A large part of the optimizer exists to remove those hidden copies, and most
-//! of them are removed; the ones that remain are invisible while coding. After
-//! the NIR optimization pipeline, a surviving copy appears as one of:
-//!
-//! - a call to a synthesized `$value_copy$T` deep-copy helper,
-//! - a `builtin::array_clone` / `array_clone_shallow` call — the lowered (and
-//!   possibly `value_copy_demote`-shallowed) spine copy of a `List<T>` or
-//!   `String`, or
-//! - a `builtin::copy_value` call — a direct deep copy of a value.
-//!
-//! NIR is the last IR that still carries per-expression source spans — WIR
-//! instructions do not — and `wir_build` lowers these copies one-to-one, so
-//! walking the optimized NIR yields the residual-copy set with exact source
-//! locations.
-//!
-//! Detection covers the entry package — the entry point and the local modules
-//! it reaches — and nothing else. A dependency, `core:` and `wasi:` are someone
-//! else's source, and their internals (`String::push` growth, …) would drown
-//! out the program under compilation. `array_copy` is excluded regardless: it
-//! is bulk buffer movement, not a value-semantic copy.
+//! NIR is the last IR carrying per-expression spans and `wir_build` lowers these
+//! one-to-one, so walking optimized NIR yields exact source locations. Detection
+//! covers the entry package alone — a dependency's internals would drown out the
+//! program — and `array_copy` is bulk movement, not a copy, so it is excluded.
 
 use crate::hashmap::IndexMap;
 use crate::module_source::ModuleSource;

--- a/wado-compiler/src/resolve.rs
+++ b/wado-compiler/src/resolve.rs
@@ -206,18 +206,11 @@ impl Resolver<'_> {
             .find_map(|scope| scope.get(name).copied())
     }
 
-    /// The declaration a name written in this module refers to.
-    ///
-    /// The layers are ordered, and the order is the rule: the enclosing item's
-    /// binders, this module's explicit imports (keyed by the local name, so an
-    /// alias resolves to what it aliases), this module's own declarations, then
-    /// the prelude — including its implementation modules, so `i32`, `List` and
-    /// a compiler item declared `internal` there (`ReflectStruct`, `Member`)
-    /// all resolve for a module that never `use`d them.
-    ///
-    /// The module's own declarations rank above the prelude, so a module that
-    /// declares `trait Left` means its own, not `core:prelude/format`'s enum
-    /// case of that name (issue #1298).
+    /// The declaration a name written in this module refers to. The layers are
+    /// ordered, and the order is the rule: the enclosing item's binders, the
+    /// module's explicit imports keyed by local name, its own declarations, then
+    /// the prelude and its implementation modules. Own declarations outranking
+    /// the prelude is what makes a local `trait Left` mean itself (#1298).
     fn resolve_name(&self, name: &str) -> DeclRef {
         if let Some(id) = self.binder(name) {
             return DeclRef::Binder(id);

--- a/wado-compiler/src/resource_move_check.rs
+++ b/wado-compiler/src/resource_move_check.rs
@@ -9,16 +9,10 @@ use crate::tir::{ResolvedType, TypeId};
 use crate::token::Span;
 
 /// Whether `type_id` transitively owns an affine resource, making a binding of
-/// that type move-only: a bare resource (`Resource` / `GenericResource`), or a
-/// struct / tuple / `Result` that carries one. A reference stops the walk — a
-/// borrowed place owns nothing. `visited` guards against recursive types.
-///
-/// The aggregate set is kept in step with `resource_cleanup::carries_resource`
-/// (which synthesizes the compositional destructor): a type is treated as
-/// move-only here only if the cleanup pass can also drop it, so the move check
-/// never enforces move-only on an aggregate the runtime would then leak. User
-/// `variant`s and generic containers (`Option` / `List` / …) are out of both
-/// until their destructors land.
+/// that type move-only: a bare resource, or a struct / tuple / `Result` carrying
+/// one. A reference stops the walk, a borrowed place owning nothing. The
+/// aggregate set stays in step with `resource_cleanup::carries_resource`, so
+/// nothing is move-only that the cleanup pass would then leak.
 fn type_carries_resource(sem: &Semantics, type_id: TypeId, visited: &mut Vec<TypeId>) -> bool {
     let base = sem.types.get_ultimate_base_type(type_id);
     if visited.contains(&base) {

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -46,12 +46,11 @@ pub struct Semantics {
     /// the in-tree [`name_span_of`] / [`span_of_key`] helpers) consult this
     /// instead of re-walking the AST on every request.
     pub(crate) ast_indices: IndexMap<ModuleSource, AstIndex>,
-    /// Shared elaborator state from [`Elaborator::annotate_modules`], paired
-    /// with `is_complete` to distinguish three outcomes: `(None, false)` —
-    /// analyze or resolve bailed, leaving only `symbols` + `ast_indices`;
-    /// `(Some(_), false)` — annotate finished but `build_tir` bailed, so
-    /// `tir_modules` is empty; `(Some(_), true)` — full success. Batch
-    /// compilation rejects all but the last, making its `expect` safe.
+    /// Shared elaborator state from [`Elaborator::annotate_modules`], paired with
+    /// `is_complete` to distinguish three outcomes: `(None, false)` — analyze or
+    /// resolve bailed, leaving only `symbols` + `ast_indices`; `(Some(_), false)`
+    /// — annotate finished but `build_tir` bailed; `(Some(_), true)` — full
+    /// success. Batch compilation rejects all but the last.
     pub(crate) state: Option<AnnotateState>,
     /// `AstIdSpace → ModuleSource` registry over the loaded modules: which
     /// module's parse minted each id space. Lets bare-`AstId` facts be

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -397,7 +397,7 @@ impl Semantics {
     /// Stable public view onto the recorded method-dispatch decision:
     /// `(resolved_function_name, defining_module, self_kind_str)`, or `None` for
     /// a synthetic or short-circuited call path. In-crate consumers read the
-    /// full [`crate::elaborator::sem::types::MethodDispatch`] instead.
+    /// full `crate::elaborator::sem::types::MethodDispatch` instead.
     #[must_use]
     pub fn method_dispatch_view(&self, id: AstId) -> Option<(String, ModuleSource, String)> {
         let dispatch = self.method_dispatch.get(&id)?;
@@ -451,7 +451,7 @@ impl Semantics {
     /// `(coercion_kind_str, target_type_id)` for an expression the body walk
     /// adapted via `try_coerce`, `None` for one that already matched or was
     /// resolved without an expected type. The string is the
-    /// [`crate::elaborator::sem::types::CoercionKind`] variant, snake-cased.
+    /// `crate::elaborator::sem::types::CoercionKind` variant, snake-cased.
     #[must_use]
     pub fn coercion_view(&self, id: AstId) -> Option<(String, TypeId)> {
         use crate::elaborator::sem::types::CoercionKind;
@@ -772,7 +772,7 @@ impl Semantics {
 
     /// Span of the defining identifier alone — what go-to-definition wants,
     /// where `Symbol::span` covers the whole `fn foo() { … }`. Read from the
-    /// per-module [`AstIndex`](crate::ast_index::AstIndex), which holds one for
+    /// per-module [`AstIndex`], which holds one for
     /// every declaration node exposing a `name_span`. `None` for nodes without
     /// one: anonymous `impl` blocks, `Item::Resource`, tests.
     #[must_use]

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -69,8 +69,8 @@ pub struct Semantics {
     /// symbol. Empty when resolve did not run or bailed early.
     pub(crate) locals: IndexMap<AstId, Symbol>,
     /// Inferred [`TypeId`] for each local binding (let / param / closure
-    /// param), keyed by the binding's defining [`AstId`](crate::ast::AstId). Populated
-    /// alongside [`Self::locals`] from the elaborator. Consumed by LSP
+    /// param), keyed by the binding's defining [`AstId`]. Populated
+    /// alongside `Self::locals` from the elaborator. Consumed by LSP
     /// inlay-hint queries via [`Semantics::local_type_name`] to render
     /// the inferred type on bindings without explicit annotation. Empty
     /// when resolve did not run or bailed before recording any bindings.
@@ -279,7 +279,7 @@ impl Semantics {
     /// Innermost AST node containing the given `(line, column)` in `module`.
     ///
     /// Returns `None` if the module is unknown or no node covers the position.
-    /// Answered from the per-module [`AstIndex`](crate::ast_index::AstIndex);
+    /// Answered from the per-module [`AstIndex`];
     /// no AST traversal happens at query time.
     #[must_use]
     pub fn ast_id_at(&self, module: &ModuleSource, line: usize, column: usize) -> Option<AstId> {
@@ -294,7 +294,7 @@ impl Semantics {
         self.symbols.get(&id).or_else(|| self.locals.get(&id))
     }
 
-    /// Resolve a use-site `AstId` (typically an [`IdentExpr`] id) to the
+    /// Resolve a use-site `AstId` (typically an [`IdentExpr`](crate::ast::IdentExpr) id) to the
     /// `AstId` of its defining binding. Returns `None` if the key does
     /// not appear in the reference map — in which case the caller should
     /// fall back to name-based lookup via the symbol table.
@@ -318,7 +318,7 @@ impl Semantics {
 
     /// Iterate every recorded use-site `(use_key, def_key)` edge.
     ///
-    /// Each `use_key` is typically an [`IdentExpr`] id; `def_key` is the
+    /// Each `use_key` is typically an [`IdentExpr`](crate::ast::IdentExpr) id; `def_key` is the
     /// binding's defining [`AstId`]. Use sites of locals, parameters,
     /// item-level definitions (functions, types, globals) and imported items
     /// are all recorded here.
@@ -331,9 +331,9 @@ impl Semantics {
     /// Find every use-site `AstId` whose definition is `def_id`.
     ///
     /// Walks [`Self::iter_references`] and collects matches. The returned keys
-    /// can be passed to [`Self::span_of_key`] for source ranges. The defining
+    /// can be passed to [`Self::span_of_id`] for source ranges. The defining
     /// occurrence itself is **not** included — callers that want it should add
-    /// it via [`Self::name_span_of`] / [`Self::span_of_key`].
+    /// it via [`Self::name_span_of`] / [`Self::span_of_id`].
     #[must_use]
     pub fn references_to(&self, def_id: AstId) -> Vec<AstId> {
         self.iter_references()
@@ -482,7 +482,7 @@ impl Semantics {
     /// rewrite site (`assert`, `matches`, comparison chain, for-of,
     /// `while`, compound assignment) or `None` for nodes that did not
     /// take a desugar path. See
-    /// [`crate::elaborator::sem::types::DesugarKind`] for the full
+    /// `crate::elaborator::sem::types::DesugarKind` for the full
     /// variant set.
     #[must_use]
     pub fn desugar_view(&self, id: AstId) -> Option<String> {

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -1,15 +1,8 @@
-//! Semantic analysis — the shared frontend entry point.
-//!
-//! [`semantics`] drives the compilation pipeline up through name resolution
-//! and type resolution (the elaborator's annotate phase), then stops. The
-//! resulting [`Semantics`] bundles every semantic fact needed to answer
-//! editor queries (hover, go-to-definition, diagnostics) without paying for
-//! monomorphize / lower / codegen.
-//!
-//! The pipeline used here is the same one that `compile_with_options` runs
-//! in its early phases: lex → parse → bind → load → analyze → resolve.
-//! Everything downstream of resolve is only needed to emit Wasm bytes, so
-//! LSP-style consumers skip it.
+//! Semantic analysis — the shared frontend entry point. [`semantics`] runs the
+//! same lex → parse → bind → load → analyze → resolve pipeline
+//! `compile_with_options` does, then stops: everything downstream exists only to
+//! emit Wasm bytes. The resulting [`Semantics`] carries every fact an editor
+//! query needs without paying for monomorphize / lower / codegen.
 
 use crate::analyze::Analyzer;
 use crate::ast::{AstId, Module};
@@ -41,40 +34,24 @@ pub struct Semantics {
     pub modules: IndexMap<ModuleSource, Module>,
     pub symbols: SymbolTable,
     pub types: TypeTable,
-    /// `ModuleSource` interner shared with the analyze + resolve phases.
-    /// LSP queries (definition / hover / references) borrow this when
-    /// they need to resolve an import path the user clicked into a
-    /// `ModuleSource`.
+    /// `ModuleSource` interner shared with the analyze + resolve phases; an LSP
+    /// query borrows it to resolve a clicked import path.
     ///
-    /// Re-entrancy: only single-threaded callers, and only one
-    /// `borrow_mut` at a time. Do not hold a [`std::cell::RefMut`]
-    /// across calls into other [`Semantics`] / [`crate::Elaborator`]
-    /// methods — a nested `borrow_mut` will panic. The intended
-    /// pattern is `sem.interner.borrow_mut().<one method call>`, dropping
-    /// the borrow at the statement boundary.
+    /// Single-threaded, one `borrow_mut` at a time: never hold a `RefMut` across
+    /// a call into [`Semantics`] or [`crate::Elaborator`], or the nested borrow
+    /// panics. Write `sem.interner.borrow_mut().<one call>` and let it drop.
     pub interner: std::rc::Rc<std::cell::RefCell<ModuleSourceInterner>>,
     /// Per-module structural index (name spans, write targets, span lookup).
     /// Built once per [`Module`] in [`semantics_of`]. LSP queries (and
     /// the in-tree [`name_span_of`] / [`span_of_key`] helpers) consult this
     /// instead of re-walking the AST on every request.
     pub(crate) ast_indices: IndexMap<ModuleSource, AstIndex>,
-    /// Shared elaborator state produced by [`Elaborator::annotate_modules`].
-    ///
-    /// `None` when analyze or [`Elaborator::annotate_modules`] bailed before
-    /// the state could be built. `Some(_)` once resolve completed — even
-    /// if a later [`Elaborator::build_tir_from_state`] bail set
-    /// [`Self::is_complete`] to `false`. The pair `(state, is_complete)`
-    /// therefore has three distinguishable states:
-    ///
-    /// - `(None, false)` — analyze or resolve bailed; the snapshot has
-    ///   only `symbols` + `ast_indices`.
-    /// - `(Some(_), false)` — annotate completed but `build_tir` bailed; the
-    ///   snapshot has everything except `tir_modules` (which is empty).
-    /// - `(Some(_), true)` — full success.
-    ///
-    /// Batch compilation rejects every non-`true` case via
-    /// [`Semantics::is_complete`], so the `expect` in `compile_with_options`
-    /// is safe. LSP queries do not inspect `state` directly.
+    /// Shared elaborator state from [`Elaborator::annotate_modules`], paired
+    /// with `is_complete` to distinguish three outcomes: `(None, false)` —
+    /// analyze or resolve bailed, leaving only `symbols` + `ast_indices`;
+    /// `(Some(_), false)` — annotate finished but `build_tir` bailed, so
+    /// `tir_modules` is empty; `(Some(_), true)` — full success. Batch
+    /// compilation rejects all but the last, making its `expect` safe.
     pub(crate) state: Option<AnnotateState>,
     /// `AstIdSpace → ModuleSource` registry over the loaded modules: which
     /// module's parse minted each id space. Lets bare-`AstId` facts be
@@ -230,36 +207,20 @@ impl Semantics {
             .map(|s| std::sync::Arc::clone(&s.world_registry))
     }
 
-    /// Component Model world registry produced during annotate.
-    ///
-    /// Carries every `world` declaration the frontend has seen — stdlib
-    /// (`wasi:cli/command`, `wasi:http/service`, `core:kiln/generator`,
-    /// …) plus any user-declared worlds. Keyed by fully-qualified name.
-    ///
-    /// Returns `None` when no elaborator state was built — that is, when
-    /// parse, load, analyze, or annotate bailed before constructing
-    /// `AnnotateState`. Batch compilation refuses to continue in any of
-    /// those cases via [`Self::is_complete`]; LSP queries proceed
-    /// without world data.
-    ///
-    /// Consumed by the WIT producer (`wado wit` /
-    /// `wado compile --embed-wit=…`) and by world-shape decisions in
-    /// codegen / DCE (see [`crate::flat_package::FlatPackage`]).
+    /// Component Model world registry produced during annotate: every `world`
+    /// declaration the frontend saw, stdlib and user-declared alike, keyed by
+    /// fully-qualified name. Consumed by the WIT producer and by world-shape
+    /// decisions in codegen / DCE. `None` when no elaborator state was built —
+    /// an LSP query proceeds without world data, batch compilation does not.
     #[must_use]
     pub fn world_registry(&self) -> Option<&WorldRegistry> {
         self.state.as_ref().map(|s| &*s.world_registry)
     }
 
-    /// Component Model interface registry produced during annotate.
-    ///
-    /// Carries the resolved `#[cm(...)]` / `#[cm_import(...)]` view of
-    /// every CM interface the frontend has seen — `wasi:*`,
-    /// `core:kiln/*`, and any future user-declared interfaces (under the
-    /// post-unification `interface` block syntax). Powers CM binding
-    /// synthesis, lift/lower, and WIT producer-side emission.
-    ///
-    /// Returns `None` under the same conditions as
-    /// [`Self::world_registry`].
+    /// Component Model interface registry produced during annotate: the resolved
+    /// `#[cm(…)]` / `#[cm_import(…)]` view of every CM interface the frontend
+    /// saw, powering binding synthesis, lift/lower, and WIT emission. `None`
+    /// under the same conditions as [`Self::world_registry`].
     #[must_use]
     pub fn cm_interface_registry(&self) -> Option<&CmInterfaceRegistry> {
         self.state.as_ref().map(|s| &*s.tysys.cm_interface_registry)
@@ -434,16 +395,10 @@ impl Semantics {
         self.method_dispatch.get(&id)
     }
 
-    /// WEP 2026-05-26: stable public view onto the recorded
-    /// method-dispatch decision at `key`.
-    ///
-    /// Returns `(resolved_function_name, defining_module, self_kind_str)`
-    /// for a `MethodCallExpr` whose dispatch was recorded by the body
-    /// walk, or `None` for synthetic / short-circuited call paths (see
-    /// [`crate::elaborator::sem::types::MethodDispatch`]). Used today as a
-    /// reachability probe in tests; the future `reify` pass / LSP hover
-    /// path consumes the full [`crate::elaborator::sem::types::MethodDispatch`]
-    /// via `pub(crate)` access from inside the crate.
+    /// Stable public view onto the recorded method-dispatch decision:
+    /// `(resolved_function_name, defining_module, self_kind_str)`, or `None` for
+    /// a synthetic or short-circuited call path. In-crate consumers read the
+    /// full [`crate::elaborator::sem::types::MethodDispatch`] instead.
     #[must_use]
     pub fn method_dispatch_view(&self, id: AstId) -> Option<(String, ModuleSource, String)> {
         let dispatch = self.method_dispatch.get(&id)?;
@@ -493,16 +448,11 @@ impl Semantics {
         self.method_dispatch.keys().copied()
     }
 
-    /// WEP 2026-05-26: stable public view onto the recorded
-    /// coercion choice at `key`.
-    ///
-    /// Returns `(coercion_kind_str, target_type_id)` for an expression
-    /// that the body walk adapted via `try_coerce`, or `None` for
-    /// expressions whose resolved type already matched the expected
-    /// type (or that were resolved without an expected type). See
-    /// [`crate::elaborator::sem::types::CoercionKind`] for the full
-    /// variant set; the returned string mirrors the variant name in
-    /// lowercase-with-underscores form.
+    /// Stable public view onto the recorded coercion choice:
+    /// `(coercion_kind_str, target_type_id)` for an expression the body walk
+    /// adapted via `try_coerce`, `None` for one that already matched or was
+    /// resolved without an expected type. The string is the
+    /// [`crate::elaborator::sem::types::CoercionKind`] variant, snake-cased.
     #[must_use]
     pub fn coercion_view(&self, id: AstId) -> Option<(String, TypeId)> {
         use crate::elaborator::sem::types::CoercionKind;
@@ -575,16 +525,11 @@ impl Semantics {
         if uri.is_empty() { None } else { Some(uri) }
     }
 
-    /// AST [`Function`](crate::ast::Function) node declaring `key`. Covers
-    /// top-level free functions and methods inside `Item::Impl` /
-    /// `Item::Trait` blocks, all of which share the `Function` AST shape.
-    /// Interface and resource methods carry a different AST shape
-    /// (`InterfaceMethod`) and are reached through the symbol table
-    /// instead — this accessor returns `None` for them.
-    ///
-    /// Resolution is O(1): the per-module [`AstIndex`] stores each
-    /// function's `(item_idx, [method_idx])` address, so no AST scan
-    /// happens at query time.
+    /// AST [`Function`](crate::ast::Function) node declaring `key` — free
+    /// functions and `impl` / `trait` methods, which share that AST shape.
+    /// `None` for interface and resource methods, which are `InterfaceMethod`
+    /// nodes reached through the symbol table. O(1): the per-module [`AstIndex`]
+    /// holds each function's address, so nothing scans the AST at query time.
     #[must_use]
     pub fn function_at(&self, id: AstId) -> Option<&crate::ast::Function> {
         use crate::ast_index::FunctionLocation;
@@ -625,16 +570,10 @@ impl Semantics {
     }
 
     /// Resolve a parsed [`SymbolNotation`](crate::symbol_notation::SymbolNotation)
-    /// to a [`Definition`] within this analysis.
-    ///
-    /// The notation's module is resolved against the entry module (so relative
-    /// paths anchor at the entry's directory; `core:` / `wasi:` are
-    /// location-independent) and must already be loaded in this `Semantics`.
-    ///
-    /// - A free notation (`mod#name`) resolves a module-level symbol.
-    /// - A receiver notation (`mod#Type::m`, `mod#Type.m`, `mod#Type^Trait::m`)
-    ///   resolves a method or associated constant on `Type` — scanning the
-    ///   `impl` blocks (and `trait` declaration for `Trait::m`) in the module.
+    /// to a [`Definition`]. A free notation (`mod#name`) resolves a module-level
+    /// symbol; a receiver notation (`mod#Type::m`) a method or associated
+    /// constant. The module is resolved against the entry — relative paths
+    /// anchor at its directory — and must already be loaded here.
     pub fn resolve_symbol_notation(
         &self,
         notation: &crate::symbol_notation::SymbolNotation,
@@ -660,16 +599,11 @@ impl Semantics {
         self.resolve_member(&module, receiver, &notation.member)
     }
 
-    /// Resolve `Type::member` / `Type.member` / `Type^Trait::member` to the
-    /// method or associated constant's definition, scanning `impl` blocks and
-    /// (for `Trait::member`) the `trait` declaration in `module`.
-    ///
-    /// Limitation: the receiver type is matched by **base name only** — generic
-    /// arguments in the notation (`List<String>`) are parsed but not used to
-    /// disambiguate. If a type has several instantiation-specific inherent
-    /// impls that each define `member` (`impl Foo<i32>` and `impl Foo<bool>`),
-    /// the first textual match wins. Trait disambiguation via `^Trait` is
-    /// honored; per-instantiation disambiguation is not yet supported.
+    /// Resolve `Type::member` / `Type.member` / `Type^Trait::member` against the
+    /// `impl` blocks — and, for `Trait::member`, the `trait` declaration — in
+    /// `module`. The receiver matches by base name only: `^Trait` disambiguates,
+    /// but generic arguments are parsed and ignored, so with both
+    /// `impl Foo<i32>` and `impl Foo<bool>` defining `member` the first wins.
     fn resolve_member(
         &self,
         module: &ModuleSource,
@@ -837,16 +771,11 @@ impl Semantics {
         self.ast_indices.get(self.module_of_id(id)?)?.span_of(id)
     }
 
-    /// Span of the defining identifier for the symbol at `key`.
-    ///
-    /// The `Symbol::span` field covers the whole declaring item — e.g. the
-    /// entire `fn foo() { ... }` block. LSP go-to-definition wants the
-    /// identifier alone (`foo`), which is carried on the AST item as
-    /// `name_span`. The lookup goes through the per-module
-    /// [`AstIndex`](crate::ast_index::AstIndex), which is populated for every
-    /// declaration node that exposes a `name_span` field. Returns `None` for
-    /// nodes without a dedicated name span (e.g. anonymous `impl` blocks,
-    /// `Item::Resource`, tests).
+    /// Span of the defining identifier alone — what go-to-definition wants,
+    /// where `Symbol::span` covers the whole `fn foo() { … }`. Read from the
+    /// per-module [`AstIndex`](crate::ast_index::AstIndex), which holds one for
+    /// every declaration node exposing a `name_span`. `None` for nodes without
+    /// one: anonymous `impl` blocks, `Item::Resource`, tests.
     #[must_use]
     pub fn name_span_of(&self, id: AstId) -> Option<Span> {
         self.ast_indices
@@ -986,18 +915,11 @@ impl<'a> Cursor<'a> {
     }
 }
 
-/// Convenience: run the full compiler frontend (parse → load →
-/// `semantics_of`) over `source` with no kiln invocations and default
-/// log level.
-///
-/// Callers that need to inspect the parsed entry between stages (LSP,
-/// kiln-aware drivers) compose the three primitives directly. Callers
-/// that need a custom log level or kiln redirects do the same.
-///
-/// Always returns a [`Semantics`]; on lex/parse/load failure
-/// [`Semantics::is_complete`] is `false` and the unreachable downstream
-/// fields are empty. Diagnostics are emitted through `host` as the
-/// phases run.
+/// Run the full frontend (parse → load → [`semantics_of`]) over `source` with no
+/// kiln invocations and the default log level. Callers needing to inspect the
+/// parsed entry between stages, or a custom log level, compose the three
+/// primitives instead. Always returns a [`Semantics`]: on failure
+/// [`Semantics::is_complete`] is `false` and the downstream fields are empty.
 pub async fn semantics<H: CompilerHost>(
     source: &str,
     host: &H,
@@ -1118,20 +1040,13 @@ pub fn lex_error_diagnostic(
 }
 
 impl Semantics {
-    /// Construct an empty [`Semantics`] with no modules at all. Used when
-    /// an upstream phase fails outright (parse error on the entry, load
-    /// failure) and callers still want to treat the result uniformly —
-    /// every query returns the natural empty answer.
+    /// An empty [`Semantics`], for when an upstream phase fails outright and
+    /// callers still want every query to return its natural empty answer.
     ///
-    /// **Latent caveat**: `entry_module_source` is set to
-    /// [`ModuleSource::entry_point_uninitialized`], whose `PartialEq`
-    /// equates to any other [`ModuleSource::EntryPoint`] regardless of
-    /// filename. Today this is masked because `modules` is empty, so
-    /// position lookups bail before reaching helpers that compare the
-    /// entry source by equality (e.g. `module_uri`'s
-    /// `module == entry` short-circuit). Future changes that populate
-    /// partial state into an `empty()` result must not rely on that
-    /// equality producing a meaningful distinction.
+    /// Caveat: `entry_module_source` is [`ModuleSource::entry_point_uninitialized`],
+    /// which compares equal to any other `EntryPoint` regardless of filename.
+    /// Empty `modules` masks it today; do not populate partial state and rely on
+    /// that equality meaning anything.
     #[must_use]
     pub fn empty() -> Self {
         let interner = std::rc::Rc::new(std::cell::RefCell::new(ModuleSourceInterner::new()));
@@ -1155,19 +1070,11 @@ impl Semantics {
     }
 }
 
-/// Stage 3 of the compiler frontend: run analyze + resolve on a pre-loaded
-/// module set and return the resulting [`Semantics`].
-///
-/// Pair with [`crate::parse`] (stage 1) and [`crate::load`] (stage 2). The
-/// convenience [`semantics`] wraps all three for callers that don't need
-/// to inspect the parsed entry between stages.
-///
-/// Always returns a [`Semantics`]; on phase bail, downstream fields are
-/// empty and [`Semantics::is_complete`] returns `false`.
-/// Build `Semantics` from an already-loaded module set. `build_tir` controls
-/// whether reify runs: the LSP engine passes `false` (facts only — it never
-/// reads TIR), while the general `semantics()` entry and any consumer that
-/// reads `Semantics::tir_modules` (e.g. kiln options extraction) pass `true`.
+/// Stage 3 of the frontend: analyze + resolve over an already-loaded module set.
+/// Pairs with [`crate::parse`] and [`crate::load`]; [`semantics`] wraps all
+/// three. `build_tir` decides whether reify runs — the LSP engine passes `false`
+/// since it reads facts and never TIR. Always returns a [`Semantics`]: on bail
+/// the downstream fields are empty and [`Semantics::is_complete`] is `false`.
 pub fn semantics_of<H: CompilerHost>(
     loaded: loader::LoadResult,
     host: &H,
@@ -1291,19 +1198,11 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         );
     };
 
-    // Run the full body-level resolve pass so each module's
-    // `ModuleSemantics::bindings` is populated by the real elaborator. This
-    // is the single source of truth for use→def edges — LSP and batch
-    // compilation both consume what the elaborator recorded here, with no
-    // separate lexical re-scan to drift out of sync.
-    //
-    // On Bail we still drain the partial reference / local maps so the LSP
-    // can answer cursor queries against whatever bodies the elaborator did
-    // reach before bailing.
-    //
-    // `build_tir == false` (the LSP path) runs only the body fact-walk
-    // (`annotate_bodies`); reify is skipped and `tir_modules` stays empty —
-    // the LSP never reads TIR. The batch path passes `true`.
+    // Run the full body-level resolve pass, the single source of truth for
+    // use→def edges: LSP and batch compilation both read what the elaborator
+    // recorded, with no second lexical scan to drift out of sync. On Bail the
+    // partial maps are still drained so cursor queries work against whatever
+    // bodies were reached. `build_tir == false` stops after `annotate_bodies`.
     let (tir_modules, lower_ok) = {
         let _span = logger.span("elaborate/build_tir");
         match Elaborator::build_tir_from_state(

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -1,25 +1,7 @@
-//! Embedded standard library sources
-//!
-//! The standard library is bundled into the compiler binary using `include_str!`.
-//! This ensures the compiler is self-contained and doesn't need to locate
-//! the library at runtime.
-//!
-//! ## Namespace Structure
-//!
-//! - `core:*` - High-level Wado standard library (e.g., `println()`, `read_file()`)
-//! - `wasi:*` - Raw WASI packages, organized by interface (e.g., `wasi:cli/stdout`)
-//!
-//! ## Usage in Wado code
-//!
-//! ```wado
-//! // High-level helpers
-//! use {println, eprintln} from "core:cli";
-//!
-//! // Raw WASI interfaces (use the specific interface path)
-//! use {Stdout} from "wasi:cli/stdout";
-//! use {Descriptor, Filesize} from "wasi:filesystem/types";
-//! use {Preopens} from "wasi:filesystem/preopens";
-//! ```
+//! Standard library sources, bundled into the compiler binary by `include_str!`
+//! so it locates nothing at runtime. `core:*` is the high-level Wado library
+//! (`core:cli`'s `println`, …) and `wasi:*` the raw WASI packages, keyed by
+//! interface (`wasi:cli/stdout`, `wasi:filesystem/types`).
 
 pub const CORE_PRELUDE: &str = include_str!("../lib/core/prelude.wado");
 

--- a/wado-compiler/src/stdlib.rs
+++ b/wado-compiler/src/stdlib.rs
@@ -154,7 +154,7 @@ pub const ALL_CORE_MODULES: &[(&str, &str)] = &[
 ///
 /// Each entry is `(canonical_path, bytes)` matching the canonical
 /// `wasm:`-style path that the loader assigns to
-/// [`ModuleSource::Wasm`].
+/// [`ModuleSource::Wasm`](crate::module_source::ModuleSource::Wasm).
 pub const ALL_CORE_WASM_ASSETS: &[(&str, &[u8])] = &[("core:libm.wat", CORE_LIBM_WAT)];
 
 /// All WASI interface statics, used for registry building.

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -72,7 +72,7 @@ pub(crate) fn get_or_init_snapshot() -> Option<Rc<Semantics>> {
 /// the cost on each worker's first compile.
 ///
 /// No-op if the snapshot is already built on this thread, or if
-/// called re-entrantly from inside [`build_snapshot`].
+/// called re-entrantly from inside `build_snapshot`.
 pub fn prewarm() {
     let _ = get_or_init_snapshot();
 }

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -1,44 +1,8 @@
 //! Per-thread snapshot of the stdlib closure's post-`semantics_with_logger`
-//! state.
-//!
-//! Every `compile_with_options` invocation that targets non-stdlib user
-//! code re-runs the loader → analyze → elaborate (annotate + `build_tir`) pipeline
-//! over the same stdlib AST closure (`core:prelude` and its transitive
-//! imports plus `core:libm.wat`). Measurements on
-//! `package-gale` (257 compiles, see WEP comments in
-//! `wado-cli/src/test.rs`) put the per-compile stdlib portion of
-//! `elaborate/build_tir` at ~112 ms — adding up to ~28 s of CPU duplicated
-//! across one `wado test` run.
-//!
-//! [`get_or_init_snapshot`] returns a thread-local [`Semantics`] that
-//! has been driven through the same pipeline on a synthetic empty
-//! entry source, so the loader's implicit-modules pass produces the
-//! exact same closure as a real compile. Per-compile consumers can
-//! clone the snapshot's [`TypeTable`], decl maps, [`BuiltinRegistry`],
-//! [`TraitEnv`] and pre-lowered [`TirModule`]s as the seed for their
-//! own [`AnnotateState`] / `elaborate/build_tir` work and run those
-//! passes only over the user modules that come on top.
-//!
-//! ## Why thread-local
-//!
-//! [`Semantics`] holds `Rc<RefCell<…>>` for the type table and
-//! per-function bodies, so it is `!Send + !Sync`. A process-global
-//! `OnceLock<Semantics>` would not type-check. The thread-local
-//! `OnceCell` strategy matches how `wado test` schedules compile work
-//! (one current-thread tokio runtime per blocking worker thread, with
-//! the same worker thread typically handling many sequential compiles
-//! from `buffer_unordered`), so each worker pays the snapshot build
-//! cost once and amortises it across every subsequent compile on that
-//! thread.
-//!
-//! ## Why an empty entry source
-//!
-//! Constructing the snapshot via the real `ModuleLoader::load_all`
-//! avoids reimplementing the loader's implicit-modules pass and Wasm
-//! asset synthesis (notably the `core:libm.wat` `ModuleSource::Wasm`
-//! that `core:prelude/primitive.wado` imports). The entry source is
-//! empty, so the resulting closure is exactly the stdlib subset every
-//! real compile transitively loads.
+//! state, so each compile seeds from it instead of re-running loader → analyze →
+//! elaborate over the same stdlib AST (~112 ms apiece, ~28 s per `wado test`
+//! run on package-gale). Thread-local because [`Semantics`] is `!Send`, and
+//! built over an empty entry source so the loader yields the real closure.
 
 use std::cell::{Cell, OnceCell, RefCell};
 use std::future::Future;
@@ -68,21 +32,14 @@ thread_local! {
     static BUILDING: Cell<bool> = const { Cell::new(false) };
 }
 
-/// Return the current thread's stdlib [`Semantics`] snapshot.
-///
-/// On first call the snapshot is built by driving the full loader +
-/// [`semantics_with_logger`] pipeline over an empty entry source. Returns
-/// [`None`] if the current call is itself running underneath
-/// [`build_snapshot`] — that is the call path the snapshot builder
-/// takes through `semantics_with_logger`, and trying to satisfy it from the
-/// (still-being-built) cache would re-enter the `OnceCell` initialiser.
+/// Return the current thread's stdlib [`Semantics`] snapshot, building it on
+/// first call by driving the loader and [`semantics_with_logger`] over an empty
+/// entry source. [`None`] under [`build_snapshot`] itself, where reading the
+/// still-being-built cache would re-enter the `OnceCell` initialiser.
 ///
 /// # Panics
-///
-/// Panics if the stdlib closure fails to load or analyze.  The stdlib
-/// is shipped with the compiler and must always compile cleanly; a
-/// failure here indicates a build-time inconsistency in the stdlib
-/// itself, which is a non-recoverable bug.
+/// If the stdlib closure fails to load or analyze — a build-time inconsistency
+/// in the shipped stdlib, which is not recoverable.
 pub(crate) fn get_or_init_snapshot() -> Option<Rc<Semantics>> {
     if BUILDING.with(Cell::get) {
         return None;
@@ -194,22 +151,11 @@ pub(crate) fn stdlib_sources(snap: &Semantics) -> IndexSet<ModuleSource> {
         .collect()
 }
 
-/// Deep-clone a cached [`TirModule`] for use in a per-compile pipeline.
-///
-/// The snapshot holds [`TirModule`]s whose `Rc<RefCell<TirFunction>>`
-/// values are shared across all stdlib modules in the snapshot, and
-/// whose `type_table` `Rc<RefCell<TypeTable>>` points at the snapshot's
-/// frozen table.  A naïve `Clone` would only bump those `Rc` refcounts,
-/// so a per-compile optimiser pass mutating a function body would
-/// corrupt the cached snapshot.
-///
-/// This helper rebuilds the function `Rc`s into fresh allocations,
-/// memoising by the source `Rc`'s pointer identity so aliasing within
-/// the module (e.g. between `functions` and `generic_functions`) is
-/// preserved.  The `type_table` field is repointed to the per-compile
-/// shared table; `TypeIds` embedded in function bodies remain valid
-/// because the per-compile table is seeded from a clone of the
-/// snapshot's table and stdlib entries occupy the same indices.
+/// Deep-clone a cached [`TirModule`] for a per-compile pipeline. A naïve `Clone`
+/// would only bump the snapshot's shared `Rc`s, letting an optimiser pass
+/// corrupt it, so the function `Rc`s are rebuilt fresh — memoised by pointer
+/// identity, preserving aliasing within the module — and `type_table` repointed.
+/// Embedded `TypeId`s stay valid, the per-compile table being a seeded clone.
 pub(crate) fn rehydrate_tir_module(
     snap_module: &TirModule,
     fresh_type_table: &Rc<RefCell<TypeTable>>,

--- a/wado-compiler/src/symbol.rs
+++ b/wado-compiler/src/symbol.rs
@@ -421,16 +421,11 @@ impl SymbolTable {
             .and_then(|key| self.symbols.get(key))
     }
 
-    /// Look up a name as it resolves when referenced from `module`: the
-    /// module's own explicit imports first, then the implicit prelude.
-    ///
-    /// The prelude (`core:prelude`) is in scope in every module without an
-    /// explicit `use`, so its public exports are consulted as a fallback. This
-    /// keeps `List`, `Option`, … resolvable everywhere while confining all
-    /// other imports to the module that declared them — a name imported by one
-    /// module never leaks into another (issue #1298). The prelude
-    /// implementation files (`core:prelude*`) resolve only their own imports;
-    /// they would otherwise recurse into themselves through this fallback.
+    /// Look up a name as it resolves when referenced from `module`: the module's
+    /// own explicit imports first, then the implicit prelude. That fallback
+    /// keeps `List`, `Option`, … resolvable everywhere while confining every
+    /// other import to the module that declared it (#1298). The prelude's own
+    /// implementation files skip it, or they would recurse into themselves.
     pub fn lookup(&self, module: &ModuleSource, name: &str) -> Option<&Symbol> {
         if let Some(symbol) = self.imported(module, name) {
             return Some(symbol);

--- a/wado-compiler/src/symbol_notation.rs
+++ b/wado-compiler/src/symbol_notation.rs
@@ -1,22 +1,8 @@
-//! Parser for Wado **symbol notation** — the official textual name for
-//! "this symbol in this module" used by docs and `wado query`.
-//!
-//! Grammar (see `docs/wep-2026-06-14-symbol-notation.md`):
-//!
-//! ```text
-//! NOTATION := MODULE '#' SYMBOL
-//! MODULE   := '"' <import specifier> '"' | <import specifier without '#'>
-//! SYMBOL   := <member>                       // free symbol
-//!           | RECEIVER '::' <member>          // static-scoped (assoc const/fn, …)
-//!           | RECEIVER '.'  <member>          // instance method
-//! RECEIVER := <type> | <type> '^' <trait>    // trait impl disambiguation
-//! ```
-//!
-//! `MODULE` is the import specifier verbatim (`core:json`, `./utils.wado`,
-//! `https://x/lib.wado`). Quotes are required only when the specifier itself
-//! contains `#`; otherwise they may be omitted. `<type>` may carry generics
-//! (`List<String>`); `::` / `.` / `^` inside `<…>` are part of the type and
-//! never act as separators.
+//! Parser for Wado **symbol notation**, `MODULE '#' SYMBOL` — the textual name
+//! for "this symbol in this module" that docs and `wado query` use (WEP
+//! 2026-06-14). `MODULE` is the import specifier verbatim, quoted only when it
+//! contains `#`; `SYMBOL` is a bare member or a receiver joined by `::` or `.`,
+//! the receiver optionally `^`-qualified. A separator inside `<…>` is not one.
 
 use std::fmt;
 

--- a/wado-compiler/src/synthesis.rs
+++ b/wado-compiler/src/synthesis.rs
@@ -1,14 +1,8 @@
-//! TIR synthesis phase.
-//!
-//! Generates synthetic TIR functions that cannot be expressed in user code:
-//! 1. **Enum traits** — auto-derived `Eq` and `Ord` for enum types
-//! 2. **Inspect/Display impls** — auto-generated `Inspect` and `Display` fallback impls
-//! 3. **Template expansion** — expands `TemplateString` TIR nodes into formatting code
-//! 4. **CM bindings** — Component Model boundary adapters for imports/exports
-//!
-//! All synthesis runs pre-monomorphize. Template expansion emits trait method calls
-//! (`Display::fmt`, `Inspect::inspect`) that the monomorphizer resolves to concrete
-//! implementations.
+//! TIR synthesis: the functions user code cannot express — auto-derived `Eq` /
+//! `Ord` for enums, `Inspect` / `Display` fallback impls, `TemplateString`
+//! expansion into formatting code, and Component Model import / export adapters.
+//! All of it runs pre-monomorphize, so the trait calls template expansion emits
+//! resolve to concrete implementations there.
 
 pub mod cm_binding;
 pub mod common;
@@ -84,19 +78,11 @@ pub fn synthesize(project: Package) -> Result<Package, String> {
         template::expand_templates(module, &tt, &trait_env);
     }
 
-    // Effect-dispatch wrapper synthesis + call-site rewriting must
-    // run BEFORE cm_binding so that user resource calls (like
-    // `tx.write(payload)` on a `StreamWritable<u8>`) get intercepted
-    // at their pre-cm_binding shape — a call with
-    // `func.method_info.cm_name` set — and routed to the per-
-    // monomorphisation dispatch wrapper. The wrapper bodies' fallback
-    // paths emit the same cm_name-tagged placeholder shape that user
-    // code emits, so cm_binding rewrites both uniformly afterward
-    // (turning `stream-write` placeholders into `cm_stream_write_u8`
-    // internal calls, etc.). The `WithHandler` desugaring stays late
-    // (in `compile_after_load`'s phase 8c) because effect-check needs
-    // the original `WithHandler` shape to know which effects are
-    // satisfied locally.
+    // Effect-dispatch wrapper synthesis and call-site rewriting run before
+    // cm_binding, so a user resource call is intercepted at its pre-cm_binding
+    // `cm_name`-tagged shape and routed to the dispatch wrapper, whose fallback
+    // emits that same shape for cm_binding to rewrite uniformly. `WithHandler`
+    // desugaring stays late: effect-check reads the original shape.
     let project = effect_dispatch::synthesize_pre_cm_binding(project)?;
 
     // Insert `resource.drop` for every owned Component Model resource that is
@@ -109,30 +95,11 @@ pub fn synthesize(project: Package) -> Result<Package, String> {
     Ok(project)
 }
 
-/// Collect every `(type_name, trait_name) -> ModuleSource` triple that the
-/// synthesis phase added to TIR, regardless of which sub-pass produced it
-/// (auto-derives, `from_synth`, `serde_synth`). Walks `module.functions`,
-/// which holds every function in the module — reify flattens impl-block
-/// methods into it alongside free functions and synthesized wrappers.
-///
-/// User-written impls already live in the AST layer, so they are excluded here
-/// to keep the synthesis layer a genuine "delta" on top of the AST.
-///
-/// Concrete-ness is propagated alongside each entry so that the
-/// monomorphizer can later distinguish "the impl is fully resolved (use the
-/// impl block's module)" from "the impl is generic (fall back to the
-/// receiver type's module so `call_rewrite`'s path-2alt mismatches the
-/// queueing convention exactly the way the legacy `trait_method_locations`
-/// did)". An impl is concrete here when the synthesized function carries
-/// no impl-level type parameters.
-///
-/// Per-module synthesis stubs are deliberately *not* recorded: every
-/// module that uses a closure of a given `Fn<arity, Ret>` shape (or an
-/// opaque resource handle like `Stream<u8>`, `Future<i32>`, …) gets its
-/// own independent stub, and a project-wide `(base, trait)` entry would
-/// mis-route calls between modules. The decision is made from the impl's
-/// receiver type via [`receiver_is_per_module_synth`]; template expansion
-/// handles their dispatch via its own per-`ResolvedType` fallback.
+/// Collect every `(type_name, trait_name) -> ModuleSource` triple TIR carries,
+/// by walking `module.functions` — reify flattens impl-block methods into it.
+/// Each entry records whether the impl is concrete (no impl-level type params),
+/// which is how the monomorphizer picks the impl block's module over the
+/// receiver's. Per-module stubs are excluded via [`receiver_is_per_module_synth`].
 fn collect_synthesised_impls(project: &Package) -> SynthesisedImpls {
     let mut impls = SynthesisedImpls::default();
     let mut instantiations: Vec<(String, String, ModuleSource)> = Vec::new();
@@ -180,20 +147,11 @@ fn collect_synthesised_impls(project: &Package) -> SynthesisedImpls {
     impls
 }
 
-/// Decide whether a synthesised trait-method impl whose `&self` parameter
-/// is `receiver_type_id` should be skipped from the project-wide synthesis
-/// layer because it is a *per-module* dispatch stub.
-///
-/// Strips `&` / `&mut` and consults the underlying `ResolvedType`:
-///
-/// - [`ResolvedType::Function`] / [`ResolvedType::GenericResource`] are
-///   anonymous parameterized types with no source-level definition; every
-///   module that uses them synthesises its own dispatch stub, so a
-///   project-wide entry would mis-route cross-module calls.
-/// - All other resolved types — `Struct`, `Enum`, `Variant`, `Newtype`,
-///   `Flags`, `Primitive`, generic instances, and tuple instances — name
-///   a single defining module, and any auto-derived impl for them is
-///   project-wide.
+/// Whether an impl on `receiver_type_id` is a *per-module* dispatch stub, to be
+/// kept out of the project-wide synthesis layer. Strips `&` / `&mut`:
+/// [`ResolvedType::Function`] and [`ResolvedType::GenericResource`] are
+/// anonymous, each using module synthesising its own stub, so a project-wide
+/// entry would mis-route. Every other type names one defining module.
 fn receiver_is_per_module_synth(
     receiver_type_id: crate::tir::TypeId,
     tt: &crate::tir::TypeTable,

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -1,14 +1,8 @@
-//! CM Binding Synthesis phase.
-//!
-//! Generates TIR binding functions for Component Model boundary crossing.
-//! Each binding handles lifting Wado values to CM flat ABI (lowering params)
-//! and lifting CM flat ABI values back to Wado types (lifting results).
-//!
-//! Pipeline position: after `effect_check`, before monomorphize.
-//! This ensures binding functions go through monomorphization, lowering,
-//! and optimization.
-//!
-//! See `docs/wep-2026-02-15-cm-binding-synthesis.md` for design details.
+//! CM Binding Synthesis: TIR binding functions for Component Model boundary
+//! crossing, each lowering Wado values to the CM flat ABI and lifting flat
+//! results back. Runs after `effect_check` and before monomorphize, so the
+//! bindings go through monomorphization, lowering and optimization like any
+//! other function. Design: `docs/wep-2026-02-15-cm-binding-synthesis.md`.
 
 mod cm_free;
 mod export_adapter;
@@ -127,18 +121,10 @@ mod record_payload_validation {
     pub(in crate::synthesis::cm_binding) struct RecordPayloadsValidated(());
 
     /// Reject a user record used as a `future`/`stream` payload when its fields
-    /// are not registered in the CM interface registry. Such a record has no CM
-    /// type to lower against, so the lower would silently mis-treat it as an i32
-    /// handle and emit an invalid component. Records are registered only for
-    /// `--lib` components (under the package default interface); in any other
-    /// world a user record has no CM home, so `get_struct_fields` returns `None`
-    /// and the use is rejected.
-    ///
-    /// The scan is scoped to functions reachable from the active world's export
-    /// bindings — the resolvability condition, not the world, decides — so a
-    /// record future in code the world drops (e.g. the non-`test` exports of a
-    /// library-shaped source like `cm_catalog.wado` compiled for the test world)
-    /// is never reached and never flagged.
+    /// are not registered in the CM interface registry: with no CM type to lower
+    /// against, the lower would mis-treat it as an i32 handle and emit an invalid
+    /// component. Records are registered only for `--lib` components. Scoped to
+    /// functions reachable from the active world's export bindings.
     pub(in crate::synthesis::cm_binding) fn reject_unresolvable_record_payloads(
         project: &Package,
     ) -> Result<RecordPayloadsValidated, String> {
@@ -1010,16 +996,11 @@ fn sync_wasi_export_strategy(
     ExportReturnStrategy::SyncReturn
 }
 
-/// Record the flattened task-return params on the `Package` for
-/// `optimize_dce` to type the shared `task_return` NIR import (the builtin
-/// `task_return` takes a single i32, but a Result-returning export passes its
-/// full flattened result). Sync-lift lib exports never call task.return, so
-/// lib worlds are skipped — except the kiln generator, which routes through
-/// the async task-return result binding.
-///
-/// The NIR import is a single shared symbol, so every returning export must
-/// flatten to the same signature; a disagreement cannot be represented and is
-/// an ICE.
+/// Record the flattened task-return params on the `Package` for `optimize_dce`
+/// to type the shared `task_return` NIR import — the builtin takes one i32, but
+/// a Result-returning export passes its full flattened result. Lib worlds are
+/// skipped, bar the kiln generator. The import is one shared symbol, so a
+/// disagreement between returning exports cannot be represented and is an ICE.
 fn record_task_return_flat_params(project: &mut Package) {
     let Some(world_info) = project.active_world_info().cloned() else {
         return;
@@ -1159,21 +1140,11 @@ fn strip_unexpanded_task_returns(project: &Package) {
     }
 }
 
-/// Synthesize binding functions for the async CM primitives —
-/// `Stream<T>.read()` on WASI record types, `Future<T>::read()`,
-/// `FutureWritable<T>::write()`, scalar / structural
-/// `StreamWritable<T>::write()` and `StreamReadable<T>::read()` — then
-/// rewrite `#[cm("...")]` resource method calls to target internal/builtin
-/// binding functions. The synthesis calls must all run before
-/// `rewrite_cm_resource_methods` so the functions it rewrites call sites to
-/// already exist. Rewriting here (instead of inline WIR emission in
-/// `wir_build/translate.rs`) sends the bindings through the normal
-/// pre-monomorphization pipeline.
-///
-/// Consumes the [`RecordPayloadsValidated`] witness: these rewrites destroy
-/// the pristine `future-new`/`stream-new` call shape that
-/// [`reject_unresolvable_record_payloads`] scans, so the validation must
-/// already have run.
+/// Synthesize binding functions for the async CM primitives — the `Stream<T>` /
+/// `Future<T>` read and write families — then rewrite `#[cm("...")]` resource
+/// method calls onto them, which requires they exist first. Consumes the
+/// [`RecordPayloadsValidated`] witness: the rewrites destroy the pristine
+/// `future-new` / `stream-new` shape that validation scans.
 fn rewrite_async_primitives(project: &mut Package, _validated: RecordPayloadsValidated) {
     synthesize_record_stream_reads(project);
     synthesize_future_reads(project);

--- a/wado-compiler/src/synthesis/cm_binding.rs
+++ b/wado-compiler/src/synthesis/cm_binding.rs
@@ -389,7 +389,7 @@ fn named_decl_of(ty: &ResolvedType) -> Option<(&String, &ModuleSource)> {
 ///
 /// Ordered pipeline: import adapters, export adapters, the shared task-return
 /// signature, test-world bindings, payload validation (producing the
-/// [`RecordPayloadsValidated`] witness), task-return stripping, and finally
+/// `RecordPayloadsValidated` witness), task-return stripping, and finally
 /// the async/resource primitive rewrites (consuming the witness).
 ///
 /// Adapter functions flow through monomorphize → lower → optimize → codegen

--- a/wado-compiler/src/synthesis/cm_binding/cm_free.rs
+++ b/wado-compiler/src/synthesis/cm_binding/cm_free.rs
@@ -1,23 +1,8 @@
-//! Which parts of a CM value own linear memory, and how to give it back.
-//!
-//! The Canonical ABI hands a memory-backed value to the host as a pointer into
-//! guest memory, and the guest allocated every buffer behind it. [`CmShape`]
-//! records where those buffers are; [`synthesize_free_cm_value`] emits the
-//! `realloc(ptr, size, align, 0)` calls that release them, walking nested
-//! buffers the outer pointer alone cannot reach — a `list<string>` owns its
-//! element array *and* one payload per element.
-//!
-//! The same classification serves both export boundaries, which differ only in
-//! where the `(ptr, len)` pairs live: behind a memory address for a
-//! synchronous lift's `post-return` ([`synthesize_free_cm_value`]), and in the
-//! flat slots handed to `task.return` for an async one
-//! ([`synthesize_free_cm_flat`]).
-//!
-//! Every offset, size and alignment comes from the `cm_abi` helpers the
-//! lowering side uses, so the two cannot disagree about layout. [`cm_shape`]
-//! panics on a type shape it does not recognise: a type reaching the CM
-//! boundary without an ownership rule fails loudly on first use rather than
-//! leaking silently.
+//! Which parts of a CM value own linear memory, and how to give it back. The
+//! guest allocated every buffer behind a memory-backed value, so [`CmShape`]
+//! records where they are — nested ones the outer pointer cannot reach included
+//! — and the `synthesize_free_cm_*` pair releases them at either export
+//! boundary. [`cm_shape`] panics on an unrecognised shape rather than leaking.
 
 use std::cell::RefCell;
 

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -1,25 +1,12 @@
-//! Export-side CM adapter synthesis.
-//!
-//! Every world export gets one binding function, built by
-//! [`synthesize_export_binding`]: a shared prelude lifts the flat CM params
-//! into Wado values ([`build_export_adapter_params`]), the user function is
-//! called once, and an [`ExportReturnStrategy`] — picked by the driver from
-//! the export's shape — selects the epilogue:
-//!
-//! - [`ExportReturnStrategy::VoidTaskReturn`] for async `() -> ()` exports:
-//!   `task-return(0)` after the call.
-//! - [`ExportReturnStrategy::SyncReturn`] for sync `--lib` exports: return
-//!   the flattened value directly (out-pointer for multi-value results).
-//! - [`ExportReturnStrategy::AsyncTaskReturn`] for `export async fn`, whose
-//!   body does its own `task return`.
-//! - [`ExportReturnStrategy::ResultTaskReturn`] for async exports returning
-//!   `Result<T, E>`: match Ok/Err, lower the payload, `task-return`.
-//!
-//! Each binding name is built by [`export_binding_func_name`]. The
-//! `synthesize_lower_to_flat` / `synthesize_variant_lower_to_flat` /
-//! `FlatLocal` triple is shared with `task_return.rs` (which expands inline
-//! `task return` into the same flat-args sequence), hence their
-//! `pub(super)` visibility.
+//! Export-side CM adapter synthesis. Every world export gets one binding from
+//! [`synthesize_export_binding`]: a shared prelude lifts the flat CM params into
+//! Wado values, the user function is called once, and the
+//! [`ExportReturnStrategy`] the driver picked from the export's shape selects the
+//! epilogue — a bare `task-return`, a direct flattened return for a sync `--lib`
+//! export, the body's own `task return` for an `export async fn`, or an Ok/Err
+//! match for an async `Result`. The `synthesize_lower_to_flat` / `FlatLocal`
+//! triple is `pub(super)` because `task_return.rs` expands inline `task return`
+//! into the same flat-args sequence.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -724,17 +711,11 @@ fn assign_flat_values_into_slots(
     }
 }
 
-/// Lift a single export parameter from flat CM params to a Wado-typed value.
-///
-/// Flat parameters are the Wasm function parameters corresponding to a single
-/// CM parameter. For example, a `String` parameter becomes two flat params
-/// `(ptr: i32, len: i32)` pointing to data in linear memory.
-///
-/// Returns the lifted TIR expression and the number of flat params consumed.
-///
-/// `lift_ctx` carries the full CM resolution stack (WASI + kiln registries,
-/// type-table cell, binding package hint) used for List / nested-struct
-/// lifts and for the `struct_type_map` lookup in WIR.
+/// Lift one export parameter from the flat CM params — the Wasm parameters a
+/// single CM parameter expands to, a `String` becoming `(ptr: i32, len: i32)` —
+/// returning the lifted expression and how many flat params it consumed.
+/// `lift_ctx` carries the CM resolution stack the List and nested-struct lifts
+/// need, plus the `struct_type_map` lookup WIR performs.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn synthesize_lift_from_flat_params(
     ty: &Type,
@@ -844,16 +825,12 @@ pub(super) fn synthesize_lift_from_flat_params(
                 if let Some(struct_decl) = find_struct_decl(&named.name, tir_modules) {
                     let mut offset = 0;
                     let mut fields_out = Vec::with_capacity(struct_decl.fields.len());
-                    // Precompute each field's AST surface while the
-                    // `TypeTable` borrow is live; drop the borrow before
-                    // recursion so the inner list lift may take
-                    // `borrow_mut()` via the `LiftContext`. Also
-                    // resolve the struct's own type_id — `target_type_id`
-                    // may arrive as a reference wrapper when the user
-                    // function took the struct by value, so we consult
-                    // the TIR struct decl's module source for the
-                    // concrete `ResolvedType::Struct` id the
-                    // `StructLiteral` WIR pass expects.
+                    // Precompute each field's AST surface under the `TypeTable`
+                    // borrow and drop it before recursing, so an inner list lift
+                    // can `borrow_mut` through the `LiftContext`. Resolve the
+                    // struct's own type id here too: `target_type_id` may arrive
+                    // as a reference wrapper, and `StructLiteral` expects the
+                    // concrete `ResolvedType::Struct` id from the TIR decl.
                     let (field_ast_tys, struct_type_id) = {
                         let tt = type_table_cell.borrow();
                         let field_tys: Vec<Type> = struct_decl
@@ -1232,16 +1209,12 @@ fn coerce_payload_slots(
     (out_locals, natural)
 }
 
-/// Lift a named `variant` value from flat CM params.
-///
-/// The CM `variant` flat ABI is `(disc: i32, ...joined-payload-flats)` where the
-/// payload slots are the positional join of every case's flattening. This reads
-/// the discriminant, then for the active case lifts its payload recursively from
-/// `flat[1..]` and constructs the GC value via `VariantConstruct`, dispatching
-/// through an if/else chain (mirroring the memory-based `synthesize_lift_wasi_variant`).
-///
-/// Returns the lifted expression and the number of flat params consumed (the
-/// discriminant plus the widest case's payload flattening).
+/// Lift a named `variant` from the flat CM ABI
+/// `(disc: i32, …joined-payload-flats)`, whose payload slots are the positional
+/// join of every case's flattening. Reads the discriminant, lifts the active
+/// case's payload from `flat[1..]`, and builds the GC value through an if/else
+/// chain, mirroring the memory-based `synthesize_lift_wasi_variant`. Consumes the
+/// discriminant plus the widest case's flattening.
 #[allow(clippy::too_many_arguments)]
 fn lift_variant_from_flat_params(
     variant_decl: &TirVariantDecl,
@@ -1363,16 +1336,12 @@ fn lift_variant_from_flat_params(
     )
 }
 
-/// Build the adapter parameters and call arguments for an export binding.
-///
-/// The shared prelude of [`synthesize_export_binding`]: lifts flat CM params
-/// back to Wado-typed args (when `export_needs_param_lifting`) or passes the
-/// user params through unchanged, regardless of which
-/// [`ExportReturnStrategy`] follows. The lifting prelude is appended to
-/// `body_stmts` and the param locals to `locals`.
-///
-/// Returns `(adapter_params, call_args, next_local)` where `next_local` is the
-/// first free local index after the params and any lifting temporaries.
+/// Build an export binding's adapter parameters and call arguments — the shared
+/// prelude of [`synthesize_export_binding`], run whichever
+/// [`ExportReturnStrategy`] follows. Lifts the flat CM params back to Wado-typed
+/// args where `export_needs_param_lifting`, else passes them through, appending
+/// the prelude to `body_stmts` and the locals to `locals`. `next_local` is the
+/// first free index after the params and any lifting temporaries.
 fn build_export_adapter_params(
     user_func_ref: &TirFunction,
     tir_modules: &IndexMap<ModuleSource, TirModule>,
@@ -1784,17 +1753,13 @@ pub(super) fn post_return_func_name(export_name: &str) -> String {
     format!("__cm_post_return__{export_name}")
 }
 
-/// Synthesize the `post-return` function for a sync-lifted export, or `None`
-/// when nothing was allocated for it to reclaim.
-///
-/// The gate is the indirect return, not memory ownership: a result wider than
-/// one core value comes back through a guest-allocated area that leaks without
-/// this, even when nothing hangs off it — a record of two `u32` owns no memory
-/// and still loses its eight bytes per call. Ownership only decides whether the
-/// walk over nested buffers emits anything.
-///
-/// The canonical ABI calls it with the lifted core function's results, which in
-/// the indirect case is that single out-pointer.
+/// Synthesize a sync-lifted export's `post-return`, or `None` when nothing was
+/// allocated to reclaim. The gate is the indirect return rather than memory
+/// ownership: a result wider than one core value comes back through a
+/// guest-allocated area that leaks without this, so a record of two `u32` owns no
+/// memory and still loses eight bytes per call. Ownership only decides whether
+/// the nested-buffer walk emits anything. The canonical ABI passes the lifted
+/// results, which here is that out-pointer.
 pub(super) fn synthesize_post_return(
     export_name: &str,
     env: &ExportBindingEnv<'_>,

--- a/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/export_adapter.rs
@@ -1,12 +1,8 @@
 //! Export-side CM adapter synthesis. Every world export gets one binding from
 //! [`synthesize_export_binding`]: a shared prelude lifts the flat CM params into
 //! Wado values, the user function is called once, and the
-//! [`ExportReturnStrategy`] the driver picked from the export's shape selects the
-//! epilogue — a bare `task-return`, a direct flattened return for a sync `--lib`
-//! export, the body's own `task return` for an `export async fn`, or an Ok/Err
-//! match for an async `Result`. The `synthesize_lower_to_flat` / `FlatLocal`
-//! triple is `pub(super)` because `task_return.rs` expands inline `task return`
-//! into the same flat-args sequence.
+//! [`ExportReturnStrategy`] the driver picked selects the epilogue — a bare
+//! `task-return`, a flattened return, `task return`, or an Ok/Err match.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -829,8 +825,7 @@ pub(super) fn synthesize_lift_from_flat_params(
                     // borrow and drop it before recursing, so an inner list lift
                     // can `borrow_mut` through the `LiftContext`. Resolve the
                     // struct's own type id here too: `target_type_id` may arrive
-                    // as a reference wrapper, and `StructLiteral` expects the
-                    // concrete `ResolvedType::Struct` id from the TIR decl.
+                    // as a reference wrapper, and `StructLiteral` needs the concrete one.
                     let (field_ast_tys, struct_type_id) = {
                         let tt = type_table_cell.borrow();
                         let field_tys: Vec<Type> = struct_decl
@@ -1213,8 +1208,7 @@ fn coerce_payload_slots(
 /// `(disc: i32, …joined-payload-flats)`, whose payload slots are the positional
 /// join of every case's flattening. Reads the discriminant, lifts the active
 /// case's payload from `flat[1..]`, and builds the GC value through an if/else
-/// chain, mirroring the memory-based `synthesize_lift_wasi_variant`. Consumes the
-/// discriminant plus the widest case's flattening.
+/// chain, mirroring the memory-based `synthesize_lift_wasi_variant`.
 #[allow(clippy::too_many_arguments)]
 fn lift_variant_from_flat_params(
     variant_decl: &TirVariantDecl,
@@ -1339,9 +1333,8 @@ fn lift_variant_from_flat_params(
 /// Build an export binding's adapter parameters and call arguments — the shared
 /// prelude of [`synthesize_export_binding`], run whichever
 /// [`ExportReturnStrategy`] follows. Lifts the flat CM params back to Wado-typed
-/// args where `export_needs_param_lifting`, else passes them through, appending
-/// the prelude to `body_stmts` and the locals to `locals`. `next_local` is the
-/// first free index after the params and any lifting temporaries.
+/// args where `export_needs_param_lifting`, else passes them through. Returns
+/// the first free local index after the params and lifting temporaries.
 fn build_export_adapter_params(
     user_func_ref: &TirFunction,
     tir_modules: &IndexMap<ModuleSource, TirModule>,
@@ -1757,9 +1750,7 @@ pub(super) fn post_return_func_name(export_name: &str) -> String {
 /// allocated to reclaim. The gate is the indirect return rather than memory
 /// ownership: a result wider than one core value comes back through a
 /// guest-allocated area that leaks without this, so a record of two `u32` owns no
-/// memory and still loses eight bytes per call. Ownership only decides whether
-/// the nested-buffer walk emits anything. The canonical ABI passes the lifted
-/// results, which here is that out-pointer.
+/// memory and still loses eight bytes per call.
 pub(super) fn synthesize_post_return(
     export_name: &str,
     env: &ExportBindingEnv<'_>,

--- a/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
+++ b/wado-compiler/src/synthesis/cm_binding/import_adapter.rs
@@ -1,16 +1,8 @@
-//! Import-side CM adapter synthesis.
-//!
-//! Generates a `__cm_binding__<iface>_<method>` TIR function for every WASI
-//! import the program references. The body lowers Wado-typed args to the
-//! flat CM ABI shape, performs the `cm_raw_call`, and (for sync imports)
-//! lifts the result back. Truly async imports return an `AsyncCall<T>`
-//! struct holding the subtask handle and outptr; the caller is responsible
-//! for `wait()`-ing on it.
-//!
-//! Entry points used by the driver: [`binding_func_name`] for the synthesized
-//! function name and [`synthesize_adapter`] for the body. The adapter shares
-//! [`make_binding_function`] with export-side synthesis, hence its
-//! `pub(super)` visibility.
+//! Import-side CM adapter synthesis: a `__cm_binding__<iface>_<method>` TIR
+//! function per referenced WASI import, lowering Wado-typed args to the flat CM
+//! ABI, performing the `cm_raw_call`, and lifting the result back for a sync
+//! import. An async one returns an `AsyncCall<T>` the caller `wait()`s on. The
+//! driver enters at [`binding_func_name`] and [`synthesize_adapter`].
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -63,17 +55,10 @@ pub(super) struct AdapterArtifacts {
 }
 
 /// Synthesize lifting of a flat Result discriminant into a GC variant struct.
-///
-/// Only reached for a Result that flattens to a bare discriminant (one flat
-/// slot) — i.e. `Result<(), ()>`: disc==0 → Ok, disc==1 → Err, neither
-/// carrying a payload. Any payload-bearing Result flattens to >1 slot and is
-/// lifted through the outptr return path instead, so it never arrives here.
-/// (The non-unit Err branch below therefore stays defensive — see the
-/// `debug_assert!` on `ok_is_unit`.)
-///
-/// `result_type_id` is the resolved `Result<T, E>` `TypeId` shared with
-/// the caller's `result_local`; the emitted `VariantConstruct` exprs use
-/// it directly so no `TypeTable::I32` placeholder leaks downstream.
+/// Only reached for a `Result<(), ()>`, which flattens to a bare discriminant;
+/// any payload-bearing Result takes >1 slot and lifts through the outptr path,
+/// so the non-unit Err branch is defensive. `result_type_id` is the resolved
+/// `Result<T, E>` id, used directly so no `TypeTable::I32` placeholder leaks.
 fn synthesize_lift_flat_result(
     ty: &Type,
     disc_expr: TirExpr,
@@ -553,22 +538,11 @@ fn lift_flat_struct_return(
     lifted
 }
 
-/// Synthesize a CM binding function for a WASI import.
-///
-/// The binding function:
-/// 1. Accepts the same parameter types as the WASI function
-/// 2. Lowers parameters to flat CM ABI (String → ptr/len, etc.)
-/// 3. Calls the lowered WASI function via `CmRawCall`
-/// 4. Lifts the result from flat CM ABI back to Wado types
-/// 5. Returns the Wado-typed result
-///
-/// The binding's Wado-level return type matches the WASI function declaration.
-/// All return types are lifted inline using `synthesize_lift` — no per-type
-/// converter functions are needed.
-///
-/// For async imports the adapter additionally emits a sibling
-/// [`synthesize_async_lift_function`]; both are returned via
-/// [`AdapterArtifacts`].
+/// Synthesize a CM binding function for a WASI import: it takes the WASI
+/// function's parameter types, lowers them to the flat CM ABI, calls through
+/// `CmRawCall`, and lifts the result back with `synthesize_lift` — inline, so no
+/// per-type converters exist. An async import also gets a sibling
+/// [`synthesize_async_lift_function`]; both come back in [`AdapterArtifacts`].
 pub(super) fn synthesize_adapter(
     func_info: &CmFunctionInfo,
     cm_interface_registry: &CmInterfaceRegistry,
@@ -1438,22 +1412,11 @@ impl<'a> AdapterBuilder<'a> {
         Some(OutptrBuffer { local, size, align })
     }
 
-    /// Async result strategy.
-    ///
-    /// WASI P3 async calling convention: the lowered function returns a
-    /// packed subtask handle/status `(subtask_handle << 4) | status`. The
-    /// result (if any) is written to the async outptr buffer when the
-    /// subtask eventually reaches `Status::Returned`.
-    ///
-    /// For Wado-level `async fn foo(...) -> AsyncCall<T>` imports, the
-    /// adapter does NOT wait for the subtask or lift the result here.
-    /// Instead it packages `(packed_handle, outptr, size, align,
-    /// __cm_lift_fn)` into an `AsyncCall<T>` struct and returns it
-    /// immediately, letting the caller interleave stream-parameter
-    /// writes with the host subtask before explicitly `.wait()`-ing.
-    /// `AsyncCall<T>::wait` then performs the wait + free; the lift
-    /// itself runs in the per-import `__cm_lift__*` function emitted
-    /// alongside this adapter and reached through `__cm_lift`.
+    /// Async result strategy. The WASI P3 lowered function returns a packed
+    /// `(subtask_handle << 4) | status`, its result reaching the outptr buffer
+    /// only at `Status::Returned`. The adapter neither waits nor lifts: it
+    /// packages `(packed_handle, outptr, size, align, __cm_lift_fn)` into an
+    /// `AsyncCall<T>`, leaving `wait()` to do both.
     fn emit_async_result(
         &mut self,
         raw_call: TirExpr,

--- a/wado-compiler/src/synthesis/cm_binding/lower.rs
+++ b/wado-compiler/src/synthesis/cm_binding/lower.rs
@@ -1,16 +1,8 @@
-//! CM ABI lower: store a Wado value into linear memory or flatten it to flat args.
-//!
-//! Two output shapes:
-//!
-//! - [`synthesize_lower`] / [`synthesize_lower_tuple`] /
-//!   [`synthesize_lower_wasi_type_to_memory`] /
-//!   [`synthesize_lower_wasi_variant_to_memory`] /
-//!   [`synthesize_lower_option_to_memory`] write to linear memory at a
-//!   given address (used for outptr returns and indirect param buffers).
-//! - [`synthesize_flatten_value_to_flat_args`] /
-//!   [`synthesize_flatten_option_to_flat_args`] flatten a GC value into
-//!   a `Vec<TirExpr>` of i32 / i64 / f32 / f64 args (used for direct
-//!   imports that take their params on the operand stack).
+//! CM ABI lower, in two output shapes: the `synthesize_lower*_to_memory` family
+//! writes a Wado value into linear memory at a given address, for outptr returns
+//! and indirect param buffers, while the `synthesize_flatten_*_to_flat_args`
+//! family flattens a GC value into a `Vec<TirExpr>` of scalar args, for a direct
+//! import taking its params on the operand stack.
 
 use crate::ast::{NamedType, Type};
 use crate::cm_abi;
@@ -1580,17 +1572,11 @@ pub(super) fn synthesize_lower_wasi_type_to_memory(
     let resolved = ctx.cm_interface_registry.resolve_type(ty);
     match &resolved {
         Type::Named(n) => {
-            // CM record lowering: store each field at its offset, keyed on
-            // the exact source interface the Named reference was resolved
-            // to. Accepts both `wasi:*` and `core:kiln/*` sources so the
-            // kiln generator's record surface (input-file, output-file,
-            // response, raw-request) lowers through the same path as WASI
-            // records. Callers (e.g. the `List<T>` element lower)
-            // populate `source_interface` via `type_id_to_ast_type` so
-            // this lookup does not need a fallback path.
-            // Resolve via the registry so lib-local records (no
-            // `source_interface` on the nested type) are found by name under
-            // their package's default-interface FQ, like WASI/kiln records.
+            // CM record lowering: store each field at its offset, keyed on the
+            // source interface the Named reference resolved to, so `wasi:*` and
+            // `core:kiln/*` records share one path. Resolution goes through the
+            // registry, which also finds a lib-local record — carrying no
+            // `source_interface` — under its package's default-interface FQ.
             let source = ctx
                 .cm_interface_registry
                 .resolve_cm_source_for(n, Some(ctx.wasi_package));

--- a/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
+++ b/wado-compiler/src/synthesis/cm_binding/resource_rewrite.rs
@@ -1,14 +1,8 @@
-//! CM resource method rewriting and stream-read binding synthesis.
-//!
-//! Two passes that run before adapter synthesis:
-//!
-//! - [`synthesize_record_stream_reads`] generates a binding function
-//!   `__cm_stream_read_<T>` for every distinct WASI record `T` referenced
-//!   by `Stream<T>::read()`, so the rewriter has a callable target.
-//! - [`rewrite_cm_resource_methods`] walks every TIR function body and
-//!   rewrites `#[cm("...")]` resource method calls into the appropriate
-//!   raw / internal / entry-module call, before downstream phases see a
-//!   `cm_name`-tagged call they don't know how to translate.
+//! Two passes ahead of adapter synthesis: [`synthesize_record_stream_reads`]
+//! generates a `__cm_stream_read_<T>` binding per WASI record
+//! `Stream<T>::read()` mentions, and [`rewrite_cm_resource_methods`] then turns
+//! every `#[cm("…")]` resource method call into its raw / internal /
+//! entry-module form, before a downstream phase meets a `cm_name`-tagged call.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/synthesis/cm_binding/task_return.rs
+++ b/wado-compiler/src/synthesis/cm_binding/task_return.rs
@@ -163,18 +163,11 @@ impl TirOptVisitor for TaskReturnStripper {
     }
 }
 
-/// Generate the inline task-return sequence for `task return value`.
-///
-/// For `Result<T, E>` values, generates:
-/// - Ok arm: flatten T → call task-return(0, ...`flat_ok_values`)
-/// - Err arm: flatten E → call task-return(1, ...`flat_err_values`)
-///
-/// For other types, flattens `value` to its CM ABI flat slots and emits
-/// `task-return(...flat_values)`. For unit-returning exports, the value
-/// is evaluated for its side effects and `task-return()` is emitted.
-///
-/// `task.return` lifts eagerly and `post-return` is illegal alongside `async`,
-/// so the sequence ends by freeing the buffers the flattening allocated.
+/// Generate the inline task-return sequence for `task return value`: a `Result`
+/// becomes a two-arm match, each flattening its payload behind the discriminant;
+/// anything else flattens straight to its CM flat slots; a unit export evaluates
+/// the value for effect and returns nothing. `task.return` lifts eagerly and
+/// `post-return` is illegal under `async`, so the sequence frees its buffers.
 fn generate_inline_task_return(
     value: TirExpr,
     return_type: &Type,

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -1,23 +1,8 @@
-//! Post-synthesis type fixups and call-site rewrites.
-//!
-//! After import-adapter synthesis the binding bodies use WASI-derived
-//! `TypeId`s (e.g. `List<Tuple<String, List<u8>>>`) while the call sites
-//! see the user's newtype-aliased types (e.g. `List<Tuple<FieldName,
-//! FieldValue>>`). [`rewrite_calls_in_block`] reaches every effect-style
-//! call and resource method call, swaps in the binding `FunctionRef`,
-//! flattens args to the binding's flat CM parameter shape, and runs
-//! [`fixup_wasi_derived_types_in_adapter`] to re-type the binding body.
-//! [`collect_effect_calls_in_block`] is the discovery pass that drives
-//! the same set of call sites for adapter generation.
-//!
-//! Design invariant: one binding function is shared by every call site of
-//! its import, so all sites must agree on the types the fixup applies. The
-//! rewrite records each adapter's applied return type and turns a
-//! disagreeing site into an ICE (see
-//! `fixup_adapter_return_from_call_site`) instead of silently overwriting
-//! an earlier site's typing. The longer-term direction is to synthesize
-//! bindings with call-site types up front and retire this pass; until
-//! then, the invariant is enforced, not assumed.
+//! Post-synthesis type fixups and call-site rewrites. Import-adapter binding
+//! bodies carry WASI-derived `TypeId`s while call sites see the user's
+//! newtype-aliased ones, so [`rewrite_calls_in_block`] swaps in the binding
+//! `FunctionRef`, flattens args to the flat CM shape, and re-types the body.
+//! One binding serves every call site, so a disagreeing site is an ICE.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -302,16 +287,11 @@ fn replace_type_in_adapter_with_names(
     }
 }
 
-/// Replaces every occurrence of `old_type` with `new_type` throughout an
-/// adapter body, and — when `rename` is set — rewrites function references
-/// whose mangled name embeds `old_name` to use `new_name` (needed for
-/// monomorphized helpers like `List<T>::with_capacity` where `T` is a
-/// WASI-derived type differing from the user's newtype alias).
-///
-/// Traversal is exhaustive via `TirMutVisitor`, so the swap reaches every
-/// expression position — match arms, nested blocks, closures, index/assign
-/// targets — rather than the partial set the previous hand-written walkers
-/// covered.
+/// Replaces every `old_type` with `new_type` throughout an adapter body, and
+/// with `rename` set also rewrites function references whose mangled name
+/// embeds `old_name` — needed for a monomorphized `List<T>::with_capacity`
+/// whose `T` is WASI-derived. Traversal rides `TirMutVisitor`, so the swap
+/// reaches every expression position.
 struct TypeReplacer<'a> {
     old_type: TypeId,
     new_type: TypeId,
@@ -679,17 +659,11 @@ impl TirMutVisitor for CallRewriteWalker<'_> {
     }
 }
 
-/// Retype a shared adapter's return from a call site. Streaming adapters keep
-/// their WIR-level i32 return (the caller-visible `Future` type stays on the
-/// call expression), so they are left untouched.
-///
-/// The adapter is shared by every call site of the import, so all sites must
-/// agree on its return type; `applied_returns` records what each adapter was
-/// typed to, and a disagreeing site is an ICE rather than a silent
-/// last-write-wins overwrite of the earlier site's typing. The map is keyed by
-/// the adapter's `Rc` identity (`adapter_key`) — not its name, which is a
-/// non-injective `interface_method` join — so two distinct adapters can never
-/// collide.
+/// Retype a shared adapter's return from a call site, leaving a streaming
+/// adapter's WIR-level i32 return alone. Every call site of the import shares
+/// the adapter, so `applied_returns` records what each was typed to and a
+/// disagreeing site is an ICE. Keyed by the adapter's `Rc` identity, its name
+/// being a non-injective `interface_method` join.
 fn fixup_adapter_return_from_call_site(
     adapter: &mut TirFunction,
     adapter_key: usize,

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -19,17 +19,12 @@ use crate::tir::{
 
 use crate::synthesis::common::{binary, builtin_call, cast, i32_const, i64_const, synth_span};
 
-/// Snapshot of the stdlib type / variant names the CM binding code
-/// matches against — `String`, `List`, `Option`, `Result` — resolved
-/// once through the `CompilerItem` registry so a stdlib rename of any
-/// of these flows through every CM lift / lower / adapter site
-/// without hard-coded literals scattered across `synthesis::cm_binding`.
-///
-/// `result` is kept for downstream callers that match against the
-/// `Result` variant name even when the current consumer set does not
-/// need it; populating it costs one registry hit + clone and keeps
-/// the snapshot's shape complete for the next CM-binding site that
-/// wants to read it.
+/// Snapshot of the stdlib type / variant names CM binding matches against,
+/// resolved once through the `CompilerItem` registry so a stdlib rename flows
+/// through every lift / lower / adapter site rather than through literals
+/// scattered across `synthesis::cm_binding`. `result` is populated even where no
+/// current consumer reads it — one registry hit keeps the snapshot's shape
+/// complete for the next site that does.
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub struct CmStdlibNames {
@@ -122,16 +117,11 @@ pub struct LiftContext<'a> {
     /// `wasi:http/ErrorCode` — or, across schemes,
     /// `wasi:http/types::Response` vs. `core:kiln/types::Response`.
     pub cm_package: &'a str,
-    /// `ModuleSource` interner shared with the package; used by
-    /// `module_source_for_cm_interface` to canonicalise the module
-    /// identity of synthesised types (e.g. `wasi:http/types`,
-    /// `core:kiln/types.wado`) so they match the elaborator's registered
-    /// `StructName`s ptr-eq.
-    ///
-    /// Re-entrancy: the lift call chain may `borrow_mut()` this cell;
-    /// callers must not hold a `RefMut` to the same cell across calls
-    /// into `synthesize_lift` or its helpers. The lift path itself only
-    /// borrows transiently inside `module_source_for_cm_interface`.
+    /// `ModuleSource` interner shared with the package, used to canonicalise a
+    /// synthesised type's module identity so it matches the elaborator's
+    /// registered `StructName`s pointer-equal. The lift chain may `borrow_mut`
+    /// it, so no caller may hold a `RefMut` across a call into `synthesize_lift`;
+    /// the lift path itself borrows only transiently.
     pub interner: &'a RefCell<ModuleSourceInterner>,
 }
 
@@ -152,16 +142,12 @@ impl LiftContext<'_> {
         module_source_for_cm_interface(&mut self.interner.borrow_mut(), source)
     }
 
-    /// Resolve a CM `Type` to its elaborator-registered `TypeId`, lib-aware.
-    ///
-    /// Unlike [`cm_type_to_type_id`], a *lib-local* named struct/variant is
-    /// resolved through its recorded entry `ModuleSource`, so it yields the
-    /// concrete GC `TypeId` the rest of the pipeline expects rather than falling
-    /// back to `i32`. WASI/core named types keep going through
-    /// `cm_type_to_type_id` (which resolves them by package). Lib-local
-    /// provenance is detected via the registry, not an FQ prefix check. Container
-    /// types (tuple/list/option/result) recurse so nested lib-local elements
-    /// resolve too.
+    /// Resolve a CM `Type` to its elaborator-registered `TypeId`, lib-aware:
+    /// unlike [`cm_type_to_type_id`], a lib-local named type resolves through its
+    /// recorded entry `ModuleSource` and yields the concrete GC id rather than
+    /// falling back to `i32`. Provenance comes from the registry, not an FQ
+    /// prefix check, and containers recurse so nested lib-local elements resolve
+    /// too. WASI and core types still go by package.
     pub(super) fn cm_type_id(&self, ty: &Type, tt: &mut TypeTable) -> TypeId {
         match ty {
             Type::Named(n) => {
@@ -246,20 +232,13 @@ pub struct LowerContext<'a> {
     pub names: CmStdlibNames,
 }
 
-/// Convert a WASI AST `Type` to a `TypeId` in the type table.
-///
-/// Every WASI binding is emitted inside a known package (e.g. `"http"`), so
-/// both the registry and the owning package are required — there is no
-/// unscoped variant. Named types are resolved by `(name, wasi_package)`; if
-/// the primary scope misses we consult the registry for the canonical owner
-/// of the bare name (e.g. `ErrorCode` is declared in `filesystem/types.wado`
-/// but referenced from `http` bindings). Same-named types from distinct
-/// interfaces are always distinct `TypeId`s.
-///
-/// This is needed for synthesized binding code that calls generic methods
-/// (e.g., `List::<String>::with_capacity()`). The monomorphizer requires
-/// concrete `TypeId`s in `MonomorphInfo::type_args` to instantiate generic
-/// methods.
+/// Convert a WASI AST `Type` to a `TypeId`. Every WASI binding is emitted inside
+/// a known package, so both the registry and the owner are required — there is
+/// no unscoped variant. A named type resolves by `(name, wasi_package)`, falling
+/// back to the registry's canonical owner of the bare name, since `http`
+/// bindings may reference an `ErrorCode` declared in `filesystem`. Same-named
+/// types from distinct interfaces stay distinct. Synthesized binding code needs
+/// the concrete ids to instantiate a generic method through `MonomorphInfo`.
 pub fn cm_type_to_type_id(
     ty: &Type,
     type_table: &mut TypeTable,
@@ -543,20 +522,13 @@ pub(super) fn is_wasm_flat_type(type_id: TypeId) -> bool {
     )
 }
 
-/// Validate that `type_id` has a Component Model value representation, returning
-/// `Err(reason)` for a type that has *none in any world* — an empty record (the
-/// CM binary format forbids zero-field records) or a 128-bit/`v128` scalar (no
-/// CM scalar type). The driver surfaces this as a proper compile error instead
-/// of emitting an invalid component or panicking in codegen.
-///
-/// The check is world-independent: it does not branch on `--lib` vs WASI. Handle
-/// and async types (`resource`, `own`/`borrow`, `stream`/`future`) *are*
-/// representable — they lower to `i32` handles identically in every world — so
-/// they pass. Recurses through containers and named aggregates to catch a
-/// non-representable type nested inside one; `visited` is the recursion path,
-/// and a type that revisits itself is rejected — WIT has no recursive types,
-/// and the lift/lower synthesizers would otherwise recurse forever generating
-/// inline code for one.
+/// Validate that `type_id` has a Component Model value representation, erroring
+/// for one that has none in any world — an empty record, which the CM binary
+/// format forbids, or a 128-bit / `v128` scalar. The driver reports this rather
+/// than emitting an invalid component. World-independent: a handle or async type
+/// lowers to an `i32` handle everywhere and passes. Recurses through containers
+/// to catch a nested offender, and rejects a type that revisits itself — WIT has
+/// no recursive types, and the synthesizers would inline one forever.
 pub(super) fn check_cm_boundary_representable(
     type_id: TypeId,
     type_table: &TypeTable,
@@ -1346,22 +1318,13 @@ pub(super) fn cm_zero(vt: cm_abi::CmValType) -> TirExpr {
     }
 }
 
-/// Reconstruct a minimal AST `Type` surface from a TIR `TypeId`.
-///
-/// Used by callers that need to re-enter AST-shaped `Type` match arms
-/// (struct/generic field recursion in
-/// `synthesize_lift_from_flat_params`, element lowering in the
-/// `List<T>` arm of `lower_to_flat_inner`). The returned value only
-/// needs the top-level `name` and (for `GenericInstance`) immediate
-/// type args; deeper structural data is already reachable through
-/// `tir_modules` + `type_table` and is looked up lazily.
-///
-/// Named types receive their `source_interface` populated via
-/// [`CmInterfaceRegistry::resolve_cm_source_for`] when the registry knows the
-/// type (`wasi:*` records or `core:kiln/*` records). Without this,
-/// downstream lower / lift helpers can't find the record's field
-/// layout because they key the registry lookup by
-/// `(source_interface, name)`.
+/// Reconstruct a minimal AST `Type` from a TIR `TypeId`, for callers that need
+/// to re-enter the AST-shaped match arms. Only the top-level name and immediate
+/// type args are filled in; deeper structure is looked up lazily through
+/// `tir_modules` and the type table. A named type gets its `source_interface`
+/// populated where the registry knows it, since the lift / lower helpers key
+/// their lookups by `(source_interface, name)` and would otherwise miss the
+/// record's field layout.
 pub(super) fn type_id_to_ast_type(
     type_id: TypeId,
     type_table: &TypeTable,
@@ -1500,20 +1463,12 @@ pub(super) fn compute_export_flat_param_types(
     out
 }
 
-/// Does a user function parameter whose TIR `TypeId` is `type_id` need CM
-/// flat-ABI lifting at the export boundary?
-///
-/// A parameter "needs lifting" when its canonical CM flat representation
-/// is not a single-slot passthrough of the same Wasm value type.
-/// Primitives (`i32`, `f64`, `bool`, `char`, ...) and handle-shaped
-/// types (resources, enums, flags) all travel as a single i32 / i64 /
-/// f32 / f64 both at the Wasm layer and at the CM layer, so no lifting
-/// step is required. Everything else — `String`, `List<T>`,
-/// `Option<T>`, `Result<T, E>`, tuples, user structs, variants — expands
-/// to either a different value type or multiple values under the flat
-/// ABI, and therefore must be reconstructed into a Wado-side value.
-///
-/// Consults [`TypeTable`] directly; no `tir_modules` or AST traversal.
+/// Whether a parameter needs CM flat-ABI lifting at the export boundary — that
+/// is, whether its flat representation is anything but a single-slot passthrough
+/// of the same Wasm value type. A primitive or handle-shaped type travels as one
+/// scalar at both layers and needs none; everything else expands to a different
+/// type or to several values, and must be reconstructed Wado-side. Reads
+/// [`TypeTable`] alone, with no AST traversal.
 pub(super) fn param_needs_lifting(type_id: TypeId, tt: &TypeTable) -> bool {
     match tt.get(type_id) {
         ResolvedType::Primitive(prim) => matches!(prim, PrimitiveType::Bool),

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -1456,9 +1456,9 @@ pub(super) fn compute_export_flat_param_types(
 
 /// Whether a parameter needs CM flat-ABI lifting at the export boundary — that
 /// is, whether its flat representation is anything but a single-slot passthrough
-/// of the same Wasm value type. A primitive or handle-shaped type travels as one
-/// scalar at both layers and needs none; everything else expands to a different
-/// type or to several values, and must be reconstructed Wado-side.
+/// of the same Wasm value type. Handle-shaped types (resource, enum, flags) and
+/// every primitive but `bool` travel as one scalar at both layers and need none;
+/// `bool`, `Unit`, and everything else must be reconstructed Wado-side.
 pub(super) fn param_needs_lifting(type_id: TypeId, tt: &TypeTable) -> bool {
     match tt.get(type_id) {
         ResolvedType::Primitive(prim) => matches!(prim, PrimitiveType::Bool),

--- a/wado-compiler/src/synthesis/cm_binding/types.rs
+++ b/wado-compiler/src/synthesis/cm_binding/types.rs
@@ -22,9 +22,7 @@ use crate::synthesis::common::{binary, builtin_call, cast, i32_const, i64_const,
 /// Snapshot of the stdlib type / variant names CM binding matches against,
 /// resolved once through the `CompilerItem` registry so a stdlib rename flows
 /// through every lift / lower / adapter site rather than through literals
-/// scattered across `synthesis::cm_binding`. `result` is populated even where no
-/// current consumer reads it — one registry hit keeps the snapshot's shape
-/// complete for the next site that does.
+/// scattered across `synthesis::cm_binding`.
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub struct CmStdlibNames {
@@ -146,8 +144,7 @@ impl LiftContext<'_> {
     /// unlike [`cm_type_to_type_id`], a lib-local named type resolves through its
     /// recorded entry `ModuleSource` and yields the concrete GC id rather than
     /// falling back to `i32`. Provenance comes from the registry, not an FQ
-    /// prefix check, and containers recurse so nested lib-local elements resolve
-    /// too. WASI and core types still go by package.
+    /// prefix check, and containers recurse. WASI and core types go by package.
     pub(super) fn cm_type_id(&self, ty: &Type, tt: &mut TypeTable) -> TypeId {
         match ty {
             Type::Named(n) => {
@@ -233,12 +230,10 @@ pub struct LowerContext<'a> {
 }
 
 /// Convert a WASI AST `Type` to a `TypeId`. Every WASI binding is emitted inside
-/// a known package, so both the registry and the owner are required — there is
-/// no unscoped variant. A named type resolves by `(name, wasi_package)`, falling
-/// back to the registry's canonical owner of the bare name, since `http`
-/// bindings may reference an `ErrorCode` declared in `filesystem`. Same-named
-/// types from distinct interfaces stay distinct. Synthesized binding code needs
-/// the concrete ids to instantiate a generic method through `MonomorphInfo`.
+/// a known package, so both the registry and the owner are required. A named
+/// type resolves by `(name, wasi_package)`, falling back to the registry's
+/// canonical owner of the bare name, since `http` bindings may reference an
+/// `ErrorCode` declared in `filesystem`.
 pub fn cm_type_to_type_id(
     ty: &Type,
     type_table: &mut TypeTable,
@@ -524,11 +519,9 @@ pub(super) fn is_wasm_flat_type(type_id: TypeId) -> bool {
 
 /// Validate that `type_id` has a Component Model value representation, erroring
 /// for one that has none in any world — an empty record, which the CM binary
-/// format forbids, or a 128-bit / `v128` scalar. The driver reports this rather
-/// than emitting an invalid component. World-independent: a handle or async type
-/// lowers to an `i32` handle everywhere and passes. Recurses through containers
-/// to catch a nested offender, and rejects a type that revisits itself — WIT has
-/// no recursive types, and the synthesizers would inline one forever.
+/// format forbids, or a 128-bit / `v128` scalar — rather than emitting an
+/// invalid component. Recurses through containers, and rejects a type revisiting
+/// itself: WIT has no recursive types, and synthesis would inline one forever.
 pub(super) fn check_cm_boundary_representable(
     type_id: TypeId,
     type_table: &TypeTable,
@@ -1320,11 +1313,9 @@ pub(super) fn cm_zero(vt: cm_abi::CmValType) -> TirExpr {
 
 /// Reconstruct a minimal AST `Type` from a TIR `TypeId`, for callers that need
 /// to re-enter the AST-shaped match arms. Only the top-level name and immediate
-/// type args are filled in; deeper structure is looked up lazily through
-/// `tir_modules` and the type table. A named type gets its `source_interface`
-/// populated where the registry knows it, since the lift / lower helpers key
-/// their lookups by `(source_interface, name)` and would otherwise miss the
-/// record's field layout.
+/// type args are filled in; deeper structure is looked up lazily. A named type
+/// gets its `source_interface` where the registry knows it, since the lift /
+/// lower helpers key by `(source_interface, name)`.
 pub(super) fn type_id_to_ast_type(
     type_id: TypeId,
     type_table: &TypeTable,
@@ -1467,8 +1458,7 @@ pub(super) fn compute_export_flat_param_types(
 /// is, whether its flat representation is anything but a single-slot passthrough
 /// of the same Wasm value type. A primitive or handle-shaped type travels as one
 /// scalar at both layers and needs none; everything else expands to a different
-/// type or to several values, and must be reconstructed Wado-side. Reads
-/// [`TypeTable`] alone, with no AST traversal.
+/// type or to several values, and must be reconstructed Wado-side.
 pub(super) fn param_needs_lifting(type_id: TypeId, tt: &TypeTable) -> bool {
     match tt.get(type_id) {
         ResolvedType::Primitive(prim) => matches!(prim, PrimitiveType::Bool),

--- a/wado-compiler/src/synthesis/common.rs
+++ b/wado-compiler/src/synthesis/common.rs
@@ -538,17 +538,11 @@ pub fn make_synthetic_free_function(
     }
 }
 
-/// Build a `f.write_str(&"text")` statement using Formatter's `write_str`
-/// method. `Formatter::write_str` takes `&String`, so the literal is
-/// wrapped in an explicit `Ref`; `ref_string_type` is the cached `&String`
-/// type id the caller already produced from `string_type`.
-///
-/// `formatter_name` is the resolved [`CompilerItem::Formatter`] struct
-/// name. Every caller already snapshotted it (either via
-/// [`super::traits::TraitsStdlibNames`] on `SynthesisCtx`, or by reading
-/// it directly off `tt.compiler_items()`), so threading it through this
-/// helper avoids a fresh registry lookup per call without re-introducing
-/// the `"Formatter"` literal here.
+/// Build a `f.write_str(&"text")` statement. `Formatter::write_str` takes
+/// `&String`, so the literal is wrapped in an explicit `Ref` using the caller's
+/// cached `ref_string_type`. `formatter_name` is the resolved
+/// [`CompilerItem::Formatter`] struct name, threaded in from the caller's own
+/// snapshot rather than looked up again here.
 pub fn write_str_stmt(
     text: impl Into<String>,
     fmt: TirExpr,
@@ -665,15 +659,10 @@ pub fn field_access(
 }
 
 /// Relocate the locals of an expression reified in another context — a struct
-/// field's default — into the synthesized function embedding it.
-///
-/// A default expression is reified in the struct's own context (a fresh
-/// `FunctionContext` numbered from 0), so e.g. a `List` literal desugars to a
-/// `SequenceLiteralBuilder` block whose `__b` local takes index 0 — which
-/// aliases the embedding function's first parameter or another field's default.
-/// The aliasing produces a core-Wasm type mismatch. Re-allocate each `Let`-bound
-/// local with a fresh index (via `alloc_named_local`, keeping
-/// `next_local`/`locals` in sync) and rewrite every reference to it.
+/// field's default — into the synthesized function embedding it. A default is
+/// reified in a fresh `FunctionContext` numbered from 0, so its locals alias the
+/// embedding function's parameters and produce a core-Wasm type mismatch. Each
+/// `Let`-bound local is re-allocated fresh and every reference rewritten.
 pub fn relocate_synthetic_locals(
     expr: &mut TirExpr,
     next_local: &mut u32,

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -1,45 +1,8 @@
-//! Effect handler dispatch synthesis (Phase 4 of WEP 2026-04-11).
-//!
-//! Runs after effect-check / stores-check, before link/monomorphize.
-//!
-//! For every effect that has at least one user-written `impl E for T`
-//! block, the pass emits the dispatch infrastructure described in the
-//! WEP and rewrites the program to route every effect-operation call
-//! through it:
-//!
-//! 1. A per-effect Wasm GC struct `__Dispatch_<E>` with a recursive
-//!    `outer: Option<&__Dispatch_<E>>` field plus one
-//!    `fn(<op_params>) -> <op_ret>` closure field per declared
-//!    operation.
-//! 2. A per-effect mutable global
-//!    `__effect_<E>: Option<&__Dispatch_<E>>` initialised to `null`.
-//! 3. One `__effect_dispatch__<E>__<op>` wrapper function per
-//!    operation. Body: read the global, restore `outer` (so handler
-//!    bodies see the outer scope and can self-delegate), call the
-//!    closure, re-install the saved value, and return the result. If
-//!    no handler is installed, fall back to the existing CM binding
-//!    adapter (WASI effects) or trap (user-defined effects).
-//! 4. `WithHandler { bindings, body }` lowers to a desugared block
-//!    that, for each binding (in source order), saves the global,
-//!    binds the handler value to a fresh local, builds closures
-//!    capturing that local and forwarding to the bound `impl E for T`
-//!    methods, populates a fresh `__Dispatch_<E>` struct, installs
-//!    the global, runs the body, and restores the saved value on
-//!    exit (in reverse install order).
-//! 5. Every `<E>::<op>` call site is rewritten to call the wrapper —
-//!    both the WASI-binding shape (`__cm_binding__<E>_<op>`) and the
-//!    user-effect namespaced shape (`<op>` in `Local{path: "<E>"}`).
-//!    Calls inside `__effect_dispatch__*` wrappers and
-//!    `__cm_binding__*` adapters are skipped to keep the WASI
-//!    fallback path reachable.
-//! 6. `Resume { value }` inside `impl E for T` method bodies is
-//!    lowered to `Return { value }` — the MVP has no post-resume
-//!    semantics.
-//!
-//! Operations the installed handler does not implement (the `..trap` rest
-//! clause in `impl Effect for T`) get a trapping stub closure
-//! populated into the dispatch struct so the dispatch global is
-//! always fully populated.
+//! Effect handler dispatch synthesis (WEP 2026-04-11 phase 4). For every effect
+//! with a user-written `impl E for T`, emit a `__Dispatch_<E>` struct (a chain
+//! through `outer`, one closure field per op), an `__effect_<E>` global, and an
+//! `__effect_dispatch__<E>__<op>` wrapper per op; then route every call site
+//! through the wrappers and desugar `WithHandler` into install/restore blocks.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::module_source::{ModuleSource, ModuleSourceInterner};
@@ -55,27 +18,17 @@ use crate::tir::{
 use crate::tir_visitor::TirRefVisitor;
 
 /// Canonical identity of an effect or resource **declaration**:
-/// `(defining_module, base_name)`.
-///
-/// One declaration may be instantiated many ways at use sites — generic
-/// resources like `Stream<T>` produce a separate instantiation per
-/// `(T = u8)`, `(T = i32)`, etc., so call-site dispatch needs the
-/// `InstantiationKey` form below. The `EffectKey` itself stays bound to
-/// the declaration: `EffectMeta` carries the **template** operation list
-/// (with type-params unsubstituted) and is shared across every
-/// instantiation that needs the same template.
+/// `(defining_module, base_name)`. It stays bound to the declaration —
+/// `EffectMeta` carries the *template* operation list, shared across every
+/// instantiation. Call-site dispatch needs [`InstantiationKey`] instead, since
+/// a generic resource like `Stream<T>` instantiates once per type argument.
 type EffectKey = (ModuleSource, String);
 
 /// Canonical identity of a per-monomorphisation dispatch instantiation:
-/// `(defining_module, base_name, type_args)`.
-///
-/// For non-generic effects / resources the `type_args` slot is empty and
-/// the key is essentially the `EffectKey` widened with `[]`; the dispatch
-/// infrastructure (`__Dispatch_<E>`, `__effect_<E>`, per-op wrappers)
-/// continues to live one-set-per-declaration. For generic resources, each
-/// distinct argument tuple gets its own dispatch struct / global / wrapper
-/// triple, with the resource declaration's operation types substituted at
-/// the type-param indices recorded by the resource decl.
+/// `(defining_module, base_name, type_args)`. Each distinct argument tuple gets
+/// its own dispatch struct / global / wrapper triple, with the declaration's
+/// operation types substituted. A non-generic effect has empty `type_args` and
+/// so keeps one set per declaration.
 pub type InstantiationKey = (ModuleSource, String, Vec<TypeId>);
 
 /// Metadata for a single effect or resource, indexed by `EffectKey`.
@@ -127,21 +80,11 @@ fn build_effect_index(project: &Package) -> IndexMap<EffectKey, EffectMeta> {
     out
 }
 
-/// Identify which (effect/resource, type-arg) instantiations need
-/// dispatch infrastructure.
-///
-/// An instantiation is "active" iff at least one user-written
-/// `impl <Effect> for <Type>` (or `impl <Resource><Args> for <Type>`)
-/// block exists for it in the package. Each distinct instantiation —
-/// `impl Stream<u8>` vs `impl Stream<i32>` — gets its own entry so the
-/// dispatch synthesis emits one infra triple per monomorphisation.
-/// Non-generic effects collapse to a single instantiation with empty
-/// `type_args`.
-///
-/// Reads the canonical `(effect_module, base_name, trait_type_args)`
-/// triple off each `HandlerImplKey` directly — no name-only matching
-/// against `effect_index` — so two effects sharing a name across modules
-/// cannot be conflated.
+/// Identify which instantiations need dispatch infrastructure: one is active iff
+/// the package holds at least one user-written impl block for it, and
+/// `impl Stream<u8>` and `impl Stream<i32>` are separate entries. Reads the
+/// canonical triple off each `HandlerImplKey` rather than matching names against
+/// `effect_index`, so same-named effects in different modules stay distinct.
 fn identify_active_effects(
     impl_index: &IndexMap<HandlerImplKey, HandlerImplInfo>,
 ) -> IndexSet<InstantiationKey> {
@@ -227,17 +170,11 @@ impl TirRefVisitor for UncoveredEffectCallCollector<'_> {
     }
 }
 
-/// All the bookkeeping needed to emit / refer to the dispatch
-/// infrastructure for a single effect.
-///
-/// A `DispatchPlan` is built once per active effect by
-/// `synthesize_dispatch_infrastructure` and consumed by the lowering
-/// (`lower_with_handler`) and call-site rewriting
-/// (`rewrite_call_sites_to_wrappers`) passes. The map of plans is
-/// stashed on `Package::dispatch_plans` between the early
-/// (`synthesize_pre_cm_binding`) and late (`synthesize_post_check`)
-/// halves of the synthesis split so the late phase doesn't re-derive
-/// the same `(struct_type_id, global_name, …)` triple.
+/// All the bookkeeping needed to emit / refer to one effect's dispatch
+/// infrastructure. Built once per active effect by
+/// `synthesize_dispatch_infrastructure`, then consumed by the lowering and
+/// call-site-rewriting passes. The map lives on `Package::dispatch_plans` so the
+/// late synthesis half does not re-derive it.
 #[derive(Debug, Clone)]
 pub struct DispatchPlan {
     /// `TypeId` of the synthesised `__Dispatch_<E>` struct.
@@ -298,17 +235,10 @@ fn impl_method_return_type(op: &TirEffectOp, type_table: &TypeTable) -> TypeId {
     }
 }
 
-/// Substitute the resource declaration's type parameters with the
-/// concrete `type_args` recorded on an `impl <Resource><Args> for <T>`
-/// block, producing per-instantiation operation signatures.
-///
-/// The resource decl's operations carry `TypeId`s that may transitively
-/// reference `TypeParam { index }` entries minted at the resource's
-/// declaration site; substitution walks each operation's parameter
-/// list and return type through `SubstitutionContext`, replacing those
-/// type-param references with the supplied concrete `TypeId`s. The
-/// resulting `TirEffectOp` list is what the per-instantiation dispatch
-/// struct / global / wrappers are synthesised against.
+/// Substitute the resource declaration's type parameters with the concrete
+/// `type_args` from an `impl <Resource><Args> for <T>` block, producing the
+/// per-instantiation operation signatures the dispatch struct / global /
+/// wrappers are synthesised against.
 fn substitute_operations(
     template: &[TirEffectOp],
     type_args: &[TypeId],
@@ -349,30 +279,11 @@ fn substitute_operations(
         .collect()
 }
 
-/// Synthesise the `__Dispatch_<E>` Wasm GC struct for one effect.
-///
-/// Two-phase construction handles the recursive
-/// `outer: Option<&__Dispatch_<E>>` field:
-///
-/// 1. `make_struct` interns an empty / forward-declared struct type id
-///    in the shared `TypeTable`.
-/// 2. Field types — including the `Option<&Self>` outer field, which
-///    references that very type id — are computed in the same borrow
-///    scope.
-///
-/// The matching `TirStruct` decl is then appended to the entry module's
-/// `structs` list. Layout:
-///
-/// ```text
-/// struct __Dispatch_<E> {
-///     outer: Option<&__Dispatch_<E>>,
-///     op_<n>: fn(<op_n_params>) -> <op_n_ret>,
-///     ...
-/// }
-/// ```
-///
-/// All synthesised dispatch infrastructure lives in the entry module,
-/// mirroring `cm_binding`'s placement of WASI binding adapters.
+/// Synthesise the `__Dispatch_<E>` struct — `outer: Option<&__Dispatch_<E>>`
+/// plus one `fn(<op_params>) -> <op_ret>` field per operation — into the entry
+/// module, where all dispatch infrastructure lives. The recursive `outer` field
+/// needs two phases: `make_struct` interns a forward-declared id first, then the
+/// field types (which reference it) are computed in the same borrow scope.
 fn synthesize_dispatch_struct(
     project: &mut Package,
     entry_source: &ModuleSource,
@@ -518,33 +429,11 @@ fn synthesize_dispatch_global(
     entry_module.globals.push(global);
 }
 
-/// Synthesise the per-(effect, op) `__effect_dispatch__<E>__<op>` wrapper
-/// function for one effect.
-///
-/// Each wrapper has the same signature as the operation itself
-/// (`<op_params> -> <op_ret>`) so call-site rewriting is a name swap.
-///
-/// Body shape:
-///
-/// ```text
-/// fn __effect_dispatch__<E>__<op>(<args>) -> <ret> {
-///     let __saved = global.get __effect_<E>;
-///     if let Some(d) = __saved {
-///         global.set __effect_<E> = d.outer;     // expose outer scope
-///         let __result = (d.op_<op>)(args);      // call the closure
-///         global.set __effect_<E> = __saved;     // restore
-///         return __result;
-///     }
-///     // Fallback path: no handler installed.
-///     // - WASI effect: call the existing CM-binding adapter.
-///     // - User effect: trap (effect-check should have ensured a handler).
-///     return __cm_binding__<E>_<op>(args);
-/// }
-/// ```
-///
-/// The outer-scope restore before the closure call implements algebraic
-/// effect forwarding: a handler method can call `<E>::<op>` again to
-/// delegate to the outer handler chain without infinite recursion.
+/// Synthesise the `__effect_dispatch__<E>__<op>` wrapper functions, each with
+/// the operation's own signature so call-site rewriting is a name swap. A
+/// wrapper installs `d.outer` for the duration of the closure call — that is
+/// what lets a handler method delegate to the outer chain without recursing —
+/// then restores. With no handler installed it falls back to the CM adapter.
 fn synthesize_dispatch_wrappers(
     project: &mut Package,
     entry_source: &ModuleSource,
@@ -815,39 +704,12 @@ fn build_dispatch_wrapper_function(
 
     let then_block = TirBlock::new(then_stmts, span);
 
-    // Else-branch: fallback.
-    //
-    // The wrapper is synthesised BEFORE `cm_binding::generate_adapters`
-    // runs, so the fallback emits the same shape user code would have
-    // emitted if no handler were installed: an effect-like `Call`
-    // (`Counter::next()` form) for effects, and a `cm_name`-tagged
-    // a call for resources. cm_binding then walks every
-    // function body — including these wrapper fallbacks — and rewrites
-    // both shapes uniformly:
-    //
-    // - effect calls trigger `synthesize_adapter` and become
-    //   `__cm_binding__<E>_<op>(args)`;
-    // - resource calls become `cm_stream_*_<elem>` / `cm_future_*` /
-    //   `__cm_binding__<R>_<op>` / `CmRawCall` per the resource's
-    //   `cm_binding_function` route, with no further work from this
-    //   pass.
-    //
-    // For user-defined effects without a CM binding (like the test
-    // `Counter` effect), the call falls through cm_binding's rewrite
-    // and reaches WIR build as a plain effect call — well-typed
-    // programs never reach the wrapper fallback for such effects
-    // because effect-check requires a handler at every call site, but
-    // we still emit the placeholder for consistency.
-    // Routing key is `op.cm_name`:
-    //   * resource ops always carry a `#[cm("...")]` attribute (the
-    //     elaborator records its payload on `TirEffectOp.cm_name`), and
-    //     `is_resource` is set when the dispatch instantiation comes from
-    //     a `pub resource ...` decl rather than a `pub effect ...` decl;
-    //   * WASI effect ops always carry `#[cm("...")]` too (every WASI
-    //     interface method is a CM canonical operation in our stdlib);
-    //   * user-defined effect ops carry no `#[cm("...")]` and are
-    //     unreachable here in well-typed programs (effect-check insists
-    //     on a handler at every call site).
+    // Else-branch: fallback. Synthesised before `cm_binding::generate_adapters`
+    // runs, so it emits the same pre-adapter shape user code would — an
+    // effect-like `Call` for effects, a `cm_name`-tagged one for resources —
+    // and cm_binding rewrites both uniformly when it walks these bodies. A
+    // user-defined effect has no `cm_name` and is unreachable here: effect-check
+    // insists on a handler at every call site.
     let mut else_stmts: Vec<TirStmt> = Vec::new();
     if is_resource {
         let placeholder_call = build_resource_fallback_call(
@@ -1007,49 +869,12 @@ fn build_dispatch_wrapper_function(
         params,
         return_type,
         task_return_type: None,
-        // The wrapper is the implementation of `<E>::<op>`.
-        //
-        // For effects, declare effect `E` on the wrapper for two reasons:
-        // - For WASI effects, the fallback path (no handler installed)
-        //   calls the existing `__cm_binding__<E>_<op>` adapter, which
-        //   carries effect `E` itself. Declaring `E` on the wrapper
-        //   matches the cm_binding convention so downstream phases that
-        //   consult `effects` (DCE root walk, inliner, codegen) treat
-        //   the wrapper consistently with a hand-written effect call.
-        // - For user-defined effects, the fallback panics; declaring
-        //   `E` is still the honest type — the wrapper *implements* `E`,
-        //   even if its body never propagates the effect further.
-        //
-        // For resources, the wrapper carries no effects: resource
-        // declarations are not effects in Wado's effect system, so a
-        // call site like `Fields::new()` does not require a `with` clause
-        // on the caller, and the matching `__cm_binding__<R>_<op>`
-        // adapter declares `effects: vec![]` for the same reason.
-        // Mirroring that here keeps the dispatch wrapper observably
-        // equivalent to the cm_binding adapter from the effect-check
-        // and codegen perspectives.
-        //
-        // Effect-check has already run by this point, so this declaration
-        // is documentation rather than an obligation; downstream passes
-        // that re-walk effects (codegen export tables, `used_wasi_*`
-        // tracking) get the right answer.
-        // Wrappers declare empty effects so that calls to them (which
-        // now happen at every user effect / resource call site) don't
-        // propagate the underlying effect to the caller. The wrapper
-        // itself satisfies the effect: its `if let Some(d)` branch
-        // dispatches into the user-installed handler (which is allowed
-        // to perform the effect via the outer-scope dispatch global),
-        // and its `else` branch emits a placeholder call that
-        // cm_binding rewrites into the right adapter / canonical
-        // intrinsic. From the caller's perspective, calling a wrapper
-        // is a plain function call with no propagated effects — much
-        // like calling a `cm_binding` adapter, which also carries
-        // `effects: vec![]`. This matches the prior pre-reorder
-        // behaviour where call sites still in their raw `Effect::op()`
-        // form went through `find_effect_signature` and returned no
-        // declared effects (effect ops aren't in the function index),
-        // so handler methods like `OffsetCounter^Counter::next` could
-        // call `Counter::next()` without re-declaring `with Counter`.
+        // A wrapper declares no effects, so calling one — which now happens at
+        // every effect / resource call site — propagates nothing to the caller.
+        // The wrapper is what satisfies the effect: its `if let Some(d)` branch
+        // dispatches into the installed handler and its `else` branch emits the
+        // placeholder cm_binding rewrites. `__cm_binding__*` adapters carry
+        // `effects: vec![]` for the same reason.
         effects: vec![],
         stores: vec![],
         body: Some(body),
@@ -1073,16 +898,10 @@ fn build_dispatch_wrapper_function(
     }
 }
 
-/// Build the wrapper-fallback placeholder for a resource operation
-/// (one that carries a `#[cm("...")]` attribute). Emits the same
-/// pre-cm_binding call shape that user code emits — a method call for
-/// instance ops (those whose first param is the synthesised `self`
-/// receiver from gap 3), `Call` for static ops — with `method_info`
-/// carrying the original `cm_name`. `cm_binding`'s
-/// `rewrite_cm_resource_methods` then walks the wrapper body and
-/// rewrites the placeholder into the appropriate
-/// `cm_stream_*` / `cm_future_*` / `__cm_binding__<R>_<op>` /
-/// `CmRawCall` form per its `cm_binding_function` routing.
+/// Build the wrapper-fallback placeholder for a resource operation: the same
+/// pre-cm_binding shape user code emits — a method call for instance ops, `Call`
+/// for static ones — with `method_info` carrying the original `cm_name`, which
+/// is what lets `rewrite_cm_resource_methods` route it afterwards.
 #[allow(dead_code, clippy::too_many_arguments)]
 fn build_resource_fallback_call(
     _entry_source: &ModuleSource,
@@ -1119,22 +938,11 @@ fn build_resource_fallback_call(
     let mut method_info = crate::name::LocalMethodName::new(label_fq, None, op.name.clone());
     method_info.cm_name = Some(cm_name);
 
-    // Carry the resource instantiation's type args as the call's
-    // `monomorph_info.impl_type_args`. WIR-build's canonical-method
-    // translator (e.g. `cm_future_payload_from_monomorph` for
-    // `future-new`) reads these to pick the right payload-parameterised
-    // canonical import (`future-new:s32` vs the trailers default). The
-    // elaborator attaches `monomorph_info` for the same reason on real
-    // user calls; the wrapper fallback must do the same so its
-    // post-cm_binding shape is indistinguishable from a hand-written
-    // `Future::<i32>::new()` call site.
-    //
-    // `method_type_args` stays empty: `ast::InterfaceMethod` carries no
-    // type-parameter list, so resource / effect operations cannot
-    // themselves be generic — only the resource type can. The `T` in
-    // `Stream<T>::read(self, max) -> List<T>` is the resource's type
-    // parameter, already substituted by `substitute_operations` and
-    // captured in `impl_type_args`.
+    // Carry the instantiation's type args as `monomorph_info.impl_type_args`,
+    // which WIR-build reads to pick the payload-parameterised canonical import
+    // (`future-new:s32` vs the default) — the fallback must be indistinguishable
+    // from a hand-written `Future::<i32>::new()`. `method_type_args` stays empty:
+    // an operation cannot itself be generic, only the resource type can.
     let monomorph_info = if type_args.is_empty() {
         None
     } else {
@@ -1199,35 +1007,20 @@ struct DispatchEnv<'a> {
     entry_source: ModuleSource,
 }
 
-/// Mutable context threaded through the dispatch-aware lowering walker.
-///
-/// Tracks the containing function's local table so the desugarer can
-/// allocate fresh locals for `__h_<E>` / `__save_<E>` / `__d_<E>`
-/// triples.
-///
-/// When the walker descends into a `TirExprKind::Closure` body, it
-/// pushes a fresh closure-local scope so any nested `WithHandler` is
-/// desugared into the closure's local-index space rather than the
-/// outer function's. Closure-scope `locals` is dropped on pop
-/// because the lower phase rebuilds each closure's local table from
-/// `Let` statements anyway.
+/// Mutable context threaded through the dispatch-aware lowering walker, holding
+/// the local table the desugarer allocates `__h_<E>` / `__save_<E>` / `__d_<E>`
+/// from. Descending into a `Closure` body pushes a fresh scope so a nested
+/// `WithHandler` lands in the closure's local-index space.
 struct LowerCtx {
     /// Stack of local-allocation scopes — one entry per active function
     /// or closure body. Top of stack is the innermost scope.
     scopes: Vec<LocalScope>,
 }
 
-/// One frame on `LowerCtx.scopes`.
-///
-/// The outermost frame is always a `Function` scope and owns the
-/// caller's `locals` vector — fresh locals are appended there and
-/// the vector is moved back into `TirFunction.locals` on exit.
-///
-/// Each `Closure` frame, pushed when the walker descends into a
-/// `TirExprKind::Closure` body, owns a closure-local `next_local`
-/// counter only — the lower phase rebuilds each closure functor's
-/// local table from the body's `Let` statements, so we don't need to
-/// track types here.
+/// One frame on `LowerCtx.scopes`. The outermost is always `Function` and owns
+/// the `locals` vector, moved back into `TirFunction.locals` on exit. A
+/// `Closure` frame owns only a `next_local` counter — the lower phase rebuilds
+/// each functor's local table from the body's `Let` statements.
 enum LocalScope {
     Function {
         next_local: u32,
@@ -1509,19 +1302,10 @@ fn walk_dispatch_children(expr: &mut TirExpr, env: &DispatchEnv, ctx: &mut Lower
     }
 }
 
-/// Return the largest local index already in use anywhere inside
-/// `expr` — both in `Local { index }` reads and in binding sites
-/// (`Let.local_index`, `IfLet`/`LetDestructure`/`Match` arm patterns,
-/// `VariadicForOf.binding_local`). Returns `0` if no locals are
-/// referenced.
-///
-/// Used to seed a closure body's local counter at synthesis time —
-/// the lower phase rebuilds each closure functor's local table later
-/// from `Let` statements, but we must not collide with indices the
-/// body already uses.
-///
-/// The walk does **not** descend into nested closures; their locals
-/// live in a different scope.
+/// Largest local index in use anywhere inside `expr`, counting reads and binding
+/// sites alike, or `0` if there are none. Seeds a closure body's local counter
+/// so synthesis does not collide with indices the body already uses. Nested
+/// closures are not descended into — their locals are a different scope.
 fn max_local_index_in_expr(expr: &TirExpr) -> u32 {
     use crate::tir_visitor::TirRefVisitor;
     let mut visitor = MaxLocalIndex(0);
@@ -1603,32 +1387,12 @@ impl crate::tir_visitor::TirRefVisitor for MaxLocalIndex {
     }
 }
 
-/// Replace a `WithHandler { bindings, body }` expression in place
-/// with the desugared dispatch-protocol block.
-///
-/// Per binding (in source order, all run before the body executes):
-///
-/// ```text
-/// let __h_<E>    = handler_expr;
-/// let __save_<E> = global.get __effect_<E>;
-/// let __d_<E>    = __Dispatch_<E> {
-///     outer:       __save_<E>,
-///     op_<n>:      |args| __h_<E>.<E>::<op_n>(args),
-///     ...
-/// };
-/// global.set __effect_<E> = Some(&__d_<E>);
-/// ```
-///
-/// After the body, in reverse install order:
-///
-/// ```text
-/// global.set __effect_<E> = __save_<E>;
-/// ```
-///
-/// Bindings whose effect is unresolved (`EffectRef::Param`) or whose
-/// handler type doesn't match any synthesised plan are skipped (a
-/// no-op for that binding) — the elaborator / effect-check should have
-/// caught such cases earlier.
+/// Replace a `WithHandler { bindings, body }` in place with the dispatch
+/// protocol: per binding, in source order, bind the handler, save the global,
+/// build a `__Dispatch_<E>` whose `outer` is the saved value and whose op fields
+/// forward to the handler's methods, and install it — then restore in reverse
+/// order after the body. A binding with an unresolved effect or no matching plan
+/// is skipped; the elaborator should have rejected it earlier.
 fn desugar_with_handler(expr: &mut TirExpr, env: &DispatchEnv, ctx: &mut LowerCtx) {
     let span = expr.span;
     let result_type = expr.type_id;
@@ -1919,18 +1683,11 @@ fn desugar_with_handler(expr: &mut TirExpr, env: &DispatchEnv, ctx: &mut LowerCt
         ));
     }
 
-    // Compose the desugared block: prelude + body.stmts + reversed restore.
-    //
-    // Before composing, walk `body` and splice the restore sequence in
-    // front of every control-flow exit that leaves this `with` body —
-    // `return`, plus `break`/`continue` whose target is declared
-    // outside the body. This keeps the per-effect dispatch global in
-    // sync with the lexical do-block scope even when the body exits
-    // via early jumps. See WEP 2026-04-11 (Effect Handler).
-    //
-    // The early-exit restore sequence has the same order as the
-    // fall-through one — reverse install order — so we materialise
-    // `restore` once into `restore_seq` and reuse it for both.
+    // Compose prelude + body.stmts + reversed restore, first splicing the same
+    // restore sequence in front of every control-flow exit that leaves this
+    // `with` body, so an early jump cannot strand the dispatch global out of
+    // sync with the lexical scope. Both paths use reverse install order, so
+    // `restore_seq` is materialised once and reused.
     let restore_seq: Vec<TirStmt> = restore.iter().rev().cloned().collect();
     let mut injector = RestoreInjector::new(&restore_seq, ctx);
     injector.visit_block(&mut body);
@@ -1983,42 +1740,12 @@ fn desugar_with_handler(expr: &mut TirExpr, env: &DispatchEnv, ctx: &mut LowerCt
     expr.type_id = result_type;
 }
 
-/// Walks a `with`-body and splices the per-`with` restore sequence in
-/// front of every control-flow statement that exits the body — i.e.
-/// every jump that would otherwise skip the fall-through restore at
-/// the end of the desugared block.
-///
-/// Exits are determined relative to the loops and labeled blocks that
-/// appear *inside* the body:
-///
-/// - `Return` — always exits (returns from the enclosing function).
-/// - `Continue` and `Break` without a label — exit when there is no
-///   anonymous loop (`loop { }` / `VariadicForOf`) currently open
-///   inside the body.
-/// - `Break { label: Some(l) }` — exits when `l` was not declared
-///   inside the body.
-///
-/// Value-carrying jumps (`return v`, `break L: v`) are rewritten to
-/// evaluate the value *before* the restore runs and *after* the
-/// dispatch global is still pointing at the do-block's handler:
-///
-/// ```text
-/// let __early_jump_<n> = v;   // evaluated under the do-block handler
-/// __restore_seq__;            // global goes back to outer scope
-/// return __early_jump_<n>;    // jump propagates the saved value
-/// ```
-///
-/// Without that bind, a `return Counter::next()` inside the body
-/// would evaluate `Counter::next()` *after* restoring, picking up
-/// whatever handler the outer scope had instead of the inner one.
-///
-/// `Closure` bodies are *not* descended into: a `return`/`break`/
-/// `continue` inside a closure targets the closure itself, not the
-/// `with` body. Inner `WithHandler` nodes have already been desugared
-/// to plain `Block` expressions by the time this runs, so each
-/// `with` only injects its own restores; nesting composes by
-/// successive splice — innermost first, outermost last — which yields
-/// the correct reverse-install order at every exit point.
+/// Splice the restore sequence in front of every jump that leaves the `with`
+/// body and would otherwise skip the fall-through restore: any `Return`, and a
+/// `Break`/`Continue` whose target is not open inside the body. A value-carrying
+/// jump binds its value to `__early_jump_<n>` first, so `return Counter::next()`
+/// evaluates under the do-block's handler rather than the restored outer one.
+/// `Closure` bodies are not descended into — their jumps target the closure.
 struct RestoreInjector<'a, 'b> {
     /// The restore statements to splice in front of every exit, in
     /// the exact order they should appear (reverse install order —
@@ -2355,27 +2082,12 @@ fn wrap_async_result(
     )
 }
 
-/// Build the `op_<n>` closure for a single (effect, op, handler-impl)
-/// triple.
-///
-/// Shape:
-///
-/// ```text
-/// |<op_params>| __h_<E>.<E>::<op>(<op_params>)
-/// ```
-///
-/// The handler value is captured by reference / value (whatever
-/// `__h_<E>` holds — typically `&T` or `&mut T`); the closure body's
-/// receiver is a `TirExprKind::Capture { index: 0 }` that the
-/// lower-phase closure pass converts into a field access on the
-/// generated functor struct.
-///
-/// The closure is typed at the call-site type, so an async operation's body
-/// wraps the method result:
-///
-/// ```text
-/// |<op_params>| __cm_wrap_async__<E>__<op>(__h_<E>.<E>::<op>(<op_params>))
-/// ```
+/// Build the `op_<n>` closure `|<op_params>| __h_<E>.<E>::<op>(<op_params>)` for
+/// one (effect, op, handler-impl) triple. The receiver is a `Capture { index: 0 }`
+/// holding whatever `__h_<E>` holds, which the lower-phase closure pass turns
+/// into a field access on the functor struct. The closure is typed at the
+/// call-site type, so an async operation wraps the result in
+/// `__cm_wrap_async__<E>__<op>`.
 fn build_handler_op_closure(
     op: &TirEffectOp,
     impl_info: &HandlerImplInfo,
@@ -2482,20 +2194,11 @@ fn build_handler_op_closure(
     )
 }
 
-/// Build a trapping stub closure for an effect operation that the
-/// installed handler does not implement (i.e. the operation falls
-/// under the `..` wildcard in `impl Effect for T { ... .. }`).
-///
-/// Body shape:
-///
-/// ```text
-/// |<op_params>| { unreachable() }
-/// ```
-///
-/// `unreachable` returns `Never`, which subtypes any return type, so
-/// the closure is well-typed at `fn(<op_params>) -> <op_ret>`. The
-/// stub captures nothing, mirroring the WEP's "trap stub funcref" for
-/// wildcard-handled operations.
+/// Build the `|<op_params>| { unreachable() }` stub for an operation the
+/// installed handler does not implement — one falling under the `..` wildcard in
+/// `impl Effect for T`. `unreachable` returns `Never`, which subtypes any return
+/// type, so the stub is well-typed at `fn(<op_params>) -> <op_ret>` and captures
+/// nothing.
 fn build_trap_closure(
     op: &TirEffectOp,
     type_table: &std::rc::Rc<std::cell::RefCell<TypeTable>>,
@@ -2604,53 +2307,24 @@ fn build_forward_closure(
     )
 }
 
-/// Rewrite every effect-operation call site so it routes through a
-/// dispatch wrapper. Runs **before** `cm_binding`, so the call shapes
-/// it recognises are the pre-cm_binding forms the elaborator emits:
-///
-/// 1. **User-effect shape** — `Call` whose `func.module_source` is
-///    `ModuleSource::Local { path: "<E>" }` and `func.name` is the
-///    bare op name. Produced by the elaborator for `Effect::op(...)`.
-/// 2. **Resource `cm_name` shape** — a static or instance call
-///    (instance) whose `func.method_info.cm_name` is `Some(...)`.
-///    Produced by the elaborator for `R::op(args)` /
-///    `receiver.op(args)` on a resource declaration.
-///
-/// Calls inside `__effect_dispatch__*` wrappers are left alone — they
-/// belong to the synthesised infrastructure and rewriting them would
-/// short-circuit the wrapper's fallback. (`cm_binding` adapters
-/// (`__cm_binding__*`) don't exist yet at this phase, so they need
-/// no carve-out.)
+/// Rewrite every effect-operation call site to route through a dispatch wrapper.
+/// Runs before `cm_binding`, so it matches the two pre-adapter shapes the
+/// elaborator emits: a `Call` in `ModuleSource::Local { path: "<E>" }` for
+/// `Effect::op(…)`, and a call with `func.method_info.cm_name` set for a
+/// resource op. Calls inside `__effect_dispatch__*` are left alone — rewriting
+/// them would short-circuit the wrapper's own fallback.
 fn rewrite_call_sites_to_wrappers(
     project: &mut Package,
     plans: &IndexMap<InstantiationKey, DispatchPlan>,
 ) {
     let entry_source = project.entry_module_source.clone();
 
-    // Pre-build lookup maps:
-    //
-    // - `user_to_wrapper`: keyed `(interface_name, op_name)` for
-    //   `Effect::op()` user-effect Calls. Effects collapse to a
-    //   single instantiation (`type_args: []`) so the lookup is
-    //   unambiguous.
-    // - `cm_to_wrappers`: keyed `(resource_module, base_name,
-    //   cm_name)` and stores every active `(type_args, wrapper_name)`
-    //   pair. The rewriter narrows by type args from the receiver
-    //   type (instance) or `method_info.struct_name()` (static).
-    // Effects vs resources route through different call shapes:
-    //   * effect ops (`Counter::next()`, `MonotonicClock::now()`)
-    //     resolve to a `Call` whose `func.module_source` is the
-    //     `Local { path: "<EffectName>" }` form (`is_effect_like()`)
-    //     even when the op carries a `#[cm("...")]` attribute. The
-    //     rewriter intercepts these via `(interface_name, op_name)` in
-    //     `user_to_wrapper`.
-    //   * resource methods (`Fields::new()`, `tx.write(payload)`,
-    //     `Stream::<u8>::new()`) resolve to a `Call`
-    //     whose `func.module_source` is the resource's declaring
-    //     module and whose `func.method_info.cm_name` is `Some(...)`.
-    //     The rewriter intercepts these via
-    //     `(decl_module, base_name, cm_name)` in `cm_to_wrappers`,
-    //     narrowing by the call's type args.
+    // Pre-build one lookup map per call shape. An effect op resolves to a
+    // `Local { path: "<EffectName>" }` call even when it carries `#[cm(…)]`, so
+    // `user_to_wrapper` keys on `(interface_name, op_name)` — unambiguous, since
+    // effects have a single instantiation. A resource method resolves against
+    // its declaring module with `method_info.cm_name` set, so `cm_to_wrappers`
+    // keys on `(decl_module, base_name, cm_name)` and narrows by type args.
     let effect_index = build_effect_index(project);
     let mut user_to_wrapper: IndexMap<(String, String), String> = IndexMap::default();
     let mut cm_to_wrappers: IndexMap<(ModuleSource, String, String), Vec<(Vec<TypeId>, String)>> =
@@ -3103,31 +2777,12 @@ fn rewrite_call_children(expr: &mut TirExpr, ctx: &RewriteCtx<'_>) {
     }
 }
 
-/// **Early phase** — synthesise the dispatch infrastructure (struct,
-/// global, per-op wrapper functions) and rewrite call sites to route
-/// through it. Runs **before** `cm_binding::generate_adapters` so:
-///
-/// - User resource calls (`tx.write(payload)`, `Stream::<u8>::new()`)
-///   are caught at their pre-cm_binding shape — a call
-///   with `func.method_info.cm_name` set — and replaced with `Call`s
-///   to the per-monomorphisation wrapper.
-/// - Wrapper fallback bodies emit the same cm_name-tagged placeholder
-///   shape that user code emits, so `cm_binding` rewrites both
-///   uniformly. (Generic resources like `Stream<T>` / `Future<T>`
-///   route through `cm_stream_*` internal binding calls and `CmRawCall`
-///   intrinsics; non-generic resources like `Fields` route through
-///   `__cm_binding__<R>_<op>` adapters; effects route through their
-///   own adapters. The placeholder's `cm_name` lets `cm_binding` pick
-///   the right shape per op without dispatch synthesis duplicating
-///   that routing.)
-///
-/// Resume rewriting also lands here because it's purely local and has
-/// no ordering constraint with `cm_binding`.
-///
-/// Returns the package with wrappers / call-site rewrites applied. The
-/// `WithHandler` desugaring is deferred to `synthesize_post_check` —
-/// it must run **after** `effect_check` validates the original
-/// `WithHandler` shape.
+/// **Early phase** — synthesise the dispatch infrastructure and rewrite call
+/// sites to route through it, before `cm_binding::generate_adapters`. That
+/// ordering catches resource calls at their pre-adapter `cm_name`-tagged shape
+/// and lets the wrapper fallbacks emit that same shape, so `cm_binding` picks
+/// each op's route without this pass duplicating it. `Resume` rewriting rides
+/// along; `WithHandler` desugaring waits for [`synthesize_post_check`].
 pub fn synthesize_pre_cm_binding(mut project: Package) -> Result<Package, String> {
     lower_resume_in_handler_methods(&mut project);
 
@@ -3191,17 +2846,12 @@ fn open_boundary_effects(project: &Package) -> IndexSet<(ModuleSource, String)> 
     out
 }
 
-/// **Late phase** — desugar `WithHandler` expressions into the
-/// dispatch protocol. Runs after `effect_check` and `stores_check`
-/// because those passes consume the original `WithHandler` shape:
-/// effect-check uses it to know which effects are satisfied locally,
-/// stores-check uses it to track reference flow through handler
-/// installs.
-///
-/// Consumes the `dispatch_plans` populated by
-/// `synthesize_pre_cm_binding`; nothing in `effect_check` or
-/// `stores_check` mutates the plans, so we can take them straight off
-/// the `Package` without re-deriving.
+/// **Late phase** — desugar `WithHandler` into the dispatch protocol, after
+/// `effect_check` and `stores_check`, both of which read the original shape:
+/// one for which effects are satisfied locally, the other for reference flow
+/// through handler installs. Takes the `dispatch_plans`
+/// [`synthesize_pre_cm_binding`] left on the `Package` — neither check mutates
+/// them.
 pub fn synthesize_post_check(mut project: Package) -> Result<Package, String> {
     let plans = std::mem::take(&mut project.dispatch_plans);
     if plans.is_empty() {
@@ -3213,26 +2863,12 @@ pub fn synthesize_post_check(mut project: Package) -> Result<Package, String> {
     Ok(project)
 }
 
-/// Orchestrates per-monomorphisation dispatch infrastructure synthesis.
-///
-/// `effect_index` is keyed by the bare declaration `(module, base_name)`
-/// and carries the **template** operation list (with the resource decl's
-/// type-params unsubstituted). `active_instantiations` enumerates the
-/// concrete `(module, base_name, type_args)` triples discovered from
-/// user impl blocks. For each instantiation we look up the template
-/// meta, substitute the template operations with the impl's type args,
-/// and synthesise one dispatch struct + global + per-op wrapper triple
-/// against the substituted operations.
-///
-/// For non-generic effects the substitution is a no-op (`type_args`
-/// empty) and behaviour collapses to the prior one-set-per-decl shape.
-/// For generic resources each `(R, [u8])` and `(R, [i32])` instantiation
-/// gets its own infrastructure with operation types resolved at the
-/// concrete instantiation, satisfying the canonical-closure-type
-/// invariant the WIR layer enforces.
-///
-/// Returns the per-instantiation [`DispatchPlan`] map the lowering /
-/// call-site-rewriting passes consume.
+/// Synthesise one dispatch struct + global + per-op wrapper triple per entry in
+/// `active_instantiations`, substituting the template operations from
+/// `effect_index` with that instantiation's type args, and return the
+/// [`DispatchPlan`] map the lowering and rewriting passes consume. `(R, [u8])`
+/// and `(R, [i32])` thus get separate infrastructure, which is what the WIR
+/// layer's canonical-closure-type invariant demands.
 fn synthesize_dispatch_infrastructure(
     project: &mut Package,
     effect_index: &IndexMap<EffectKey, EffectMeta>,
@@ -3286,16 +2922,11 @@ fn synthesize_dispatch_infrastructure(
     plans
 }
 
-/// Canonical identity of an `impl <Effect> for <Type>` block, including
-/// the trait-side type arguments at this impl site:
+/// Canonical identity of an `impl <Effect> for <Type>` block:
 /// `(handler_type_name, effect_defining_module, base_effect_name,
-///   trait_type_args)`.
-///
-/// Two impls of the same generic resource at different instantiations —
-/// `impl Stream<u8> for MockCM` vs `impl Stream<i32> for MockCM` — sit
-/// at distinct keys so each gets its own per-monomorphisation dispatch
-/// infrastructure synthesised. For non-generic effects / resources the
-/// `trait_type_args` slot is `vec![]`.
+/// trait_type_args)`. The trait-side type args keep
+/// `impl Stream<u8> for MockCM` and `impl Stream<i32> for MockCM` at distinct
+/// keys, so each gets its own dispatch infrastructure.
 type HandlerImplKey = (String, ModuleSource, String, Vec<TypeId>);
 
 #[derive(Debug, Clone)]
@@ -3323,17 +2954,11 @@ struct HandlerMethodTarget {
     method_info: LocalMethodName,
 }
 
-/// Walk every TIR function tagged with `method_info.base_trait_name` and
-/// build a canonical `HandlerImplKey -> HandlerImplInfo` map.
-///
-/// The handler-method's [`crate::name::LocalMethodName`] carries
-/// `base_trait_module` populated by the elaborator via
-/// [`crate::elaborator::Elaborator::canonical_decl_key`] whenever the impl
-/// targets a user-declared trait / effect / resource; the routine
-/// consults `effect_index` for membership using that canonical pair —
-/// impl methods whose trait does not match any effect / resource
-/// declaration belong to a regular user trait or to a synthesis-derived
-/// prelude auto-impl and are skipped.
+/// Build the `HandlerImplKey -> HandlerImplInfo` map from every TIR function
+/// tagged with `method_info.base_trait_name`. Membership is decided by looking
+/// the method's canonical `(base_trait_module, trait_name)` pair up in
+/// `effect_index`; a method whose trait matches no effect or resource belongs to
+/// a regular user trait or a prelude auto-impl and is skipped.
 fn build_handler_impl_index(
     project: &Package,
     effect_index: &IndexMap<EffectKey, EffectMeta>,
@@ -3426,16 +3051,10 @@ fn deref_type(tt: &TypeTable, type_id: TypeId) -> TypeId {
     }
 }
 
-/// Walk every method in every `impl Effect for T` or `impl Resource for T`
-/// block and rewrite `Resume { value }` to `Return { value }`. Per the WEP
-/// MVP, `resume` has no post-resume continuation, so it is semantically
-/// identical to `return`. Resource impl methods share the handler-method
-/// shape with effect impl methods (see WEP 2026-04-11: resources
-/// participate in the same dispatch protocol).
-///
-/// The elaborator flattens impl-block methods into `TirModule.functions`
-/// and tags each with `method_info: { struct_name, trait_name, ... }`.
-/// We use the `trait_name` to recognise handler methods.
+/// Rewrite `Resume { value }` to `Return { value }` in every `impl Effect for T`
+/// / `impl Resource for T` method, recognised by `method_info.trait_name`. The
+/// MVP has no post-resume continuation, so the two are identical; resources
+/// participate in the same dispatch protocol as effects.
 fn lower_resume_in_handler_methods(project: &mut Package) {
     // Collect bare names of every effect and resource declaration so we
     // can recognise candidate impl blocks. A name collision between an

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -712,7 +712,6 @@ fn build_dispatch_wrapper_function(
     let mut else_stmts: Vec<TirStmt> = Vec::new();
     if is_resource {
         let placeholder_call = build_resource_fallback_call(
-            entry_source,
             effect_module,
             base_name,
             label,
@@ -900,9 +899,8 @@ fn build_dispatch_wrapper_function(
 /// pre-cm_binding shape user code emits — a method call for instance ops, `Call`
 /// for static ones — with `method_info` carrying the original `cm_name`, which
 /// is what lets `rewrite_cm_resource_methods` route it afterwards.
-#[allow(dead_code, clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn build_resource_fallback_call(
-    _entry_source: &ModuleSource,
     effect_module: &ModuleSource,
     base_name: &str,
     label: &str,

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -707,9 +707,8 @@ fn build_dispatch_wrapper_function(
     // Else-branch: fallback. Synthesised before `cm_binding::generate_adapters`
     // runs, so it emits the same pre-adapter shape user code would — an
     // effect-like `Call` for effects, a `cm_name`-tagged one for resources —
-    // and cm_binding rewrites both uniformly when it walks these bodies. A
-    // user-defined effect has no `cm_name` and is unreachable here: effect-check
-    // insists on a handler at every call site.
+    // and cm_binding rewrites both uniformly. A user-defined effect never gets
+    // here: effect-check insists on a handler at every call site.
     let mut else_stmts: Vec<TirStmt> = Vec::new();
     if is_resource {
         let placeholder_call = build_resource_fallback_call(
@@ -872,9 +871,8 @@ fn build_dispatch_wrapper_function(
         // A wrapper declares no effects, so calling one — which now happens at
         // every effect / resource call site — propagates nothing to the caller.
         // The wrapper is what satisfies the effect: its `if let Some(d)` branch
-        // dispatches into the installed handler and its `else` branch emits the
-        // placeholder cm_binding rewrites. `__cm_binding__*` adapters carry
-        // `effects: vec![]` for the same reason.
+        // dispatches into the installed handler, its `else` branch emits the
+        // placeholder cm_binding rewrites. `__cm_binding__*` adapters likewise.
         effects: vec![],
         stores: vec![],
         body: Some(body),
@@ -1391,8 +1389,7 @@ impl crate::tir_visitor::TirRefVisitor for MaxLocalIndex {
 /// protocol: per binding, in source order, bind the handler, save the global,
 /// build a `__Dispatch_<E>` whose `outer` is the saved value and whose op fields
 /// forward to the handler's methods, and install it — then restore in reverse
-/// order after the body. A binding with an unresolved effect or no matching plan
-/// is skipped; the elaborator should have rejected it earlier.
+/// order after the body. A binding with no matching plan is skipped.
 fn desugar_with_handler(expr: &mut TirExpr, env: &DispatchEnv, ctx: &mut LowerCtx) {
     let span = expr.span;
     let result_type = expr.type_id;
@@ -1744,8 +1741,7 @@ fn desugar_with_handler(expr: &mut TirExpr, env: &DispatchEnv, ctx: &mut LowerCt
 /// body and would otherwise skip the fall-through restore: any `Return`, and a
 /// `Break`/`Continue` whose target is not open inside the body. A value-carrying
 /// jump binds its value to `__early_jump_<n>` first, so `return Counter::next()`
-/// evaluates under the do-block's handler rather than the restored outer one.
-/// `Closure` bodies are not descended into — their jumps target the closure.
+/// evaluates under the do-block's handler. `Closure` bodies are skipped.
 struct RestoreInjector<'a, 'b> {
     /// The restore statements to splice in front of every exit, in
     /// the exact order they should appear (reverse install order —
@@ -2085,9 +2081,8 @@ fn wrap_async_result(
 /// Build the `op_<n>` closure `|<op_params>| __h_<E>.<E>::<op>(<op_params>)` for
 /// one (effect, op, handler-impl) triple. The receiver is a `Capture { index: 0 }`
 /// holding whatever `__h_<E>` holds, which the lower-phase closure pass turns
-/// into a field access on the functor struct. The closure is typed at the
-/// call-site type, so an async operation wraps the result in
-/// `__cm_wrap_async__<E>__<op>`.
+/// into a field access on the functor struct. Typed at the call-site type, so an
+/// async operation wraps the result in `__cm_wrap_async__<E>__<op>`.
 fn build_handler_op_closure(
     op: &TirEffectOp,
     impl_info: &HandlerImplInfo,
@@ -2310,9 +2305,8 @@ fn build_forward_closure(
 /// Rewrite every effect-operation call site to route through a dispatch wrapper.
 /// Runs before `cm_binding`, so it matches the two pre-adapter shapes the
 /// elaborator emits: a `Call` in `ModuleSource::Local { path: "<E>" }` for
-/// `Effect::op(…)`, and a call with `func.method_info.cm_name` set for a
-/// resource op. Calls inside `__effect_dispatch__*` are left alone — rewriting
-/// them would short-circuit the wrapper's own fallback.
+/// `Effect::op(…)`, and one with `func.method_info.cm_name` set for a resource
+/// op. Calls inside `__effect_dispatch__*` are left alone.
 fn rewrite_call_sites_to_wrappers(
     project: &mut Package,
     plans: &IndexMap<InstantiationKey, DispatchPlan>,
@@ -2321,10 +2315,9 @@ fn rewrite_call_sites_to_wrappers(
 
     // Pre-build one lookup map per call shape. An effect op resolves to a
     // `Local { path: "<EffectName>" }` call even when it carries `#[cm(…)]`, so
-    // `user_to_wrapper` keys on `(interface_name, op_name)` — unambiguous, since
-    // effects have a single instantiation. A resource method resolves against
-    // its declaring module with `method_info.cm_name` set, so `cm_to_wrappers`
-    // keys on `(decl_module, base_name, cm_name)` and narrows by type args.
+    // `user_to_wrapper` keys on `(interface_name, op_name)`. A resource method
+    // resolves against its declaring module with `method_info.cm_name` set, so
+    // `cm_to_wrappers` keys on `(decl_module, base_name, cm_name)` plus type args.
     let effect_index = build_effect_index(project);
     let mut user_to_wrapper: IndexMap<(String, String), String> = IndexMap::default();
     let mut cm_to_wrappers: IndexMap<(ModuleSource, String, String), Vec<(Vec<TypeId>, String)>> =
@@ -2780,9 +2773,8 @@ fn rewrite_call_children(expr: &mut TirExpr, ctx: &RewriteCtx<'_>) {
 /// **Early phase** — synthesise the dispatch infrastructure and rewrite call
 /// sites to route through it, before `cm_binding::generate_adapters`. That
 /// ordering catches resource calls at their pre-adapter `cm_name`-tagged shape
-/// and lets the wrapper fallbacks emit that same shape, so `cm_binding` picks
-/// each op's route without this pass duplicating it. `Resume` rewriting rides
-/// along; `WithHandler` desugaring waits for [`synthesize_post_check`].
+/// and lets the wrapper fallbacks emit that same shape. `WithHandler`
+/// desugaring waits for [`synthesize_post_check`].
 pub fn synthesize_pre_cm_binding(mut project: Package) -> Result<Package, String> {
     lower_resume_in_handler_methods(&mut project);
 
@@ -2850,8 +2842,7 @@ fn open_boundary_effects(project: &Package) -> IndexSet<(ModuleSource, String)> 
 /// `effect_check` and `stores_check`, both of which read the original shape:
 /// one for which effects are satisfied locally, the other for reference flow
 /// through handler installs. Takes the `dispatch_plans`
-/// [`synthesize_pre_cm_binding`] left on the `Package` — neither check mutates
-/// them.
+/// [`synthesize_pre_cm_binding`] left on the `Package`.
 pub fn synthesize_post_check(mut project: Package) -> Result<Package, String> {
     let plans = std::mem::take(&mut project.dispatch_plans);
     if plans.is_empty() {
@@ -2866,9 +2857,8 @@ pub fn synthesize_post_check(mut project: Package) -> Result<Package, String> {
 /// Synthesise one dispatch struct + global + per-op wrapper triple per entry in
 /// `active_instantiations`, substituting the template operations from
 /// `effect_index` with that instantiation's type args, and return the
-/// [`DispatchPlan`] map the lowering and rewriting passes consume. `(R, [u8])`
-/// and `(R, [i32])` thus get separate infrastructure, which is what the WIR
-/// layer's canonical-closure-type invariant demands.
+/// [`DispatchPlan`] map the later passes consume. `(R, [u8])` and `(R, [i32])`
+/// thus get separate infrastructure, as WIR's canonical closure types demand.
 fn synthesize_dispatch_infrastructure(
     project: &mut Package,
     effect_index: &IndexMap<EffectKey, EffectMeta>,

--- a/wado-compiler/src/synthesis/effect_dispatch.rs
+++ b/wado-compiler/src/synthesis/effect_dispatch.rs
@@ -1389,7 +1389,8 @@ impl crate::tir_visitor::TirRefVisitor for MaxLocalIndex {
 /// protocol: per binding, in source order, bind the handler, save the global,
 /// build a `__Dispatch_<E>` whose `outer` is the saved value and whose op fields
 /// forward to the handler's methods, and install it — then restore in reverse
-/// order after the body. A binding with no matching plan is skipped.
+/// order after the body. A binding with no matching plan panics: annotate and
+/// this pass are out of sync.
 fn desugar_with_handler(expr: &mut TirExpr, env: &DispatchEnv, ctx: &mut LowerCtx) {
     let span = expr.span;
     let result_type = expr.type_id;

--- a/wado-compiler/src/synthesis/resource_cleanup.rs
+++ b/wado-compiler/src/synthesis/resource_cleanup.rs
@@ -1,49 +1,13 @@
-//! Resource drop elaboration.
+//! Resource drop elaboration. A CM `own<resource>` handle must be released with
+//! `resource.drop` exactly once, and Wado has no destructors, so an untransferred
+//! resource would leak a host table slot. Runs pre-monomorphize, inserting a drop
+//! wherever a value is still owned at the end of its scope.
 //!
-//! A Component Model `own<resource>` handle (`Request`, `Response`, `Fields`,
-//! `RequestOptions`, …) must be released with `resource.drop` exactly once.
-//! Wado's surface language has no destructors, so without this pass every
-//! resource a guest creates or receives — and never explicitly transfers —
-//! leaks a host resource-table slot. Under `wado serve`'s pooled instance
-//! reuse the table eventually exhausts (issue #1133).
-//!
-//! This pass runs pre-monomorphize, before CM-binding synthesis rewrites
-//! resource method calls into canonical intrinsics. For every
-//! function body it tracks each owned resource value and inserts a
-//! `resource.drop` (emitted as a `CmRawCall` to the `resource-drop:<cm>`
-//! canonical intrinsic) on every control-flow path where the value is still
-//! owned at the end of its scope.
-//!
-//! ## Ownership model
-//!
-//! A resource value is *owned* by the binding it is stored in (a parameter or
-//! a `let`). Ownership is *transferred* when the value is:
-//!
-//! - passed as a by-value argument to a call (constructors such as
-//!   `Response::new(fields, …)`, consumers such as
-//!   `Request::consume_body(request, …)`, or any user function taking the
-//!   resource by value),
-//! - returned, or placed into an aggregate / variant payload.
-//!
-//! A resource used only as a borrowing method receiver (`fields.has(…)`), a
-//! `matches` test, or behind `&` is *not* transferred. The pass drops exactly
-//! those owned resources that are never transferred on a given path, so the
-//! drop is always the unique remaining owner — it can never double-free.
-//!
-//! A binding whose type only *contains* a resource (e.g.
-//! `Result<Fields, HeaderError>` returned by `Fields::from_list`) is dropped
-//! structurally: a synthesized `match` extracts and drops the resource in the
-//! case(s) that carry one.
-//!
-//! ## Relationship to the ownership system
-//!
-//! Ownership transfer is read straight off the surface program: a value is
-//! transferred when it is passed by value, returned, placed in an aggregate,
-//! or used as the receiver of a by-value (`self`) method. Extraction is a
-//! by-value method (`Result::unwrap(self) -> T`), so it needs no special
-//! casing — the receiver is consumed like any other by-value argument. The
-//! pass therefore drops "every owned binding not transferred on this path"
-//! with no aggregate-shape guessing.
+//! A resource is *owned* by its binding and *transferred* when passed by value,
+//! returned, or placed in an aggregate; a borrowing receiver, a `matches` test
+//! and a `&` are not. So the drop is always the unique remaining owner and
+//! cannot double-free. A binding that merely *contains* one is dropped through a
+//! synthesized `match` over the cases carrying it.
 
 use crate::canonical::CanonicalIntrinsic;
 use crate::compiler_item::CompilerItem;

--- a/wado-compiler/src/synthesis/resource_cleanup.rs
+++ b/wado-compiler/src/synthesis/resource_cleanup.rs
@@ -1,13 +1,8 @@
 //! Resource drop elaboration. A CM `own<resource>` handle must be released with
-//! `resource.drop` exactly once, and Wado has no destructors, so an untransferred
-//! resource would leak a host table slot. Runs pre-monomorphize, inserting a drop
-//! wherever a value is still owned at the end of its scope.
-//!
-//! A resource is *owned* by its binding and *transferred* when passed by value,
-//! returned, or placed in an aggregate; a borrowing receiver, a `matches` test
-//! and a `&` are not. So the drop is always the unique remaining owner and
-//! cannot double-free. A binding that merely *contains* one is dropped through a
-//! synthesized `match` over the cases carrying it.
+//! `resource.drop` exactly once and Wado has no destructors, so this inserts a
+//! drop wherever a value is still owned at the end of its scope. A resource is
+//! *transferred* when passed by value, returned, or placed in an aggregate — not
+//! by a borrowing receiver or a `&` — so the drop cannot double-free.
 
 use crate::canonical::CanonicalIntrinsic;
 use crate::compiler_item::CompilerItem;

--- a/wado-compiler/src/synthesis/serde_synth.rs
+++ b/wado-compiler/src/synthesis/serde_synth.rs
@@ -141,15 +141,10 @@ pub fn synthesize_serde(project: &mut Package) {
 }
 
 /// Distribute bound-driven `Serialize` / `Deserialize` requests (WEP
-/// 2026-06-25-trait-derivation) into the `synthesis_requests` of each
-/// request's own defining module — exactly where an explicit
-/// `impl Trait for T;` marker's request already lives — so the drain loop
-/// above sees one uniform list regardless of which path produced an entry.
-///
-/// Reads `TypeTable::bound_driven_synth_requests` as a snapshot, not a
-/// drain: `synthesis::traits::synthesize_traits` reads the same shared set
-/// for its `Eq` / `Ord` entries, so this pass only consumes the `Serialize`
-/// / `Deserialize` ones (matched by trait name) and leaves the rest.
+/// 2026-06-25) into each request's own defining module — where an explicit
+/// `impl Trait for T;` marker's request already lives — so the drain loop above
+/// sees one uniform list. Reads `bound_driven_synth_requests` as a snapshot, not
+/// a drain: `synthesize_traits` reads the same set for its own entries.
 fn distribute_bound_driven_requests(project: &mut Package) {
     let Some(type_table) = project
         .tir_modules

--- a/wado-compiler/src/synthesis/template.rs
+++ b/wado-compiler/src/synthesis/template.rs
@@ -1,14 +1,8 @@
-//! Template string expansion synthesis phase.
-//!
-//! Expands `TirExprKind::TemplateString` nodes into concrete formatting code:
-//! a `__tmpl` labeled block containing `String::with_capacity`, `push_str` calls,
-//! `Formatter` construction, and `Display`/`Inspect` trait dispatch.
-//!
-//! Pipeline position: pre-monomorphize synthesis phase.
-//! Template expansion emits trait method calls (`Display::fmt`, `Inspect::inspect`)
-//! that the monomorphizer resolves to concrete implementations. This approach
-//! eliminates the need for post-mono `has_trait_impl` checks and standalone inspect
-//! functions.
+//! Template string expansion: `TirExprKind::TemplateString` becomes a `__tmpl`
+//! labeled block of `String::with_capacity`, `push_str` calls, `Formatter`
+//! construction, and `Display` / `Inspect` dispatch. Runs pre-monomorphize, so
+//! the emitted trait calls resolve there — no post-mono `has_trait_impl` check
+//! or standalone inspect function is needed.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -26,17 +20,10 @@ use crate::tir::{
 use crate::token::Span;
 
 /// Snapshot of every `core:prelude/format` symbol name + case index the
-/// template-expansion synthesiser needs. Resolved once through the
-/// [`CompilerItem`] registry per template-string expansion, then threaded
-/// through the helpers so stdlib renames flow without touching synthesis
-/// sites — same shape as
-/// [`super::cm_binding::types::CmStdlibNames`].
-///
-/// Every format-family trait is single-method, so each `<trait>` field
-/// is paired with a `<trait>_method` field carrying the trait's
-/// resolved method name (e.g. `"fmt"` for `Display`, `"inspect"` for
-/// `Inspect`). Both values come from
-/// [`CompilerItems::trait_method_name`].
+/// template-expansion synthesiser needs, resolved once through the
+/// [`CompilerItem`] registry so stdlib renames flow without touching synthesis
+/// sites. Every format-family trait is single-method, so each `<trait>` field is
+/// paired with a `<trait>_method` from [`CompilerItems::trait_method_name`].
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub(super) struct FormatStdlibNames {
@@ -326,16 +313,11 @@ fn expand_expr(expr: &mut TirExpr, alloc: &mut FuncLocalAlloc, ctx: &TemplateCtx
             body_locals,
             ..
         } => {
-            // Closure bodies own an independent local-index namespace
-            // (see `TirExprKind::Closure::body_locals` / `address_taken_locals`).
-            // Template synth locals (`__r`, `__f`, …) must be allocated in
-            // that namespace; otherwise their indices collide with closure
-            // params or body lets and `LocalCollector` in closure planning
-            // merges incompatibly-typed locals into the same Wasm slot,
-            // producing a module that fails core-Wasm validation.
-            //
-            // Mirrors the same closure-scope switch in
-            // `lower::translate::pattern::lower_expr`'s `Closure` arm.
+            // Closure bodies own an independent local-index namespace, so the
+            // template synth locals (`__r`, `__f`, …) must be allocated there;
+            // otherwise they collide with closure params or body lets and
+            // `LocalCollector` merges incompatibly-typed locals into one Wasm
+            // slot. Mirrors the closure-scope switch in pattern lowering.
             let mut closure_alloc = FuncLocalAlloc {
                 next_index: (params.len() + body_locals.len()) as u32,
                 new_locals: Vec::new(),
@@ -1433,19 +1415,11 @@ fn trait_impl_module(
     {
         return loc.clone();
     }
-    // Fallbacks for impls `TraitEnv` cannot index:
-    //
-    // - Auto-derived/synthesized impls (Inspect / Display fallbacks for
-    //   structs, enums, variants, newtypes, flags). `synthesize_traits`
-    //   places these in the same module as the receiver type, so the
-    //   type's `module_source` is correct.
-    // - Function types are anonymous and have no defining module, so
-    //   their `Fn<N, Ret>^Inspect` / `^InspectAlt` impls are auto-derived
-    //   per-module (no cross-module dedup, since
-    //   `collect_existing_trait_methods` is per-module). After `link()`
-    //   every function's `module_source` is rewritten to its hosting
-    //   module, so the impl callable from this template lives under the
-    //   current module's namespace.
+    // Fallbacks for impls `TraitEnv` cannot index. An auto-derived impl lands in
+    // the receiver type's module, so the type's `module_source` is right. A
+    // function type is anonymous and has no defining module, so its
+    // `Fn<N, Ret>^Inspect` impl is auto-derived per-module and, after `link()`,
+    // lives under the current module's namespace.
     if let Some(m) = type_module {
         return m;
     }

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -1,7 +1,8 @@
-//! Trait synthesis: auto-derives the `Eq` / `Ord` impls for enums and variants
-//! (discriminant, then payload), `Inspect` for debug formatting, `Display` for
-//! an enum's bare case name, and the `DisplayAlt` / `InspectAlt` fallbacks that
-//! delegate to their plain halves. Runs before monomorphize.
+//! Trait synthesis: auto-derives `Eq` / `Ord` for structs and enums and `Eq` for
+//! variants (discriminant, then payload), `Default` for structs, `Inspect` for
+//! debug formatting, `Display` for an enum's bare case name, and the
+//! `DisplayAlt` / `InspectAlt` fallbacks that delegate to their plain halves.
+//! Runs before monomorphize.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -1,14 +1,7 @@
-//! Trait synthesis phase.
-//!
-//! Generates auto-derived trait implementations for types that support them:
-//! - `EnumName^Eq::eq(&self, &Self) -> bool` - discriminant equality
-//! - `EnumName^Ord::cmp(&self, &Self) -> Ordering` - discriminant ordering
-//! - `VariantName^Eq::eq(&self, &Self) -> bool` - case-discriminated payload equality
-//! - `TypeName^Inspect::inspect(&self, &mut Formatter)` - debug formatting
-//! - `EnumName^Display::fmt(&self, &mut Formatter)` - bare case name
-//! - `TypeName^DisplayAlt::fmt_alt(&self, &mut Formatter)` - delegates to `Display`
-//!
-//! Pipeline position: runs as part of the synthesis phase, before monomorphize.
+//! Trait synthesis: auto-derives the `Eq` / `Ord` impls for enums and variants
+//! (discriminant, then payload), `Inspect` for debug formatting, `Display` for
+//! an enum's bare case name, and the `DisplayAlt` / `InspectAlt` fallbacks that
+//! delegate to their plain halves. Runs before monomorphize.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -111,16 +104,11 @@ impl TraitsStdlibNames {
     }
 }
 
-/// One half of an auto-derived trait pair: the `Display`/`DisplayAlt`/`InspectAlt`
-/// fallback machinery is parameterised over which trait to emit and which trait
-/// to delegate to.
-///
-/// Every name in this struct — both trait names and their method names —
-/// flows from the `CompilerItem` registry. The stdlib's
-/// `#[compiler_item("...")]` annotations control the spelling on both
-/// halves, so renaming `Display::fmt` to `Display::display_value` flows
-/// to the synthesised fallback's emitted call without touching this
-/// code.
+/// One half of an auto-derived trait pair: which trait the fallback machinery
+/// emits, and which it delegates to. Every name here — traits and methods alike
+/// — comes from the `CompilerItem` registry, so renaming `Display::fmt` in the
+/// stdlib's `#[compiler_item("…")]` annotations reaches the synthesised call
+/// without touching this code.
 struct TraitPair {
     /// e.g. `Display` or `DisplayAlt`, named by its declaring module.
     target_trait: crate::name::FqTraitName,
@@ -3021,31 +3009,14 @@ pub(crate) struct SynthesisCtx<'env, 'pend, 'req> {
 }
 
 impl SynthesisCtx<'_, '_, '_> {
-    /// `true` when an impl of `trait_name` for `<type_name>` is already known
-    /// to the project — either user-written (in the AST layer of `TraitEnv`,
-    /// regardless of which module it lives in) or generated earlier in this
-    /// synthesis pass for the *current* module.
-    ///
-    /// The two halves are deliberately scoped differently:
-    ///
-    /// - The AST-layer check is module-agnostic. A user-written
-    ///   `impl Display for String` in `core:prelude/format` must suppress
-    ///   `synthesize_traits`'s DisplayAlt-delegates-to-Display fallback even
-    ///   when this pass is currently synthesising `core:prelude/string`
-    ///   (String's defining module). Restricting the check to
-    ///   `self.module` would silently shadow the user's impl with the
-    ///   auto-derived fallback the synthesised layer later wins via the
-    ///   `type_module` hint at the call site.
-    /// - The in-pass `pending` check stays module-scoped so two same-name
-    ///   receiver types in different modules (e.g. `struct Widget` in
-    ///   module A and module B) each still get their own auto-derived
-    ///   impl. Without the module component the second derivation would
-    ///   be silently skipped.
-    ///
-    /// `receiver` names the namespace it is spelled in: the in-pass `pending`
-    /// set is keyed by the same string the caller holds, while the AST-layer
-    /// query must ask the map that namespace lives in — a mangled receiver
-    /// looked up as a declaration name reaches nothing.
+    /// `true` when the project already has this impl, user-written or derived
+    /// earlier in this pass. The two halves are scoped differently on purpose:
+    /// the AST-layer check is module-agnostic, so a user's
+    /// `impl Display for String` in `format` suppresses the fallback while
+    /// synthesising `string`; the in-pass `pending` check stays module-scoped, so
+    /// two modules' same-named receivers each still get their own impl.
+    /// `receiver` names its own namespace — a mangled one looked up as a
+    /// declaration name reaches nothing.
     pub(crate) fn has_impl(
         &self,
         receiver: ImplReceiver<'_>,
@@ -3542,22 +3513,12 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
     module.functions.extend(generated);
 }
 
-/// Generate auto-derived `Default` trait implementations for structs whose
-/// fields all carry a declared default expression.
-///
-/// For a non-generic struct `S { f0: T0 = e0, f1: T1 = e1, ... }`, synthesize:
-/// - `S^Default::default() -> S` — returns `S { f0: e0, f1: e1, ... }`.
-///
-/// Skips:
-/// - structs where any field has no default expression,
-/// - structs that already have a user-provided `impl Default for S`,
-/// - generic structs (generic field defaults may depend on bounds; left for
-///   a follow-up — monomorphized instances never hit this pass because
-///   `monomorph_info.is_some()`).
-///
-/// Effect purity of the default expressions is already enforced by
-/// `check_default_purity_semantic` before synthesis runs; if it had failed the
-/// pipeline would have bailed, so every `default_expr` reaching here is pure.
+/// Auto-derive `S^Default::default() -> S` for a non-generic struct whose fields
+/// all declare a default, returning `S { f0: e0, … }`. Skips a struct with any
+/// undefaulted field, one already carrying a user `impl Default`, and generic
+/// structs, whose field defaults may depend on bounds. Every `default_expr`
+/// reaching here is pure: `check_default_purity_semantic` would have bailed the
+/// pipeline otherwise.
 fn generate_struct_default_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_, '_>) {
     if module.structs.is_empty() {
         return;
@@ -4108,16 +4069,11 @@ fn generate_newtype_fmt_fn(
     )
 }
 
-/// Generate `Fn<N, Ret>^Inspect::inspect(&self, &mut Formatter)` as
-/// an auto-derived dispatch stub.
-///
-/// The TIR body is `None` — the function entry exists only so call
-/// sites referring to it from templates / user code resolve. A bodyless
-/// TIR function naturally bypasses the inliner and other body walkers;
-/// WIR build recognises [`FunctionKind::FnCanonicalDispatch`] and
-/// supplies the real body: a `call_ref` through the matching
-/// `CanonicalClosure_K`'s `inspect` vtable slot. See WEP: Inspect
-/// (Debug Output) > Closure Inspect via Runtime Dispatch.
+/// Generate `Fn<N, Ret>^Inspect::inspect(&self, &mut Formatter)` as a dispatch
+/// stub with no TIR body — the entry exists only so call sites resolve, and
+/// being bodyless it bypasses the inliner and the other body walkers. WIR build
+/// recognises [`FunctionKind::FnCanonicalDispatch`] and supplies the real body,
+/// a `call_ref` through the matching `CanonicalClosure_K`'s vtable slot.
 fn generate_fn_inspect_fn(
     module_source: &ModuleSource,
     type_arg_names: &[FqTypeName],
@@ -4633,16 +4589,10 @@ fn generate_inspect_alt_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
     module.functions.extend(generated);
 }
 
-/// Generate `StructName^InspectAlt::inspect_alt` for non-generic structs (pretty-print).
-///
-/// Body uses Formatter helpers for clean synthesis:
-/// ```text
-/// f.begin_block("StructName {\n");
-/// f.write_indent(); f.write_str("field1: "); self.field1.inspect_alt(f); f.write_str(",\n");
-/// f.write_indent(); f.write_str("field2: "); self.field2.inspect_alt(f); f.write_str(",\n");
-/// f.end_block("}");
-/// ```
-/// Pass an empty `impl_type_params` slice for non-generic structs.
+/// Generate the pretty-printing `StructName^InspectAlt::inspect_alt`, whose body
+/// is a `begin_block` / per-field `write_indent` + `inspect_alt` / `end_block`
+/// sequence of Formatter calls. `impl_type_params` is empty for a non-generic
+/// struct.
 fn generate_struct_inspect_alt_fn(
     struct_name: &str,
     impl_type_params: &[TirTypeParam],
@@ -5653,35 +5603,14 @@ fn decompose_type_for_method_name(
     }
 }
 
-/// Determine the module where an Inspect impl lives for a given type.
-/// Determine the module where a trait impl lives for a given type.
-///
-/// `ref_module` is used for Ref/MutRef types (`traits()` for Eq/Ord, `format()` for Inspect).
-/// `string_module` is used for String (`string()` for Eq/Ord, `format()` for Inspect).
 /// Resolve `module_source` for a `value.<trait>::<method>` call inside an
-/// auto-derived body — issue #1110 (1): the `FunctionRef`'s `module_source`
-/// must be the module that hosts the callee's body.
-///
-/// Strategy:
-///   1. Ask `TraitEnv` where `impl <trait> for <receiver-type>` lives.
-///      `TraitEnv` indexes every AST-layer impl block by struct name and
-///      trait name, so this hits for cross-module impls
-///      (`impl Display for String` in `core:prelude/format`,
-///      `impl<..T> Inspect for [..T]` in `core:prelude/tuple`, ref/mutref
-///      blankets, etc.). This is a deterministic resolution, not a
-///      fall-back to whichever module the synthesis pass happens to be
-///      visiting.
-///   2. If `TraitEnv` is silent — the impl is being auto-derived in the
-///      current synthesis pass and hasn't been published to the
-///      synthesised layer yet — fall back to the receiver type's own
-///      module. `synthesis::traits::generate_*_impls` places auto-
-///      derived bodies in the receiver type's module by convention, so
-///      that's where the body will live.
-///   3. For receivers with no defining module (`TypeParam`, unresolved),
-///      use the caller-supplied `fallback` (the current synthesis module).
-///      The fallback only applies to producer outputs that the
-///      monomorphizer immediately overwrites with a concrete-type
-///      module after type-param substitution.
+/// auto-derived body: it must name the module hosting the callee's body. Ask
+/// `TraitEnv` first — it indexes every AST-layer impl block, so a cross-module
+/// impl resolves deterministically rather than defaulting to whichever module
+/// synthesis happens to be visiting. If it is silent, the impl is being derived
+/// in this pass and will land in the receiver type's own module by convention.
+/// A receiver with no defining module takes the caller's `fallback`, which the
+/// monomorphizer overwrites after substitution.
 fn resolve_impl_module_via_env(
     type_id: TypeId,
     trait_name: &crate::name::FqTraitName,
@@ -5735,22 +5664,12 @@ fn resolve_impl_module_via_env(
     type_module.unwrap_or_else(|| fallback.clone())
 }
 
-/// Collect parameterized types that need Inspect/Display impls — per-`TypeId`
-/// kinds whose codegen genuinely depends on the distinct `TypeId`.
-///
-/// Returns `(type_id, base_name, type_arg_names)` for each concrete
-/// parameterized type. Includes tuples and resource handle types (Future,
-/// Stream, etc.).
-///
-/// `ResolvedType::Function` is intentionally **not** enumerated here.
-/// `Fn` dispatch stubs depend only on `(arity, return_type)` because
-/// `wir_build::build_fn_canonical_dispatch_body` casts `self` to the shared
-/// `canonical_inspectable_base` before reading the vtable, so the per-
-/// parameter `TypeId`s are irrelevant at codegen. Enumerating Function
-/// types per `TypeId` here would emit one identical stub per `TypeId` and
-/// collide on `function_id_for`, which is required to be injective over
-/// `project.functions` (asserted in `optimize/dce`). Use
-/// [`collect_canonical_fn_signatures`] for the `(arity, return_type)` view.
+/// Collect the parameterized types needing Inspect/Display impls — the kinds
+/// whose codegen genuinely depends on the distinct `TypeId`, tuples and resource
+/// handles included. `ResolvedType::Function` is deliberately absent: a `Fn`
+/// dispatch stub depends only on `(arity, return_type)`, so enumerating per
+/// `TypeId` would emit identical stubs that collide on `function_id_for`, which
+/// `optimize/dce` asserts is injective. Use [`collect_canonical_fn_signatures`].
 fn collect_parameterized_types(tt: &TypeTable) -> Vec<(TypeId, String, Vec<FqTypeName>)> {
     tt.all_types()
         .filter_map(|(id, resolved)| match resolved {
@@ -5779,16 +5698,11 @@ fn collect_parameterized_types(tt: &TypeTable) -> Vec<(TypeId, String, Vec<FqTyp
         .collect()
 }
 
-/// Canonical `Fn` signature for dispatch-stub synthesis.
-///
-/// `Fn` dispatch stubs (`Fn<arity, ret>^Inspect::inspect`,
-/// `Fn<arity, ret>^InspectAlt::inspect_alt`, and fallbacks) are keyed by
-/// `(arity, return_type)` alone — see `collect_parameterized_types` for the
-/// rationale. `repr_type_id` is the first encountered `ResolvedType::Function`
-/// `TypeId` with this signature; synthesis uses it to build the stub's `&self`
-/// type via `tt.make_ref(repr_type_id)`. Any `TypeId` with the same signature
-/// would work — the choice is deterministic-by-iteration-order so two
-/// compiles produce byte-identical output.
+/// Canonical `Fn` signature for dispatch-stub synthesis, keyed by
+/// `(arity, return_type)` alone — see [`collect_parameterized_types`].
+/// `repr_type_id` is the first `ResolvedType::Function` seen with this
+/// signature, used to build the stub's `&self` type. Any id with the signature
+/// would do; taking the first makes two compiles byte-identical.
 struct FnSignature {
     repr_type_id: TypeId,
     arity: usize,
@@ -5887,16 +5801,8 @@ fn generate_enum_eq_fn(
     )
 }
 
-/// Generate `EnumName^Ord::cmp(&self, &Self) -> Ordering`
-///
-/// Body:
-/// ```text
-/// let a = *self;
-/// let b = *other;
-/// if a < b { return Ordering::Less; }
-/// if a > b { return Ordering::Greater; }
-/// return Ordering::Equal;
-/// ```
+/// Generate `EnumName^Ord::cmp(&self, &Self) -> Ordering`, comparing the two
+/// dereferenced discriminants and returning `Less` / `Greater` / `Equal`.
 fn generate_enum_ord_fn(
     module_source: &ModuleSource,
     enum_name: &str,
@@ -6286,17 +6192,9 @@ fn field_access_local(
     )
 }
 
-/// Generate `StructName^Ord::cmp(&self, &Self) -> Ordering` for non-generic structs.
-///
-/// Body (lexicographic):
-/// ```text
-/// let c = self.f0.cmp(&other.f0);
-/// if c != Ordering::Equal { return c; }
-/// let c = self.f1.cmp(&other.f1);
-/// if c != Ordering::Equal { return c; }
-/// ...
-/// return Ordering::Equal;
-/// ```
+/// Generate `StructName^Ord::cmp(&self, &Self) -> Ordering` for a non-generic
+/// struct: compare field by field in declaration order, returning the first
+/// non-`Equal` result, else `Equal`.
 fn generate_struct_ord_fn(
     struct_name: &str,
     impl_type_params: &[TirTypeParam],

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -3013,10 +3013,7 @@ impl SynthesisCtx<'_, '_, '_> {
     /// earlier in this pass. The two halves are scoped differently on purpose:
     /// the AST-layer check is module-agnostic, so a user's
     /// `impl Display for String` in `format` suppresses the fallback while
-    /// synthesising `string`; the in-pass `pending` check stays module-scoped, so
-    /// two modules' same-named receivers each still get their own impl.
-    /// `receiver` names its own namespace — a mangled one looked up as a
-    /// declaration name reaches nothing.
+    /// synthesising `string`; the in-pass `pending` check stays module-scoped.
     pub(crate) fn has_impl(
         &self,
         receiver: ImplReceiver<'_>,
@@ -3517,8 +3514,7 @@ fn generate_struct_eq_ord_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'
 /// all declare a default, returning `S { f0: e0, … }`. Skips a struct with any
 /// undefaulted field, one already carrying a user `impl Default`, and generic
 /// structs, whose field defaults may depend on bounds. Every `default_expr`
-/// reaching here is pure: `check_default_purity_semantic` would have bailed the
-/// pipeline otherwise.
+/// reaching here is pure, `check_default_purity_semantic` having run.
 fn generate_struct_default_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, '_, '_>) {
     if module.structs.is_empty() {
         return;
@@ -5605,12 +5601,9 @@ fn decompose_type_for_method_name(
 
 /// Resolve `module_source` for a `value.<trait>::<method>` call inside an
 /// auto-derived body: it must name the module hosting the callee's body. Ask
-/// `TraitEnv` first — it indexes every AST-layer impl block, so a cross-module
-/// impl resolves deterministically rather than defaulting to whichever module
-/// synthesis happens to be visiting. If it is silent, the impl is being derived
-/// in this pass and will land in the receiver type's own module by convention.
-/// A receiver with no defining module takes the caller's `fallback`, which the
-/// monomorphizer overwrites after substitution.
+/// `TraitEnv` first, so a cross-module impl resolves deterministically; if it is
+/// silent, the impl is being derived in this pass and lands in the receiver's own
+/// module. A receiver with no defining module takes the caller's `fallback`.
 fn resolve_impl_module_via_env(
     type_id: TypeId,
     trait_name: &crate::name::FqTraitName,
@@ -5667,9 +5660,8 @@ fn resolve_impl_module_via_env(
 /// Collect the parameterized types needing Inspect/Display impls — the kinds
 /// whose codegen genuinely depends on the distinct `TypeId`, tuples and resource
 /// handles included. `ResolvedType::Function` is deliberately absent: a `Fn`
-/// dispatch stub depends only on `(arity, return_type)`, so enumerating per
-/// `TypeId` would emit identical stubs that collide on `function_id_for`, which
-/// `optimize/dce` asserts is injective. Use [`collect_canonical_fn_signatures`].
+/// dispatch stub depends only on `(arity, return_type)`, so use
+/// [`collect_canonical_fn_signatures`] instead.
 fn collect_parameterized_types(tt: &TypeTable) -> Vec<(TypeId, String, Vec<FqTypeName>)> {
     tt.all_types()
         .filter_map(|(id, resolved)| match resolved {

--- a/wado-compiler/src/test_names.rs
+++ b/wado-compiler/src/test_names.rs
@@ -1,26 +1,12 @@
-//! Encoding of the `org.wado-lang.test-names` custom section.
+//! Encoding of the `org.wado-lang.test-names` custom section. A CM export name
+//! must be ASCII kebab-case, so `test-0-hello-world` is a lossy rendering of
+//! `test "Hello, World!"`; codegen writes this section mapping each export name
+//! back to the faithful one for `wado test` to label results with. Writer and
+//! reader both depend on this module, so the wire format lives in one place.
 //!
-//! Component Model export names must be ASCII kebab-case, so the test export
-//! name (`test-0-hello-world`) is an ASCII-folded, lowercased rendering of the
-//! original `test "Hello, World!"` string — lossy and unsuitable for display.
-//! To recover the faithful name, codegen writes this custom section mapping
-//! each test export name to its original (lossless, possibly multibyte) name.
-//! The `wado test` runner reads it back to label results.
-//!
-//! Both the writer (`wado-compiler` codegen) and the reader (`wado-cli`)
-//! depend on this module so the wire format lives in exactly one place.
-//!
-//! ## Wire format
-//!
-//! All integers are little-endian `u32`. Strings are UTF-8, length-prefixed.
-//!
-//! ```text
-//! count: u32
-//! repeat `count` times:
-//!   export_name_len: u32, export_name: [u8; export_name_len]
-//!   has_name: u8 (0 = unnamed test, 1 = named)
-//!   name_len: u32, name: [u8; name_len]   // name_len is 0 when has_name == 0
-//! ```
+//! Integers are little-endian `u32` and strings length-prefixed UTF-8: a `count`
+//! followed by that many `(export_name, has_name, name)` records, where a `0`
+//! `has_name` marks an unnamed test and leaves `name_len` zero.
 
 /// Name of the custom section embedded in test-world components.
 pub const SECTION_NAME: &str = "org.wado-lang.test-names";

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -3334,9 +3334,8 @@ impl TypeTable {
     /// Mangle `id` as a type argument inside a generic instance's or monomorph's
     /// identity name — the `T` in `Result<unit, T>`. Unlike
     /// [`Self::mangle_type_name`], every named user-defined head is qualified by
-    /// its declaring `ModuleSource` — otherwise two same-named types from
-    /// different modules collapse onto one WIR identity, and the second silently
-    /// inherits the first's representation. All such identities must agree.
+    /// its declaring `ModuleSource`, or two same-named types collapse onto one
+    /// WIR identity and the second inherits the first's representation.
     pub fn mangle_type_arg_for_generic(&self, id: TypeId) -> String {
         match self.get(id) {
             ResolvedType::Variant {

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -1,13 +1,7 @@
-//! Typed Intermediate Representation (TIR) for Wado
-//!
-//! TIR is the post-type-resolution representation used for lowering,
-//! optimization, and code generation. Every expression has a resolved type.
-//!
-//! Key properties:
-//! - All types resolved to `TypeId` (no string-based type names)
-//! - All variable references resolved (local index known)
-//! - All function calls resolved
-//! - No syntactic sugar (desugared before TIR)
+//! Typed Intermediate Representation — the post-type-resolution form used for
+//! lowering, optimization, and codegen. Every type is a `TypeId`, every variable
+//! reference a local index, every call a resolved target, and all syntactic
+//! sugar is already desugared.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -30,17 +24,10 @@ pub enum TypeParamScope {
     Function,
 }
 
-/// A resolved effect reference.
-///
-/// In AST, effects are bare strings. In TIR, they are resolved to include
-/// the module source where the effect is defined, enabling cross-module
-/// effect identity.
-///
-/// Identity is `(module_source, name)` for `Concrete` and `name` alone for
-/// `Param` — same as every other resolved symbol in the compiler. The
-/// elaborator canonicalises the module source, so `with Stdout` imported from
-/// `wasi:cli` and `core:cli` both end up with `module_source = wasi:cli`
-/// (the defining module) and compare equal.
+/// A resolved effect reference — a bare string in the AST, carrying its defining
+/// module here. Identity is `(module_source, name)` for `Concrete` and `name`
+/// alone for `Param`. The elaborator canonicalises the module, so `with Stdout`
+/// imported from `wasi:cli` and from `core:cli` compare equal.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum EffectRef {
     /// A concrete effect resolved to a module source (e.g., `Stdout` from `wasi:cli`)
@@ -382,20 +369,13 @@ pub enum ResolvedType {
         name: String,
         module_source: ModuleSource,
     },
-    // NOTE: Option<T> is no longer a dedicated type variant.
-    // It is represented as GenericInstance { name: "Option", module_source: types(), type_args: [T] }.
-    // Use TypeTable::as_option() to check if a type is Option<T>.
+    // `Option<T>` is a `GenericInstance`, not a variant here — see
+    // `TypeTable::as_option`. `Future<T>` / `Stream<T>` and their writable twins
+    // are `GenericResource`, see `make_future` / `as_future`.
     //
-    // TODO: Re-add NullableRef optimization for Option<T> where T is non-nullable.
-    // When T is a reference type (struct, array, string, etc.), Option<T> can be
-    // represented as (ref null T) — null means None, non-null means Some(T).
-    // This avoids the SubtypeHierarchy overhead (discriminant struct + case subtypes).
-    // Key requirement: Option<Option<T>> MUST NOT use NullableRef (ambiguous null).
-    // See wep-2026-02-09-variant-independent-types.md for the general optimization strategy.
-    //
-    // NOTE: Future<T>, Stream<T>, FutureWritable<T>, StreamWritable<T> are no longer dedicated
-    // type variants. They are represented as GenericResource { name: "Future", ... }.
-    // Use TypeTable::make_future() / as_future() etc. to create and inspect them.
+    // TODO: represent `Option<T>` as `ref null T` when `T` is a non-nullable
+    // reference, dropping the discriminant struct. `Option<Option<T>>` must not
+    // take that route — its null would be ambiguous.
     /// Generic resource instantiation (e.g., `Future<i32>`, `Stream<String>`).
     /// Represents opaque i32 handles to Component Model resources with type parameters.
     GenericResource {
@@ -437,16 +417,11 @@ pub enum ResolvedType {
     /// type ever considered does, so a pass enumerating
     /// [`TypeTable::all_types`] must select with [`TypeTable::is_concrete`].
     InferVar(InferVarId),
-    /// Type pack parameter (e.g., `..T` in `fn foo<..T>(x: [..T])`)
-    /// Used inside tuples before monomorphization; expanded to concrete types during substitution.
-    ///
-    /// `mapped_elem` distinguishes an identity pack from a pack-map:
-    /// - `None` — `..F`: each element is the pack's own element `F_i`.
-    /// - `Some(R)` — a mapped pack: element `i` is `R[F := F_i]`. The pack
-    ///   param may recur inside `R` as a scalar `TypeParam` placeholder
-    ///   (constructor map, e.g. `[..Case<T, P>]` for `cases()`); a
-    ///   pack-independent `R` (`..F::method()`) degenerates to `R` repeated
-    ///   `|F|` times.
+    /// Type pack parameter (`..T` in `fn foo<..T>(x: [..T])`), living inside
+    /// tuples until substitution expands it. `mapped_elem` separates an identity
+    /// pack (`None` — element `i` is `F_i`) from a mapped one (`Some(R)` —
+    /// element `i` is `R[F := F_i]`, degenerating to `|F|` copies of `R` when
+    /// `R` does not mention the pack).
     TypePack {
         name: String,
         index: u32,
@@ -523,21 +498,11 @@ impl ResolvedType {
     }
 }
 
-/// A dense map from [`TypeId`] to `V`, backed by a `Vec` indexed by
-/// `TypeId.0`.
-///
-/// `TypeId`s are dense and sequential — [`TypeTable::intern`] only ever
-/// hands out [`TypeMap::next_id`] — so a `Vec` replaces what would
-/// otherwise be a `TypeId`-keyed hash map and every access becomes a
-/// hash-free array index. This matters because [`TypeTable::get`] is the
-/// single hottest accessor in the compiler.
-///
-/// The newtype keeps the storage **type-safe**: callers index by `TypeId`
-/// (never a bare `usize`), so an unrelated integer or the wrong table
-/// cannot be passed by mistake, and the lone `TypeId`→`usize` conversion
-/// lives here. Absent / erased entries are `None`; [`TypeMap::retain`]
-/// punches holes rather than renumbering, so surviving `TypeId`s keep
-/// their indices.
+/// A dense map from [`TypeId`] to `V`, backed by a `Vec` indexed by `TypeId.0`.
+/// `TypeId`s are dense and sequential, so every access is a hash-free array
+/// index — [`TypeTable::get`] is the compiler's hottest accessor. The newtype
+/// keeps the lone `TypeId`→`usize` conversion in one place. Erased entries are
+/// `None`: [`TypeMap::retain`] punches holes rather than renumbering.
 #[derive(Debug, Clone)]
 pub(crate) struct TypeMap<V> {
     slots: Vec<Option<V>>,
@@ -608,16 +573,10 @@ impl<V> TypeMap<V> {
     }
 }
 
-/// A dense set of [`TypeId`], backed by a bitset indexed by `TypeId.0`.
-///
-/// Membership and insertion are O(1) and hash-free — one bit per type, so
-/// even a transient "visited" set over the type graph costs a single small
-/// `Vec<u64>` instead of a hashed [`IndexSet`] that allocates and rehashes
-/// as it grows. This is the set-shaped companion to [`TypeMap`]; reach for
-/// it wherever a `IndexSet<TypeId>` is used purely for membership.
-///
-/// Iteration yields ascending `TypeId` order, **not** insertion order, so
-/// callers that depend on insertion order must keep an ordered set.
+/// A dense set of [`TypeId`], backed by a bitset — the set-shaped companion to
+/// [`TypeMap`]. One bit per type, so a transient "visited" set over the type
+/// graph costs a small `Vec<u64>` instead of a hash set that reallocates as it
+/// grows. Iteration yields ascending `TypeId` order, *not* insertion order.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct TypeSet {
     words: Vec<u64>,
@@ -709,19 +668,11 @@ pub struct TypeTable {
     /// Index from (struct name, module source) to `TypeId` for O(1) lookup.
     /// Populated incrementally when Struct types are interned.
     struct_name_index: IndexMap<(String, ModuleSource), TypeId>,
-    /// Canonical map: declared-type symbol → `TypeId`.
-    ///
-    /// Populated by the elaborator whenever it creates a decl-backed type
-    /// (`make_struct`, `make_enum`, `make_variant`, `make_flags`,
-    /// `make_newtype`, `make_resource`) via [`TypeTable::register_decl_type`].
-    /// Lets LSP-style queries translate a [`AstId`](crate::ast::AstId) — the canonical
-    /// identity of a declaration — to the `TypeId` it represents without
-    /// searching by name.
-    ///
-    /// Monomorphized instances are NOT entered here; the base generic's key
-    /// still resolves to the base `TypeId`. Use `symbol_of_type` to walk from
-    /// any decl-backed `TypeId` (including monomorphizations) back to the
-    /// declaring symbol.
+    /// Canonical map: declared-type symbol → `TypeId`, populated whenever the
+    /// elaborator mints a decl-backed type, so an LSP-style query can go from an
+    /// [`AstId`](crate::ast::AstId) to its type without searching by name.
+    /// Monomorphized instances are not entered — the base generic's key still
+    /// resolves to the base id; `symbol_of_type` walks the other way.
     type_by_symbol: IndexMap<crate::ast::AstId, TypeId>,
     /// Inverse of `type_by_symbol` plus monomorphization tracking: every
     /// decl-backed `TypeId` — including monomorphized instances —
@@ -729,18 +680,11 @@ pub struct TypeTable {
     ///
     /// A sparse [`TypeMap`] keyed by the decl-backed `TypeId`.
     symbol_by_type: TypeMap<crate::ast::AstId>,
-    /// `(type_name, module, trait_name)` triples that satisfied a `T:
-    /// Serialize` / `T: Deserialize` / `T: Eq` / `T: Ord` bound structurally
-    /// during elaboration (bound-driven synthesis, see
-    /// `docs/wep-2026-06-25-trait-derivation.md`). Keyed nominally, not by
-    /// `TypeId`, so a generic struct/variant records once against its own
-    /// declaration regardless of instantiation count.
-    ///
-    /// Lives on the one `TypeTable` every module's `Rc<RefCell<…>>` handle
-    /// shares, since elaboration runs one fresh `Elaborator` per module.
-    /// Read by both `synthesis::serde_synth::synthesize_serde` and
-    /// `synthesis::traits::synthesize_traits`, each filtering for the trait
-    /// names it owns.
+    /// `(type_name, module, trait_name)` triples that satisfied a `Serialize` /
+    /// `Deserialize` / `Eq` / `Ord` bound structurally during elaboration
+    /// (bound-driven synthesis, WEP 2026-06-25). Keyed nominally rather than by
+    /// `TypeId`, so a generic records once against its declaration. Lives on the
+    /// shared `TypeTable` because elaboration runs one `Elaborator` per module.
     bound_driven_synth_requests: IndexSet<(String, ModuleSource, TraitKey)>,
     /// Variant case templates: `(variant name, module)` → `(case name, case
     /// index, payload TypeId)`. Payload ids are in the declaring template's
@@ -911,17 +855,11 @@ impl TypeTable {
         id
     }
 
-    /// Mint a brand-new `TypeId` for `ty`, bypassing `intern`'s structural
-    /// dedup: even a `ResolvedType` identical to an already-interned one
-    /// gets its own fresh id.
-    ///
-    /// `intern_map`/`struct_name_index` are deliberately NOT updated: they
-    /// are keyed by `(name, module_source)` alone, so inserting a second,
-    /// same-named entry would silently overwrite the first one's mapping.
-    /// This is the primitive a function-scoped local type declaration mints
-    /// through — identity comes from the caller's own `AstId` (via
-    /// `register_decl_type`), not from this type's name, so two local
-    /// declarations that happen to share a name never alias.
+    /// Mint a brand-new `TypeId` for `ty`, bypassing `intern`'s structural dedup.
+    /// `intern_map` / `struct_name_index` are deliberately not updated — keyed by
+    /// `(name, module_source)`, a second same-named entry would overwrite the
+    /// first. This is what a function-scoped local type declaration mints
+    /// through: its identity is the caller's `AstId`, not this type's name.
     pub fn push_fresh(&mut self, ty: ResolvedType) -> TypeId {
         let id = self.types.next_id();
         self.types.push(ty);
@@ -1044,23 +982,13 @@ impl TypeTable {
         self.type_by_symbol.get(key).copied()
     }
 
-    /// Canonical `TypeId` for a declared-type [`AstId`](crate::ast::AstId),
-    /// for callers that already hold one (e.g. `StructFieldInfo::defined_at`)
-    /// and know the declaration was interned during `collect_types`.
+    /// Canonical `TypeId` for a declared-type [`AstId`](crate::ast::AstId).
+    /// Prefer this over re-deriving one from `(name, module_source)`: the
+    /// `AstId` is a cheap `Copy` key, and it stays unique even where name+module
+    /// does not — a function-scoped local type can share another's name.
     ///
-    /// Prefer this over re-deriving a `TypeId` from `(name, module_source)`
-    /// via `make_struct`/`make_enum`/`make_variant`/`make_resource`: the
-    /// `AstId` is a cheap `Copy` key with no string clone or re-hash, and —
-    /// unlike name+module — it stays unique even for declarations that do
-    /// not have a unique `(name, module_source)` (a function-scoped local
-    /// type declared under the same name as another).
-    ///
-    /// # Panics
-    /// If `collect_types` has not yet run for this declaration. Every
-    /// decl-backed `TypeId` is registered by `register_decl_type` at the
-    /// point it is minted, so a miss here means the caller queried before
-    /// collection completed, or the `AstId` does not name a decl-backed type
-    /// — both are compiler bugs, not recoverable conditions.
+    /// Panics if `collect_types` has not run for this declaration; both that and
+    /// a non-decl-backed `AstId` are compiler bugs, not recoverable conditions.
     pub fn type_id_of_decl(&self, key: crate::ast::AstId) -> TypeId {
         self.type_of_symbol(&key).unwrap_or_else(|| {
             panic!(
@@ -1231,22 +1159,11 @@ impl TypeTable {
         None
     }
 
-    /// Remove all type entries whose `TypeId` is not in `keep`.
-    ///
-    /// Erased entries become empty (`None`) holes in the backing [`TypeMap`]s
-    /// rather than being physically removed — `TypeId`s are never renumbered,
-    /// so surviving ids keep their indices — and `all_types` / `iter_type_ids`
-    /// skip the holes, so subsequent iterations (e.g. WIR type registration)
-    /// no longer see them. The intern map and secondary indices are rebuilt to
-    /// stay consistent.
-    ///
-    /// `retain` preserves the invariant that `self.get(id)` does not panic
-    /// for any surviving `id`. After `erase_newtypes_and_flags`, `get(id)`
-    /// follows `self.redirects` to a canonical `TypeId`; if the redirect's
-    /// target were removed, `get(id)` would panic on a surviving id.
-    /// To keep the invariant, the kept set is implicitly extended with
-    /// the redirect targets of every kept id, and stale redirect entries
-    /// (whose source or target did not survive) are dropped.
+    /// Remove all type entries whose `TypeId` is not in `keep`. Erased entries
+    /// become `None` holes rather than being renumbered away, so surviving ids
+    /// keep their indices, and the intern map and secondary indices are rebuilt.
+    /// `get(id)` must not panic for a surviving id, so `keep` is implicitly
+    /// closed under `redirects` and stale redirect entries are dropped.
     pub fn retain(&mut self, keep: &IndexSet<TypeId>) {
         // Implicit closure under `redirects`: every kept id whose `get`
         // result lives at a different id must keep that target alive too.
@@ -1913,23 +1830,11 @@ impl TypeTable {
         None
     }
 
-    /// Find any decl-backed named type (resource, enum, variant, struct,
-    /// flags, or newtype) scoped to a CM package.
-    ///
-    /// Matches types whose `module_source` prefix resolves to
-    /// `{cm_package}/` — both `Wasi { interface: "{pkg}/…" }` (e.g.
-    /// `wasi:http/types.wado`) and `Core { name: "{pkg}/…" }` (e.g.
-    /// `core:kiln/types.wado`) are considered. The key invariant: two
-    /// CM interfaces in distinct packages that happen to share a type
-    /// name (`wasi:cli/ErrorCode` vs `wasi:http/ErrorCode`, or
-    /// `wasi:http/types::Response` vs `core:kiln/types::Response`)
-    /// resolve to distinct `TypeId`s because `module_source` is part of
-    /// the intern key.
-    ///
-    /// `cm_package` is the bare package segment — `"http"`, `"kiln"`,
-    /// `"cli"`, etc. — not a fully-qualified source string. Callers
-    /// synthesizing CM bindings normally retrieve it from
-    /// [`crate::world_registry::WorldInfo::package`].
+    /// Find a decl-backed named type scoped to a CM package, matching any
+    /// `module_source` under the `{cm_package}/` prefix — `Wasi` and `Core`
+    /// alike. `cm_package` is the bare segment (`"http"`, `"kiln"`), not a
+    /// fully-qualified source. Same-named types in distinct packages stay
+    /// distinct because `module_source` is part of the intern key.
     pub fn find_named_type_by_cm_package(&self, name: &str, cm_package: &str) -> Option<TypeId> {
         let prefix = format!("{cm_package}/");
         for (type_id, resolved) in self.all_types() {
@@ -2047,16 +1952,10 @@ impl TypeTable {
         }
     }
 
-    /// Peel reference layers AND any `Box<T>` wrapper introduced by the
-    /// boxing pass, returning the underlying value type.
-    ///
-    /// The boxing pass rewrites `&T` / `&mut T` into `Box<T>` wrapper
-    /// structs for primitives, variants and function types. Sites that
-    /// inspect receiver / argument types in post-boxing IR — DCE inspect
-    /// scanning, dispatch synthesis, etc. — should reach for this
-    /// helper instead of [`Self::peel_refs`] so a `&fn(...)` parameter
-    /// (now `Box<fn(...)>`) and an unwrapped `fn(...)` value look the
-    /// same. For non-boxed types the result matches `peel_refs`.
+    /// Peel reference layers and any `Box<T>` the boxing pass introduced,
+    /// returning the underlying value type. Post-boxing IR should use this over
+    /// [`Self::peel_refs`] so a `&fn(…)` parameter — by then `Box<fn(…)>` — and
+    /// an unwrapped `fn(…)` look the same. Matches `peel_refs` when unboxed.
     pub fn peel_refs_and_box(&self, type_id: TypeId) -> TypeId {
         let peeled = self.peel_refs(type_id);
         self.box_payload_types
@@ -2361,16 +2260,10 @@ impl TypeTable {
     }
 
     /// Register associated-type resolutions for a freshly monomorphized struct.
-    ///
-    /// When a generic struct `Foo<T>` that implements a trait with `type Item = …`
-    /// is instantiated as the monomorphized struct `concrete_id` (a
-    /// [`ResolvedType::Struct`], which carries no type args), the projection
-    /// `Foo<…>::Item` can no longer be resolved through
-    /// [`Self::resolve_generic_assoc_type`] (that path only handles
-    /// `GenericInstance`). We therefore eagerly resolve each associated-type
-    /// definition registered for `base_decl` against the instantiation
-    /// `substitution` and record the result keyed by `concrete_id`, so later
-    /// [`Self::resolve_assoc_type`] lookups succeed.
+    /// A [`ResolvedType::Struct`] carries no type args, so `Foo<…>::Item` can no
+    /// longer go through [`Self::resolve_generic_assoc_type`]; each definition on
+    /// `base_decl` is instead resolved eagerly against `substitution` and
+    /// recorded under `concrete_id` for later [`Self::resolve_assoc_type`] hits.
     pub fn register_monomorphized_assoc_types(
         &mut self,
         concrete_id: TypeId,
@@ -2446,15 +2339,10 @@ impl TypeTable {
     }
 
     /// Monomorphization-time associated-type resolution for a `GenericInstance`.
-    ///
-    /// Unlike [`Self::resolve_generic_assoc_type`] (a `&self` fast path that only
-    /// substitutes a bare-`TypeParam` def and cannot intern a substituted
-    /// composite def), this substitutes the instance's type args into the def
-    /// positionally (param index `i` -> `type_args[i]`) via
-    /// [`Self::substitute_type_params`], so a reference / composite / nested
-    /// associated type (`&T`, `I::Item`) becomes fully concrete. The mutual
-    /// recursion through `substitute_type_params` resolves nested projections
-    /// one level at a time, each with its own instance's args.
+    /// Where [`Self::resolve_generic_assoc_type`] is a `&self` fast path limited
+    /// to a bare-`TypeParam` def, this substitutes positionally through
+    /// [`Self::substitute_type_params`], so a composite or nested definition
+    /// (`&T`, `I::Item`) becomes fully concrete one level per recursion.
     pub fn resolve_generic_assoc_type_mono(
         &mut self,
         concrete_id: TypeId,
@@ -2570,19 +2458,11 @@ impl TypeTable {
         Some(self.substitute_type_params(def_type_id, &subst))
     }
 
-    /// Substitute `TypeParam` and `TypePack` indices in `type_id` using `substitution`,
-    /// leaving the projections rooted at those slots abstract.
-    ///
-    /// Returns a new `TypeId` with the substitutions applied. Missing indices
-    /// are permissive: unmatched `TypeParam`s remain in place so callers can
-    /// perform partial substitution during type inference, or let downstream
-    /// code report errors.
-    ///
-    /// Handles all container forms (`Ref`, `MutRef`, `BuiltinArray`,
-    /// `Function`, `GenericInstance`, `GenericResource`) including `TypePack`
-    /// expansion inside tuple `GenericInstance`s, and `AssocTypeProjection`
-    /// resolution whenever the underlying parameter becomes fully concrete
-    /// after substitution.
+    /// Substitute `TypeParam` and `TypePack` indices in `type_id`, descending
+    /// through every container form, expanding a `TypePack` inside a tuple, and
+    /// resolving an `AssocTypeProjection` once its parameter turns concrete.
+    /// Missing indices are permissive — an unmatched `TypeParam` stays put, so
+    /// callers can substitute partially during inference.
     pub fn substitute_type_params(
         &mut self,
         type_id: TypeId,
@@ -3441,78 +3321,22 @@ impl TypeTable {
         }
     }
 
-    /// Get a mangled name for a type suitable for use in struct/function names.
-    ///
-    /// Unlike `type_name` which returns human-readable names (e.g., `[i32, String]`),
-    /// this returns mangled names suitable for monomorphization (e.g., `Tuple<i32,String>`).
-    ///
-    /// The format is:
-    /// - Primitives: `i32`, `f64`, `bool`, etc.
-    /// - Unit: `unit`
-    /// - Struct: struct name
-    /// - Tuple: `Tuple<T1,T2,...>`
-    /// - Option: `Option<T>`
-    /// - Result: `Result<T,E>`
-    /// - List: `List<T>`
-    /// - Function: `Fn<paramCount,returnType>`
-    /// - `GenericInstance`: `Name<T1,T2,...>`
-    /// - Ref/MutRef: inner type (references are stripped for mangling)
-    ///
+    /// Mangle a type for use inside struct / function names — `Tuple<i32,String>`
+    /// where [`Self::type_name`] would give the human-readable `[i32, String]`.
+    /// A generic renders as `Name<T1,T2,…>`, a function as
+    /// `Fn<paramCount,returnType>`, and references are stripped.
     #[must_use]
     pub fn mangle_type_name(&self, id: TypeId) -> String {
         let info = self.get_type_name_info(id);
         format_type_name(info)
     }
 
-    /// Mangle `id` for use as a type argument inside a generic instance's
-    /// or monomorphized entity's identity name (e.g. as the `T` in
-    /// `Result<unit, T>` or `Box<T>`).
-    ///
-    /// Unlike [`Self::mangle_type_name`], this *always* qualifies named
-    /// user-defined types whose simple name alone is not unique across
-    /// the type table — `Variant`, `Enum`, `Resource`, `Newtype`, and
-    /// `Flags` — by prefixing their declaring `ModuleSource`. Without
-    /// this, two distinct types from different modules sharing a simple
-    /// name (e.g. `wasi:filesystem`'s `pub variant ErrorCode` and
-    /// `wasi:cli`'s `pub enum ErrorCode`) collapse onto the same generic-
-    /// instance / monomorph identity at the WIR layer, causing
-    /// `register_mono_variants` to register only the first instantiation
-    /// it encounters and the later one's case-struct payload to silently
-    /// inherit the wrong representation.
-    ///
-    /// `Struct` and `GenericInstance` are qualified here too, so that
-    /// the mangled name a type takes inside a generic-instance identity
-    /// is stable regardless of where the type was defined.
-    ///
-    /// Without `Struct` qualification, two same-named structs from
-    /// distinct modules collapsed to the same `List<S>` mangled fq
-    /// at the WIR layer, leaving `List<S>` registered with one
-    /// module's element struct and code constructing the other module's
-    /// struct stored into that array — a Wasm GC validation failure
-    /// (regression `cross_module_same_name_struct_iter.wado`).
-    ///
-    /// Without `GenericInstance` qualification the mangled name flips
-    /// at the substitution boundary `GenericInstance → Struct`
-    /// (`IterFilter<ListIter<i32>>` while still `GenericInstance` vs
-    /// `IterFilter<core:prelude/list.wado/ListIter<i32>>` once the
-    /// inner is monomorphized to `Struct`), producing duplicate WIR
-    /// registrations of the same logical struct.
-    ///
-    /// All sites that build a generic-instance identity, register a
-    /// struct, or look one up by name must agree on this qualified
-    /// form. `wir_build::context::type_id_to_wir_type`'s `List<T>`
-    /// lookup, `wir_build::types::register_struct`'s fq construction,
-    /// and the `synthesis::cm_binding` / `synthesis::serde_synth`
-    /// name builders all flow through this function or through
-    /// `mangle_type_name` (which delegates here for type args).
-    ///
-    /// Standalone uses (e.g. `mangle_type_name(ErrorCode)` outside a
-    /// generic instance, or method-dispatch `base_struct_name`) keep the
-    /// short name so that `cm_interface_registry`, `LocalMethodName`, and
-    /// `ModuleSource::interface_name` keys remain unchanged.
-    ///
-    /// User-facing display (`TypeTable::type_name`) is independent and
-    /// is unaffected by this function.
+    /// Mangle `id` as a type argument inside a generic instance's or monomorph's
+    /// identity name — the `T` in `Result<unit, T>`. Unlike
+    /// [`Self::mangle_type_name`], every named user-defined head is qualified by
+    /// its declaring `ModuleSource` — otherwise two same-named types from
+    /// different modules collapse onto one WIR identity, and the second silently
+    /// inherits the first's representation. All such identities must agree.
     pub fn mangle_type_arg_for_generic(&self, id: TypeId) -> String {
         match self.get(id) {
             ResolvedType::Variant {
@@ -3666,16 +3490,11 @@ impl TypeTable {
         }
     }
 
-    /// The name a struct is *stored* under in the package's struct list and
-    /// named by in a `StructLiteral`: the declaration or instantiation name
-    /// with the head left bare, module disambiguation carried alongside as a
-    /// `ModuleSource` rather than folded into the string.
-    ///
-    /// Every mangler qualifies a declared head by its module; this namespace
-    /// must not, because that is how the struct list is keyed. The list holds
-    /// one entry per instantiation, so an instantiation is spelled with its
-    /// arguments — `decl_name` alone names a template nothing stores. `None`
-    /// for a type that is not struct-shaped.
+    /// The name a struct is *stored* under in the package's struct list: the
+    /// head left bare, with module disambiguation carried alongside as a
+    /// `ModuleSource` rather than folded in — unlike every mangler, because that
+    /// is how the list is keyed. It holds one entry per instantiation, so an
+    /// instantiation is spelled with its arguments. `None` if not struct-shaped.
     #[must_use]
     pub fn struct_list_name(&self, id: TypeId) -> Option<String> {
         match self.get(id) {
@@ -3843,17 +3662,10 @@ impl TypeTable {
         }
     }
 
-    /// Convert a resolved type to its name info for formatting.
-    ///
-    /// This separates type resolution (here in tir.rs) from name formatting
-    /// (in name.rs), following the principle that name format details belong
-    /// in name.rs.
-    /// The structured fq name of `id`.
-    ///
-    /// The type table is the only thing that knows a declaration's module, so
-    /// it hands back structure and lets the caller render or inspect. Rendering
-    /// here and re-deriving the module from the string later is not possible —
-    /// a `ModuleSource` cannot be rebuilt without the interner — which is why
+    /// The structured fq name of `id`. The type table is the only thing that
+    /// knows a declaration's module, so it hands back structure and lets the
+    /// caller render or inspect. Rendering here would be one-way — a
+    /// `ModuleSource` cannot be rebuilt from a string without the interner — so
     /// the name stays structured all the way to its consumers.
     #[must_use]
     pub fn fq_type_name(&self, id: TypeId) -> crate::name::FqTypeName {
@@ -4424,16 +4236,11 @@ pub enum TirExprKind {
         /// for synthesised closures (e.g. effect-handler dispatch),
         /// which never take addresses.
         address_taken_locals: crate::hashmap::IndexSet<u32>,
-        /// Body-level let-bindings inside the closure, in declaration
-        /// order. Indices `0..params.len()` belong to the closure's
-        /// parameters (whose info lives in `params`); these body locals
-        /// occupy `params.len()..params.len()+body_locals.len()` in the
-        /// closure's local-index namespace.
-        ///
-        /// Captured at resolve time from the closure's `FunctionContext`
-        /// so pattern lowering can seed a closure-scoped allocator
-        /// without re-walking the body. Synthetic closures created by
-        /// `synthesis/` have an empty `body_locals`.
+        /// Body-level let-bindings inside the closure, in declaration order,
+        /// occupying `params.len()..` in its local-index namespace (the params
+        /// themselves live in `params`). Captured at resolve time so pattern
+        /// lowering can seed a closure-scoped allocator without re-walking the
+        /// body. Empty for the synthetic closures `synthesis/` creates.
         body_locals: Vec<TirLocal>,
         /// Effects the closure type was annotated with at the use site (let
         /// annotation, function-typed parameter, etc.). `Some` only when the
@@ -4571,17 +4378,11 @@ pub struct TirHandlerBinding {
     /// Used by codegen to pick the correct `impl E for T` methods.
     pub handler_type: TypeId,
     pub span: Span,
-    /// If `Some(id)`, this binding came from a bundled `with &mut h do`
-    /// expansion. All bindings produced from one bundled clause share the
-    /// same `id`. The dispatch synthesis uses this to allocate a single
-    /// `__h_<bundle>` local that every per-effect closure captures, so the
-    /// handler value is evaluated once and mutations from any installed
-    /// effect are observed by the rest. `None` for explicit
-    /// `Effect => handler` bindings (each gets its own `__h_<E>` local).
-    ///
-    /// IDs are unique within a single `WithHandler` expression but are not
-    /// reused across separate `with` blocks; the synthesis pass starts
-    /// fresh for each `WithHandler` it visits.
+    /// `Some(id)` marks a binding from a bundled `with &mut h do` expansion; all
+    /// bindings from one clause share the id, so dispatch synthesis can allocate
+    /// a single `__h_<bundle>` local that every per-effect closure captures —
+    /// the handler is evaluated once and one effect's mutations are seen by the
+    /// rest. `None` for an explicit `Effect => handler`. Unique per `WithHandler`.
     pub bundle_group: Option<u32>,
 }
 
@@ -4753,22 +4554,11 @@ impl TirBlock {
     }
 }
 
-/// Value-yielding type of a block, mirroring how `let x = { ... }`
-/// resolves: the last statement determines the type, with two
-/// special cases:
-///
-/// - `If` / `IfLet` with both branches: both branches must agree
-///   (or one must be `Never`); otherwise the block has no
-///   meaningful value and is `Unit`. The elaborator enforces the
-///   "both agree" rule when typing the surrounding expression, so
-///   the `None` fallback at a stale mismatch is benign — the
-///   surrounding diagnostic already reports the error.
-/// - `Return` / `Break` / `Continue`: diverging statements yield
-///   `Never`.
-///
-/// Used by the elaborator, to type `let x = { /* block */ }` (the call
-/// lives on `Elaborator` for historical reasons but delegates here) and
-/// to type the `if let` → `Let` + `Match` lowering's arms.
+/// Value-yielding type of a block: the last statement decides, except that a
+/// two-branch `If` / `IfLet` needs its branches to agree (or one to be `Never`)
+/// and falls back to `Unit`, and a diverging `Return` / `Break` / `Continue`
+/// yields `Never`. The elaborator enforces the agreement rule while typing the
+/// surrounding expression, so a mismatch here is already reported.
 pub fn block_result_type(block: &TirBlock) -> TypeId {
     block
         .stmts
@@ -5205,20 +4995,11 @@ pub enum FunctionKind {
     /// `type_id`. Calls to such functions may be elided when the argument is
     /// provably fresh.
     ValueCopy { type_id: TypeId },
-    /// Auto-derived `Fn<arity, return_type>^Inspect::inspect` (or
-    /// `^InspectAlt::inspect_alt`) dispatch stub.
-    ///
-    /// The TIR body is `unreachable()` — a placeholder that exists
-    /// only so the function is registered and the call is resolvable
-    /// from templates and from user code. WIR build recognises this
-    /// kind and supplies the real body: a `call_ref` through the
-    /// matching `CanonicalClosure_K`'s `inspect` / `inspect_alt`
-    /// vtable slot. Carries `(arity, return_type)` as structured
-    /// fields so neither WIR build nor DCE has to recover them by
-    /// parsing the mangled function name.
-    ///
-    /// See WEP: Inspect (Debug Output) > Closure Inspect via Runtime
-    /// Dispatch.
+    /// Auto-derived `Fn<arity, return_type>^Inspect::inspect` dispatch stub (or
+    /// its `^InspectAlt` twin). The TIR body is `unreachable()` — enough for the
+    /// function to be registered and the call resolvable — and WIR build
+    /// supplies the real one, a `call_ref` through `CanonicalClosure_K`'s vtable
+    /// slot. `(arity, return_type)` are structured so nobody parses the mangle.
     FnCanonicalDispatch {
         trait_kind: FnDispatchTrait,
         arity: usize,
@@ -5304,22 +5085,11 @@ impl TirFunction {
     }
 }
 
-/// A resolved local-slot entry in a function, global initializer, or
-/// closure scope, identified by its declaration / order in the surrounding
-/// local environment.
-///
-/// `FunctionContext::add_local` records every local — source-level
-/// parameters, `let` bindings, destructure bindings, and elaborator-generated
-/// temporaries — as a `TirLocal`. The single source of truth for the local
-/// namespace is `FunctionContext::locals: Vec<TirLocal>`; from there it is
-/// projected onto:
-///
-/// * `TirFunction::locals` and `TirGlobal::locals` — the function/global's
-///   absolute local table, keyed by Wasm local index.
-/// * `TirExprKind::Closure { body_locals, .. }` — the closure's
-///   body-level let-bindings (params live in `params` so they aren't
-///   duplicated). Pattern lowering reconstructs the closure-scope local
-///   table from `params + body_locals` while descending in.
+/// A resolved local slot in a function, global initializer, or closure scope.
+/// `FunctionContext::locals` is the single source of truth — every parameter,
+/// `let`, destructure binding and elaborator temporary — and is projected onto
+/// `TirFunction::locals` / `TirGlobal::locals` (keyed by Wasm local index) and
+/// onto `Closure { body_locals }`, whose params stay in `params` instead.
 #[derive(Debug, Clone)]
 pub struct TirLocal {
     /// Source-level name of the binding (or a synthesised `__name` for
@@ -5640,16 +5410,11 @@ pub struct ClosureFunctor {
     pub call_method: Rc<RefCell<TirFunction>>,
     /// Captures from the original closure
     pub captures: Vec<TirCapture>,
-    /// Canonical user-declared (name, type) pairs of the closure literal —
-    /// `[]` for `|| ...`, `[("x", i32)]` for `|x: i32| ...`. Captured at
-    /// functor creation and never mutated. `wir_build`'s
-    /// `register_closure_wrappers` uses this list to choose the wrapper's
-    /// external signature: the function-table type the closure was coerced
-    /// to is `fn(env, canonical_user_params...) -> canonical_return`,
-    /// independent of any DAE shrinkage that happens later on
-    /// `call_method.params`. Without this snapshot, dropping a "dead" param
-    /// from `__call` would also shrink the wrapper signature and
-    /// desynchronise it from the typed-fn callers.
+    /// Canonical user-declared `(name, type)` pairs of the closure literal,
+    /// captured at functor creation and never mutated. `register_closure_wrappers`
+    /// derives the wrapper's external signature
+    /// (`fn(env, ..canonical_user_params) -> canonical_return`) from this
+    /// snapshot, so a later DAE shrink of `__call` cannot desynchronise it.
     pub canonical_user_params: Vec<(String, TypeId)>,
     /// Canonical return type of the closure literal. Same role as
     /// `canonical_user_params` — drives the wrapper external signature.

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -371,7 +371,7 @@ pub enum ResolvedType {
     },
     // `Option<T>` is a `GenericInstance`, not a variant here — see
     // `TypeTable::as_option`. `Future<T>` / `Stream<T>` and their writable twins
-    // are `GenericResource`, see `make_future` / `as_future`.
+    // are `GenericResource`, built by `make_future` / `make_future_writable`.
     //
     // TODO: represent `Option<T>` as `ref null T` when `T` is a non-nullable
     // reference, dropping the discriminant struct. `Option<Option<T>>` must not
@@ -4554,7 +4554,7 @@ impl TirBlock {
 }
 
 /// Value-yielding type of a block: the last statement decides, except that a
-/// two-branch `If` / `IfLet` needs its branches to agree (or one to be `Never`)
+/// two-branch `If` needs its branches to agree (or one to be `Never`)
 /// and falls back to `Unit`, and a diverging `Return` / `Break` / `Continue`
 /// yields `Never`. The elaborator enforces the agreement rule while typing the
 /// surrounding expression, so a mismatch here is already reported.

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -89,7 +89,7 @@ impl TypeParamId {
 /// and a partially concrete target leaves gaps no positional list can express.
 /// Keying by position asks the caller to reconstruct that, which it cannot;
 /// `impl<T, ..F> Emit for T` is enough to break the reconstruction.
-/// [`MethodSig::instantiate_call`] takes the same view.
+/// `instantiate_call` takes the same view.
 #[derive(Debug, Clone, Default)]
 pub struct SubstitutionContext {
     substitutions: IndexMap<TypeId, TypeId>,
@@ -458,7 +458,7 @@ pub enum ResolvedType {
         assoc_type_bindings: Vec<(String, TypeId)>,
     },
     /// Raw GC array intrinsic (`Array<T>`)
-    /// This is the underlying storage type for String and List<T> structs
+    /// This is the underlying storage type for `String` and `List<T>` structs
     BuiltinArray(TypeId),
     /// Newtype: a distinct type wrapping a base type with the same representation.
     /// Created by `type T = U;` declarations.
@@ -481,7 +481,7 @@ pub enum ResolvedType {
 }
 
 impl ResolvedType {
-    /// Get the module path as a Vec<String> for backwards compatibility.
+    /// Get the module path as a `Vec<String>` for backwards compatibility.
     /// This is a transitional helper during the migration to `ModuleSource`.
     #[must_use]
     pub fn module_path(&self) -> Vec<String> {
@@ -1283,9 +1283,9 @@ impl TypeTable {
     }
 
     /// Canonical name of a registered struct / trait / variant / enum
-    /// [`CompilerItem`], forwarded from the registry so call sites read
-    /// `tt.compiler_struct_name(item)` instead of chaining through
-    /// `compiler_items()`.
+    /// [`CompilerItem`](crate::compiler_item::CompilerItem), forwarded from the
+    /// registry so call sites read `tt.compiler_struct_name(item)` instead of
+    /// chaining through `compiler_items()`.
     pub fn compiler_struct_name(&self, item: crate::compiler_item::CompilerItem) -> &str {
         self.compiler_items.struct_name(item)
     }
@@ -1346,7 +1346,7 @@ impl TypeTable {
     }
 
     /// Owned `(module, name)` for a registered struct / enum item — forwards
-    /// the registry's [`CompilerItems::struct_owned`] so single-expression
+    /// the registry's `CompilerItems::struct_owned` so single-expression
     /// callers query the table directly instead of through `compiler_items()`.
     pub fn compiler_struct_owned(
         &self,
@@ -1394,14 +1394,14 @@ impl TypeTable {
 
     /// Get the module source where the `Default` trait is defined, if
     /// the stdlib has registered it. Thin wrapper around
-    /// [`CompilerItems::trait_module`].
+    /// `CompilerItems::trait_module`.
     pub fn default_trait_module_source(&self) -> Option<&ModuleSource> {
         self.compiler_items
             .trait_module(crate::compiler_item::CompilerItem::Default)
     }
 
-    /// Make the struct type for a registered [`CompilerItem`] variant
-    /// of kind [`CompilerItemKind::Struct`]. Reads both the module
+    /// Make the struct type for a registered `CompilerItem` variant
+    /// of kind `CompilerItemKind::Struct`. Reads both the module
     /// source and the struct name from the registry so the call site
     /// does not hard-code either. Panics with a clear ICE message when
     /// the item is not registered or has the wrong kind.
@@ -1410,8 +1410,8 @@ impl TypeTable {
         self.make_struct(name, module_source)
     }
 
-    /// Make the enum type for a registered [`CompilerItem`] variant
-    /// of kind [`CompilerItemKind::Enum`] (currently `Ordering`).
+    /// Make the enum type for a registered `CompilerItem` variant
+    /// of kind `CompilerItemKind::Enum` (currently `Ordering`).
     /// Same shape as [`Self::make_compiler_struct`]: routes both name
     /// and module through the registry.
     pub fn make_compiler_enum(&mut self, item: crate::compiler_item::CompilerItem) -> TypeId {
@@ -1638,7 +1638,7 @@ impl TypeTable {
         crate::name::mangle_generic_name(decl_name, &args)
     }
 
-    /// Create a monomorphized struct type (e.g., "Box<i32>")
+    /// Create a monomorphized struct type (e.g., `"Box<i32>"`)
     ///
     /// - `name`: The fully mangled name (e.g., "`TreeMap`<String,i32>")
     /// - `base_name`: The original generic struct name (e.g., "`TreeMap`")
@@ -2758,7 +2758,7 @@ impl TypeTable {
         })
     }
 
-    /// Create an List<T> type (`GenericInstance` { name: "List", ... })
+    /// Create a `List<T>` type (`GenericInstance` { name: "List", ... })
     pub fn make_list(&mut self, element: TypeId) -> TypeId {
         self.make_generic_instance("List".to_string(), ModuleSource::list(), vec![element])
     }
@@ -2857,7 +2857,7 @@ impl TypeTable {
         self.get_ultimate_base_type(a) == self.get_ultimate_base_type(b)
     }
 
-    /// Check if a type is List<T> and return the element type if so.
+    /// Check if a type is `List<T>` and return the element type if so.
     /// Also unwraps Ref/MutRef types to check the inner type.
     pub fn as_list(&self, id: TypeId) -> Option<TypeId> {
         match self.get(id) {
@@ -4102,7 +4102,7 @@ pub enum TirExprKind {
         /// `args[0]`, so `args[i]` maps to `params[i]` for every call shape.
         args: Vec<CallArg>,
         /// Whether `args[0]` is the receiver of an instance method, set by
-        /// [`TirExprKind::method_call`] alone — so it marks dot syntax. A
+        /// `TirExprKind::method_call` alone — so it marks dot syntax. A
         /// trait-qualified (UFCS) call carries its receiver in `args[0]` too but
         /// leaves this `false`: it spells the receiver's mode itself
         /// (`Trait::m(&mut x, …)`), so the receiver is already reference-typed
@@ -4734,7 +4734,8 @@ pub fn method_param_offset(impl_type_params: &[TirTypeParam]) -> u32 {
 /// Information about monomorphization origin for instantiated items
 #[derive(Debug, Clone)]
 pub struct MonomorphInfo {
-    /// Original generic name (e.g., "Box" for "Box<i32>", or "`BTreeNode`<`K,V>::insert`" for methods)
+    /// Original generic name: `"Box"` for `"Box<i32>"`, or
+    /// `"BTreeNode<K,V>::insert"` for methods.
     pub generic_name: String,
     /// Impl-level type arguments (from the struct/type, e.g. `[i32]` for `List<i32>`)
     pub impl_type_args: Vec<TypeId>,

--- a/wado-compiler/src/tir_visitor.rs
+++ b/wado-compiler/src/tir_visitor.rs
@@ -1,14 +1,8 @@
-//! Generic visitor traits for mutable and immutable traversal of TIR trees.
-//!
-//! Provides three visitor traits:
-//! - `TirMutVisitor`: mutable traversal (monomorphizer, lowering)
-//! - `TirRefVisitor`: immutable traversal (analysis, collection)
-//! - `TirOptVisitor`: mutable traversal with change tracking (optimization
-//!   and synthesis passes); covers every TIR node, including the
-//!   pre-lowering forms (`TaskReturn`, `VariadicForOf`, `WithHandler`,
-//!   `Resume`, `TemplateString`)
-//!
-//! Also provides utility functions for common TIR queries like `block_has_break_to`.
+//! Visitor traits for TIR traversal: `TirMutVisitor` for mutation (the
+//! monomorphizer, lowering), `TirRefVisitor` for analysis, and `TirOptVisitor`
+//! for mutation with change tracking (optimization and synthesis), which also
+//! covers the pre-lowering forms `TaskReturn`, `VariadicForOf`, `WithHandler`,
+//! `Resume` and `TemplateString`. Plus a few shared TIR queries.
 
 use crate::flat_package::FlatPackage;
 use crate::tir::{

--- a/wado-compiler/src/token.rs
+++ b/wado-compiler/src/token.rs
@@ -264,21 +264,11 @@ impl Span {
     }
 }
 
-/// Append a stable byte encoding of `kind` to `out`.
-///
-/// Concatenating these encodings for every non-comment token in a source
-/// file yields a hash input that ignores comments, whitespace, and span
-/// positions — used by the Kiln source-hash so a docstring or
-/// reformatting edit on a generator's `.wado` files does not churn the
-/// `generator_source_hash` field of every consumer's `<primary>.kiln.json`.
-///
-/// **Stability constraint:** any change to `TokenKind` (rename a variant,
-/// add a keyword, tweak a payload) alters this encoding and therefore
-/// invalidates every cached generator component and the
-/// `generator_source_hash` field of every committed `*.kiln.json`. Bump
-/// the magic in `wado-cli/src/kiln_provider.rs::combined_sources_hash`
-/// (and `INDEX_VERSION`) in lockstep, and expect a single noisy diff
-/// against committed kiln json after the bump lands.
+/// Append a stable byte encoding of `kind` to `out`. Concatenated over a file's
+/// non-comment tokens this is the Kiln source-hash input, blind to comments,
+/// whitespace and spans, so a reformatting edit churns no consumer's
+/// `generator_source_hash`. Any `TokenKind` change invalidates every cached
+/// generator component, so bump `combined_sources_hash` and `INDEX_VERSION` too.
 pub fn canonical_token_bytes(out: &mut Vec<u8>, kind: &TokenKind) {
     use TokenKind::{
         AmpEq, Ampersand, And, Arrow, As, Assert, Async, Break, ByteCharLit, ByteStringLit, Caret,

--- a/wado-compiler/src/trace.rs
+++ b/wado-compiler/src/trace.rs
@@ -1,25 +1,8 @@
-//! Compiler-internal tracing for development debugging.
-//!
-//! Targets are selected by the `WADO_TRACE` env var (comma-separated list,
-//! or `*` for everything). Output goes to stderr with a `[target]` prefix.
-//! Inactive targets cost one env-var lookup (cached on first access) and a
-//! linear scan over the configured target list — fine for any rate that
-//! makes sense in a compiler pass.
-//!
-//! `compiler_trace!` is for *developer* diagnostics only; user-facing
-//! diagnostics still flow through `Logger` / `CompilerHost::emit_diagnostic`.
-//!
-//! Examples (all from a development shell):
-//!
-//! ```sh
-//! WADO_TRACE=sroa_variant_return cargo run --bin wado -- compile foo.wado
-//! WADO_TRACE=sroa_variant_return,inline cargo run --bin wado -- compile foo.wado
-//! WADO_TRACE='*' cargo run --bin wado -- compile foo.wado
-//! ```
-//!
-//! The macro expands to a guarded `eprintln!`. On `wasm32-unknown-unknown`
-//! `std::env::var` returns `Err(NotPresent)` so the filter is empty and
-//! no output is produced.
+//! Compiler-internal tracing for development debugging, selected by the
+//! `WADO_TRACE` env var — a comma-separated target list, or `*` — and written to
+//! stderr under a `[target]` prefix. `compiler_trace!` expands to a guarded
+//! `eprintln!` and is for *developer* diagnostics only; user-facing ones still
+//! flow through `Logger`. On `wasm32-unknown-unknown` the filter is always empty.
 
 use std::sync::OnceLock;
 

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -205,7 +205,7 @@ impl<'a> Unparser<'a> {
         Self::default()
     }
 
-    /// Attach a parser-populated [`TriviaMap`]. Builder-style so the
+    /// Attach a parser-populated [`TriviaMap`](crate::comment::TriviaMap). Builder-style so the
     /// formatter pipeline can opt in with
     /// `Unparser::new().with_trivia(&trivia)`, while paths that don't
     /// care about comments (e.g. AST dump) just call `Unparser::new()`.

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -2006,25 +2006,11 @@ impl<'a> Unparser<'a> {
     }
 
     fn unparse_call(&mut self, c: &CallExpr) {
-        // Parenthesize callee shapes that would re-parse differently
-        // without parens. The rule of thumb: anything whose precedence
-        // sits above the postfix level (call/index/field/method), plus a
-        // couple of postfix-level shapes that are still syntactically
-        // ambiguous with call syntax.
-        //
-        // - `FieldAccess`: `self.f(args)` would re-parse as a method call.
-        // - `Closure`: a closure with an expression body greedily
-        //   consumes the rest of the line, so `|x| x + 1(41)` re-parses
-        //   as `|x| (x + 1(41))` rather than calling the closure.
-        // - `Cast`: `f as T(args)` does not re-parse — `T(args)` is not a
-        //   valid type and the trailing `(` becomes a stray token.
-        // - `Unary` / `Binary` / `Assign` / `CompoundAssign` /
-        //   `ComparisonChain` / `Range`: all live above postfix, so the
-        //   call `(args)` would bind tighter on re-parse.
-        //
-        // `If` / `Match` / `Block` / `LabeledBlock` / `WithHandler` are
-        // explicitly excluded: they end with `}` which terminates the
-        // expression cleanly before the call's `(`.
+        // Parenthesize a callee that would re-parse differently bare: anything
+        // above the postfix level, whose `(args)` would bind tighter, plus
+        // `FieldAccess` (re-parses as a method call), `Closure` (an expression
+        // body swallows the call), and `Cast`. `If` / `Match` / `Block` and
+        // friends end with `}`, which terminates the expression cleanly.
         let needs_parens = matches!(
             &c.callee,
             Expr::FieldAccess(_)
@@ -3925,20 +3911,10 @@ pub fn unparse_assoc_const_signature(c: &AssociatedConst) -> String {
     out
 }
 
-/// Render an `impl` block as Wado with member **signatures** only (bodies
-/// omitted), for type overviews:
-///
-/// ```text
-/// impl<T> Trait for Type {
-///     const C: T
-///     fn m(&self) -> T
-/// }
-/// ```
-///
-/// With `public_only`, an inherent `impl` (no trait) shows only `pub` members;
-/// a trait `impl`'s members are always shown (they are the trait's public
-/// surface). Returns an empty string when no member is visible, so callers can
-/// drop the block.
+/// Render an `impl` block as Wado with member **signatures** only, for type
+/// overviews. Under `public_only` an inherent `impl` shows only `pub` members,
+/// while a trait `impl`'s are always shown, being the trait's public surface.
+/// Empty when nothing is visible, so the caller can drop the block.
 pub fn unparse_impl_block_signature(b: &ImplBlock, public_only: bool) -> String {
     let inherent = b.trait_type.is_none();
     let visible = |visibility| crate::semantics::member_visible(public_only, inherent, visibility);
@@ -5202,20 +5178,11 @@ fn tir_unary_op_str(op: TirUnaryOp) -> &'static str {
     }
 }
 
-/// Unparse a TIR closure as `|name: Type, ...| body` (or `|name: Type, ...|
-/// captures[...] body` when the closure captures locals) source text.
-///
-/// Used by `lower::plan::closure` to bake the per-literal source string into
-/// `__Closure_N^InspectAlt::inspect_alt` without requiring every TIR
-/// `Closure` node to carry an unparsed-AST string.
-///
-/// The `captures[name1, name2, ...]` clause has no surface-syntax
-/// counterpart in Wado (closures capture implicitly), but is shown in
-/// the `:#?` debug output by design: it makes captured-environment
-/// dependencies visible at inspect time, which is the whole point of
-/// pretty-printing a closure in the first place. Non-capturing closures
-/// produce output that round-trips through the parser; capturing
-/// closures intentionally do not.
+/// Unparse a TIR closure as `|name: Type, …| body`, or `|…| captures[…] body`
+/// when it captures. `lower::plan::closure` bakes the result into
+/// `__Closure_N^InspectAlt::inspect_alt`. The `captures[…]` clause has no
+/// surface syntax — closures capture implicitly — but is shown deliberately, so
+/// only a non-capturing closure round-trips through the parser.
 pub fn unparse_tir_closure_source(
     params: &[(String, TypeId)],
     captures: &[crate::tir::TirCapture],

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -1,17 +1,8 @@
-//! WIR (Wasm IR) — tree-structured intermediate representation between TIR and Wasm binary.
-//!
-//! WIR is close to Wasm semantics but retains enough high-level information to be
-//! readable and debuggable. It maps almost 1:1 to Wasm instructions with these
-//! ergonomic improvements:
-//!
-//! - Named locals (not pre-allocated indices)
-//! - Named types (Wado-level struct/variant/enum/flags, not Wasm type section entries)
-//! - Wado-level value types (Bool, Char, I8, U8, etc. instead of Wasm's i32-for-everything)
-//! - Structured control flow (tree nodes, not flat instruction sequences)
-//! - Explicit value copy operations
-//! - TIR metadata preserved for debugging and unparse
-//!
-//! See `docs/wep-2026-02-14-wir-layer.md` for the full design rationale.
+//! WIR — the tree-structured IR between TIR and the Wasm binary, mapping almost
+//! 1:1 to Wasm instructions while staying readable: locals and types are named
+//! rather than indexed, value types keep their Wado distinctions instead of
+//! collapsing to `i32`, control flow is a tree rather than a flat sequence, value
+//! copies are explicit, and TIR metadata survives for unparse. See WEP 2026-02-14.
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -123,18 +114,11 @@ pub struct WirPackage {
     /// Codegen iterates this to decide membership per phase rather than
     /// re-deriving it (the `codegen.rs` principle: codegen emits the plan).
     pub import_plan: Vec<ImportEntry>,
-    /// Absolute Wasm function index of the first defined function (i.e. the
-    /// number of imported functions). Defined function `i` (the `i`-th entry
-    /// in [`functions`](Self::functions)) has the absolute index
-    /// `defined_func_base + i`, which is the value carried by `WirFuncId`.
-    ///
-    /// - GC module (built by `wir_build`): [`crate::wir_build::DEFINED_FUNC_BASE`].
-    /// - Memory module (built by `WasmModuleInfo::to_wir_package`): `0` (no
-    ///   function imports).
-    ///
-    /// Used by DCE / compaction passes to translate between absolute
-    /// `WirFuncId` indices and 0-based array indices into
-    /// [`functions`](Self::functions) without hard-coding the offset.
+    /// Absolute Wasm index of the first defined function — the number of imported
+    /// ones — so the `i`-th entry in [`functions`](Self::functions) has the
+    /// absolute index a `WirFuncId` carries. `DEFINED_FUNC_BASE` for the GC
+    /// module, `0` for the import-less memory module. DCE and compaction read it
+    /// to convert between the two index spaces without hard-coding an offset.
     pub defined_func_base: u32,
     /// Trait-bound violations collected instead of trapping the build, so the
     /// driver can emit a clean diagnostic and bail. Empty in well-formed programs.
@@ -666,16 +650,10 @@ pub struct WirFuncType {
     pub results: Vec<WirType>,
 }
 
-/// WIR type — Wado-level primitives + GC references.
-///
-/// Unlike Wasm's `ValType` (i32/i64/f32/f64 only), WIR preserves the full
-/// Wado type distinctions. The emit phase lowers these:
-///   - I8/I16/U8/U16/Bool/Char → i32 (locals) or i8/i16 (packed struct fields)
-///   - I32/U32 → i32
-///   - I64/U64 → i64
-///   - F32 → f32
-///   - F64 → f64
-///   - Enum/Flags → i32
+/// WIR type — Wado-level primitives plus GC references, preserving the
+/// distinctions Wasm's four-way `ValType` erases. Emit lowers a sub-word integer
+/// to `i32`, or to `i8` / `i16` in a packed struct field; the 64-bit types to
+/// `i64`; floats to their own; and enums and flags to `i32`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum WirType {
     // Signed integers
@@ -1403,20 +1381,12 @@ pub enum WirInstr {
         value: Box<WirInstr>,
         len: Box<WirInstr>,
     },
-    /// Deep-copy an `Array<T>`: allocates a new array the same
-    /// length as `src` and copies every element. Emitted by codegen as the
-    /// same JIT-compiled loop that previously lived inside `emit_value_copy`
-    /// for raw array struct fields.
-    ///
-    /// `element_copy_type` is set when `T` is a value-typed struct that
-    /// needs its own deep copy on every element. Without it the loop
-    /// would just `array.set(dst, i, array.get(src, i))`, which on Wasm
-    /// GC stores the *same* element ref into both arrays — fine for
-    /// primitives, but unsound for struct elements (every clone would
-    /// share the underlying struct with the source). When set, the
-    /// loop calls that type's `$value_copy$` helper between
-    /// `array.get` and `array.set` so each destination element is a
-    /// fresh struct.
+    /// Deep-copy an `Array<T>`: allocate one the length of `src` and copy every
+    /// element. `element_copy_type` is set when `T` is a value-typed struct
+    /// needing its own copy per element — a bare
+    /// `array.set(dst, i, array.get(src, i))` stores the *same* ref into both
+    /// arrays, fine for a primitive but leaving every struct clone sharing the
+    /// source. Set, the loop calls that type's `$value_copy$` helper in between.
     ArrayClone {
         type_id: WirTypeId,
         src: Box<WirInstr>,
@@ -1779,21 +1749,14 @@ impl WirInstr {
         }
     }
 
-    /// Whether this instruction tree is expressible as a Wasm 3.0 GC
-    /// constant init expression. This is the single authority on
-    /// const-ness for global initializers: `wir_optimize::const_global`
-    /// gates eager-global promotion on it, and `codegen::emit`'s
-    /// `push_const_instrs` mirrors exactly this accepted set (a node
-    /// reaching the emitter that fails this predicate is an ICE).
-    ///
-    /// Accepted, recursively: scalar consts, `ref.null` / `ref.i31` /
-    /// `ref.func`, and `struct.new` / `array.new_fixed` /
-    /// `array.new_default` with const children. Notably excludes
-    /// `global.get` (so a const init never references another global,
-    /// sidestepping the core-Wasm const-expr ordering restriction) and
-    /// `array.new_data` / `array.new_elem` (not valid const instructions —
-    /// they read a segment at runtime, so data-backed values like a
-    /// `String`'s repr stay lazy).
+    /// Whether this tree is expressible as a Wasm 3.0 GC constant init — the sole
+    /// authority on const-ness for global initializers, which
+    /// `wir_optimize::const_global` gates eager promotion on and `codegen::emit`
+    /// mirrors exactly, a node failing it at the emitter being an ICE. Accepts,
+    /// recursively, scalar consts, the `ref.*` constants, and the aggregate
+    /// constructors over const children. Excludes `global.get`, so a const init
+    /// never references another global, and `array.new_data` / `array.new_elem`,
+    /// which read a segment at runtime — leaving a `String`'s repr lazy.
     pub fn is_const_expressible(&self) -> bool {
         match self {
             Self::I32Const(_) | Self::I64Const(_) | Self::F32Const(_) | Self::F64Const(_) => true,

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -331,7 +331,7 @@ impl fmt::Display for WirName {
 /// - `fq`: fully-qualified name shared via `Rc<str>` for Debug output
 ///
 /// `Eq` and `Hash` use `index` only (O(1) integer operations).
-/// `Debug` prints the fq name (e.g., "core:prelude//List<i32>").
+/// `Debug` prints the fq name (e.g., `"core:prelude//List<i32>"`).
 /// `Clone` is O(1) — Rc refcount increment (non-atomic, near zero cost).
 #[derive(Clone)]
 pub struct WirTypeId {

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -1385,8 +1385,7 @@ pub enum WirInstr {
     /// element. `element_copy_type` is set when `T` is a value-typed struct
     /// needing its own copy per element — a bare
     /// `array.set(dst, i, array.get(src, i))` stores the *same* ref into both
-    /// arrays, fine for a primitive but leaving every struct clone sharing the
-    /// source. Set, the loop calls that type's `$value_copy$` helper in between.
+    /// arrays — and the loop then calls that type's `$value_copy$` helper.
     ArrayClone {
         type_id: WirTypeId,
         src: Box<WirInstr>,
@@ -1752,11 +1751,8 @@ impl WirInstr {
     /// Whether this tree is expressible as a Wasm 3.0 GC constant init — the sole
     /// authority on const-ness for global initializers, which
     /// `wir_optimize::const_global` gates eager promotion on and `codegen::emit`
-    /// mirrors exactly, a node failing it at the emitter being an ICE. Accepts,
-    /// recursively, scalar consts, the `ref.*` constants, and the aggregate
-    /// constructors over const children. Excludes `global.get`, so a const init
-    /// never references another global, and `array.new_data` / `array.new_elem`,
-    /// which read a segment at runtime — leaving a `String`'s repr lazy.
+    /// mirrors exactly. Excludes `global.get` and the segment-reading
+    /// `array.new_data` / `array.new_elem`, leaving a `String`'s repr lazy.
     pub fn is_const_expressible(&self) -> bool {
         match self {
             Self::I32Const(_) | Self::I64Const(_) | Self::F32Const(_) | Self::F64Const(_) => true,

--- a/wado-compiler/src/wir_build/calls.rs
+++ b/wado-compiler/src/wir_build/calls.rs
@@ -1274,16 +1274,11 @@ impl FunctionTranslator<'_, '_> {
             );
         };
 
-        // Build `CanonicalClosure_K`. Field order must match the struct
-        // declaration in `WirContext::get_or_create_canonical_closure_type`:
-        //
-        // - Inspectable layout: `{ env, inspect, inspect_alt, func }` —
-        //   the env + vtable prefix is the layout of the shared
-        //   `$canonical_inspectable_base` supertype, and the typed `func`
-        //   slot comes last (per-signature).
-        // - Slim layout: `{ env, func }` — no shared supertype, no
-        //   inspect slots. Production builds that never inspect closures
-        //   stay on this shape.
+        // Build `CanonicalClosure_K`, field order matching
+        // `WirContext::get_or_create_canonical_closure_type`: the inspectable
+        // layout `{ env, inspect, inspect_alt, func }`, whose prefix is the
+        // shared `$canonical_inspectable_base`, or the slim `{ env, func }` a
+        // build that never inspects a closure stays on.
         let mut fields = vec![functor_instr];
         if is_inspectable {
             let inspect_id = wrappers

--- a/wado-compiler/src/wir_build/component_imports.rs
+++ b/wado-compiler/src/wir_build/component_imports.rs
@@ -1,15 +1,8 @@
 //! The complete set of CM interfaces the component imports, resolved as
-//! structured data at the WIR layer.
-//!
-//! This is where the import decision lives. Codegen (`generate_cm_imports` + the
-//! resource and HTTP phases), the WIT producer (`wit_emit`), and the CM embedding
-//! all read this one plan rather than each re-deriving membership from the
-//! registry / `used_wasi_functions` — upholding the `codegen.rs` principle
-//! ("emit `Package` as is, without knowledge of earlier phases"). See WEP
-//! `wep-2026-05-02-wit-interoperability.md` §"Faithful imports".
-//!
-//! `tests/wit_import_plan.rs` asserts the plan equals the compiled component's
-//! actual CM imports, so the two cannot drift.
+//! structured data at the WIR layer — the one place the import decision lives.
+//! Codegen, the WIT producer, and the CM embedding all read this plan rather
+//! than re-deriving membership, upholding `codegen.rs`'s "emit `Package` as is".
+//! `tests/wit_import_plan.rs` asserts the plan matches the compiled component.
 
 use crate::ast::Type;
 use crate::canonical::{CanonicalIntrinsic, CmFuturePayload};
@@ -181,16 +174,11 @@ pub fn resolve_import_plan(
         worklist.extend(more);
     }
 
-    // Phase 3: resource-getter interfaces (returning `option<resource>`) whose
-    // accessor is used. The gate is `NirPackage::has_interface` — whether a
-    // `{interface}::` function appears in `used_wasi_functions` — which is the
-    // gate codegen applies inline, NOT the registry's same-named `with`-set
-    // predicate; the two are distinct. For each used getter the plan carries two
-    // imports: the getter interface itself (`ResourceGetter`; codegen's getter
-    // phase — http getters go through the HTTP phase instead, so they are
-    // excluded here) and, when the returned resource is *defined elsewhere*, that
-    // defining interface (`ResourceSource`, so the resource type is in scope
-    // before the getter is encoded).
+    // Phase 3: resource-getter interfaces whose accessor is used, gated on
+    // `NirPackage::has_interface` — the gate codegen applies inline, not the
+    // registry's same-named `with`-set predicate. Each used getter contributes
+    // the getter interface itself (http ones going through the HTTP phase) and,
+    // for a resource defined elsewhere, its defining interface.
     for interface_info in registry.interfaces() {
         let Some((resource_wado_name, _)) = &interface_info.resource_type else {
             continue;

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -52,7 +52,7 @@ pub struct WorldExportPlan {
     /// Raw Wado parameter types `(name, type)` for `--lib` exports; empty for
     /// the WASI worlds (which use [`Self::cm_params`]). The lib export path
     /// defines its own CM value types top-level from these, so it never goes
-    /// through the WASI-only [`resolve_cm_export_type`].
+    /// through the WASI-only `resolve_cm_export_type`.
     pub param_types: Vec<(String, Type)>,
     /// Raw Wado return type for `--lib` exports; `None` for the WASI worlds.
     pub result_type: Option<Type>,

--- a/wado-compiler/src/wir_build/component_plan.rs
+++ b/wado-compiler/src/wir_build/component_plan.rs
@@ -118,18 +118,11 @@ pub enum CmExportType {
         /// not by probing the type registry.
         is_resource: bool,
     },
-    /// `result<own<resp>, error>` synthesized for the world's handler return.
-    ///
-    /// Produced when the export's return type is `Result<X, Y>` with at least
-    /// one non-unit component. Codegen resolves this variant through the
-    /// structural type interner, keyed on the `ok`/`err` arm types, so it
-    /// shares the type the import/world-type helpers interned.
-    ///
-    /// The resolved `ok`/`err` boundary types are carried so codegen can
-    /// enumerate the named CM types to re-export in an interface-instance
-    /// export (e.g. `response`, `error-code`) without re-deriving them from
-    /// hardcoded type names. Either arm may be [`Self::Unit`] (e.g.
-    /// `Result<(), Error>`); such arms contribute no re-exported type.
+    /// `result<own<resp>, error>` synthesized for the world's handler return,
+    /// produced when the export returns a `Result` with a non-unit arm. Codegen
+    /// resolves it through the structural interner keyed on the arm types, so it
+    /// shares what the world-type helpers interned. The resolved arms are carried
+    /// so codegen can enumerate the named CM types to re-export.
     HandlerResult {
         ok: Box<CmExportType>,
         err: Box<CmExportType>,
@@ -328,27 +321,17 @@ fn build_world_export_plans(
         .collect()
 }
 
-/// Resolve a Wado [`Type`] reachable from a world export signature into the
-/// CM-level boundary representation.
-///
-/// Recognised shapes:
-///
-/// - `()` / unit / `Result<(), ()>` → [`CmExportType::Unit`]
-/// - `Result<X, Y>` with at least one non-unit component →
-///   [`CmExportType::HandlerResult`]
-/// - Any other named type whose source interface and CM kebab-name are known
-///   to the registry → [`CmExportType::Named`]
-///
-/// Panics on shapes the registry cannot resolve. World export signatures
-/// originate in stdlib `lib/wasi/**/worlds.wado` and
-/// `lib/core/kiln/worlds.wado`, so any unresolved name indicates a bug in the
-/// stdlib bootstrap rather than user input.
 /// Whether `name` is a Wado primitive that maps directly to a Component Model
 /// primitive value type at the export boundary.
 fn is_cm_primitive_name(name: &str) -> bool {
     crate::component_model::wado_primitive_name_to_cm(name).is_some()
 }
 
+/// Resolve a Wado [`Type`] reachable from a world export signature into its
+/// CM-level boundary representation: unit shapes to [`CmExportType::Unit`], a
+/// `Result` with a non-unit arm to [`CmExportType::HandlerResult`], any other
+/// registry-known named type to [`CmExportType::Named`]. Panics otherwise —
+/// world signatures come from the stdlib, so an unresolved name is a bug there.
 fn resolve_cm_export_type(
     ty: &Type,
     cm_interface_registry: &CmInterfaceRegistry,

--- a/wado-compiler/src/wir_build/context.rs
+++ b/wado-compiler/src/wir_build/context.rs
@@ -153,9 +153,8 @@ pub struct WirContext<'a> {
     /// Shared inspectable supertype `$canonical_inspectable_base`, created lazily
     /// at the first inspectable `CanonicalClosure_K` registration. The dispatch
     /// stub `ref.cast`s `self` to it, so every inspectable closure reaches the
-    /// same slot positions whatever its parameter types — without it the stub
-    /// would have to pick one `CanonicalClosure_K` per signature and trap on any
-    /// value belonging to a different per-signature struct.
+    /// same slot positions whatever its parameter types — otherwise the stub
+    /// would trap on any value from a different per-signature struct.
     pub canonical_inspectable_base_type_id: Option<WirTypeId>,
 
     /// Available WASI function names (computed during component generation).
@@ -177,8 +176,7 @@ pub struct WirContext<'a> {
     /// `(function_name, module_source)` since a name alone is not unique across
     /// modules. The value is the callee's per-result `(field_name, type_id)` in
     /// declaration order, which the call-site translator uses to build named
-    /// split locals without re-deriving the aggregate shape. Computed at
-    /// WIR-build start.
+    /// split locals without re-deriving the aggregate shape.
     pub multi_value_return_funcs: IndexMap<(String, ModuleSource), Vec<(String, TypeId)>>,
     /// Unresolved `Type^Trait::method` calls (unsatisfied trait bounds),
     /// collected rather than trapping; the driver reports them and bails.
@@ -450,12 +448,8 @@ impl<'a> WirContext<'a> {
     /// Get or create the `(fn_type_id, closure_struct_type_id)` pair for a
     /// signature — the vtable shape trait dispatch needs on an `Fn<N, Ret>` held
     /// behind a parameter, field or global. An inspectable struct is laid out
-    /// `{ env, inspect, inspect_alt, func }`, the first three forming the GC
-    /// subtype prefix it shares with `$canonical_inspectable_base` and the typed
-    /// `func` slot coming last; the callback type takes abstract
-    /// `(ref null struct)` args, so one type covers every literal and each
-    /// wrapper refcasts before forwarding. A non-inspectable signature keeps the
-    /// slim `{ env, func }` and needs no supertype, its stub never synthesised.
+    /// `{ env, inspect, inspect_alt, func }`, the first three being the GC subtype
+    /// prefix shared with `$canonical_inspectable_base`; others keep `{ env, func }`.
     pub fn get_or_create_canonical_closure_type(
         &mut self,
         param_wirs: Vec<WirType>,

--- a/wado-compiler/src/wir_build/context.rs
+++ b/wado-compiler/src/wir_build/context.rs
@@ -144,28 +144,18 @@ pub struct WirContext<'a> {
     pub closure_wrapper_funcs: IndexMap<(ModuleSource, u32), ClosureWrapperFuncs>,
     /// Counter for canonical closure type naming.
     pub canonical_closure_counter: u32,
-    /// Set of `(arity, return_type)` signatures whose
-    /// `Fn^Inspect` / `Fn^InspectAlt` dispatch stub survived DCE.
-    /// Computed once at WIR build start by scanning
-    /// `package.functions` for surviving
-    /// `FunctionKind::FnCanonicalDispatch` entries. Drives the per-
-    /// `(N, Ret)` gate that decides whether `CanonicalClosure_K`
-    /// carries `inspect` / `inspect_alt` vtable slots — closures
-    /// whose `(N, Ret)` is unreachable here keep the slim
-    /// `{ env, func }` shape so production builds that never inspect
-    /// closures pay nothing.
+    /// The `(arity, return_type)` signatures whose `Fn^Inspect` / `^InspectAlt`
+    /// dispatch stub survived DCE, scanned once at WIR build start. Gates whether
+    /// a `CanonicalClosure_K` carries the `inspect` / `inspect_alt` vtable slots:
+    /// a signature absent here keeps the slim `{ env, func }` shape, so a build
+    /// that never inspects closures pays nothing.
     pub inspectable_fn_dispatch: IndexSet<(usize, TypeId)>,
-    /// Shared inspectable supertype `$canonical_inspectable_base`
-    /// (`{ env, inspect, inspect_alt }`). Lazily created on the first
-    /// inspectable `CanonicalClosure_K` registration; the
-    /// `Fn<N, Ret>^Inspect` dispatch stub `ref.cast`s `self` to this
-    /// type so any inspectable closure value reaches the same `inspect`
-    /// / `inspect_alt` slot positions regardless of its parameter
-    /// types. Without this shared supertype the dispatch stub would
-    /// have to pick one specific `CanonicalClosure_K` per `(arity,
-    /// return_type)` pair and trap whenever a runtime value belongs to
-    /// a different per-signature canonical struct sharing the same
-    /// `(arity, return_type)`.
+    /// Shared inspectable supertype `$canonical_inspectable_base`, created lazily
+    /// at the first inspectable `CanonicalClosure_K` registration. The dispatch
+    /// stub `ref.cast`s `self` to it, so every inspectable closure reaches the
+    /// same slot positions whatever its parameter types — without it the stub
+    /// would have to pick one `CanonicalClosure_K` per signature and trap on any
+    /// value belonging to a different per-signature struct.
     pub canonical_inspectable_base_type_id: Option<WirTypeId>,
 
     /// Available WASI function names (computed during component generation).
@@ -183,16 +173,12 @@ pub struct WirContext<'a> {
     /// Value: the `WirFuncId` for the registered import.
     pub needed_canonicals: IndexMap<CanonicalIntrinsic, WirFuncId>,
 
-    /// Map of `(function_name, module_source)` for functions whose TIR
-    /// `return_abi` is `MultiValue`. Names alone are not unique across
-    /// modules (e.g. two `make_pair` in different `.wado` files), so the
-    /// pair is what the call-site translator queries.
-    /// Value is the callee's per-result `(field_name, type_id)` in
-    /// declaration order — `("0", i32)` / `("1", i32)` for tuple returns,
-    /// `("x", i32)` / `("y", i32)` for user-struct returns. The
-    /// call-site translator uses this to build named split locals
-    /// without re-deriving the aggregate shape.
-    /// Computed from `package.functions` at WIR-build start.
+    /// Functions whose TIR `return_abi` is `MultiValue`, keyed by
+    /// `(function_name, module_source)` since a name alone is not unique across
+    /// modules. The value is the callee's per-result `(field_name, type_id)` in
+    /// declaration order, which the call-site translator uses to build named
+    /// split locals without re-deriving the aggregate shape. Computed at
+    /// WIR-build start.
     pub multi_value_return_funcs: IndexMap<(String, ModuleSource), Vec<(String, TypeId)>>,
     /// Unresolved `Type^Trait::method` calls (unsatisfied trait bounds),
     /// collected rather than trapping; the driver reports them and bails.
@@ -209,16 +195,10 @@ pub struct PendingFunctionBody {
     pub type_table: Rc<RefCell<TypeTable>>,
 }
 
-/// Scan `package.functions` and return the set of `Fn<arity, ret>`
-/// signatures whose `Fn^Inspect::inspect` or `Fn^InspectAlt::inspect_alt`
-/// impl is reachable.
-///
-/// Auto-derived dispatch stubs for `Fn<arity, return_type>^Inspect`
-/// / `^InspectAlt` are produced per-module by `synthesize_traits`
-/// and tagged `FunctionKind::FnCanonicalDispatch`. After DCE prunes
-/// unreachable functions, the survivors here drive the per-
-/// `(N, Ret)` schema gate so canonical closures whose signature is
-/// never inspected stay slim.
+/// The `Fn<arity, ret>` signatures whose `^Inspect` / `^InspectAlt` impl is
+/// still reachable: `synthesize_traits` emits a dispatch stub per module tagged
+/// `FunctionKind::FnCanonicalDispatch`, and the ones DCE leaves behind drive the
+/// per-signature schema gate that keeps an uninspected canonical closure slim.
 fn compute_inspectable_fn_dispatch(package: &NirPackage) -> IndexSet<(usize, TypeId)> {
     let mut set: IndexSet<(usize, TypeId)> = IndexSet::default();
     for func_rc in &package.functions {
@@ -238,16 +218,11 @@ fn compute_inspectable_fn_dispatch(package: &NirPackage) -> IndexSet<(usize, Typ
     set
 }
 
-/// Per-functor wrapper functions stored in `CanonicalClosure_K` vtable
-/// slots. Populated by `register_closure_wrappers` and consumed by
-/// `translate_closure_to_canonical` to initialise the canonical
-/// closure struct.
-///
-/// `inspect` and `inspect_alt` are `None` when the per-`(N, Ret)`
-/// gate (`WirContext::inspectable_fn_dispatch`) reports the
-/// signature as unreachable — in that case `CanonicalClosure_K` uses
-/// the slim `{ env, func }` schema and `translate_closure_to_canonical`
-/// only emits two `struct.new` operands.
+/// Per-functor wrapper functions for the `CanonicalClosure_K` vtable slots,
+/// populated by `register_closure_wrappers` and read by
+/// `translate_closure_to_canonical`. `inspect` / `inspect_alt` are `None` where
+/// [`WirContext::inspectable_fn_dispatch`] calls the signature unreachable, and
+/// the struct then takes the slim `{ env, func }` schema.
 #[derive(Clone, Debug)]
 pub struct ClosureWrapperFuncs {
     /// `__closure_wrapper_N(env, args...) -> ret` — refcasts env to
@@ -472,45 +447,15 @@ impl<'a> WirContext<'a> {
         )
     }
 
-    /// Get or create a canonical closure type pair (func type + closure struct) for a
-    /// function signature. Returns `(fn_type_id, closure_struct_type_id)`.
-    ///
-    /// The struct schema is the vtable shape required by trait dispatch on
-    /// `Fn<N, Ret>` values held behind function parameters, struct fields,
-    /// or globals (the indirect-call case). Per WEP: Inspect (Debug
-    /// Output) > Closure Inspect via Runtime Dispatch, the inspectable
-    /// layout puts `env` + the two callback slots first so they form the
-    /// Wasm GC subtype prefix shared with `$canonical_inspectable_base`,
-    /// and the per-signature `func` slot comes last:
-    ///
-    /// ```text
-    /// CanonicalClosure_K {
-    ///     env:         (ref null struct),
-    ///     inspect:     (ref $canonical_callback_fn),
-    ///     inspect_alt: (ref $canonical_callback_fn),
-    ///     func:        (ref $canonical_fn_K),
-    /// }
-    /// ```
-    ///
-    /// `$canonical_callback_fn = (env, formatter) -> ()` is shared across
-    /// all signatures: the `env`/`formatter` slots use abstract `(ref null
-    /// struct)` so a single function type covers every closure literal.
-    /// Each per-literal wrapper refcasts both args back to its concrete
-    /// `&__Closure_N` and `&Formatter` before forwarding.
-    ///
-    /// Inspectable canonical structs share the supertype
-    /// `$canonical_inspectable_base` (built lazily via
-    /// [`Self::get_or_create_canonical_inspectable_base`]); per-signature
-    /// canonical structs add a typed `func` field at the end. The
-    /// `Fn<N, Ret>^Inspect` dispatch stub casts to that base, so any
-    /// inspectable closure value reaches the shared `inspect` /
-    /// `inspect_alt` slots regardless of its parameter types — the only
-    /// requirement is that the field layout `{ env, inspect, inspect_alt,
-    /// func }` is identical across subtypes (Wasm GC `sub` constraint).
-    ///
-    /// Non-inspectable signatures keep the slim `{ env, func }` layout
-    /// without any supertype: the dispatch stub is never synthesised for
-    /// them, so the base type is irrelevant.
+    /// Get or create the `(fn_type_id, closure_struct_type_id)` pair for a
+    /// signature — the vtable shape trait dispatch needs on an `Fn<N, Ret>` held
+    /// behind a parameter, field or global. An inspectable struct is laid out
+    /// `{ env, inspect, inspect_alt, func }`, the first three forming the GC
+    /// subtype prefix it shares with `$canonical_inspectable_base` and the typed
+    /// `func` slot coming last; the callback type takes abstract
+    /// `(ref null struct)` args, so one type covers every literal and each
+    /// wrapper refcasts before forwarding. A non-inspectable signature keeps the
+    /// slim `{ env, func }` and needs no supertype, its stub never synthesised.
     pub fn get_or_create_canonical_closure_type(
         &mut self,
         param_wirs: Vec<WirType>,

--- a/wado-compiler/src/wir_build/functions.rs
+++ b/wado-compiler/src/wir_build/functions.rs
@@ -571,17 +571,11 @@ fn register_literal_data(ctx: &mut WirContext<'_>) {
     }
 }
 
-/// Every `PackedArray` payload in the program that needs a segment.
-///
-/// The lower phase's recorded literal lists are not the whole set: the
-/// optimizer writes literals back that no source literal accounts for — a
-/// compile-time call producing a constant `String` becomes one — so the NIR is
-/// the authority. Registering after the recorded lists keeps their segment
-/// indices, appending only what they missed.
-///
-/// Only what the module will emit counts: a dead function is never lowered,
-/// and the arena keeps every node an in-place rewrite displaced. Counting
-/// either would put a segment in the binary that nothing reads.
+/// Every `PackedArray` payload in the program that needs a segment. The lower
+/// phase's recorded lists are not the whole set — the optimizer writes back
+/// literals no source literal accounts for — so NIR is the authority, appended
+/// after the recorded lists to keep their indices. Only what the module emits
+/// counts: a dead function or a displaced arena node would leave a dead segment.
 fn synthesized_packed_payloads(
     package: &crate::nir_package::NirPackage,
     threshold: usize,
@@ -901,16 +895,11 @@ fn translate_global_init(
 
 /// Build a mangled function name from TIR function and module source.
 fn build_mangled_name(tir_func: &NirFunction, _module_source: &ModuleSource) -> String {
-    // For monomorphized functions, prefer `tir_func.name` because the
-    // monomorphizer set it to the canonical mangled name produced by
-    // `function_instantiation_name` / `method_instantiation_name`. The
-    // string-typed `method_info.method_type_args` field is populated by
-    // elaborator/monomorphizer call sites that historically used
-    // `mangle_type_name` (unqualified for `Variant`/`Newtype`/etc.); calling
-    // `method_info.to_mangled_name()` on a monomorphized function would
-    // therefore drop the module qualification that the call-rewrite path
-    // already baked into `tir_func.name`, leaving the func_map registered
-    // under a name no call site looks up.
+    // For a monomorphized function prefer `tir_func.name`, which the
+    // monomorphizer set to the canonical mangled name. `method_info`'s type args
+    // are strings mangled unqualified, so `to_mangled_name()` would drop the
+    // module qualification the call-rewrite path baked into `tir_func.name` and
+    // register the func_map under a name no call site looks up.
     if tir_func.monomorph_info.is_some() {
         return tir_func.name.clone();
     }

--- a/wado-compiler/src/wir_build/pattern_match.rs
+++ b/wado-compiler/src/wir_build/pattern_match.rs
@@ -202,11 +202,9 @@ impl FunctionTranslator<'_, '_> {
 
     /// Bind `let [a, b] = builtin::i64_mul_wide_u(…)` straight into the binding
     /// locals: the instruction pushes both results, so `MultiValueLocalBind` pops
-    /// them with no tuple struct in between — the one expression-position
-    /// lowering builds would otherwise need a WIR pass to recover. The pattern
-    /// must name every result, one `local.set` per pushed value, or the operand
-    /// stack is left unbalanced; a rest pattern or a shorter tuple falls through
-    /// to the tuple-struct path.
+    /// them with no tuple struct in between. The pattern must name every result,
+    /// one `local.set` per pushed value, or the operand stack is unbalanced; a
+    /// rest pattern or shorter tuple falls through to the tuple-struct path.
     fn try_bind_multivalue_builtin(&mut self, pattern: PatId, value: Operand) -> Option<WirInstr> {
         let PatKind::Tuple(patterns, has_rest) = &self.body.pats[pattern].kind else {
             return None;
@@ -249,9 +247,8 @@ impl FunctionTranslator<'_, '_> {
     /// Translate a `LetDestructure`. Pattern lowering has already rewritten every
     /// form but the multivalue-builtin one into plain `Let` / `Expr`, so only a
     /// `Tuple` over such a call — or a `Binding` for its single result — reaches
-    /// here. Any other shape means lowering stopped rewriting something it used
-    /// to, and panics: emitting nothing would silently drop the destructure and
-    /// leave its bindings unassigned.
+    /// here. Any other shape panics: emitting nothing would silently drop the
+    /// destructure and leave its bindings unassigned.
     pub(super) fn translate_let_pattern(&mut self, pattern: PatId, value: Operand) -> WirInstr {
         if let Some(instr) = self.try_bind_multivalue_builtin(pattern, value) {
             return instr;
@@ -366,9 +363,8 @@ impl FunctionTranslator<'_, '_> {
             // Translate the body in two parts — the binding writes and the body
             // proper — so a guarded branch can place each write at exactly one
             // point: in the condition `Seq` where the guard can read it, or in
-            // the inner `then_body`, never both. Emitting at both would leave a
-            // redundant `_n = i; if guard { _n = i; … }` that no later pass
-            // cleans up, write-only elimination dropping only locals never read.
+            // the inner `then_body`, never both. Emitting at both leaves a
+            // redundant `_n = i; if guard { _n = i; … }` no later pass cleans up.
             let mut bindings = Vec::new();
             let body = {
                 for _ in 0..if_nesting {
@@ -441,10 +437,8 @@ impl FunctionTranslator<'_, '_> {
                 // Guarded arm: fold the pattern test and the guard into one
                 // short-circuiting condition, so the fall-through subtree sits at
                 // exactly one tree depth. A nested two-`If` form would clone it
-                // into both `else` branches at depths differing by one, and since
-                // break depths are baked in when an arm body is translated, the
-                // shallower copy would carry a stale `Br` depth and produce
-                // invalid core Wasm. Also avoids a 2^N clone explosion.
+                // into both `else` branches at depths differing by one, and break
+                // depths are baked in at translation. Also avoids a 2^N blowup.
                 let guard_expr = self.translate_operand(*guard);
                 let pattern_is_trivially_true = matches!(&condition, WirInstr::I32Const(1));
                 let folded_condition = if pattern_is_trivially_true {
@@ -495,11 +489,10 @@ impl FunctionTranslator<'_, '_> {
     }
 
     /// Per source-order arm, whether it lowers as irrefutable — emitted as its
-    /// body and bindings with no surrounding `If`. Two sources: an
-    /// always-true pattern with no guard, or the guardless last arm of an
-    /// exhaustive variant-or-enum match, where every earlier arm has failed and
-    /// both the test and the trailing `unreachable` are dead. The caller uses the
-    /// result for depth accounting *and* emission, so the two cannot drift.
+    /// body and bindings with no surrounding `If`. Two sources: an always-true
+    /// pattern with no guard, or the guardless last arm of an exhaustive
+    /// variant-or-enum match. The caller uses the result for depth accounting
+    /// *and* emission, so the two cannot drift.
     fn compute_emitted_as_irrefutable(&self, scrut_type: TypeId, arms: &[ArmData]) -> Vec<bool> {
         let mut out: Vec<bool> = arms
             .iter()
@@ -1227,8 +1220,7 @@ impl FunctionTranslator<'_, '_> {
     /// `LocalSet` is well-typed under wasm GC's exact-type rules. In priority
     /// order: wrap in a `StructNew` when the local is a `Box` the source is not,
     /// narrow with `RefAsNonNull` when the local is non-nullable and the source
-    /// is not, and skip entirely for a unit binding, which has no Wasm local. An
-    /// unknown source type falls through to the raw `LocalSet`.
+    /// is not, and skip a unit binding, which has no Wasm local.
     fn emit_pattern_binding_set(
         &self,
         local_index: u32,

--- a/wado-compiler/src/wir_build/pattern_match.rs
+++ b/wado-compiler/src/wir_build/pattern_match.rs
@@ -200,18 +200,13 @@ impl FunctionTranslator<'_, '_> {
         }
     }
 
-    /// Bind `let [a, b] = builtin::i64_mul_wide_u(…)` straight into the
-    /// binding locals: the Wasm instruction pushes its two results on the
-    /// stack, so `MultiValueLocalBind` pops them into the bindings with no
-    /// tuple struct in between (a `Wildcard` slot drops its result). The
-    /// tuple struct the expression-position lowering builds
-    /// (`calls::wrap_multivalue_i64`) would otherwise have to be recovered
-    /// by a WIR pass.
-    ///
-    /// The pattern must name every result: one `local.set` per pushed value,
-    /// or the operand stack is left unbalanced. A rest pattern (`[a, ..]`)
-    /// does not, and neither does a shorter tuple — both fall through to the
-    /// tuple-struct path.
+    /// Bind `let [a, b] = builtin::i64_mul_wide_u(…)` straight into the binding
+    /// locals: the instruction pushes both results, so `MultiValueLocalBind` pops
+    /// them with no tuple struct in between — the one expression-position
+    /// lowering builds would otherwise need a WIR pass to recover. The pattern
+    /// must name every result, one `local.set` per pushed value, or the operand
+    /// stack is left unbalanced; a rest pattern or a shorter tuple falls through
+    /// to the tuple-struct path.
     fn try_bind_multivalue_builtin(&mut self, pattern: PatId, value: Operand) -> Option<WirInstr> {
         let PatKind::Tuple(patterns, has_rest) = &self.body.pats[pattern].kind else {
             return None;
@@ -251,22 +246,12 @@ impl FunctionTranslator<'_, '_> {
         })
     }
 
-    /// Translate a `LetDestructure` statement.
-    ///
-    /// By the time WIR build runs, pattern lowering
-    /// ([`crate::lower::translate::pattern::lower`]) has rewritten every
-    /// `LetDestructure` form *except* the multivalue-builtin tuple
-    /// shape (a tuple whose RHS is a builtin call producing multiple
-    /// scalar return values) into plain `Let` / `Expr` statements.
-    /// So the only variant that reaches this translator is:
-    ///
-    /// * `Tuple` — multivalue-builtin call returning a tuple; destructure
-    ///   each element into its `Binding` slot or skip `Wildcard` slots.
-    ///
-    /// `Binding` (a single multivalue result) is also accepted. Any other shape
-    /// means pattern lowering stopped rewriting one it used to rewrite; emitting
-    /// nothing would drop the destructure and leave its bindings unassigned, so
-    /// it panics instead.
+    /// Translate a `LetDestructure`. Pattern lowering has already rewritten every
+    /// form but the multivalue-builtin one into plain `Let` / `Expr`, so only a
+    /// `Tuple` over such a call — or a `Binding` for its single result — reaches
+    /// here. Any other shape means lowering stopped rewriting something it used
+    /// to, and panics: emitting nothing would silently drop the destructure and
+    /// leave its bindings unassigned.
     pub(super) fn translate_let_pattern(&mut self, pattern: PatId, value: Operand) -> WirInstr {
         if let Some(instr) = self.try_bind_multivalue_builtin(pattern, value) {
             return instr;
@@ -378,17 +363,12 @@ impl FunctionTranslator<'_, '_> {
             let source_idx = arms.len() - 1 - reverse_idx;
             let if_nesting = if_depths[source_idx];
 
-            // Translate the body in two parts: the binding-emission instrs
-            // (which set up local slots referenced by the body and/or the
-            // guard) and the body-proper instr. Keeping them separate lets
-            // the guarded branches place each binding write at exactly one
-            // point — either in the condition `Seq` (so the guard can read
-            // it) or in the inner-if's `then_body`, never both. Emitting the
-            // bindings unconditionally inside both sites would leave a
-            // visibly redundant `_n = i; if guard { _n = i; … }` shape in
-            // the lowered output that no later pass cleans up: write-only
-            // local elimination only removes locals that are *never* read,
-            // not locals that get overwritten by a duplicate store.
+            // Translate the body in two parts — the binding writes and the body
+            // proper — so a guarded branch can place each write at exactly one
+            // point: in the condition `Seq` where the guard can read it, or in
+            // the inner `then_body`, never both. Emitting at both would leave a
+            // redundant `_n = i; if guard { _n = i; … }` that no later pass
+            // cleans up, write-only elimination dropping only locals never read.
             let mut bindings = Vec::new();
             let body = {
                 for _ in 0..if_nesting {
@@ -458,18 +438,13 @@ impl FunctionTranslator<'_, '_> {
                     result = WirInstr::Seq(body_instrs);
                 }
             } else if let Some(guard) = &arm.guard {
-                // Guarded arm. Fold the pattern test and the guard into a single
-                // short-circuiting condition so the fall-through subtree
-                // (`result`) is placed at exactly one tree depth.
-                //
-                // A nested two-`If` form (outer pattern test, inner guard test)
-                // would clone `result` into both the inner guard-`else` and the
-                // outer pattern-`else` — copies that sit at depths differing by
-                // one. Break depths are baked in when an arm body is translated,
-                // so the shallower copy ends up with a stale (too-large) `Br`
-                // depth, producing invalid core Wasm (issue #1418). Collapsing to
-                // one `If` keeps `result` at a single depth and also avoids the
-                // 2^N clone explosion for many guarded arms.
+                // Guarded arm: fold the pattern test and the guard into one
+                // short-circuiting condition, so the fall-through subtree sits at
+                // exactly one tree depth. A nested two-`If` form would clone it
+                // into both `else` branches at depths differing by one, and since
+                // break depths are baked in when an arm body is translated, the
+                // shallower copy would carry a stale `Br` depth and produce
+                // invalid core Wasm. Also avoids a 2^N clone explosion.
                 let guard_expr = self.translate_operand(*guard);
                 let pattern_is_trivially_true = matches!(&condition, WirInstr::I32Const(1));
                 let folded_condition = if pattern_is_trivially_true {
@@ -519,20 +494,12 @@ impl FunctionTranslator<'_, '_> {
         WirInstr::Seq(seq)
     }
 
-    /// Returns, per source-order arm, whether that arm will be lowered as
-    /// irrefutable — i.e. emitted as just its body (with pattern bindings)
-    /// and no surrounding `If` test.
-    ///
-    /// Two sources:
-    /// * The pattern itself is always true (wildcard / binding / struct /
-    ///   tuple) and the arm has no guard.
-    /// * The arm is the LAST arm of an exhaustive variant-or-enum match,
-    ///   every earlier arm has failed by the time control reaches it, and
-    ///   the arm has no guard. The pattern test and the trailing
-    ///   `unreachable` fallback are both dead in that case.
-    ///
-    /// The caller uses the resulting `Vec<bool>` both for depth accounting
-    /// and for emission, so the two stages cannot drift.
+    /// Per source-order arm, whether it lowers as irrefutable — emitted as its
+    /// body and bindings with no surrounding `If`. Two sources: an
+    /// always-true pattern with no guard, or the guardless last arm of an
+    /// exhaustive variant-or-enum match, where every earlier arm has failed and
+    /// both the test and the trailing `unreachable` are dead. The caller uses the
+    /// result for depth accounting *and* emission, so the two cannot drift.
     fn compute_emitted_as_irrefutable(&self, scrut_type: TypeId, arms: &[ArmData]) -> Vec<bool> {
         let mut out: Vec<bool> = arms
             .iter()
@@ -1256,32 +1223,12 @@ impl FunctionTranslator<'_, '_> {
         }
     }
 
-    /// Store the result of `source` into the local for a pattern
-    /// `Binding`, wrapping or narrowing as needed so the `LocalSet` is
-    /// well-typed under wasm GC's exact-type rules.
-    ///
-    /// Three coercions land here, applied in priority order:
-    ///
-    /// 1. **Box wrap.** When the binding's local is a `Ref` to a
-    ///    different struct than the source produces (the
-    ///    address-taken boxing pass promoted a `T` local to `Box<T>`,
-    ///    or the elaborator typed a variant-generic site as
-    ///    `Box<primitive>`), wrap the source in `StructNew { box_tid,
-    ///    fields: [source] }` so the source value lands in the Box's
-    ///    payload field. Also covers the primitive-into-Box case
-    ///    (`i32` / `i64` / `f32` / `f64` / `v128`).
-    /// 2. **Nullability narrow.** When the binding is `Ref { nullable:
-    ///    false }` but the source produces `Ref { nullable: true }`
-    ///    (e.g. variant `payload_0` declared nullable for the
-    ///    `Option<&T> = &T | null` boxing optimisation), wrap with
-    ///    `RefAsNonNull`.
-    /// 3. **Unit binding.** Pattern bindings of unit type don't have a
-    ///    Wasm local; skip the `LocalSet` entirely.
-    ///
-    /// `source_wir = None` means the source's WIR type isn't known
-    /// (only `get_case_payload_wir_type`'s missing-struct fallback
-    /// produces this today); in that case fall through to the raw
-    /// `LocalSet`.
+    /// Store `source` into a pattern `Binding`'s local, coercing so the
+    /// `LocalSet` is well-typed under wasm GC's exact-type rules. In priority
+    /// order: wrap in a `StructNew` when the local is a `Box` the source is not,
+    /// narrow with `RefAsNonNull` when the local is non-nullable and the source
+    /// is not, and skip entirely for a unit binding, which has no Wasm local. An
+    /// unknown source type falls through to the raw `LocalSet`.
     fn emit_pattern_binding_set(
         &self,
         local_index: u32,

--- a/wado-compiler/src/wir_build/primitive_ops.rs
+++ b/wado-compiler/src/wir_build/primitive_ops.rs
@@ -585,16 +585,11 @@ impl FunctionTranslator<'_, '_> {
                 ),
             ) => Self::truncate_to_sub_i32(inner_instr, to_prim),
             _ => {
-                // Other casts (newtype reinterprets, SIMD `v128` lane-type
-                // reinterprets, enum→i32, struct→struct) are no-ops at the
-                // Wasm level and pass through. But a pass-through only
-                // produces valid Wasm when both sides share a representation
-                // kind. A reference↔scalar cast reaching here means an
-                // earlier phase failed to lower it — e.g. the struct-source
-                // `i128/u128 as f64` of issue #1328, which used to silently
-                // feed a boxed `(ref $type)` into an `f64` slot and only
-                // tripped the validator deep in codegen. Fail loudly here,
-                // at the layer that owns the lowering, instead.
+                // Other casts — newtype and SIMD reinterprets, enum→i32,
+                // struct→struct — are Wasm-level no-ops and pass through, which
+                // is valid only when both sides share a representation kind. A
+                // reference↔scalar cast here means an earlier phase failed to
+                // lower it, so fail loudly at the layer that owns the lowering.
                 let from_wir = self.ctx.type_id_to_wir_type(self.type_table, from_type);
                 let to_wir = self.ctx.type_id_to_wir_type(self.type_table, to_type);
                 assert_eq!(

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -122,10 +122,8 @@ fn resolve_local_names(raw: &IndexMap<u32, String>, params: &[NirParam]) -> Inde
 /// Register one wrapper per `CanonicalClosure_K` vtable slot for each reachable
 /// functor — `__closure_wrapper_N` forwarding to `__call`, plus
 /// `__closure_inspect_wrapper_N` / `_alt_` forwarding to the per-functor
-/// `^Inspect` / `^InspectAlt` impls — each refcasting its args first. A
-/// non-inspectable signature takes the slim `{ env, func }` schema and gets only
-/// the call wrapper. Must run before `translate_function_bodies`, which resolves
-/// `ClosureToCanonical` references against these.
+/// `^Inspect` impls — each refcasting its args first. Must run before
+/// `translate_function_bodies`, which resolves `ClosureToCanonical` against it.
 pub fn register_closure_wrappers(ctx: &mut WirContext<'_>) {
     use crate::wir::WirType;
 
@@ -451,10 +449,9 @@ fn register_call_wrapper(
 
 /// Build an inspect / `inspect_alt` wrapper for a functor. Its external
 /// signature is fixed at `(env, formatter)` by the canonical callback type, so
-/// the function-table slot stays stable across DAE shrinkage on the impl:
-/// internally only the impl's surviving params are forwarded, and a refcast is
-/// skipped where its param was dropped. A DCE'd impl leaves an `Unreachable`
-/// body — the slot stays populated so the canonical schema holds.
+/// the function-table slot stays stable across DAE shrinkage on the impl: only
+/// surviving params are forwarded. A DCE'd impl leaves an `Unreachable` body,
+/// keeping the slot populated so the canonical schema holds.
 #[allow(clippy::too_many_arguments)]
 fn register_inspect_wrapper(
     ctx: &mut WirContext<'_>,
@@ -631,9 +628,7 @@ fn register_inspect_wrapper(
 /// `self` to the shared `$canonical_inspectable_base`, then
 /// `call_ref (struct.get base $slot self) (self.env, f)`. The cast targets the
 /// shared base rather than one `CanonicalClosure_K`, so a single stub serves
-/// every parameter shape with that signature instead of trapping on the others.
-/// `None` when no inspectable canonical struct exists — the stub is then
-/// unreachable, and the bodyless TIR placeholder can stay.
+/// every parameter shape. `None` when no inspectable canonical struct exists.
 #[allow(clippy::needless_pass_by_value)] // signature mirrors the param-name plumbing in translate_function_bodies
 fn build_fn_canonical_dispatch_body(
     ctx: &mut WirContext<'_>,
@@ -778,9 +773,7 @@ fn else_is_empty(else_body: &Option<Vec<WirInstr>>) -> bool {
 /// entries by wrapping the enclosing condition in [`WirInstr::BranchHint`]. Two
 /// shapes: a marker inside an `if` branch hints that branch unlikely, and an
 /// else-less `if cond { <diverges> }` whose fall-through reaches a marker hints
-/// the condition likely — the guard-clause idiom
-/// `if ok { return v } cold_path(); return err`. The marker itself emits
-/// nothing, and the pass runs regardless of optimization level.
+/// the condition likely. The marker itself emits nothing.
 fn apply_cold_path_hints(instrs: &mut [WirInstr]) {
     for instr in instrs.iter_mut() {
         apply_cold_path_hints_instr(instr);
@@ -792,8 +785,7 @@ fn apply_cold_path_hints(instrs: &mut [WirInstr]) {
 /// whether the path just *after* this slice reaches a `cold_path()` marker
 /// before any non-cold divergence; the return value says the same for the path
 /// *before* it. A guard in front of a cold path gets its taken branch hinted
-/// likely. The walk descends transparent `Seq`/`Block` tails, so a guard inside
-/// an `if let` / `while let` desugaring still finds its enclosing-block marker.
+/// likely. Descends transparent `Seq`/`Block` tails, so desugarings still match.
 fn hint_guard_fall_through(instrs: &mut [WirInstr], mut reaches_cold: bool) -> bool {
     for i in (0..instrs.len()).rev() {
         if reaches_cold
@@ -1256,8 +1248,7 @@ impl FunctionTranslator<'_, '_> {
     /// `struct.new List<T> { repr: array.new_fixed<T>(e0, …), used: N }`,
     /// mirroring `translate_string_literal`'s structurally identical
     /// `String { repr, used }`. The element type is read off the struct's `repr`
-    /// field rather than tracked again on the NIR node, and the resulting
-    /// `ArrayNewFixed` is what `wir_optimize::array` already consumes.
+    /// field rather than tracked again on the NIR node.
     fn build_array_literal(
         &mut self,
         array_type_id: crate::tir::TypeId,
@@ -1779,9 +1770,7 @@ impl FunctionTranslator<'_, '_> {
                             // nested control flow. `lift_struct_new_to_seq`
                             // turns each leaf `StructNew` into its own
                             // `Return { Seq(fields) }`, so the lifted expression
-                            // replaces the whole `Return` — re-wrapping it would
-                            // hand the validator an empty stack in the
-                            // control-flow case.
+                            // replaces the whole `Return` rather than nesting.
                             mut other @ (WirInstr::Seq(_)
                             | WirInstr::Block { .. }
                             | WirInstr::If { .. }) => {
@@ -1937,8 +1926,7 @@ impl FunctionTranslator<'_, '_> {
     /// Translate a call's operands, receiver first, erasing unit-typed
     /// parameters while preserving every argument's evaluation and its
     /// left-to-right order: a unit argument that still evaluates joins the
-    /// prelude, and every non-unit argument to its left spills to a temp so it
-    /// goes first. One with no evaluation of its own is dropped. Returns
+    /// prelude, and every non-unit argument to its left spills to a temp. Returns
     /// `(prelude, call_args)` — wrap with [`Self::wrap_call_with_prelude`].
     pub(super) fn translate_args_erasing_unit(
         &mut self,
@@ -2799,8 +2787,6 @@ impl FunctionTranslator<'_, '_> {
 /// `ReturnAbi::MultiValue` function. Recurses into a `Seq` tail, both `If`
 /// branch tails (clearing the `If`'s `result`, since branches now transfer
 /// control themselves), and each `StructNew; Br depth` exit of a `match` block.
-/// `wrap_in_return` is false only at the outer call, whose caller supplies the
-/// `Return`.
 fn lift_struct_new_to_seq(expr: &mut WirInstr, wrap_in_return: bool) {
     match expr {
         WirInstr::StructNew { .. } => {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -75,17 +75,11 @@ fn collect_let_names(body: &Body, names: &mut IndexMap<u32, String>, block: Bloc
     }
 }
 
-/// Pre-compute the WIR-side name for every TIR local index, applying the
-/// same shadow / param-collision rules `local_name` used to compute on the
-/// fly. The live formulation iterated `params` and the entire `local_names`
-/// map per call, which is O(N) per local reference; doing it once up front
-/// keeps `local_name` to an O(1) hash lookup at every visit site.
-///
-/// Rules (mirrored from the original `local_name`):
-/// - When two params share a raw name, every such param is suffixed with
-///   `_{local_index}`.
-/// - A non-param local that shadows a param-or-let keeps the original
-///   name unchanged on the param/let and suffixes the non-param.
+/// Pre-compute the WIR-side name for every TIR local index, once, so
+/// [`FunctionTranslator::local_name`] is an O(1) lookup rather than a scan of
+/// `params` and `local_names` per reference. Two params sharing a raw name are
+/// both suffixed with `_{local_index}`; a non-param local shadowing a param or
+/// let takes the suffix alone, leaving the shadowed name untouched.
 fn resolve_local_names(raw: &IndexMap<u32, String>, params: &[NirParam]) -> IndexMap<u32, String> {
     let param_indices: IndexSet<u32> = params.iter().map(|p| p.local_index).collect();
 
@@ -125,27 +119,13 @@ fn resolve_local_names(raw: &IndexMap<u32, String>, params: &[NirParam]) -> Inde
     out
 }
 
-/// Register canonical closure wrapper functions for all closure functors.
-/// Must be called before `translate_function_bodies` so wrappers are available
-/// for `ClosureToCanonical` references.
-///
-/// For each reachable functor we register three wrappers — one per
-/// vtable slot in `CanonicalClosure_K`:
-///
-/// 1. `__closure_wrapper_N(env, args...) -> ret` — refcasts `env` to
-///    `&__Closure_N` and forwards to `__call`.
-/// 2. `__closure_inspect_wrapper_N(env, formatter)` — refcasts both
-///    args and forwards to `__Closure_N^Inspect::inspect`.
-/// 3. `__closure_inspect_alt_wrapper_N(env, formatter)` — refcasts
-///    both args and forwards to `__Closure_N^InspectAlt::inspect_alt`.
-///
-/// The per-functor `__Closure_N^Inspect` / `InspectAlt` impls are
-/// synthesised in lower (Phase 2). For non-inspectable signatures the
-/// canonical struct uses the slim `{ env, func }` schema and only the
-/// call wrapper is registered; the `inspect` / `inspect_alt` wrappers
-/// don't exist and the corresponding fields aren't on the struct, so
-/// nothing has to be filled in. For inspectable signatures all three
-/// wrappers are registered and reach the per-functor impls.
+/// Register one wrapper per `CanonicalClosure_K` vtable slot for each reachable
+/// functor — `__closure_wrapper_N` forwarding to `__call`, plus
+/// `__closure_inspect_wrapper_N` / `_alt_` forwarding to the per-functor
+/// `^Inspect` / `^InspectAlt` impls — each refcasting its args first. A
+/// non-inspectable signature takes the slim `{ env, func }` schema and gets only
+/// the call wrapper. Must run before `translate_function_bodies`, which resolves
+/// `ClosureToCanonical` references against these.
 pub fn register_closure_wrappers(ctx: &mut WirContext<'_>) {
     use crate::wir::WirType;
 
@@ -469,18 +449,12 @@ fn register_call_wrapper(
     ctx.register_function(func, None)
 }
 
-/// Build an inspect / `inspect_alt` wrapper for a functor.
-///
-/// The wrapper's external signature is fixed by the canonical inspect
-/// callback type `(env: ref null struct, formatter: ref null struct)`,
-/// so the function-table slot type stays stable across DAE shrinkage on
-/// the per-functor impl. Internally, we look up the impl's surviving
-/// params and forward only the matching wrapper-locals: `self` (env) is
-/// fed by `__typed_env` (refcast of `__env`), `f` (formatter) is fed by
-/// `__typed_formatter`. Either or both refcasts are skipped when the
-/// corresponding param has been DAE'd. If the impl was DCE'd entirely
-/// the body falls back to `Unreachable` — the slot stays populated to
-/// keep the canonical struct schema consistent.
+/// Build an inspect / `inspect_alt` wrapper for a functor. Its external
+/// signature is fixed at `(env, formatter)` by the canonical callback type, so
+/// the function-table slot stays stable across DAE shrinkage on the impl:
+/// internally only the impl's surviving params are forwarded, and a refcast is
+/// skipped where its param was dropped. A DCE'd impl leaves an `Unreachable`
+/// body — the slot stays populated so the canonical schema holds.
 #[allow(clippy::too_many_arguments)]
 fn register_inspect_wrapper(
     ctx: &mut WirContext<'_>,
@@ -653,22 +627,13 @@ fn register_inspect_wrapper(
     ctx.register_function(func, None)
 }
 
-/// Build the WIR body for a `FunctionKind::FnCanonicalDispatch`
-/// stub: cast `self` to the shared `$canonical_inspectable_base`
-/// supertype, then `call_ref (struct.get base $slot self) (self.env,
-/// f)` where `$slot` is `inspect` or `inspect_alt` depending on
-/// `trait_kind`.
-///
-/// Casting to the shared base — instead of one specific
-/// `CanonicalClosure_K` per `(arity, return_type)` — lets the same
-/// dispatch stub serve every parameter shape with that signature
-/// pair; without it the cast would trap whenever a runtime value
-/// belonged to a different per-signature canonical struct.
-///
-/// Returns `None` when no inspectable canonical struct has been
-/// registered: in that case the dispatch stub is unreachable from any
-/// emitted closure value (every canonical struct is slim `{ env, func
-/// }`), so leaving the bodyless TIR placeholder in place is fine.
+/// Build the WIR body for a `FunctionKind::FnCanonicalDispatch` stub: cast
+/// `self` to the shared `$canonical_inspectable_base`, then
+/// `call_ref (struct.get base $slot self) (self.env, f)`. The cast targets the
+/// shared base rather than one `CanonicalClosure_K`, so a single stub serves
+/// every parameter shape with that signature instead of trapping on the others.
+/// `None` when no inspectable canonical struct exists — the stub is then
+/// unreachable, and the bodyless TIR placeholder can stay.
 #[allow(clippy::needless_pass_by_value)] // signature mirrors the param-name plumbing in translate_function_bodies
 fn build_fn_canonical_dispatch_body(
     ctx: &mut WirContext<'_>,
@@ -809,26 +774,13 @@ fn else_is_empty(else_body: &Option<Vec<WirInstr>>) -> bool {
     }
 }
 
-/// Finalize `builtin::cold_path()` markers into Wasm branch hints.
-///
-/// `cold_path()` lowers to a side-effect-free [`WirInstr::ColdPath`] left in
-/// the branch body. This pass finds the enclosing conditional and wraps its
-/// condition in [`WirInstr::BranchHint`] so the emitter records a
-/// `metadata.code.branch_hint` entry. Two shapes are recognized:
-///
-///  - **In-branch**: an `if` whose then/else body carries the marker. A cold
-///    then-branch hints the condition unlikely-true (`likely = false`); a cold
-///    else-branch hints it likely-true (`likely = true`).
-///  - **Fall-through / implicit-else**: an `if cond { <diverges> }` with no
-///    `else` (or a `nop`-only else, as `if let` / `while let` lower to) whose
-///    fall-through path unconditionally reaches a marker later in the same
-///    block. The condition-false side is cold, so the condition is hinted
-///    likely-true. This covers the guard-clause idiom
-///    `if ok { return v } cold_path(); return err`, including its
-///    `if let Some(v) = … { return v } cold_path(); …` form.
-///
-/// The marker itself stays in place and emits nothing. Runs unconditionally at
-/// WIR finalization, so the hint is independent of the optimization level.
+/// Finalize `builtin::cold_path()` markers into `metadata.code.branch_hint`
+/// entries by wrapping the enclosing condition in [`WirInstr::BranchHint`]. Two
+/// shapes: a marker inside an `if` branch hints that branch unlikely, and an
+/// else-less `if cond { <diverges> }` whose fall-through reaches a marker hints
+/// the condition likely — the guard-clause idiom
+/// `if ok { return v } cold_path(); return err`. The marker itself emits
+/// nothing, and the pass runs regardless of optimization level.
 fn apply_cold_path_hints(instrs: &mut [WirInstr]) {
     for instr in instrs.iter_mut() {
         apply_cold_path_hints_instr(instr);
@@ -836,16 +788,12 @@ fn apply_cold_path_hints(instrs: &mut [WirInstr]) {
     hint_guard_fall_through(instrs, false);
 }
 
-/// Backward fall-through pass for the guard-clause idiom. `reaches_cold` is
-/// whether the path immediately *after* this slice unconditionally reaches a
-/// `cold_path()` marker before any non-cold divergence; the return value is the
-/// same predicate for the path *before* the slice.
-///
-/// A guard `if cond { <diverges> }` (with no/empty else) sitting in front of a
-/// cold path has a cold fall-through, so its taken branch is hinted likely. The
-/// walk descends transparent `Seq`/`Block` tails so a guard inside an `if let` /
-/// `while let` desugaring — which lowers to a `Seq`-wrapped `if … else { nop }`
-/// whose `cold_path()` sibling lives in the enclosing block — is still reached.
+/// Backward fall-through pass for the guard-clause idiom. `reaches_cold` says
+/// whether the path just *after* this slice reaches a `cold_path()` marker
+/// before any non-cold divergence; the return value says the same for the path
+/// *before* it. A guard in front of a cold path gets its taken branch hinted
+/// likely. The walk descends transparent `Seq`/`Block` tails, so a guard inside
+/// an `if let` / `while let` desugaring still finds its enclosing-block marker.
 fn hint_guard_fall_through(instrs: &mut [WirInstr], mut reaches_cold: bool) -> bool {
     for i in (0..instrs.len()).rev() {
         if reaches_cold
@@ -1032,16 +980,11 @@ pub(super) struct FunctionTranslator<'a, 'b> {
     /// Used to skip unnecessary value copies when an immutable binding
     /// is initialized from another immutable local.
     pub(super) immutable_locals: IndexSet<u32>,
-    /// TIR locals that hold a multi-value-call result, mapped to the WIR
-    /// split locals they were unpacked into, keyed by source field name.
-    /// When a `let __tmp = Call(f)` targets a function with
-    /// `ReturnAbi::MultiValue { field_names, .. }`, we emit
-    /// `MultiValueLocalBind [__tmp_0, __tmp_1, …] = Call(f)` and record
-    /// `local_index → { field_name → (split_local_name, ty) }`.
-    /// Subsequent `FieldAccess(LocalGet(__tmp), name)` accesses read the
-    /// matching split local directly instead of `StructGet(__tmp, name)`
-    /// (which would panic at codegen since `__tmp` was never assigned a
-    /// struct ref).
+    /// TIR locals holding a multi-value-call result, mapped to the WIR split
+    /// locals they were unpacked into and keyed by field name. A later
+    /// `FieldAccess(LocalGet(__tmp), name)` reads the matching split local
+    /// instead of `StructGet(__tmp, name)`, which would panic at codegen —
+    /// `__tmp` was never assigned a struct ref.
     pub(super) multi_value_split_locals: IndexMap<u32, IndexMap<String, (String, WirType)>>,
     /// Set while lowering a call whose N results have a taker: the split locals
     /// of a `let` bind, the wildcards of a discard, or the enclosing
@@ -1059,24 +1002,10 @@ pub(super) struct FunctionTranslator<'a, 'b> {
 }
 
 impl FunctionTranslator<'_, '_> {
-    /// Get the WIR local name for a given local index.
-    /// Uses the TIR variable name if available, otherwise falls back to `__local_N`.
-    ///
-    /// WIR locals are looked up by name during codegen (`current_locals` is
-    /// keyed by name in `codegen::emit::resolve_local`), so any two locals
-    /// that share a name would clobber each other's entry and silently
-    /// mis-resolve. The disambiguation rules here mirror
-    /// `wir_build::functions`'s construction of `WirFunction::param_names`:
-    ///
-    /// - When two params share a name (e.g. a synthesised closure's
-    ///   implicit `self: &__Closure` env collides with an explicit
-    ///   `self`-named param forwarded from a source method), every such
-    ///   param's name is suffixed with `_{local_index}`.
-    /// - A non-param local that shadows a param keeps the original
-    ///   collision-resolution shape: the param keeps its raw name and the
-    ///   non-param gets the `_{index}` suffix. This avoids renaming params
-    ///   just because a `let self = ...` happens to shadow them in the
-    ///   body.
+    /// The WIR local name for `index`, as [`resolve_local_names`] computed it,
+    /// falling back to `__local_N`. Codegen resolves locals by name, so two
+    /// sharing one would silently mis-resolve — hence the disambiguation there,
+    /// which mirrors `wir_build::functions`' construction of `param_names`.
     pub(super) fn local_name(&self, index: u32) -> String {
         self.resolved_local_names
             .get(&index)
@@ -1323,16 +1252,12 @@ impl FunctionTranslator<'_, '_> {
         (type_id, fields)
     }
 
-    /// Lower a `ExprKind::ArrayLiteral` to the `Array<T>` struct shape
-    /// `struct.new List<T> { repr: array.new_fixed<T>(e0, …, eN-1), used: N }`.
-    ///
-    /// `List<T>` is `{ repr: Array<T>, used: i32 }` (see
-    /// `lib/core/prelude/list.wado`); this mirrors `translate_string_literal`,
-    /// which builds the structurally identical `String { repr, used }`. The
-    /// raw `Array<T>` type is read from the struct's `repr` field, so
-    /// no element-type bookkeeping is duplicated on the NIR node. The resulting
-    /// `ArrayNewFixed` is what `wir_optimize::array::{promote_constant_arrays_to_data,
-    /// split_large_array_literals}` already consume.
+    /// Lower an `ArrayLiteral` to
+    /// `struct.new List<T> { repr: array.new_fixed<T>(e0, …), used: N }`,
+    /// mirroring `translate_string_literal`'s structurally identical
+    /// `String { repr, used }`. The element type is read off the struct's `repr`
+    /// field rather than tracked again on the NIR node, and the resulting
+    /// `ArrayNewFixed` is what `wir_optimize::array` already consumes.
     fn build_array_literal(
         &mut self,
         array_type_id: crate::tir::TypeId,
@@ -1392,16 +1317,11 @@ impl FunctionTranslator<'_, '_> {
         }
     }
 
-    /// Translate `*r = v` for an in-place aggregate referent (struct /
-    /// `String` / `List<T>` / tuple): copy `v` into the shared handle
-    /// field by field, through two temps so each side is evaluated once.
-    ///
-    /// Statement-position deref-assigns are already expanded at lower
-    /// (`lower::translate::try_expand_deref_aggregate_assign`); this covers
-    /// the expression-position shape (`let u = (*r = v);`) that reaches WIR
-    /// as a plain `Assign { target: Deref, .. }`. Box-shaped referents never
-    /// arrive here — the lower boxing rewrite folds them to a `.value`
-    /// field assignment.
+    /// Translate `*r = v` for an in-place aggregate referent by copying `v` into
+    /// the shared handle field by field, through two temps so each side is
+    /// evaluated once. Only the expression-position shape (`let u = (*r = v);`)
+    /// reaches here — lower already expands the statement-position one, and
+    /// folds a box-shaped referent to a `.value` assignment.
     fn translate_deref_assign(&mut self, ref_expr: Operand, val: WirInstr) -> WirInstr {
         let recv = self.translate_operand(ref_expr);
         let wir_type = self.wir_type(self.operand_type_id(ref_expr));
@@ -1855,19 +1775,13 @@ impl FunctionTranslator<'_, '_> {
                             WirInstr::StructNew { fields, .. } => Some(WirInstr::Return {
                                 value: Some(Box::new(WirInstr::Seq(fields))),
                             }),
-                            // A scaffolded return value: a sequential block
-                            // (`return { let a = …; [a, b] }`, which inlining
-                            // produces when an element needs a binding), or
-                            // nested control flow (`return match { … }` /
-                            // `return if …`). `lift_struct_new_to_seq` rewrites
-                            // each leaf aggregate `StructNew` into its own
-                            // `Return { Seq(fields) }` in place, so the lifted
-                            // expression replaces the whole `Return`: a block's
-                            // tail returns explicitly, and a branch's leaf
-                            // returns before the outer one would — wrapping the
-                            // outer expression in `Return` instead would feed
-                            // the validator an empty stack for the control-flow
-                            // case.
+                            // A scaffolded return value: a sequential block, or
+                            // nested control flow. `lift_struct_new_to_seq`
+                            // turns each leaf `StructNew` into its own
+                            // `Return { Seq(fields) }`, so the lifted expression
+                            // replaces the whole `Return` — re-wrapping it would
+                            // hand the validator an empty stack in the
+                            // control-flow case.
                             mut other @ (WirInstr::Seq(_)
                             | WirInstr::Block { .. }
                             | WirInstr::If { .. }) => {
@@ -1972,13 +1886,6 @@ impl FunctionTranslator<'_, '_> {
         }
     }
 
-    /// Translate a TIR expression to a WIR instruction.
-    ///
-    /// When the expression has type `never` (bottom type), the returned instruction
-    /// diverges.  The `Seq([instr, Unreachable])` wrapper tells the Wasm validator
-    /// that any subsequent type expectations in the same block are vacuously satisfied,
-    /// so `never`-typed sub-expressions can appear in any value position (binary
-    /// operands, struct fields, array elements, function arguments, …).
     /// Handle a `FunctionRef` that did not resolve to a generated function. A
     /// `Type^Trait::method` name is an unsatisfied trait bound that escaped
     /// earlier checks: record it and emit `Unreachable` so the build finishes
@@ -2003,6 +1910,10 @@ impl FunctionTranslator<'_, '_> {
         }
     }
 
+    /// Translate a TIR expression, wrapping a `never`-typed one in
+    /// `Seq([instr, Unreachable])` so it diverges. That tells the validator any
+    /// later type expectation in the block is vacuously satisfied, which is what
+    /// lets a `never`-typed sub-expression sit in any value position.
     pub(super) fn translate_expr(&mut self, expr_id: ExprId) -> WirInstr {
         let instr = self.translate_expr_inner(expr_id);
         if self.body.exprs[expr_id].type_id == TypeTable::NEVER && !instr.ends_with_terminator() {
@@ -2023,17 +1934,12 @@ impl FunctionTranslator<'_, '_> {
         }
     }
 
-    /// Translate a call's operands (receiver first, if any), erasing
-    /// unit-typed parameters from the emitted call while preserving every
-    /// argument's evaluation and the left-to-right order. A unit argument
-    /// still evaluates (`touch(p.f = 5)`, `touch(bump())`): its (void)
-    /// instruction joins the returned prelude, and every non-unit argument to
-    /// its left spills into a temp so it evaluates first. A unit argument
-    /// with no evaluation of its own — a promoted pure value or a bare local
-    /// read — is simply dropped.
-    ///
-    /// Returns `(prelude, call_args)`; wrap a non-empty prelude around the
-    /// call with [`Self::wrap_call_with_prelude`].
+    /// Translate a call's operands, receiver first, erasing unit-typed
+    /// parameters while preserving every argument's evaluation and its
+    /// left-to-right order: a unit argument that still evaluates joins the
+    /// prelude, and every non-unit argument to its left spills to a temp so it
+    /// goes first. One with no evaluation of its own is dropped. Returns
+    /// `(prelude, call_args)` — wrap with [`Self::wrap_call_with_prelude`].
     pub(super) fn translate_args_erasing_unit(
         &mut self,
         ordered: &[Operand],
@@ -2888,24 +2794,13 @@ impl FunctionTranslator<'_, '_> {
     }
 }
 
-/// Recursively rewrite leaf `StructNew` nodes in the value of a `Return`
-/// statement so the function pushes its N fields onto the stack instead
-/// of constructing a heap struct. Only applied when the enclosing
-/// function has `ReturnAbi::MultiValue`. Handles:
-///
-/// - direct `StructNew` (the common `return Point { x, y }` case)
-/// - `Seq(items)` — recurse into the trailing item
-/// - `If` produced by `return if …` — recurse into both branch tails;
-///   each branch tail's `StructNew` becomes its own `Return { Seq(fields) }`
-///   and the `If`'s `result` is cleared since branches now transfer
-///   control directly
-/// - typed `Block` produced by `return match …` (`BrTable` lowering) —
-///   rewrite each `StructNew; Br depth` exit pair to `Return { Seq(fields) }`
-///
-/// `wrap_in_return = false` is the outer call (the caller's `Return`
-/// will wrap the produced `Seq`); recursive calls into branch tails use
-/// `wrap_in_return = true` so each branch transfers control before the
-/// outer (now-unused) Return would.
+/// Rewrite the leaf `StructNew` nodes of a `Return` value so the function pushes
+/// its N fields instead of building a heap struct — only for a
+/// `ReturnAbi::MultiValue` function. Recurses into a `Seq` tail, both `If`
+/// branch tails (clearing the `If`'s `result`, since branches now transfer
+/// control themselves), and each `StructNew; Br depth` exit of a `match` block.
+/// `wrap_in_return` is false only at the outer call, whose caller supplies the
+/// `Return`.
 fn lift_struct_new_to_seq(expr: &mut WirInstr, wrap_in_return: bool) {
     match expr {
         WirInstr::StructNew { .. } => {

--- a/wado-compiler/src/wir_build/translate.rs
+++ b/wado-compiler/src/wir_build/translate.rs
@@ -1246,8 +1246,8 @@ impl FunctionTranslator<'_, '_> {
 
     /// Lower an `ArrayLiteral` to
     /// `struct.new List<T> { repr: array.new_fixed<T>(e0, …), used: N }`,
-    /// mirroring `translate_string_literal`'s structurally identical
-    /// `String { repr, used }`. The element type is read off the struct's `repr`
+    /// mirroring the structurally identical `String { repr, used }` that
+    /// `seq_literal` builds. The element type is read off the struct's `repr`
     /// field rather than tracked again on the NIR node.
     fn build_array_literal(
         &mut self,

--- a/wado-compiler/src/wir_build/types.rs
+++ b/wado-compiler/src/wir_build/types.rs
@@ -637,16 +637,10 @@ fn register_tuple_types(ctx: &mut WirContext<'_>) {
                 }
 
                 // A tuple is a generic instance, so its elements are type
-                // arguments and must be mangled with the module-qualified form.
-                // The non-type-arg mangler qualifies inconsistently — a
-                // monomorphized `Struct` element keeps its short stored name
-                // while the equivalent `GenericInstance` element comes out
-                // qualified (the substitution-boundary flip) — so the same
-                // logical tuple (e.g. `[String, TreeMap<String,i32>]`) would
-                // register under two different fqs, yielding two distinct WIR
-                // struct types and a `ref`/`ref null` validation mismatch where
-                // they meet (e.g. iterating a `TreeMap`-valued map's entries).
-                // Newtypes still resolve to their base so they share the type.
+                // arguments and take the module-qualified mangling. The
+                // non-type-arg mangler qualifies inconsistently across the
+                // substitution boundary, so one logical tuple would register
+                // under two fqs and hit a `ref`/`ref null` validation mismatch.
                 let elem_names: Vec<String> = elements
                     .iter()
                     .map(|&e| type_table.mangle_type_arg_for_generic_resolving_newtypes(e))
@@ -1142,17 +1136,11 @@ fn register_canonical_closure_types(ctx: &mut WirContext<'_>) {
     }
 }
 
-/// Register List<T> wrapper structs for all `GenericInstance("List", [T])` types
-/// found in any module's type table.
-///
-/// In the TIR, `List<T>` is `GenericInstance { name: "List", type_args: [T] }`,
-/// not a struct definition. We create wrapper structs here to provide the
-/// underlying GC array types that the WIR emitter needs.
-///
-/// Types are processed in dependency order: if `T` is itself `List<U>`,
-/// `List<U>` is fully registered (raw array + wrapper struct) before
-/// `List<List<U>>` so that the backing array gets a concrete element type
-/// instead of abstract `structref`.
+/// Register a `List<T>` wrapper struct for every `GenericInstance("List", [T])`
+/// in any module's type table, TIR carrying no struct definition of its own to
+/// supply the GC array type the emitter needs. Processed in dependency order, so
+/// a nested `List<U>` is registered before `List<List<U>>` and the backing array
+/// gets a concrete element type rather than an abstract `structref`.
 fn register_list_wrapper_structs(ctx: &mut WirContext<'_>) {
     use crate::tir::ResolvedType;
 

--- a/wado-compiler/src/wir_optimize.rs
+++ b/wado-compiler/src/wir_optimize.rs
@@ -1,24 +1,10 @@
-//! WIR optimization — structural and peephole passes on `WirPackage`.
-//! Runs after `wir_build`, before `codegen::emit`.
-//!
-//! Each pass lives in its own module below and documents itself there; the
-//! phase sequence in [`optimize_wir`] is the only statement of what runs and in
-//! what order. [`docs/optimizer.md`](../../../docs/optimizer.md) is the
-//! reader-facing inventory.
-//!
-//! `nullable_ref` is a mandatory representation lowering, not an optimization:
-//! it runs at every `-O`. The rest are optimizations, skipped at `-O0`.
-//!
-//! Related passes live elsewhere: dead-arg/-return elim and single-field param
-//! SROA moved to NIR (`optimize::{dae,drve,sroa_param,elide_box_local}`) to join
-//! its fixed-point loop, and variant-return widening followed them
-//! (`optimize::sroa_variant_return`), leaving only the slot flattening that
-//! needs post-lowering shapes. Write-only-local elim is split —
-//! `optimize::elide_local` for TIR locals, `elide_local` here for
-//! `wir_build`-synthesised locals TIR can't see.
-//!
-//! A `#![wasm_module(...)]` core module — the allocator — runs this same list as
-//! a package of its own ([`optimize_wasm_modules`]), under its own pass names.
+//! WIR optimization — structural and peephole passes on `WirPackage`, between
+//! `wir_build` and `codegen::emit`. Each documents itself in its own module; the
+//! phase sequence in [`optimize_wir`] is the only statement of what runs in what
+//! order. `nullable_ref` is a mandatory representation lowering and runs at every
+//! `-O`; the rest are skipped at `-O0`. What is left here needs post-lowering
+//! shapes — the rest moved to NIR to join its fixed-point loop. A
+//! `#![wasm_module(…)]` core module runs the same list as its own package.
 
 pub(crate) mod array;
 mod branch_hint;
@@ -100,16 +86,11 @@ fn wir_pass(
     pass_dump::dump_wir(&name, module, Phase::After);
 }
 
-/// Run the WIR-level optimizations on the module (in-place).
-///
-/// Passes are skipped at `-O0`; only dead-item compaction runs, so the emitter
-/// never sees `dead_*_indices`.
-///
-/// `lower_nullable_refs` is the exception — a mandatory representation lowering,
-/// not an optimization, so it runs before the `-O0` gate. The frontend already
-/// emits `None` as `ref.null` (the `?`-desugar yields `TirExprKind::Null`); this
-/// picks the matching WIR repr, so skipping it miscompiles rather than just slowing
-/// code. (The frontend/WIR repr split is a known layering smell, tracked separately.)
+/// Run the WIR-level optimizations in place. At `-O0` only dead-item compaction
+/// runs, so the emitter never sees `dead_*_indices`. `lower_nullable_refs` is the
+/// exception, running before that gate: the frontend already emits `None` as
+/// `ref.null`, and this picks the matching WIR repr, so skipping it miscompiles
+/// rather than merely slowing things down.
 pub fn optimize_wir(
     module: &mut WirPackage,
     opt_level: OptLevel,

--- a/wado-compiler/src/wir_optimize.rs
+++ b/wado-compiler/src/wir_optimize.rs
@@ -2,9 +2,7 @@
 //! `wir_build` and `codegen::emit`. Each documents itself in its own module; the
 //! phase sequence in [`optimize_wir`] is the only statement of what runs in what
 //! order. `nullable_ref` is a mandatory representation lowering and runs at every
-//! `-O`; the rest are skipped at `-O0`. What is left here needs post-lowering
-//! shapes — the rest moved to NIR to join its fixed-point loop. A
-//! `#![wasm_module(…)]` core module runs the same list as its own package.
+//! `-O`; the rest are skipped at `-O0`. What is left here needs post-lowering shapes.
 
 pub(crate) mod array;
 mod branch_hint;

--- a/wado-compiler/src/wir_optimize/array.rs
+++ b/wado-compiler/src/wir_optimize/array.rs
@@ -1,15 +1,7 @@
-//! List optimization passes for WIR.
-//!
-//! - **Constant array data promotion**: `ArrayNewFixed` of constants → `ArrayNewData`,
-//!   when packing encodes smaller than the inline operands.
-//! - **Large array literal splitting**: `array.new_fixed` (>= threshold) → `array.new_default` + sets.
-//!
-//! List literals reach WIR already as `ArrayNewFixed`: the NIR
-//! `optimize::array_literal` pass materializes `ExprKind::ArrayLiteral` from
-//! the `SequenceLiteralBuilder` push sequence, and `wir_build` lowers it
-//! directly. The former WIR-level `collapse_array_push_sequences` that
-//! reconstructed `ArrayNewFixed` from inlined `List::push` chains is therefore
-//! retired; the passes below consume the `ArrayNewFixed` it used to produce.
+//! List optimization passes for WIR, over the `ArrayNewFixed` that list literals
+//! already reach WIR as: promoting one of constants to `ArrayNewData` where
+//! packing encodes smaller than inline operands, and splitting one past the
+//! threshold into `array.new_default` + sets.
 
 use crate::wir::{WirData, WirInstr, WirPackage, WirType, WirTypeDef};
 use crate::wir_visitor::WirMutVisitor;
@@ -57,20 +49,10 @@ fn signed_leb128_len(mut value: i64) -> usize {
 }
 
 /// Whether packing `count` elements of `elem_width` bytes into a passive data
-/// segment is worth it, given what the same elements cost as inline
-/// `array.new_fixed` operands.
-///
-/// A data segment stores every element at its full width, while an operand is
-/// LEB128-compressed: a `List<i32>` of small values costs 3 bytes per element
-/// inline but 4 packed, so promoting it *grows* the module — and, because
-/// `array.new_data` is not a Wasm constant instruction, also demotes a global
-/// that would otherwise have become an eager constant to a runtime-initialized
-/// one.
-///
-/// Past [`ARRAY_NEW_FIXED_LIMIT`] the comparison is moot: the alternative is
-/// not `array.new_fixed` at all but the `array.new_default` + N × `array.set`
-/// build sequence `split_large_array_literals` produces, which is larger than
-/// either and is what the limit exists to avoid.
+/// segment beats leaving them as inline `array.new_fixed` operands. A segment
+/// stores full width while an operand is LEB128-compressed, so a `List<i32>` of
+/// small values *grows* when promoted — and loses eager-const status besides.
+/// Past [`ARRAY_NEW_FIXED_LIMIT`] the alternative is the larger split sequence.
 pub(crate) fn data_promotion_pays(
     count: usize,
     elem_width: usize,
@@ -281,19 +263,11 @@ fn encode_constant_element(
 /// The `array.set` form consumes each value immediately, keeping stack depth low.
 pub(crate) const ARRAY_NEW_FIXED_LIMIT: usize = 256;
 
-/// Split large `ArrayNewFixed` instructions into `ArrayNewDefault` + `ArraySet` sequences.
-///
-/// Walks all function bodies and rewrites any `ArrayNewFixed` with more than
-/// [`ARRAY_NEW_FIXED_LIMIT`] elements. Uses a module-level counter for unique local names.
-///
-/// Unlike `promote_constant_arrays_to_data`, this deliberately skips global
-/// initializers: the split form is a `Seq` of `DeclareLocal` / `LocalSet` /
-/// `ArraySet` / `LocalGet`, none of which is a valid Wasm constant instruction,
-/// so it cannot serve as an eager const-global init. A large *dynamic* array
-/// literal is instead extracted to the `__initialize_module` function body by
-/// lowering, where this pass reaches it; a large *const* array literal that
-/// stays an eager global init keeps `array.new_fixed` (the JIT-time concern is a
-/// runtime code path, not one-time module init).
+/// Rewrite every `ArrayNewFixed` past [`ARRAY_NEW_FIXED_LIMIT`] elements into an
+/// `ArrayNewDefault` + `ArraySet` sequence, naming locals from a module-level
+/// counter. Global initializers are skipped: none of those instructions is a
+/// valid Wasm constant, so a const array literal keeps `array.new_fixed` while a
+/// dynamic one is reached inside `__initialize_module`.
 pub(super) fn split_large_array_literals(module: &mut WirPackage) {
     let mut visitor = SplitLargeArrays { counter: 0 };
     for func in &mut module.functions {

--- a/wado-compiler/src/wir_optimize/branch_hint.rs
+++ b/wado-compiler/src/wir_optimize/branch_hint.rs
@@ -1,18 +1,11 @@
-//! Branch-hint passes: trap-based hint inference and `br_if` selection.
+//! Branch-hint passes. `infer_branch_hints` derives hints from control flow
+//! rather than source markers: an `if` arm always reaching an `unreachable` is
+//! cold, a `br_if` whose fall-through always traps is likely taken. Divergence
+//! alone never counts — only a trap does — and an explicit `cold_path()` hint
+//! always wins. Runs at every `-O`, so hints stay level-independent.
 //!
-//! `infer_branch_hints` derives branch hints from control flow instead of
-//! source markers: an `if` arm that always reaches an `unreachable` trap is
-//! cold, and a `br_if` whose fall-through always traps is likely taken.
-//! Divergence alone (`br` / `return`) never counts as cold — a `break` or an
-//! early `return` is ordinary control flow, only a trap is. Explicit hints
-//! (synthesized from `builtin::cold_path()` at WIR build) always win over
-//! inference. The pass runs at every optimization level so hints stay
-//! independent of `-O`, matching `apply_cold_path_hints`; `-f
-//! no-branch-hinting` skips it (see `CodegenFlags::branch_hinting`).
-//!
-//! `select_br_ifs` collapses `if cond { br N }` with an empty else into a
-//! single `br_if N-1`, carrying any branch hint on the condition over to the
-//! `br_if`. It must run before `infer_branch_hints`, so the trap-tail rule
+//! `select_br_ifs` collapses an else-less `if cond { br N }` into `br_if N-1`,
+//! carrying the condition's hint over. It runs first, so the trap-tail rule
 //! sees the selected `br_if`s.
 
 use crate::wir::{WirInstr, WirPackage};

--- a/wado-compiler/src/wir_optimize/const_forward.rs
+++ b/wado-compiler/src/wir_optimize/const_forward.rs
@@ -218,18 +218,11 @@ fn collect_aliased_locals(
     aliased
 }
 
-/// Recursively collect aliased locals.
-///
-/// `in_non_stores_arg`: when true, we are inside a Call argument whose callee
-/// does not declare `stores` for this parameter position. In this context,
-/// `RefAsNonNull(LocalGet)` and bare `LocalGet` do not create persistent aliases.
-///
-/// A plain `LocalSet(b, LocalGet a)` copy does NOT alias either side: the two
-/// names share the object (value semantics emit explicit `value_copy` calls
-/// where deep copies are required), but the copy itself creates no untracked
-/// mutation channel — `copy_field_knowledge` transfers the facts and every
-/// mutation channel (`StructSet`, call argument, escaped reference)
-/// invalidates the whole copy group.
+/// Recursively collect aliased locals. `in_non_stores_arg` marks a Call argument
+/// whose callee declares no `stores` for that position, where `LocalGet` — bare
+/// or under `RefAsNonNull` — creates no persistent alias. A plain
+/// `LocalSet(b, LocalGet a)` copy aliases neither side: it opens no untracked
+/// mutation channel, and every real one invalidates the whole copy group.
 fn collect_aliased_in_instr(
     instr: &WirInstr,
     aliased: &mut IndexSet<String>,
@@ -573,22 +566,11 @@ fn branches_at_or_beyond(instr: &WirInstr, label_depth: u32) -> bool {
     }
 }
 
-/// Invalidate what a **call** inside `instr` may mutate, before the statement
-/// is rewritten.
-///
-/// [`update_knowledge_from_instr`] runs after the rewrite, which is right for a
-/// statement's own store — `c.n = c.n + 1` evaluates its operand before storing,
-/// so folding that read stays correct — and wrong for a call, whose arguments
-/// evaluate in order: `total(bump(&mut c), c.n, c.n)` mutates in the first and
-/// reads in the next two.
-///
-/// Conservative within the statement: every call invalidates, including one
-/// evaluated after a read, since the rewrite does not walk in evaluation order.
-///
-/// Stops at a nested body, as `InvalidationScope::Statement` does — the
-/// recursive [`forward_fields_in_body`] pre-invalidates each of *its* statements
-/// in turn, and descending here would apply a call buried in a loop to the
-/// statements before that loop (`opt_licm_in_match_arm`).
+/// Invalidate what a **call** inside `instr` may mutate, before the statement is
+/// rewritten. [`update_knowledge_from_instr`] runs *after*, which is right for a
+/// statement's own store but wrong for a call, whose arguments evaluate in
+/// order: `total(bump(&mut c), c.n, c.n)`. Conservative within the statement,
+/// and stops at a nested body, whose own recursion pre-invalidates in turn.
 fn invalidate_call_effects_before_rewrite(instr: &WirInstr, known: &mut FieldKnowledge<'_>) {
     match instr {
         WirInstr::Call { args, .. } => {
@@ -860,16 +842,11 @@ fn skip_trailing_unreachable(body: &[WirInstr]) -> &[WirInstr] {
     &body[..end]
 }
 
-/// Extract the local name from a block's result value.
-/// Matches patterns like: `[..., LocalGet { name }, Br { depth: 0 }]`
-/// or `[..., Seq([LocalGet { name }, Br { depth: 0 }])]`.
-///
-/// Only safe when the block has a single exit point (one `Br { depth: 0 }`):
-/// with multiple exits, another path may hand out a different local.
-///
-/// Trailing `Unreachable` instructions are ignored — the code generator
-/// may append `unreachable` after a `Br` so the Wasm validator accepts
-/// the typed block even when the fallthrough path is dead.
+/// Extract the local name from a block's result value:
+/// `[..., LocalGet { name }, Br { depth: 0 }]`, possibly inside a `Seq`. Only
+/// safe with a single exit, since another path may hand out a different local.
+/// A trailing `Unreachable` is ignored — codegen appends one after a `Br` so the
+/// validator accepts the typed block with a dead fallthrough.
 fn extract_block_result_local(body: &[WirInstr]) -> Option<String> {
     if count_br_depth_zero(body) != 1 {
         return None;
@@ -897,18 +874,11 @@ fn extract_block_result_local(body: &[WirInstr]) -> Option<String> {
     None
 }
 
-/// Extract a `StructNew` from a block's result value.
-/// Matches patterns like: `[..., StructNew { ... }, Br { depth: 0 }]`
-/// or `[..., Seq([StructNew { ... }, Br { depth: 0 }])]`.
-/// Returns the (`type_id`, fields) cloned from the `StructNew`.
-///
-/// Only safe when the block has a single exit point (one `Br { depth: 0 }`).
-/// Blocks with multiple exits (e.g., early `break` inside branches) may
-/// produce different `StructNew` values on different paths.
-///
-/// Trailing `Unreachable` instructions are ignored — the code generator
-/// may append `unreachable` after a `Br` so the Wasm validator accepts
-/// the typed block even when the fallthrough path is dead.
+/// Extract a `StructNew` from a block's result value:
+/// `[..., StructNew { … }, Br { depth: 0 }]`, possibly inside a `Seq`, returning
+/// its cloned (`type_id`, fields). Only safe with a single exit, since multiple
+/// exits may produce different values. A trailing `Unreachable` is ignored —
+/// codegen appends one after a `Br` for the validator.
 fn extract_block_result_struct_new(body: &[WirInstr]) -> Option<(WirTypeId, Vec<WirInstr>)> {
     // Count Br { depth: 0 } in the block body. If there are multiple, the
     // block result is ambiguous and we cannot safely forward fields.

--- a/wado-compiler/src/wir_optimize/const_global.rs
+++ b/wado-compiler/src/wir_optimize/const_global.rs
@@ -1,13 +1,8 @@
 //! Constant global-initializer promotion: a user-immutable global whose
 //! initializer is no syntactic Wasm constant becomes an `__initialize_module`
 //! runtime assignment, which NIR optimization often reduces back to a constant.
-//! This is the single eager/lazy classifier — it moves the constant into the
-//! eager `init`, marks the global immutable, and drops the `GlobalSet`s.
-//!
-//! The assignment is found wherever it ends up, including duplicated per entry
-//! export when module-init is inlined, so the scan recurses and promotes when
-//! *every* assignment is constant — they are copies of one init. Const-ness is
-//! decided by [`WirInstr::is_const_expressible`], which leaves strings lazy.
+//! This is the single eager/lazy classifier, promoting when *every* assignment
+//! is [`WirInstr::is_const_expressible`] — leaving a string lazy.
 
 use super::dedupe_const_globals::const_key;
 use crate::hashmap::{IndexMap, IndexSet};

--- a/wado-compiler/src/wir_optimize/const_global.rs
+++ b/wado-compiler/src/wir_optimize/const_global.rs
@@ -1,35 +1,13 @@
-//! Constant global-initializer promotion for WIR.
+//! Constant global-initializer promotion: a user-immutable global whose
+//! initializer is no syntactic Wasm constant becomes an `__initialize_module`
+//! runtime assignment, which NIR optimization often reduces back to a constant.
+//! This is the single eager/lazy classifier — it moves the constant into the
+//! eager `init`, marks the global immutable, and drops the `GlobalSet`s.
 //!
-//! A user-immutable global (`global X = …`, not `global mut`) whose
-//! initializer is not a syntactic Wasm constant is extracted by
-//! `lower::plan::globals::extract` into an `__initialize_module` runtime
-//! assignment, leaving the Wasm global mutable with a `null`/zero
-//! placeholder. After NIR optimization (`array_literal`, `string_push`,
-//! `const_folding`, …) collapses builder sequences, that runtime
-//! assignment frequently reduces to a constant `struct.new` /
-//! `array.new_fixed` / scalar.
-//!
-//! This pass is the single eager/lazy classifier, realizing the "lazy iff
-//! optimize could not simplify it" rule at the point where the value is
-//! already correctly lowered to WIR (variant representation, non-null field
-//! wrapping all baked in). For each such global it moves the constant value
-//! into the global's eager `init`, marks the global immutable, and drops the
-//! now-redundant `GlobalSet`(s). The dead init temps, emptied
-//! `__initialize_module` body, and `__modules_initialized` guard are
-//! reclaimed by `dce` / `cleanup` in the same phase.
-//!
-//! The init assignment is reached wherever it ends up: a standalone
-//! `__initialize_module` body, or — when that module-init is inlined into
-//! the entry points — nested inside an `__inline___initialize_modules`
-//! guard block and *duplicated* once per entry export. The scan therefore
-//! recurses into nested instructions and treats a global as promotable when
-//! every assignment to it is constant (they are identical copies of one
-//! init, since a user-immutable global is assigned exactly once in source).
-//!
-//! It subsumes the former NIR `const_global_promotion` (scalar-only):
-//! const-ness is decided once here, via [`WirInstr::is_const_expressible`].
-//! Strings stay lazy — a `String`'s `array.new_data<u8>` repr is not a valid
-//! Wasm constant instruction, so it is excluded by that predicate.
+//! The assignment is found wherever it ends up, including duplicated per entry
+//! export when module-init is inlined, so the scan recurses and promotes when
+//! *every* assignment is constant — they are copies of one init. Const-ness is
+//! decided by [`WirInstr::is_const_expressible`], which leaves strings lazy.
 
 use super::dedupe_const_globals::const_key;
 use crate::hashmap::{IndexMap, IndexSet};

--- a/wado-compiler/src/wir_optimize/dce.rs
+++ b/wado-compiler/src/wir_optimize/dce.rs
@@ -79,11 +79,8 @@ fn collect_global_refs_recursive(instr: &WirInstr, out: &mut IndexSet<String>) {
 /// Mark globals reached by no `GlobalGet` / `GlobalSet` anywhere and by no
 /// export, whose value can therefore never be observed. This reclaims the
 /// const-object globals whose only uses sat in a cold panic branch the peephole
-/// folded away — taking fill and read with it, before
-/// `promote_const_global_inits` could make the fill an eager initializer, and
-/// leaving a `global mut` the immutable-only `dedupe_const_globals` never
-/// merges. Only fully unreferenced globals go, and since the instructions
-/// address globals by name, removal patches nothing.
+/// folded away, leaving a `global mut` the immutable-only `dedupe_const_globals`
+/// never merges. Instructions address globals by name, so removal patches nothing.
 pub fn mark_unreferenced_globals(module: &mut WirPackage) {
     let mut referenced: IndexSet<String> = IndexSet::default();
     for (i, func) in module.functions.iter().enumerate() {
@@ -141,10 +138,9 @@ fn remap_func_ids(instr: &mut WirInstr, remap: &IndexMap<u32, u32>) {
 
 /// Flag defined functions unreachable from exports and elements into
 /// `dead_func_indices`, leaving the removal and reindexing to
-/// [`compact_dead_items`]. Catches functions whose call sites never
-/// materialized — notably the monomorphic `List<T>::push` and `grow` for a
-/// single-element `[v]`, which `optimize::array_literal` rewrote into an
-/// `array.new_fixed` before the push chain was ever emitted.
+/// [`compact_dead_items`]. Catches functions whose call sites never materialized
+/// — notably `List<T>::push` and `grow` for a single-element `[v]`, which
+/// `optimize::array_literal` rewrote into an `array.new_fixed`.
 pub fn mark_unreachable_defined_functions(module: &mut WirPackage) {
     let num_funcs = u32::try_from(module.functions.len()).unwrap();
     if num_funcs == 0 {
@@ -383,8 +379,7 @@ fn collect_instr_type_refs(instr: &mut WirInstr, out: &mut IndexSet<u32>) {
 /// module's arrays and remapping every reference so the emitter can take the
 /// result as-is: `WirFuncId`s across bodies, exports and element tables, and
 /// `WirTypeId`s across bodies, signatures, import descriptors, globals, the type
-/// definitions themselves and `variant_case_info`. Globals need no patching,
-/// being addressed by name.
+/// definitions and `variant_case_info`. Globals are addressed by name.
 pub fn compact_dead_items(module: &mut WirPackage) {
     if module.dead_func_indices.is_empty()
         && module.dead_type_indices.is_empty()

--- a/wado-compiler/src/wir_optimize/dce.rs
+++ b/wado-compiler/src/wir_optimize/dce.rs
@@ -1,16 +1,8 @@
-//! Dead Code Elimination (DCE) passes for WIR.
-//!
-//! - **`mark_unreachable_defined_functions`**: marks defined functions
-//!   not reachable from exports/elements as dead via
-//!   `dead_func_indices`.
-//! - **`dce_unreachable_types`**: marks GC types not referenced by any
-//!   live code as dead via `dead_type_indices`.
-//! - **`compact_dead_items`**: removes all dead-marked items and remaps
-//!   indices.
-//!
-//! All three operate on either the GC module or the memory module — the
-//! base offset between absolute `WirFuncId` indices and 0-based
-//! `module.functions` array indices is read from
+//! WIR dead-code elimination: the `mark_*` passes flag unreachable functions,
+//! globals and types into the module's `dead_*_indices`, and
+//! [`compact_dead_items`] then removes them and remaps every index. All of them
+//! work on the GC module and the memory module alike, reading the offset between
+//! absolute `WirFuncId`s and 0-based array indices from
 //! [`WirPackage::defined_func_base`].
 
 use std::rc::Rc;
@@ -84,22 +76,14 @@ fn collect_global_refs_recursive(instr: &WirInstr, out: &mut IndexSet<String>) {
     instr.for_each_child(&mut |child| collect_global_refs_recursive(child, out));
 }
 
-/// Mark globals referenced by no `GlobalGet`/`GlobalSet` (in any function body,
-/// global initializer, or active data-segment offset) and by no export as dead
-/// (`dead_global_indices`), so
-/// [`compact_dead_items`] drops them. A global read nowhere and written nowhere
-/// affects nothing observable — its value can never be seen. This reclaims the
-/// synthesized const-object globals (`const_object_globalization` lazy-fill
-/// targets) whose only uses were a now-folded cold assert/bounds-check panic
-/// branch: the peephole eliminates the dead branch (taking the `GlobalSet` fill
-/// and `GlobalGet` read with it) before `promote_const_global_inits` can turn
-/// the fill into an eager initializer, leaving an unreferenced `global mut`
-/// declaration that `dedupe_const_globals` (immutable-only) never merges.
-///
-/// Only fully-unreferenced globals are removed, so any global still read or
-/// written — including a write-only user `global mut` whose store survives —
-/// stays. `GlobalGet`/`GlobalSet` address globals by name, so removal needs no
-/// instruction patching.
+/// Mark globals reached by no `GlobalGet` / `GlobalSet` anywhere and by no
+/// export, whose value can therefore never be observed. This reclaims the
+/// const-object globals whose only uses sat in a cold panic branch the peephole
+/// folded away — taking fill and read with it, before
+/// `promote_const_global_inits` could make the fill an eager initializer, and
+/// leaving a `global mut` the immutable-only `dedupe_const_globals` never
+/// merges. Only fully unreferenced globals go, and since the instructions
+/// address globals by name, removal patches nothing.
 pub fn mark_unreferenced_globals(module: &mut WirPackage) {
     let mut referenced: IndexSet<String> = IndexSet::default();
     for (i, func) in module.functions.iter().enumerate() {
@@ -155,24 +139,12 @@ fn remap_func_ids(instr: &mut WirInstr, remap: &IndexMap<u32, u32>) {
     });
 }
 
-/// Mark defined functions unreachable from exports/elements as dead
-/// (`module.dead_func_indices`), so the subsequent `compact_dead_items`
-/// removes them and remaps every `WirFuncId` reference.
-///
-/// Works on both the GC module (defined function indices start at
-/// [`crate::wir_build::DEFINED_FUNC_BASE`]) and the memory module
-/// (0-based indices) by reading the offset from
-/// [`WirPackage::defined_func_base`].
-///
-/// Catches functions whose only call sites never materialized — most
-/// notably the monomorphic `List<T>::push` (and its `List<T>::grow`
-/// callee) for a single-element array literal `[v]`. NIR
-/// `optimize::array_literal` rewrites `[v]` to `ExprKind::ArrayLiteral`,
-/// which `wir_build` lowers to `array.new_fixed`, so the `push` chain is
-/// never emitted and these instantiations have no callers.
-///
-/// This pass only sets dead flags; the actual removal + reindexing
-/// happens in [`compact_dead_items`].
+/// Flag defined functions unreachable from exports and elements into
+/// `dead_func_indices`, leaving the removal and reindexing to
+/// [`compact_dead_items`]. Catches functions whose call sites never
+/// materialized — notably the monomorphic `List<T>::push` and `grow` for a
+/// single-element `[v]`, which `optimize::array_literal` rewrote into an
+/// `array.new_fixed` before the push chain was ever emitted.
 pub fn mark_unreachable_defined_functions(module: &mut WirPackage) {
     let num_funcs = u32::try_from(module.functions.len()).unwrap();
     if num_funcs == 0 {
@@ -273,18 +245,11 @@ pub fn mark_unreachable_defined_functions(module: &mut WirPackage) {
     }
 }
 
-/// Mark types that are not referenced by any live function, import, or global
-/// as dead by adding them to `module.dead_type_indices`.
-///
-/// After function DCE (at TIR level) and WIR optimization, some type definitions
-/// may be registered but never actually used by any live code. This pass identifies
-/// those orphan types and marks them so the emitter skips them.
-///
-/// Types are collected transitively: a struct field type, array element type,
-/// or variant payload type that is only referenced from a dead type is also dead.
-///
-/// This is a standalone pass, separate from `optimize_wir`, so it can also run
-/// at O0 if needed. Currently called at the end of `optimize_wir`.
+/// Flag types no live function, import or global references into
+/// `dead_type_indices`, so the emitter skips the orphans left registered after
+/// function DCE. Collected transitively: a field, element or payload type reached
+/// only from a dead type is dead too. Standalone rather than part of
+/// `optimize_wir`, so it could also run at `-O0`.
 pub fn dce_unreachable_types(module: &mut WirPackage) {
     let num_types = module.types.len();
     if num_types == 0 {
@@ -414,19 +379,12 @@ fn collect_instr_type_refs(instr: &mut WirInstr, out: &mut IndexSet<u32>) {
     });
 }
 
-/// Remove all dead-marked items from the module and remap their indices.
-///
-/// Consumes `dead_func_indices`, `dead_type_indices`, and `dead_global_indices`,
-/// physically removing those items from the module's arrays and updating every
-/// reference so the module is consistent and the emitter can emit it as-is.
-///
-/// - **Functions** (`dead_func_indices`): removed; `WirFuncId` values in all bodies,
-///   exports, and element tables are remapped.
-/// - **Types** (`dead_type_indices`): removed; `WirTypeId` values in all bodies,
-///   function `type_ids`, import descriptors, globals, type definitions themselves,
-///   and `variant_case_info` are remapped.
-/// - **Globals** (`dead_global_indices`): removed from the globals array.
-///   GlobalGet/GlobalSet use string names so no instruction patching is needed.
+/// Consume the three `dead_*_indices` sets, removing those items from the
+/// module's arrays and remapping every reference so the emitter can take the
+/// result as-is: `WirFuncId`s across bodies, exports and element tables, and
+/// `WirTypeId`s across bodies, signatures, import descriptors, globals, the type
+/// definitions themselves and `variant_case_info`. Globals need no patching,
+/// being addressed by name.
 pub fn compact_dead_items(module: &mut WirPackage) {
     if module.dead_func_indices.is_empty()
         && module.dead_type_indices.is_empty()

--- a/wado-compiler/src/wir_optimize/dedupe_const_globals.rs
+++ b/wado-compiler/src/wir_optimize/dedupe_const_globals.rs
@@ -1,14 +1,8 @@
 //! Deduplicate identical immutable constant globals, which `const_global`
-//! promotes one apiece however many share a value. Such a global has no
-//! observable identity under Wado's value semantics — reads copy out, `==` is
-//! structural — so two with byte-identical inits and slot metadata are
-//! interchangeable, and each group collapses to one canonical global.
-//!
-//! Identity *is* observable through `ref.eq` on two `&T` operands, so the pass
-//! bails outright on a module containing any. Slot metadata joins the group key,
-//! nullability deciding codegen's `ref.as_non_null`, and an exported global is
-//! never merged away. Removal defers to `compact_globals`, a `Vec::retain` here
-//! shifting its position-keyed index set.
+//! promotes one apiece however many share a value: such a global has no
+//! observable identity, so each group of byte-identical init and slot metadata
+//! collapses to one. Identity *is* observable through `ref.eq`, so the pass
+//! bails on a module containing any, and an exported global never merges away.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::wir::{WirExportDesc, WirFuncId, WirInstr, WirPackage, WirType, WirTypeId};

--- a/wado-compiler/src/wir_optimize/dedupe_const_globals.rs
+++ b/wado-compiler/src/wir_optimize/dedupe_const_globals.rs
@@ -1,44 +1,14 @@
-//! Deduplicate identical immutable constant globals.
+//! Deduplicate identical immutable constant globals, which `const_global`
+//! promotes one apiece however many share a value. Such a global has no
+//! observable identity under Wado's value semantics — reads copy out, `==` is
+//! structural — so two with byte-identical inits and slot metadata are
+//! interchangeable, and each group collapses to one canonical global.
 //!
-//! `const_global` promotes each constant aggregate global to an eager,
-//! immutable Wasm constant — but identical const aggregates (two `[10, 20, 30]`
-//! hoisted by `const_object_globalization`, two equal user const globals, two
-//! `"hi"` short-string globals, duplicate Gale grammar tables, …) each get
-//! their own global. An immutable, const-expressible, value-typed global has no
-//! observable identity under Wado's value semantics — reads copy out and `==`
-//! is structural — so two with byte-identical inits and identical slot metadata
-//! are interchangeable. This pass merges each such group to one canonical
-//! global, rewrites every reference, and marks the rest dead.
-//!
-//! ## Soundness
-//!
-//! - **Reference identity.** The one way to observe that two equal-value
-//!   references are distinct objects is `==` on two `&T` operands, which the
-//!   elaborator lowers to `ref.eq` (`reify.rs`; `GlobalGet` of a value-typed
-//!   global is never itself a `ref.eq` operand, but `&GLOBAL` is). Tracing
-//!   which globals can reach a `ref.eq` through locals is flow-sensitive; since
-//!   `ref.eq` is absent from ordinary programs (it needs an explicit
-//!   `&a == &b`), the pass simply **bails entirely if the module contains any
-//!   `ref.eq`**. Conservative and cheap.
-//! - **Slot metadata.** Slot nullability decides whether codegen narrows a
-//!   `global.get` with `ref.as_non_null`, so two globals are merged only when
-//!   their `lazy_init`, `is`-nullable type, and `wado_mutable` all match —
-//!   folded into the group key alongside the structural `(ty, init)`.
-//! - **Exports.** An exported global is never merged away (its export names it).
-//!
-//! ## Removal
-//!
-//! Globals are removed by recording their indices in `dead_global_indices` —
-//! the same channel the `#![wasm_module]` extractor uses — so
-//! phase-8 `compact_globals` drops them in one pass. Removing them here with
-//! `Vec::retain` would shift indices out from under that position-keyed set and
-//! corrupt it; deferring keeps every index in one space. All references to a
-//! merged-away global (`GlobalGet`/`GlobalSet` in function bodies, global
-//! inits, and data/element segment offsets) are rewritten to the canonical
-//! first, so the dead globals are unreferenced when `compact_globals` runs.
-//!
-//! Runs in phase 7, right after `promote_const_global_inits` makes the
-//! candidates immutable.
+//! Identity *is* observable through `ref.eq` on two `&T` operands, so the pass
+//! bails outright on a module containing any. Slot metadata joins the group key,
+//! nullability deciding codegen's `ref.as_non_null`, and an exported global is
+//! never merged away. Removal defers to `compact_globals`, a `Vec::retain` here
+//! shifting its position-keyed index set.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::wir::{WirExportDesc, WirFuncId, WirInstr, WirPackage, WirType, WirTypeId};

--- a/wado-compiler/src/wir_optimize/elide_local.rs
+++ b/wado-compiler/src/wir_optimize/elide_local.rs
@@ -1,33 +1,8 @@
-//! Write-only local elimination pass for WIR.
-//!
-//! The TIR-level `optimize::elide_local` covers locals that originate at
-//! TIR (user `let`, SROA / variant-lowering shadow temps, etc.). It can't
-//! see locals that the WIR builder synthesises during lowering — match
-//! scrutinee temps (`__match_scrut_N`), multi-value temps, the
-//! `__pair_temp_N` pair Future / Stream `new` returns into, and so on —
-//! because those names don't exist at TIR. Once `wir_build` runs, those
-//! locals can become write-only when the surrounding lowering shape
-//! turns out not to need their value (e.g. every match arm has a
-//! wildcard / binding pattern, so nothing reads `__match_scrut_N`).
-//!
-//! This pass cleans those up after `wir_build`. For each `LocalSet(x,
-//! v)` whose `x` is never read in the function body — reads inside this
-//! store's own `v` don't count, so a self-referencing dead store
-//! `x = x + 1` with no other reads still elides — the assignment is
-//! rewritten:
-//!
-//! - `v` has no observable side effects → drop the whole `LocalSet`.
-//! - `v` has observable side effects → replace with `Drop(v)` so the
-//!   side effects still run, but the dead store is gone.
-//!
-//! Recurses to a fixed point so that eliding one write doesn't strand a
-//! second write that was only kept alive by a (now-eliminated) read of
-//! the first. The matching `DeclareLocal` is taken out by the
-//! subsequent `cleanup` pass.
-//!
-//! Locals that *are* read remain untouched — this pass deliberately does
-//! not subsume copy propagation or constant propagation; it's a narrow
-//! cleanup pass for write-only locals only.
+//! Write-only local elimination for the locals `wir_build` synthesises, whose
+//! names do not exist at TIR for `optimize::elide_local` to see. A
+//! `LocalSet(x, v)` whose `x` is never read elsewhere loses its store: the whole
+//! statement when `v` is side-effect-free, else a bare `Drop(v)`. Runs to a
+//! fixed point, since eliding one write can strand another.
 
 use crate::hashmap::IndexMap;
 use crate::wir::{WirInstr, WirPackage};
@@ -110,19 +85,11 @@ impl WirMutVisitor for ElideWriteOnly<'_> {
             self.changed = true;
             return;
         }
-        // `drop(side_effect_free_expr)` is dead — the dropped value is
-        // discarded by definition, so a sub-tree with no observable
-        // effect contributes nothing. Catches the
-        // `Expr(struct.new T { ... })` /
-        // `Expr(self.field)` shapes the TIR-level `elide_local` cannot
-        // remove in stmt position (those Exprs may have started life as
-        // `Expr(Call(...))` or labeled-block remnants of a
-        // `stores`-annotated call, and the TIR pass conservatively
-        // leaves them be — see the `stores_optimize_mixed_calls`
-        // regression test). At WIR level, every effect the call ever
-        // had is already in the WIR shape (`Call` / `LocalSet` /
-        // `StructSet` / ...), so a residual `Drop` whose sub-tree
-        // satisfies `is_side_effect_free` is genuinely dead.
+        // `drop(side_effect_free_expr)` is dead — the value is discarded by
+        // definition. Catches the statement-position `Expr(struct.new …)` /
+        // `Expr(self.field)` shapes the TIR pass leaves alone, not knowing what
+        // they were before lowering. At WIR level every effect a call had is
+        // already its own node, so a `is_side_effect_free` sub-tree is dead.
         if let WirInstr::Drop(value) = instr
             && is_side_effect_free(value)
             && !may_trap_in(value, self.null)

--- a/wado-compiler/src/wir_optimize/elide_struct.rs
+++ b/wado-compiler/src/wir_optimize/elide_struct.rs
@@ -1,16 +1,8 @@
-//! Box-local elimination passes for WIR.
-//!
-//! - **Adjacent-use box elision** (`elide_adjacent_box_locals`): substitutes a
-//!   single-field `StructNew` local's `inner` at its one `StructGet` use, even
-//!   for a heap-reading `inner`, sound because it moves `inner` only into a
-//!   single-use site whose preceding ops are all pure and unconditional. Targets
-//!   the `Box<T>` locals lowering mints for `&primitive` payload bindings
-//!   (`match r { Token(i) => f(*i) }`); these are born during NIR->WIR lowering
-//!   (`lower::plan::boxing`), so NIR's `elide_box_local` never sees them.
-//! - **Flatten seq assignments**: canonicalizes `LocalSet(x, Seq([preamble, final]))`.
-//!
-//! Struct locals NIR can see are decomposed there, by `sroa` / `sroa_param` /
-//! `elide_box_local`.
+//! Box-local elimination for WIR: `elide_adjacent_box_locals` substitutes a
+//! single-field `StructNew` local's `inner` at its one `StructGet` use — sound
+//! even for a heap-reading `inner`, the preceding ops all being pure and
+//! unconditional — targeting the `Box<T>` locals minted during NIR→WIR lowering,
+//! which NIR's own `elide_box_local` never sees.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::wir::{WirInstr, WirPackage};

--- a/wado-compiler/src/wir_optimize/nullable_ref.rs
+++ b/wado-compiler/src/wir_optimize/nullable_ref.rs
@@ -1,13 +1,8 @@
-//! `NullableRef` representation lowering for variant types.
-//!
-//! Rewrites a 2-case `{Unit, Payload(T)}` variant whose `T` is a non-nullable
-//! reference to a null-niche shape: unit case → `ref.null none`, payload case →
-//! the payload ref itself, no Wasm types emitted for the variant. Dropping the
-//! discriminant struct is a size win, but the pass is a mandatory lowering, not an
-//! optimization (see `optimize_wir`): the frontend already emits `None` as
-//! `ref.null`, so this makes the WIR type match.
-//!
-//! Runs before SROA and the optimization passes so they see the lowered types.
+//! `NullableRef` representation lowering: a 2-case `{Unit, Payload(T)}` variant
+//! over a non-nullable reference becomes a null niche — unit to `ref.null none`,
+//! payload to the ref itself, no Wasm types emitted. Dropping the discriminant
+//! struct is a size win, but this is mandatory lowering, not optimization: the
+//! frontend already emits `None` as `ref.null`. Runs before SROA.
 
 use crate::hashmap::IndexMap;
 use crate::wir::{WirAbstractHeapType, WirInstr, WirPackage, WirType, WirTypeDef, WirVariantRepr};

--- a/wado-compiler/src/wir_optimize/peephole.rs
+++ b/wado-compiler/src/wir_optimize/peephole.rs
@@ -1,17 +1,9 @@
-//! Peephole optimization pass for WIR.
-//!
-//! Per-function pass that applies local rewrites:
-//! - Constant folding on integer comparisons
-//! - Dead `If` elimination (constant condition)
-//! - Redundant `ValueCopy` elision
-//! - Copy-used-only-for-field-reads elision
-//! - Sign-extension folding into loads / mask elision
-//! - Redundant `ref.cast` / `ref.test` elimination
-//! - `local.set` + first `local.get` fusion into `local.tee`
-//!
-//! These are Wasm-instruction-selection-level rewrites that have no NIR
-//! analogue (`local.tee`, the signed-load variants, `ref.cast` redundancy
-//! against the WIR static type), so they only make sense after lowering.
+//! Per-function peephole rewrites for WIR: constant folding on comparisons,
+//! dead `If` and redundant `ValueCopy` elision, sign-extension folding into
+//! loads, redundant `ref.cast` / `ref.test` removal, and `local.set` +
+//! `local.get` fusion into `local.tee`. All are instruction-selection-level and
+//! have no NIR analogue — `local.tee`, the signed loads, and cast redundancy
+//! against the WIR static type only exist after lowering.
 
 use crate::wir::{WirInstr, WirPackage, WirType, WirTypeDef, WirTypeId};
 use crate::wir_optimize::nullability::Nullability;
@@ -55,25 +47,13 @@ fn is_immediate_const(instr: &WirInstr) -> bool {
     )
 }
 
-/// Propagate trivial copies (`alias = source`) and constant bindings
-/// (`alias = 0`) across a function: every use of `alias` is replaced, then the
-/// now-dead definition is deleted.
-///
-/// A copy `LocalSet { alias, LocalGet { source } }` is propagated when:
-/// - `alias` is single-def: this copy is its only `LocalSet`, it is never
-///   `LocalTee`'d, and it is not a parameter. Every read of `alias` therefore
-///   observes the value written by this copy.
-/// - `source` has at most one definition and is never `LocalTee`'d, and that
-///   definition (if any) structurally dominates the copy — or `source` is a
-///   parameter. Together this means `source` is never rewritten between the
-///   copy and the alias uses, so it is invariant over that span.
-/// - the copy dominates every use of `alias` (checked structurally over the
-///   WIR control flow), so no use can observe `alias`'s zero-initialized value
-///   before the copy runs.
-///
-/// Under those conditions `alias == source` holds at every use of `alias`, so
-/// the substitution is sound. Running before SROA also lets variant SROA see
-/// direct RefTest/RefCast patterns on the original local.
+/// Propagate trivial copies and constant bindings across a function, replacing
+/// every use of `alias` and deleting the dead definition. Sound when `alias` is
+/// single-def and never tee'd, `source` is invariant over the span (at most one
+/// definition, dominating the copy, or a parameter), and the copy dominates
+/// every use — so no read observes the zero-initialized value. Together these
+/// give `alias == source` at every use. Running before SROA also lets variant
+/// SROA see `RefTest` / `RefCast` on the original local.
 pub(super) fn propagate_trivial_copies(module: &mut WirPackage) {
     for func in &mut module.functions {
         let Some(body) = &mut func.body else {
@@ -193,23 +173,12 @@ impl WirRefVisitor for CopyCollector<'_> {
     }
 }
 
-/// Structural dominance check: walks the function in execution order tracking,
-/// per scope, which locals have had a definition executed. It enforces two
-/// conditions per candidate copy `alias = source`:
-///
-/// - the copy dominates every use of `alias` — a `LocalGet alias` reached
-///   before the copy disqualifies `alias`, so no use observes the alias's
-///   zero-initialized value;
-/// - `source` is invariant from the copy onward — its definition must already
-///   dominate the copy (or `source` is a parameter / never defined). Combined
-///   with `source` having at most one definition (checked by `CopyCollector`),
-///   this guarantees `source` is not rewritten between the copy and the alias
-///   uses, so `alias == source` holds at every use.
-///
-/// `defined` is threaded by value into conditional and looping scopes
-/// (`Block` / `Loop` / `If` branches) so a definition inside one of them does
-/// not count as executed on paths that skip it. `Seq` is unconditional
-/// straight-line code, so definitions inside it leak to the enclosing scope.
+/// Structural dominance check for [`propagate_trivial_copies`]: walks in
+/// execution order tracking which locals have a definition executed per scope,
+/// disqualifying a copy whose `alias` is read before it or whose `source` is not
+/// already dominated. `defined` is threaded by value into conditional and looping
+/// scopes, so a definition inside one does not count on paths that skip it;
+/// `Seq` is straight-line, so its definitions leak to the enclosing scope.
 fn check_dominance_in_body(
     body: &[WirInstr],
     candidates: &IndexMap<String, CopySource>,
@@ -394,21 +363,13 @@ fn apply_in_instr(instr: &mut WirInstr, subst: &IndexMap<String, CopySource>) {
     }
 }
 
-/// Run the peephole rewrites over one function body to a fixed point.
-///
-/// Each sub-pass is one whole-tree post-order sweep (children fold before
-/// their parents within a sweep), and the sub-pass sequence loops until no
-/// sweep changes anything: one rewrite routinely enables another across
-/// sub-pass boundaries — e.g. `try_simplify_ref_op` folding a `RefTest`
-/// condition to a constant hands `try_eliminate_const_if` a dead branch.
-/// Usually quiescent after 2 rounds; a defensive cap guards against a
-/// pathological rewrite cycle.
-///
-/// Value-copy elision is a single whole-function pass (see
-/// `elide_value_copies_whole_function`) rather than per-scope, because safe
-/// elision requires knowing every trailing instruction reachable after the
-/// copy — including those in enclosing scopes — and recursive per-scope calls
-/// cannot observe them.
+/// Run the peephole rewrites over one function body to a fixed point. Each
+/// sub-pass is a whole-tree post-order sweep, and the sequence loops until
+/// nothing changes: one rewrite routinely enables another across sub-pass
+/// boundaries, as folding a `RefTest` to a constant hands the next a dead
+/// branch. Usually quiescent after two rounds, with a defensive cap. Value-copy
+/// elision runs whole-function instead of per-scope, since it must see every
+/// trailing instruction reachable after the copy, enclosing scopes included.
 pub(super) fn run_peephole(instrs: &mut [WirInstr], null: &Nullability, _types: &[WirTypeDef]) {
     const MAX_ROUNDS: u32 = 8;
     let mut rounds = 0;
@@ -904,18 +865,11 @@ fn is_boolean_valued(instr: &WirInstr) -> bool {
     )
 }
 
-/// Fold integer sign-extension instructions into a cheaper equivalent.
-///
-/// All of these are pure Wasm-instruction-selection rewrites:
-/// - `i32.extend8_s(i32.load8_u a)` → `i32.load8_s a` (and the 16-bit variant);
-///   the unsigned load + explicit sign-extend collapses into the signed load.
-/// - `i32.extend8_s(i32.load8_s a)` → `i32.load8_s a`; re-extending an already
-///   sign-extended byte is a no-op (idempotent).
-/// - `i32.extend8_s(x & mask)` → `i32.extend8_s(x)` when `mask`'s low 8 bits are
-///   all set; `extend8_s` only inspects the low byte, so the mask is dead.
-/// - `i32.extend8_s(i32.extend8_s x)` → `i32.extend8_s x` (idempotent), and
-///   `i32.extend16_s(i32.extend8_s x)` → `i32.extend8_s x` (the 8-bit result
-///   already fits the 16-bit signed range).
+/// Fold an integer sign-extension into a cheaper equivalent: over an unsigned
+/// load it collapses into the signed load, over an already-extended value it is
+/// idempotent (as is a wider extension over a narrower one, whose result already
+/// fits), and over a mask whose low bits are all set the mask is dead, since the
+/// extension inspects only those bits.
 fn try_fold_sign_extension(instr: &mut WirInstr) -> bool {
     // The width (in bits) this sign extension reads from: 8 or 16.
     let width = match instr {
@@ -1025,17 +979,12 @@ fn static_ref_type(instr: &WirInstr) -> Option<(WirTypeId, bool)> {
     }
 }
 
-/// Eliminate a redundant `ref.cast` / `ref.test` against the WIR static type.
-///
-/// - `ref.cast $T(expr)` where `expr` is statically a `$T` reference is the
-///   identity. It collapses to `expr`, or to `ref.as_non_null(expr)` when the
-///   cast asserts non-null but the source type is nullable.
-/// - `ref.test $T(expr)` where `expr` is statically a `$T` reference and the
-///   test cannot fail (the source is non-null, or the test accepts null) folds
-///   to `1`, provided dropping `expr`'s evaluation is observably safe.
-///
-/// Only exact `type_id` matches are recognised; supertype/subtype narrowing
-/// (the shape variant pattern matching emits) is deliberately left untouched.
+/// Eliminate a `ref.cast` / `ref.test` made redundant by the WIR static type. A
+/// cast to a type the operand already has is the identity, collapsing to the
+/// operand or to `ref.as_non_null` where it asserts non-null over a nullable
+/// source; a test that cannot fail folds to `1`, provided dropping the operand's
+/// evaluation is observably safe. Only exact `type_id` matches count —
+/// supertype narrowing, which variant pattern matching emits, is left alone.
 fn try_simplify_ref_op(instr: &mut WirInstr, null: &Nullability) -> bool {
     match instr {
         WirInstr::RefCast {
@@ -1099,23 +1048,13 @@ fn fuse_local_tees(instrs: &mut [WirInstr]) -> bool {
     fuser.changed | fuse_local_tee(instrs)
 }
 
-/// Fuse a `local.set` with the first subsequent `local.get` of the same local
-/// into a single `local.tee`.
-///
-/// When a statement `local.set $x (v)` is followed — skipping `Nop`s minted by
-/// earlier sub-passes — by a statement whose first-evaluated leaf is
-/// `local.get $x`, the pair `(local.set $x v) … (local.get $x …)` collapses to
-/// `(local.tee $x v) …`, dropping one `local.get`. The set value `v` is
-/// evaluated at the tee site, which is the first thing the consumer statement
-/// runs — so nothing executes between the old set and the moved evaluation and
-/// the order is preserved. The emptied `local.set` becomes a `Nop`, which the
-/// phase-7 `cleanup` removes.
-///
-/// Restricted to non-reference locals so the tee never interacts with codegen's
-/// `ref.as_non_null`-on-`local.tee` narrowing for `ref_locals`. Descent into the
-/// consumer stops at control flow (`Block`/`Loop`/`If`/`Seq`/`Br*`/`Select`):
-/// these either evaluate their first child conditionally / repeatedly, or list
-/// their operands in an order that does not match Wasm's evaluation order.
+/// Fuse a `local.set` with the next statement's first-evaluated `local.get` of
+/// the same local into one `local.tee`, dropping the read. Order is preserved:
+/// the set value moves to the tee site, which is the first thing the consumer
+/// runs, so nothing executes in between. The emptied set becomes a `Nop` for
+/// `cleanup`. Restricted to non-reference locals, away from codegen's
+/// `ref.as_non_null`-on-tee narrowing, and descent stops at control flow, which
+/// evaluates its first child conditionally or in a different order.
 fn fuse_local_tee(instrs: &mut [WirInstr]) -> bool {
     let mut changed = false;
     for i in 0..instrs.len() {

--- a/wado-compiler/src/wir_optimize/peephole.rs
+++ b/wado-compiler/src/wir_optimize/peephole.rs
@@ -2,8 +2,7 @@
 //! dead `If` and redundant `ValueCopy` elision, sign-extension folding into
 //! loads, redundant `ref.cast` / `ref.test` removal, and `local.set` +
 //! `local.get` fusion into `local.tee`. All are instruction-selection-level and
-//! have no NIR analogue — `local.tee`, the signed loads, and cast redundancy
-//! against the WIR static type only exist after lowering.
+//! have no NIR analogue, the shapes they match existing only after lowering.
 
 use crate::wir::{WirInstr, WirPackage, WirType, WirTypeDef, WirTypeId};
 use crate::wir_optimize::nullability::Nullability;
@@ -49,11 +48,9 @@ fn is_immediate_const(instr: &WirInstr) -> bool {
 
 /// Propagate trivial copies and constant bindings across a function, replacing
 /// every use of `alias` and deleting the dead definition. Sound when `alias` is
-/// single-def and never tee'd, `source` is invariant over the span (at most one
-/// definition, dominating the copy, or a parameter), and the copy dominates
-/// every use — so no read observes the zero-initialized value. Together these
-/// give `alias == source` at every use. Running before SROA also lets variant
-/// SROA see `RefTest` / `RefCast` on the original local.
+/// single-def and never tee'd, `source` is invariant over the span, and the copy
+/// dominates every use — together giving `alias == source` everywhere. Running
+/// before SROA also lets variant SROA see casts on the original local.
 pub(super) fn propagate_trivial_copies(module: &mut WirPackage) {
     for func in &mut module.functions {
         let Some(body) = &mut func.body else {
@@ -177,8 +174,7 @@ impl WirRefVisitor for CopyCollector<'_> {
 /// execution order tracking which locals have a definition executed per scope,
 /// disqualifying a copy whose `alias` is read before it or whose `source` is not
 /// already dominated. `defined` is threaded by value into conditional and looping
-/// scopes, so a definition inside one does not count on paths that skip it;
-/// `Seq` is straight-line, so its definitions leak to the enclosing scope.
+/// scopes; `Seq` is straight-line, so its definitions leak to the enclosing one.
 fn check_dominance_in_body(
     body: &[WirInstr],
     candidates: &IndexMap<String, CopySource>,
@@ -365,10 +361,8 @@ fn apply_in_instr(instr: &mut WirInstr, subst: &IndexMap<String, CopySource>) {
 
 /// Run the peephole rewrites over one function body to a fixed point. Each
 /// sub-pass is a whole-tree post-order sweep, and the sequence loops until
-/// nothing changes: one rewrite routinely enables another across sub-pass
-/// boundaries, as folding a `RefTest` to a constant hands the next a dead
-/// branch. Usually quiescent after two rounds, with a defensive cap. Value-copy
-/// elision runs whole-function instead of per-scope, since it must see every
+/// nothing changes: folding a `RefTest` to a constant hands the next sub-pass a
+/// dead branch. Value-copy elision runs whole-function, needing to see every
 /// trailing instruction reachable after the copy, enclosing scopes included.
 pub(super) fn run_peephole(instrs: &mut [WirInstr], null: &Nullability, _types: &[WirTypeDef]) {
     const MAX_ROUNDS: u32 = 8;
@@ -981,10 +975,9 @@ fn static_ref_type(instr: &WirInstr) -> Option<(WirTypeId, bool)> {
 
 /// Eliminate a `ref.cast` / `ref.test` made redundant by the WIR static type. A
 /// cast to a type the operand already has is the identity, collapsing to the
-/// operand or to `ref.as_non_null` where it asserts non-null over a nullable
-/// source; a test that cannot fail folds to `1`, provided dropping the operand's
-/// evaluation is observably safe. Only exact `type_id` matches count —
-/// supertype narrowing, which variant pattern matching emits, is left alone.
+/// operand or to `ref.as_non_null` over a nullable source; a test that cannot
+/// fail folds to `1`, if dropping the operand is observably safe. Only exact
+/// `type_id` matches count — supertype narrowing is left alone.
 fn try_simplify_ref_op(instr: &mut WirInstr, null: &Nullability) -> bool {
     match instr {
         WirInstr::RefCast {
@@ -1050,11 +1043,9 @@ fn fuse_local_tees(instrs: &mut [WirInstr]) -> bool {
 
 /// Fuse a `local.set` with the next statement's first-evaluated `local.get` of
 /// the same local into one `local.tee`, dropping the read. Order is preserved:
-/// the set value moves to the tee site, which is the first thing the consumer
-/// runs, so nothing executes in between. The emptied set becomes a `Nop` for
-/// `cleanup`. Restricted to non-reference locals, away from codegen's
-/// `ref.as_non_null`-on-tee narrowing, and descent stops at control flow, which
-/// evaluates its first child conditionally or in a different order.
+/// the set value moves to the tee site, the first thing the consumer runs.
+/// Restricted to non-reference locals, away from codegen's `ref.as_non_null`
+/// narrowing, and descent stops at control flow.
 fn fuse_local_tee(instrs: &mut [WirInstr]) -> bool {
     let mut changed = false;
     for i in 0..instrs.len() {

--- a/wado-compiler/src/wir_optimize/prune_dead_data.rs
+++ b/wado-compiler/src/wir_optimize/prune_dead_data.rs
@@ -1,14 +1,8 @@
-//! Removes passive data segments with no surviving `array.new_data` reference.
-//!
-//! `register_literal_data` conservatively registers a segment for every
-//! string/bytes literal whose payload exceeds `string_inline_max_bytes`,
-//! before later per-occurrence decisions (a bounded force-eager override for
-//! `const_object_globalization`-hoisted globals, dead-store elimination in
-//! `promote_const_global_inits`) settle whether any occurrence of that
-//! payload actually ends up reading the segment. A payload that ends up
-//! wholly represented via `array.new_fixed` leaves its registered segment
-//! referenced by nothing. This pass finds those and drops them, then
-//! compacts and remaps the surviving `data_index`s.
+//! Remove passive data segments with no surviving `array.new_data` reference.
+//! `register_literal_data` registers one per over-long literal payload before
+//! the later per-occurrence decisions settle whether anything reads it, so a
+//! payload that ends up wholly `array.new_fixed` leaves its segment orphaned.
+//! This drops those, then compacts and remaps the surviving `data_index`es.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::wir::{WirInstr, WirPackage};

--- a/wado-compiler/src/wir_optimize/sroa_variant_return.rs
+++ b/wado-compiler/src/wir_optimize/sroa_variant_return.rs
@@ -1,16 +1,8 @@
-//! Nested result-slot flattening for variant returns.
-//!
-//! Widening a variant return into `[i32 disc, payload…]` happens at NIR
-//! (`optimize::sroa_variant_return`, feeding `optimize::multi_value_return`).
-//! What stays here is the one step that needs WIR shapes: splitting a `ref W`
-//! *result slot* whose `W` is itself a small variant — the `Ok(ref Option<T>)`
-//! a widening leaves boxed.
-//!
-//! The split is decidable only after lowering. Its gates read how each call
-//! site consumes the slot and whether every return decomposes, neither of which
-//! NIR can see; a NIR analogue was measured and cost more than it recovered
-//! (`docs/wep-2026-08-03-variant-return-abi.md`). So the NIR pass declines the
-//! shape and this reaches it instead.
+//! Nested result-slot flattening for variant returns. Widening one into
+//! `[i32 disc, payload…]` happens at NIR; what stays here is the step needing
+//! WIR shapes — splitting a `ref W` *result slot* whose `W` is itself a small
+//! variant, the `Ok(ref Option<T>)` a widening leaves boxed. Its gates read
+//! shapes NIR cannot see (WEP 2026-08-03).
 
 use crate::compiler_trace;
 use crate::wir::WirPackage;

--- a/wado-compiler/src/wir_optimize/sroa_variant_return/access.rs
+++ b/wado-compiler/src/wir_optimize/sroa_variant_return/access.rs
@@ -350,19 +350,11 @@ pub(super) fn replace_variant_accesses(
     });
 }
 
-/// Check that every reference to `local_name` is a shape the call-site
-/// rewriter (`replace_variant_accesses` / `collect_refcast_aliases`)
-/// replaces:
-/// - `RefTest { type_id ∈ case_types, expr: LocalGet(name) }` — discriminant test
-/// - `StructGet { expr: RefCast { type_id ∈ case_types, expr: LocalGet(name) } }` — payload access
-/// - `LocalSet(alias, RefCast { type_id ∈ case_types, expr: LocalGet(name) })` —
-///   cast-alias binding, provided the alias is single-def and read only via
-///   `StructGet(LocalGet(alias))`.
-///
-/// The type-id constraint matters: the rewriter's `case_disc_values` /
-/// `field_to_local` maps are keyed by the candidate's payload-bearing case
-/// types, so an access naming any other type would survive the rewrite and
-/// read the deleted temp.
+/// Check that every reference to `local_name` is a shape the call-site rewriter
+/// replaces: a `RefTest` discriminant test, a `StructGet` payload access through
+/// a `RefCast`, or a cast-alias `LocalSet` whose alias is single-def and read
+/// only through `StructGet`. The `type_id ∈ case_types` constraint matters: an
+/// access naming any other type survives the rewrite and reads a deleted temp.
 pub(super) fn all_uses_are_variant_access(
     instrs: &[WirInstr],
     local_name: &str,

--- a/wado-compiler/src/wir_optimize/sroa_variant_return/slot_flatten.rs
+++ b/wado-compiler/src/wir_optimize/sroa_variant_return/slot_flatten.rs
@@ -1,26 +1,8 @@
-//! Nested variant-slot flattening.
-//!
-//! Single-level SROA turns `next_element<i64>` into a function returning the
-//! multi-value vector `[outer_disc, ref Option<i64>, ref Err]`. A `ref W` result
-//! slot whose `W` is itself a small variant is still heap-boxed at every return
-//! (`struct.new W::Case`) and immediately matched at every call site. This phase
-//! splits such a slot into `W`'s own multi-value layout `[inner_disc,
-//! payloads...]` (via [`compute_variant_layout`], the same layout engine
-//! single-level SROA uses), removing the per-element inner allocation — the
-//! dominant cost when deserializing arrays of scalars.
-//!
-//! This generalizes the layout analysis recursively: the inner `W` may be any
-//! eligible `SubtypeHierarchy` variant (`Result`, a multi-case variant, an
-//! `Option<(scalar, scalar)>`), not just `Option<scalar>`. Only `Option<&T>`
-//! null-niche variants (already unboxed, no discriminant field) are out of
-//! scope.
-//!
-//! Bail-everywhere: a slot is expanded only when every return of the function
-//! decomposes structurally and every call site's slot local is consumed solely
-//! via variant access — either directly, or through the lowered `?`-unwrap
-//! `local = if Ok { payload } else { return Err }` (whose then-arm copies the
-//! slot out and whose else-arm diverges). Any other shape leaves the slot at its
-//! single-level (boxed) form, which is already correct.
+//! Nested variant-slot flattening. Single-level SROA leaves a `ref W` result
+//! slot heap-boxed at every return when `W` is itself a small variant; this
+//! phase splits it into `W`'s own `[inner_disc, payloads...]` layout via
+//! [`compute_variant_layout`]. Bail-everywhere: expanded only when every return
+//! decomposes and every slot local is consumed solely via variant access.
 
 use crate::hashmap::{IndexMap, IndexSet};
 use crate::wir::{
@@ -70,18 +52,10 @@ fn slot_variant_layout(module: &WirPackage, slot_ty: &WirType) -> Option<(u32, V
 }
 
 /// Build the all-default result vector for `cand`'s inner variant — used when a
-/// return leaves the slot unused (a null ref, e.g. an `Err` return).
-///
-/// These locals are dead on this path: a read of the inner slot is dominated by
-/// the outer discriminant check that selects this case (the inner match is
-/// lowered inside the outer `Ok` arm), so the outer case not being taken means
-/// the inner match is never reached. To avoid relying on that invariant for
-/// soundness, the discriminant is chosen to match *no* payload-bearing case —
-/// the unit case's value when one exists, else an out-of-range sentinel (the
-/// case count). The only slot reads `classify_slot_consumer` admits lower to
-/// `inner_disc == case_disc`, so were one to execute against this default it
-/// would correctly miss every case (as `ref.test` on the old boxed null did)
-/// rather than spuriously match case 0.
+/// return leaves the slot unused (a null ref, e.g. an `Err` return). Rather than
+/// rely on those locals being dead, the discriminant is chosen to match *no*
+/// payload-bearing case: the unit case's value if one exists, else the case
+/// count. An admitted read then misses every case, as `ref.test` on null did.
 fn default_variant_vector(cand: &SlotFlattenCand) -> Vec<WirInstr> {
     let vi = &cand.layout.variant_info;
     let disc = vi
@@ -227,14 +201,9 @@ enum SlotConsumer {
 
 /// True when a `?`-unwrap then-arm is *exactly* the slot copied out — either
 /// `[<slot extraction>]` or `[LocalSet(t, <slot extraction>), LocalGet(t)]`,
-/// where `<slot extraction>` is `LocalGet(slot)` under zero or more
-/// `RefAsNonNull` wrappers. `rewrite_unwrap_to_guard` discards the whole
-/// then-arm, so anything richer (a side-effecting prefix statement, a branch, a
-/// second definition of the temp) must be rejected or a needed statement would
-/// be silently dropped. For the two-statement form the copy temp `t` must
-/// have no reads outside the discarded pair (`def_use.get_count(t) == 1` —
-/// the pair's own `LocalGet`): a read elsewhere would observe a local whose
-/// only definition was dropped.
+/// where `<slot extraction>` is `LocalGet(slot)` under `RefAsNonNull` wrappers.
+/// `rewrite_unwrap_to_guard` discards the whole then-arm, so anything richer is
+/// rejected, and `t` must have no reads outside the discarded pair.
 fn then_is_pure_slot_copy(then_body: &[WirInstr], slot_local: &str, def_use: &LocalDefUse) -> bool {
     fn is_slot_extraction(e: &WirInstr, slot: &str) -> bool {
         match e {
@@ -305,18 +274,10 @@ fn find_unwrap_alias(body: &[WirInstr], slot_local: &str, def_use: &LocalDefUse)
 }
 
 /// Classify the consumer of `slot_local` in `body`, or `None` if not cleanly
-/// rewritable. `case_types` is the inner variant's payload-bearing case set
-/// (the only type the nested rewrite's `VariantReplacement` maps carry).
-///
-/// This is a *structural* consumer check: it verifies every use of the slot is a
-/// payload-case `ref.test` / `ref.cast` (directly or through the `?`-unwrap
-/// alias), not that those reads are dominated by the outer discriminant guard
-/// that guarantees the slot was materialized. Correctness does not hinge on that
-/// dominance: on a path where the slot is absent it decodes via
-/// [`default_variant_vector`] to a discriminant matching no payload case, so an
-/// accepted read misses every case exactly as `ref.test` on the old boxed null
-/// did. A use naming a *unit* case is rejected here (its struct type is not in
-/// `case_types`), so the flattened form only ever answers payload-case tests.
+/// rewritable. A *structural* check: every use must be a payload-case
+/// `ref.test` / `ref.cast`, directly or through the `?`-unwrap alias. Dominance
+/// is not required — an absent slot decodes via [`default_variant_vector`] to a
+/// discriminant matching no payload case. `case_types` excludes unit cases.
 fn classify_slot_consumer(
     body: &[WirInstr],
     slot_local: &str,

--- a/wado-compiler/src/wir_optimize/sroa_variant_return/wrapper.rs
+++ b/wado-compiler/src/wir_optimize/sroa_variant_return/wrapper.rs
@@ -4,20 +4,10 @@
 use crate::wir::WirInstr;
 
 /// Resolve the value-producing leaf of a call-site RHS through `Block` / `Seq`
-/// wrappers, verifying that stripping the wrappers is sound.
-///
-/// Soundness of stripping requires:
-/// - No prefix statement may branch to *any* `Block` frame being stripped
-///   — not just the innermost one: a `BrIf { depth: 1 }` in a nested
-///   block's prefix targeting the outer block would dangle once both
-///   wrappers are removed.
-/// - A break-with-value `Br` must target the block it exits (`depth == 0`);
-///   a deeper target carries the value elsewhere.
-/// - A trailing `Unreachable` after a break-with-value (appended by
-///   `translate_stmts_as_value` so the Wasm validator sees no fallthrough
-///   value) is dead code — skipped in `Block` bodies only; a `Seq` has no
-///   such emitter convention, so its trailing `Unreachable` means "then
-///   trap" and blocks unwrapping.
+/// wrappers, verifying the strip is sound: no prefix statement may branch to
+/// *any* stripped frame, not just the innermost, or the branch dangles; a
+/// break-with-value must target the block it exits. A trailing `Unreachable` is
+/// the emitter's dead filler in a `Block`, but means "then trap" in a `Seq`.
 fn resolve_wrapped_result(instr: &WirInstr, stripped_blocks: u32) -> Option<&WirInstr> {
     match instr {
         WirInstr::Seq(body) => {

--- a/wado-compiler/src/wir_optimize/util.rs
+++ b/wado-compiler/src/wir_optimize/util.rs
@@ -168,19 +168,11 @@ pub(super) fn is_root_observable(instr: &WirInstr) -> bool {
     )
 }
 
-/// True if `instr` (or any descendant) can trap at runtime on some inputs.
-///
-/// Used to keep `Drop(value)` instructions whose `value` is otherwise
-/// `is_side_effect_free` but would trap on certain inputs — the Wado
-/// language requires those traps to be observable even when the read
-/// value is discarded (`let _ = arr[-1]` must trap). Distinct from
-/// [`is_root_observable`] which the WIR optimizer deliberately keeps lax
-/// to enable CSE / dead-load elimination of trapping operations whose
-/// result IS used.
-///
-/// A receiver's nullability comes from the [`Nullability`] oracle, not the read
-/// site's `result_ty` (inlining can leave that stale-nullable). Rewriting
-/// `result_ty` instead would cost a codegen `ref.as_non_null` per read.
+/// True if `instr` or any descendant can trap at runtime, which keeps a
+/// `Drop(value)` whose value is otherwise side-effect-free: Wado requires the
+/// trap of `let _ = arr[-1]` to be observable. Distinct from
+/// [`is_root_observable`], kept lax so CSE can still touch a trapping operation
+/// whose result *is* used. Nullability comes from the [`Nullability`] oracle.
 pub(super) fn may_trap_in(instr: &WirInstr, null: &Nullability) -> bool {
     // Operand-dependent: `ref.as_non_null(inner)` only traps when `inner`
     // could itself produce null.

--- a/wado-compiler/src/wit_bundle.rs
+++ b/wado-compiler/src/wit_bundle.rs
@@ -1,19 +1,8 @@
-//! Embed a `component-type` custom section into a compiled component.
-//!
-//! Producer-side embedding step of WIT interoperability (WEP
-//! `wep-2026-05-02-wit-interoperability.md`). [`wit_emit`](crate::wit_emit)
-//! renders the WIT *text*; this module encodes it to the binary `component-type`
-//! section and appends it to the component codegen emitted.
-//!
-//! The section is *additive*: a Wado artifact is already a self-describing
-//! component, so `wasm-tools component wit` (`wit_parser::decode`) recovers WIT
-//! from the component's own types and does not read this section (it consults a
-//! `component-type` payload only for a WIT-package blob / core module). The
-//! section's value is full fidelity — the component's own type is tree-shaken to
-//! the used surface, whereas the encoded payload carries the complete upstream
-//! interfaces, exact versions, and a `producers` record (the
-//! `wit_component::metadata::encode` convention `wkg` / `wasm-tools metadata`
-//! consume).
+//! Embed a `component-type` custom section into a compiled component — the
+//! producer side of WIT interoperability (WEP 2026-05-02), encoding the text
+//! [`wit_emit`](crate::wit_emit) renders. Purely additive: a Wado artifact
+//! already self-describes. The section's value is fidelity, carrying the
+//! complete upstream interfaces where the component's own type is tree-shaken.
 
 use std::borrow::Cow;
 
@@ -24,17 +13,10 @@ use crate::semantics::Semantics;
 use crate::wit_emit::{self, WitEmitError, WitEmitInput, WitEmitOptions, WitScope};
 
 /// Append a `component-type` custom section to `component_bytes`, derived from
-/// the WIT text [`wit_emit::emit_wit_text`] renders for `sem` under `opts`.
-///
-/// The embedded section is always self-contained: `metadata::encode` types the
-/// world against a fully-resolved [`wit_parser::Resolve`], which requires every
-/// referenced upstream package's body to be present. `opts.scope` is therefore
-/// ignored here and the full interface closure is always emitted — a `local`
-/// (registry-referencing) document does not re-parse standalone. `local` scope
-/// remains meaningful only for `wado wit` *text*. The returned bytes are the
-/// original component with one extra custom section — the component's own type
-/// structure (what `wasm-tools component wit` reads) is untouched, so the
-/// artifact still decodes as a `Component`.
+/// the WIT text [`wit_emit::emit_wit_text`] renders for `sem`. The section is
+/// always self-contained — `metadata::encode` needs a fully-resolved
+/// `Resolve` — so `opts.scope` is ignored and the whole interface closure is
+/// emitted. The component's own type structure is untouched.
 pub fn embed_component_type(
     component_bytes: &[u8],
     sem: &Semantics,

--- a/wado-compiler/src/wit_bundle.rs
+++ b/wado-compiler/src/wit_bundle.rs
@@ -1,6 +1,6 @@
 //! Embed a `component-type` custom section into a compiled component — the
 //! producer side of WIT interoperability (WEP 2026-05-02), encoding the text
-//! [`wit_emit`](crate::wit_emit) renders. Purely additive: a Wado artifact
+//! [`crate::wit_emit`] renders. Purely additive: a Wado artifact
 //! already self-describes. The section's value is fidelity, carrying the
 //! complete upstream interfaces where the component's own type is tree-shaken.
 

--- a/wado-compiler/src/wit_emit.rs
+++ b/wado-compiler/src/wit_emit.rs
@@ -1,9 +1,8 @@
 //! WIT text emission from [`Semantics`] — the producer side of WIT
 //! interoperability (WEP 2026-05-02), rendering the frontend's interfaces,
 //! exports, world and type table through [`wit_encoder`]. `wado wit` prints it;
-//! `wado compile` embeds it via [`crate::wit_bundle`]. Name and type resolution
-//! fully determine WIT, so emission reads a [`WitEmitInput`] view and never
-//! touches monomorphize, lower or codegen.
+//! `wado compile` embeds it via [`crate::wit_bundle`]. Reads a [`WitEmitInput`]
+//! view, so it never touches monomorphize, lower or codegen.
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/wado-compiler/src/wit_emit.rs
+++ b/wado-compiler/src/wit_emit.rs
@@ -1,15 +1,9 @@
-//! WIT text emission from [`Semantics`].
-//!
-//! This is the producer side of WIT interoperability (WEP
-//! `wep-2026-05-02-wit-interoperability.md`). It takes the frontend
-//! output — declared interfaces, exported items, the active world, and the
-//! type table — and renders a WIT document with [`wit_encoder`].
-//!
-//! `wado wit` prints the text; `wado compile` embeds it as a `component-type`
-//! custom section (see [`crate::wit_bundle`]). WIT is fully determined by name
-//! and type resolution, so emission reads a [`WitEmitInput`] view — over a live
-//! [`Semantics`] or a detached [`WitEmitSnapshot`] — and never touches
-//! monomorphize / lower / codegen.
+//! WIT text emission from [`Semantics`] — the producer side of WIT
+//! interoperability (WEP 2026-05-02), rendering the frontend's interfaces,
+//! exports, world and type table through [`wit_encoder`]. `wado wit` prints it;
+//! `wado compile` embeds it via [`crate::wit_bundle`]. Name and type resolution
+//! fully determine WIT, so emission reads a [`WitEmitInput`] view and never
+//! touches monomorphize, lower or codegen.
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -160,16 +160,11 @@ impl WorldInfo {
         })
     }
 
-    /// The CM package segment of this world's fully-qualified name.
-    ///
-    /// `wasi:http/service` → `"http"`, `core:kiln/generator` → `"kiln"`.
-    /// Returns an empty slice when `fq_name` has no scheme/package
-    /// structure (e.g. the built-in synthetic `test` world).
-    ///
-    /// This is a computed accessor, not a stored field — `fq_name` is the
-    /// single source of truth. Use [`Self::namespace_prefix`] when the
-    /// caller needs a `starts_with`-friendly form that also pins the
-    /// scheme.
+    /// The CM package segment of this world's fully-qualified name:
+    /// `wasi:http/service` → `"http"`. Empty when `fq_name` has no
+    /// scheme/package structure, as the synthetic `test` world does not. For a
+    /// `starts_with`-friendly form that pins the scheme, use
+    /// [`Self::namespace_prefix`].
     pub fn package(&self) -> &str {
         fq_name_package(&self.fq_name)
     }
@@ -262,26 +257,11 @@ impl WorldRegistry {
         Self::default()
     }
 
-    /// Register a world from a parsed world declaration.
-    ///
-    /// The world is keyed by its fully-qualified name from the `#[cm("...")]` attribute.
-    /// If no attribute is present, the `PascalCase` name is used as fallback.
-    ///
-    /// `lookup_interface_export` resolves an `export Foo;` interface reference
-    /// to the interface's CM FQ and methods. Interface exports for which the
-    /// callback returns `None` are silently skipped (the world will be
-    /// registered without that export); this happens when the referenced
-    /// interface declaration is not yet known.
-    ///
-    /// `lookup_interface_import` is the analogous elaborator for `import Foo;`
-    /// and only needs to surface the CM FQ (the methods are tree-shaken from
-    /// usage). Returning `None` leaves `cm_interface_fq` unfilled.
-    ///
-    /// If another world is already registered under the same `fq_name`, the
-    /// first registrant is kept and this registration is skipped (with a
-    /// warning logged to stderr). Two distinct worlds sharing a fully-qualified
-    /// name is a bug in the stdlib or user input — silently overwriting would
-    /// make the earlier world invisible to the code generator.
+    /// Register a world from a parsed declaration, keyed by the `#[cm("…")]`
+    /// fully-qualified name or, failing that, the `PascalCase` name. The
+    /// `lookup_interface_*` callbacks resolve an `export Foo;` / `import Foo;`
+    /// to its CM FQ; `None` skips the entry. A duplicate `fq_name` keeps the
+    /// first registrant and warns — overwriting would hide it from codegen.
     pub fn register(
         &mut self,
         world: &WorldDecl,

--- a/wado-compiler/src/world_registry.rs
+++ b/wado-compiler/src/world_registry.rs
@@ -30,7 +30,7 @@ pub const GENERATOR_HOST_INTERFACE: &str = "KilnHost";
 /// World exports take two AST shapes (`export Foo;` interface form and
 /// `export fn name(...);` function form). Both are normalized into this
 /// flat struct: an `export Foo;` is expanded by the registry into one
-/// `WorldExportInfo` per interface method, with [`from_interface_fq`]
+/// `WorldExportInfo` per interface method, with `from_interface_fq`
 /// populated. Bare function exports leave `from_interface_fq` as `None`.
 #[derive(Debug, Clone)]
 pub struct WorldExportInfo {


### PR DESCRIPTION
No comment block in `wado-compiler/src` runs to ten lines or more, and every
surviving comment is five lines or fewer. Self-evident `///` and `//` comments
are gone entirely; what remains states intent — the invariant, the ordering
constraint, the reason a narrow gate is narrow — rather than restating the code
below it. Comments carry no `file.rs:NNN` citations: where one named a
counterpart, it names the symbol instead, which survives edits to the file it
points into.

Executable code is untouched. Stripping comments leaves all 201 files
byte-identical to their base versions.

Several comments described code that had moved on, and are corrected here:

- Docs orphaned by past function removals are reunited with their owners or
  deleted. One item in `codegen/emit.rs` carried four stacked docs from removed
  helpers; one in `elaborator/reify.rs` was truncated mid-sentence.
- `elaborator/item.rs` scopes the parameter-default ban to `export fn` and the
  closure ban to everything crossing the CM boundary, matching the two distinct
  gates.
- `niri/region.rs` lists the unrooted-write disqualifier, which is implemented
  only as a `?` in `record_write`.
- `optimize/param_spec.rs` records why the pass is not gate-aware: a summary
  taken before a callee gained a write would license an unsound substitution.
- `elaborator/types.rs` ends the `TypeLookup` precedence chain at imports, with
  no global scan (#1416).
- `synthesis/effect_dispatch.rs` says a binding with no matching plan panics.
- `synthesis/traits.rs` names what each shape derives: `Eq` / `Ord` for structs
  and enums, `Eq` alone for variants.
- `lower/plan/value_copy/last_use.rs` scopes the pass to every body, unioned
  with the source-level `moved_local_spans`.
- `optimize/dae.rs` describes the one pin `collect_closure_call_keys` lifts.
- `synthesis/cm_binding/types.rs` counts `bool` and `Unit` among the types
  needing flat-ABI lifting.
- `nir_value_graph/builder.rs` says the heap is seeded from `heap_seed` and the
  caller filters the results.
- `name.rs`, `parser.rs`, `module_source.rs` and `loader.rs` state the name and
  path shapes the code actually produces.
- `tir.rs`, `wir_build/translate.rs` and `lower/translate.rs` name items that
  exist (`make_future`, `seq_literal`, `TirStmtKind::If`).

`cargo doc -p wado-compiler` is warning-free: bare generics like `List<T>` and
`option<T>` sit in code spans instead of parsing as HTML tags, intra-doc links
resolve, and links to private items are plain code spans.

`build_resource_fallback_call` in `synthesis/effect_dispatch.rs` carries no
`dead_code` allow — the wrapper-fallback path calls it — and takes no unused
`entry_source` parameter.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Upq8L1GH6zrQebKeK6uEct)_