### PR TITLE
refactor(elaborator): read a module's visible type names off the resolution table

### DIFF
--- a/docs/wep-2026-08-12-declaration-identity.md
+++ b/docs/wep-2026-08-12-declaration-identity.md
@@ -433,6 +433,3 @@ caller of the same first-wins index. A removed mechanism takes one fix.
       arguments stored as text. Blocked by the first item: `written_type_args`
       renders an `ast::Type` by spelling because the arguments' own reference
       sites are not resolved where it stands.
-- [ ] `module_import_scope` deleted. It no longer answers what a name means, but
-      still computes a set of visible spellings for `module_visible_types`,
-      which is a heuristic rather than a resolution and does not belong here.

--- a/docs/wep-2026-08-12-declaration-identity.md
+++ b/docs/wep-2026-08-12-declaration-identity.md
@@ -144,9 +144,11 @@ incidental fallbacks:
    same name always shadows.
 
 `Scope` is private to `crate::resolve`. `SymbolTable`'s name-keyed accessors,
-`module_import_scope`, `ModuleImports` and `TypeLookup`'s import branch are
-deleted. The facts they carried that are not scope — a module's re-export list, an
-interface's members — stay, keyed by `DefId`.
+`ModuleImports` and `TypeLookup`'s import branch are deleted, and with them the
+name-scope half of `module_import_scope`; what survives it is `namespace_imports_of`,
+answering the one import fact the symbol table does not record — which module a
+namespace alias stands for. The facts they carried that are not scope — a module's
+re-export list, an interface's members — stay, keyed by `DefId`.
 
 What an explicit `use` means is the analyzer's answer and only its answer: it
 resolves aliases and re-export chains once and records them, and every consumer

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -323,12 +323,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         if self.current_module_source == *module {
             return body(self);
         }
-        let scope = self.tysys.trait_env.import_scope(module);
+        let namespaces = self.tysys.trait_env.namespace_imports(module);
         let saved_src = std::mem::replace(&mut self.current_module_source, module.clone());
-        let saved_ns = std::mem::replace(
-            &mut self.sem.imports.namespace_imports,
-            scope.namespace_imports,
-        );
+        let saved_ns = std::mem::replace(&mut self.sem.imports.namespace_imports, namespaces);
         let saved_local_struct = std::mem::take(&mut self.sem.decls.local_struct_fields);
         let saved_local_newtypes = std::mem::take(&mut self.sem.decls.local_newtypes);
         let saved_local_enum = std::mem::take(&mut self.sem.decls.local_enum_cases);

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -311,10 +311,10 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
     }
 
     /// Run `body` in `module`'s perspective, swapping the current module and its
-    /// import scope — type sources and namespace imports both — and clearing
-    /// locals, which describe in-progress resolution rather than the target's
-    /// definitions. For callee-scope work only, such as a parameter default;
-    /// already being there skips the swap, keeping the locals in reach.
+    /// namespace imports and clearing locals, which describe in-progress
+    /// resolution rather than the target's definitions. For callee-scope work
+    /// only, such as a parameter default; already being there skips the swap,
+    /// keeping the locals in reach.
     pub(super) fn with_module_perspective_for<R>(
         &mut self,
         module: &ModuleSource,

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -1308,13 +1308,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             }
             let module = modules.get(module_source).expect("module should exist");
 
-            let namespace_imports = super::trait_env::namespace_imports_of(
-                &mut state.interner.borrow_mut(),
-                module,
-                module_source,
-                Some(&entry_module_source),
-                &state.invocations,
-            );
+            let namespace_imports = state.tysys.trait_env.namespace_imports(module_source);
             // Imported function names (namespace type members already in scope).
             let mut imported_functions = IndexSet::default();
             for item in &module.items {

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -338,15 +338,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 if stdlib_set.contains(module_source) {
                     continue;
                 }
-                let import_scope = Self::build_imported_type_sources(
+                let namespace_imports = super::trait_env::namespace_imports_of(
                     &mut interner.borrow_mut(),
                     module,
                     module_source,
                     Some(entry_module_source),
                     &invocations,
-                    symbols,
                 );
-                let namespace_imports = import_scope.namespace_imports;
                 let empty_struct: IndexMap<String, StructFieldInfo> = IndexMap::default();
                 let empty_newtype: IndexMap<String, TypeId> = IndexMap::default();
                 let empty_enum: IndexMap<String, EnumInfo> = IndexMap::default();
@@ -441,15 +439,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 // Stdlib fields are already resolved in the seeded maps.
                 continue;
             }
-            let import_scope = Self::build_imported_type_sources(
+            let namespace_imports = super::trait_env::namespace_imports_of(
                 &mut interner.borrow_mut(),
                 module,
                 module_source,
                 Some(entry_module_source),
                 &invocations,
-                symbols,
             );
-            let namespace_imports = import_scope.namespace_imports;
 
             // Helper closure: build a fresh TypeLookup pointed at the
             // current state of the shared tables. Recreated per call site so
@@ -797,7 +793,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             let _span = logger.span("elaborate/trait_env");
             super::trait_env::TraitEnv::build(
                 modules,
-                symbols,
                 &mut interner.borrow_mut(),
                 Some(entry_module_source),
                 &invocations,
@@ -992,8 +987,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 }
             }
 
+            let defs = resolutions.defs();
             let mut visible: IndexMap<ModuleSource, IndexSet<String>> = IndexMap::default();
-            for (ms, module) in modules {
+            for ms in modules.keys() {
                 let mut set: IndexSet<String> = IndexSet::default();
                 for prim in crate::tir::PrimitiveType::all_primitive_names() {
                     set.insert(prim.to_string());
@@ -1002,22 +998,16 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     set.extend(own.iter().cloned());
                 }
                 set.extend(prelude_types.iter().cloned());
-                // Types brought in by this module's `use` declarations.
-                let import_scope = Self::build_imported_type_sources(
-                    &mut interner.borrow_mut(),
-                    module,
-                    ms,
-                    Some(entry_module_source),
-                    &invocations,
-                    symbols,
-                );
-                for (local_name, src) in &import_scope.sources {
-                    let original = import_scope
-                        .original_names
-                        .get(local_name)
-                        .unwrap_or(local_name);
-                    if local.get(src).is_some_and(|s| s.contains(original)) {
-                        set.insert(local_name.clone());
+                // Types brought in by this module's `use` declarations, under
+                // the local name it wrote — which is the alias where it wrote
+                // one. What each import reaches is the analyzer's answer, read
+                // off the resolution table rather than re-derived here.
+                for (local_name, def) in resolutions.imports_in(ms) {
+                    if local
+                        .get(defs.module(def))
+                        .is_some_and(|s| s.contains(defs.name(def)))
+                    {
+                        set.insert(local_name.to_string());
                     }
                 }
                 visible.insert(ms.clone(), set);
@@ -1318,17 +1308,13 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             }
             let module = modules.get(module_source).expect("module should exist");
 
-            // Full import scope; namespace *type* members are already expanded
-            // here, namespace *function* members into `imported_functions` below.
-            let import_scope = Self::build_imported_type_sources(
+            let namespace_imports = super::trait_env::namespace_imports_of(
                 &mut state.interner.borrow_mut(),
                 module,
                 module_source,
                 Some(&entry_module_source),
                 &state.invocations,
-                symbols,
             );
-            let namespace_imports = import_scope.namespace_imports;
             // Imported function names (namespace type members already in scope).
             let mut imported_functions = IndexSet::default();
             for item in &module.items {
@@ -1749,29 +1735,6 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
             }
         }
         imported
-    }
-
-    /// Build a map of imported names to their source modules from use declarations.
-    /// Build a mapping from local import names to their source modules and original names.
-    ///
-    /// Returns `(local_name -> module_source, local_name -> original_name)`.
-    /// The `original_name` is different from `local_name` when `use { Foo as Bar }` is used.
-    pub(super) fn build_imported_type_sources(
-        interner: &mut ModuleSourceInterner,
-        module: &Module,
-        from_module: &ModuleSource,
-        entry_module: Option<&ModuleSource>,
-        invocations: &crate::kiln::InvocationIndex,
-        symbols: &crate::symbol::SymbolTable,
-    ) -> super::trait_env::ModuleImportScope {
-        super::trait_env::module_import_scope(
-            interner,
-            module,
-            from_module,
-            entry_module,
-            invocations,
-            symbols,
-        )
     }
 
     /// Topologically sort modules based on struct field type dependencies.

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -998,10 +998,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                     set.extend(own.iter().cloned());
                 }
                 set.extend(prelude_types.iter().cloned());
-                // Types brought in by this module's `use` declarations, under
-                // the local name it wrote — which is the alias where it wrote
-                // one. What each import reaches is the analyzer's answer, read
-                // off the resolution table rather than re-derived here.
+                // The import tier alone: cases ride a tier only value position
+                // consults, so this one holds exactly the names asked for here.
                 for (local_name, def) in resolutions.imports_in(ms) {
                     if local
                         .get(defs.module(def))

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -3312,8 +3312,8 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
                 }
                 // `ns::Type` namespace-import alias in type position: resolve
                 // the `ns$Type` alias via the `Named` / `Generic` arms, which
-                // route through `imported_type_sources` to the namespace's own
-                // module. Mirrors the dynamic resolver's namespace-alias branch.
+                // route through the import tier to the namespace's own module.
+                // Mirrors the dynamic resolver's namespace-alias branch.
                 if lookup
                     .namespace_imports
                     .contains_key(namespaced.namespace.as_str())

--- a/wado-compiler/src/elaborator/reify.rs
+++ b/wado-compiler/src/elaborator/reify.rs
@@ -8871,7 +8871,7 @@ impl<'a, H: CompilerHost> Reify<'a, H> {
 
         // 5b. Imported free function reference resolved through the symbol
         //     table (covers namespace-import functions, whose `ns$fn` aliases
-        //     are not in `imported_type_sources`). Mirrors annotate's
+        //     name functions rather than types). Mirrors annotate's
         //     `resolve_func_ref_ident` → `lookup_func_ast_for_ref` and emits a
         //     `FuncRef` keyed by the function's defining module + original name.
         if self.sem.decls.imported_functions.contains(&ident.name)

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -14,68 +14,23 @@ use crate::name;
 use crate::tir::TypeTable;
 use crate::token::Span;
 
-/// A module's type-name import scope, derived once from its `use`
-/// declarations. The single source of truth for how a module resolves a type
-/// name, shared by its body walk and by sites that reconstruct its perspective.
-#[derive(Clone, Default, Debug)]
-pub(crate) struct ModuleImportScope {
-    /// In-scope type name → declaring module, including `ns$Type` aliases for
-    /// each namespace import's public type members.
-    pub(super) sources: IndexMap<String, ModuleSource>,
-    /// Aliased local name → original declaration name (`use { A as B }` and the
-    /// `ns$Type` → `Type` namespace-member aliases).
-    pub(super) original_names: IndexMap<String, String>,
-    /// Namespace-import alias (`use ns from "…"`) → the namespace's module.
-    /// Drives `ns::Type` resolution (issue #1415).
-    pub(super) namespace_imports: IndexMap<String, ModuleSource>,
-}
+/// Namespace-import alias (`use ns from "…"`) → the namespace's module.
+/// Drives `ns::Type` resolution (issue #1415).
+pub(crate) type NamespaceImports = IndexMap<String, ModuleSource>;
 
-/// Compute a module's import scope from its `use` declarations. Pure over
-/// `(module, from_module, entry_module, invocations, symbols)` plus the
-/// (idempotent, loader-warmed) interner; safe to memoize per module. This is
-/// the body behind `Elaborator::build_imported_type_sources`, lifted to a free
-/// function so [`TraitEnv::build`] can pre-compute the per-module scopes
-/// without an `Elaborator`/host in hand. `symbols` is needed to enumerate a
-/// namespace import's public type members.
-pub(super) fn module_import_scope(
+/// Which module each of `module`'s namespace aliases stands for.
+///
+/// The one import fact the symbol table does not record — it registers the
+/// members, not the alias — so the `use` declarations still answer for it.
+/// What a *name* means is [`crate::resolve`]'s answer and is not asked here.
+pub(super) fn namespace_imports_of(
     interner: &mut ModuleSourceInterner,
     module: &Module,
     from_module: &ModuleSource,
     entry_module: Option<&ModuleSource>,
     invocations: &InvocationIndex,
-    symbols: &SymbolTable,
-) -> ModuleImportScope {
-    let mut scope = ModuleImportScope::default();
-    // Case (variant/enum/flags) names brought in by imported types. Applied
-    // after every type name is in scope, so a type always shadows a same-named
-    // case (e.g. a `FieldKind::List` case must not hide the prelude `List`
-    // type). Collected here, inserted with `or_insert` at the end.
-    let mut pending_cases: Vec<(String, ModuleSource)> = Vec::new();
-
-    // What an explicit `use` means is decided once, by the analyzer, and
-    // recorded in the symbol table: the local name (an alias, or a namespace
-    // import's `ns$member`) paired with the declaration it reaches, re-export
-    // chains already followed (issue #1416). Re-walking the `use` declarations
-    // here answered the same question a second way, with its own module-path
-    // resolution and its own alias handling, and the two could disagree.
-    for (local_name, sym) in symbols.imports_in(from_module) {
-        let def_source = sym.module_source().clone();
-        scope
-            .sources
-            .insert(local_name.to_string(), def_source.clone());
-        if local_name != sym.name {
-            scope
-                .original_names
-                .insert(local_name.to_string(), sym.name.clone());
-        }
-        // Importing a variant/enum/flags type brings its case names into scope
-        // so bare `Some` / `Ok` / enum cases resolve through the import branch.
-        collect_case_names(&mut pending_cases, sym, &def_source);
-    }
-
-    // Which module a namespace alias stands for is the one import fact the
-    // symbol table does not record — it registers the members, not the alias —
-    // so the `use` declarations still answer for it.
+) -> NamespaceImports {
+    let mut out = NamespaceImports::default();
     for item in &module.items {
         if let Item::Use(use_decl) = item {
             let namespaces = use_decl.items.iter().filter_map(|use_item| match use_item {
@@ -92,80 +47,14 @@ pub(super) fn module_import_scope(
                     entry_module,
                     invocations,
                 );
-                scope.namespace_imports.insert(ns.clone(), source);
+                out.insert(ns.clone(), source);
             }
         }
     }
-
-    // Auto-import the prelude: inject `core:prelude`'s exported type names into
-    // the scope so prelude types (`String`, `List`, `Option`, …) resolve
-    // through the import branch like any `use`. Modules opting out
-    // (`#![no_prelude]` — the prelude sub-modules and
-    // `core:rt`/`builtin`/`allocator`) import explicitly. Explicit `use`
-    // items above take precedence, so they are not overwritten.
-    if !module.has_no_prelude() {
-        let prelude = ModuleSource::prelude();
-        for name in symbols.reexport_names(&prelude) {
-            if scope.sources.contains_key(&name) {
-                continue;
-            }
-            let Some(sym) = symbols.lookup_in_module(&prelude, &name) else {
-                continue;
-            };
-            if !matches!(
-                sym.kind,
-                crate::symbol::SymbolKind::Struct(_)
-                    | crate::symbol::SymbolKind::Enum(_)
-                    | crate::symbol::SymbolKind::Flags(_)
-                    | crate::symbol::SymbolKind::Variant(_)
-                    | crate::symbol::SymbolKind::Newtype(_)
-                    | crate::symbol::SymbolKind::Resource(_)
-                    | crate::symbol::SymbolKind::BuiltinType
-                    | crate::symbol::SymbolKind::Trait(_)
-            ) {
-                continue;
-            }
-            let def_source = sym.module_source().clone();
-            scope.sources.insert(name.clone(), def_source.clone());
-            if name != *sym.name {
-                scope.original_names.insert(name, sym.name.clone());
-            }
-            collect_case_names(&mut pending_cases, sym, &def_source);
-        }
-    }
-
-    // Apply case names last, never overwriting a type name: a type always wins
-    // a name clash with a case (see `pending_cases`).
-    for (case, src) in pending_cases {
-        scope.sources.entry(case).or_insert(src);
-    }
-
-    scope
-}
-
-/// Collect a variant/enum/flags symbol's case (or member) names so they can
-/// resolve unqualified (`Some`, `Ok`, an enum case used bare), pointing at the
-/// type's defining module. Other symbol kinds are ignored. Cases cannot be
-/// aliased, so each name maps to itself.
-fn collect_case_names(
-    pending: &mut Vec<(String, ModuleSource)>,
-    sym: &crate::symbol::Symbol,
-    def_source: &ModuleSource,
-) {
-    use crate::symbol::SymbolKind;
-    let cases: &[String] = match &sym.kind {
-        SymbolKind::Variant(v) => &v.cases,
-        SymbolKind::Enum(e) => &e.cases,
-        SymbolKind::Flags(f) => &f.members,
-        _ => return,
-    };
-    for case in cases {
-        pending.push((case.clone(), def_source.clone()));
-    }
+    out
 }
 
 use super::types::TypeError;
-use crate::symbol::SymbolTable;
 
 /// Pick a `ModuleSource` from the AST and synthesised candidate lists: a
 /// `prefer` hint wins wherever it appears, else the first AST entry, else the
@@ -861,12 +750,10 @@ pub struct TraitEnv {
     /// Type name → modules declaring a `newtype` of that name, in build order.
     /// The fallback half of `find_struct_module_source`'s module lookup.
     pub(super) newtype_decl_modules: IndexMap<String, Vec<ModuleSource>>,
-    /// Per-module import scope (`use`-derived `imported_type_sources` /
-    /// `import_original_names`), pre-computed once. Dispatch-core queries that
-    /// resolve type names in a foreign impl/callee signature read this instead
-    /// of rebuilding it from the module AST in `loaded_modules`. See
-    /// [`module_import_scope`].
-    pub(super) module_import_scopes: IndexMap<ModuleSource, ModuleImportScope>,
+    /// Per-module namespace-import aliases, pre-computed once, so a query
+    /// standing in a foreign module's perspective reads them instead of
+    /// re-walking its `use` declarations. See [`namespace_imports_of`].
+    pub(super) module_namespace_imports: IndexMap<ModuleSource, NamespaceImports>,
     /// Associated-type name → the declaring trait's bounds for it, first
     /// declaration wins (matching the previous whole-program scan order).
     /// Consumed by `find_assoc_type_bounds` without an AST scan.
@@ -957,32 +844,24 @@ impl SynthesisedImpls {
 impl TraitEnv {
     /// Build the trait indices from all loaded modules, once, before per-module
     /// resolution begins, and check the orphan rule on local impl blocks. Every
-    /// receiver-type and trait-name reference in an `impl` header is
-    /// canonicalised through `symbols` against that module's own import context,
-    /// so two modules' same-named traits produce distinct [`DeclKey`]s.
+    /// receiver-type and trait-name reference in an `impl` header is resolved
+    /// from the module that wrote it, so two modules' same-named traits produce
+    /// distinct [`DeclKey`]s.
     pub(super) fn build(
         modules: &IndexMap<ModuleSource, Module>,
-        symbols: &SymbolTable,
         interner: &mut ModuleSourceInterner,
         entry_module: Option<&ModuleSource>,
         invocations: &InvocationIndex,
         resolutions: &crate::resolve::Resolutions,
     ) -> (Arc<Self>, Vec<(ModuleSource, TypeError)>) {
-        // Pre-compute every module's `use`-derived import scope so dispatch
-        // queries read it instead of rebuilding from the module AST.
-        let mut module_import_scopes: IndexMap<ModuleSource, ModuleImportScope> =
+        // Pre-compute every module's namespace aliases so dispatch queries read
+        // them instead of re-walking the module AST.
+        let mut module_namespace_imports: IndexMap<ModuleSource, NamespaceImports> =
             IndexMap::default();
         for (module_source, module) in modules {
-            module_import_scopes.insert(
+            module_namespace_imports.insert(
                 module_source.clone(),
-                module_import_scope(
-                    interner,
-                    module,
-                    module_source,
-                    entry_module,
-                    invocations,
-                    symbols,
-                ),
+                namespace_imports_of(interner, module, module_source, entry_module, invocations),
             );
         }
         let mut impl_index: TraitImplIndex = IndexMap::default();
@@ -1409,7 +1288,7 @@ impl TraitEnv {
                 function_type_params,
                 struct_like_decl_modules,
                 newtype_decl_modules,
-                module_import_scopes,
+                module_namespace_imports,
                 assoc_type_bound_index,
                 blanket_impls,
                 static_method_index,
@@ -1422,12 +1301,11 @@ impl TraitEnv {
         )
     }
 
-    /// The pre-computed import scope for `module`, cloned for callers that
-    /// install it via `with_module_perspective_for` (which takes the maps by
-    /// value). Returns empty maps for a module with no recorded scope,
-    /// matching the previous `…unwrap_or_default()` behaviour.
-    pub(super) fn import_scope(&self, module: &ModuleSource) -> ModuleImportScope {
-        self.module_import_scopes
+    /// The pre-computed namespace aliases for `module`, cloned for callers that
+    /// install them via `with_module_perspective_for` (which takes the map by
+    /// value). Empty for a module with no recorded aliases.
+    pub(super) fn namespace_imports(&self, module: &ModuleSource) -> NamespaceImports {
+        self.module_namespace_imports
             .get(module)
             .cloned()
             .unwrap_or_default()

--- a/wado-compiler/src/elaborator/trait_env.rs
+++ b/wado-compiler/src/elaborator/trait_env.rs
@@ -21,8 +21,8 @@ pub(crate) type NamespaceImports = IndexMap<String, ModuleSource>;
 /// Which module each of `module`'s namespace aliases stands for.
 ///
 /// The one import fact the symbol table does not record — it registers the
-/// members, not the alias — so the `use` declarations still answer for it.
-/// What a *name* means is [`crate::resolve`]'s answer and is not asked here.
+/// members, not the alias. What a *name* means is [`crate::resolve`]'s answer
+/// and is not asked here.
 pub(super) fn namespace_imports_of(
     interner: &mut ModuleSourceInterner,
     module: &Module,
@@ -854,8 +854,6 @@ impl TraitEnv {
         invocations: &InvocationIndex,
         resolutions: &crate::resolve::Resolutions,
     ) -> (Arc<Self>, Vec<(ModuleSource, TypeError)>) {
-        // Pre-compute every module's namespace aliases so dispatch queries read
-        // them instead of re-walking the module AST.
         let mut module_namespace_imports: IndexMap<ModuleSource, NamespaceImports> =
             IndexMap::default();
         for (module_source, module) in modules {
@@ -1301,9 +1299,8 @@ impl TraitEnv {
         )
     }
 
-    /// The pre-computed namespace aliases for `module`, cloned for callers that
-    /// install them via `with_module_perspective_for` (which takes the map by
-    /// value). Empty for a module with no recorded aliases.
+    /// The pre-computed namespace aliases for `module`. Empty for a module
+    /// with none.
     pub(super) fn namespace_imports(&self, module: &ModuleSource) -> NamespaceImports {
         self.module_namespace_imports
             .get(module)

--- a/wado-compiler/src/elaborator/type_resolution.rs
+++ b/wado-compiler/src/elaborator/type_resolution.rs
@@ -304,9 +304,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             .contains_key(namespaced.namespace.as_str())
         {
             // `ns::Type` / `ns::Type<args>` (`ns` is a namespace-import alias):
-            // resolve the `ns$Type` alias, which `imported_type_sources` scopes
-            // to the namespace's own module. Mirrors `canonical_ns_ref` for
-            // idents.
+            // resolve the `ns$Type` alias, which the import tier scopes to the
+            // namespace's own module. Mirrors `canonical_ns_ref` for idents.
             let alias =
                 crate::name::namespace_member_alias(&namespaced.namespace, &namespaced.name);
             if namespaced.args.is_empty() {

--- a/wado-compiler/src/name.rs
+++ b/wado-compiler/src/name.rs
@@ -22,9 +22,9 @@ pub const CLOSURE_CALL_METHOD: &str = "__call";
 /// Separator between a namespace-import alias and the imported member in the
 /// canonical `ns$member` name a `ns::member` reference resolves to. `$` is not
 /// a valid Wado identifier character, so the alias is a single `::`-free token
-/// that flows through the per-name import maps (`imported_type_sources`,
-/// `imported_globals`, the symbol-table imports) like a `use { X as Y }`
-/// alias, scoped to the namespace's own module.
+/// that flows through the resolution table's import tier and the per-name
+/// import maps (`imported_globals`, the symbol-table imports) like a
+/// `use { X as Y }` alias, scoped to the namespace's own module.
 pub const NAMESPACE_MEMBER_SEP: char = '$';
 
 /// Build the `ns$member` alias for a namespace-imported symbol.

--- a/wado-compiler/src/resolve.rs
+++ b/wado-compiler/src/resolve.rs
@@ -275,6 +275,18 @@ impl Resolutions {
             .copied()
     }
 
+    /// Every declaration `module` explicitly `use`d, by the local name it
+    /// wrote — an alias where it wrote one, and the `ns$member` name a
+    /// namespace import registers.
+    pub fn imports_in(&self, module: &ModuleSource) -> impl Iterator<Item = (&str, DefId)> {
+        self.scopes
+            .imports
+            .get(module)
+            .into_iter()
+            .flatten()
+            .map(|(name, def)| (name.as_str(), *def))
+    }
+
     /// The declaration `module` explicitly `use`d under the local name `name`.
     ///
     /// The import tier alone, so an alias answers with what it aliases and a
@@ -730,7 +742,38 @@ mod tests {
         assert_eq!(r.defs().module(list), &entry);
     }
 
-    /// An alias names what it aliases, not itself.
+    /// An alias names what it aliases, not itself, and the import tier answers
+    /// under the name the module wrote. It holds no cases — those ride a tier
+    /// of their own — so a visibility set read off this tier answers for type
+    /// position alone.
+    #[test]
+    fn imports_in_answers_under_the_local_name_and_holds_no_cases() {
+        let (r, entry, other) = resolve(
+            r#"use { FieldKind as FK } from "./other.wado";"#,
+            "pub variant FieldKind { List(i32), Leaf }",
+        );
+        let imports: Vec<(&str, DefId)> = r.imports_in(&entry).collect();
+        assert_eq!(imports.len(), 1, "{imports:?}");
+        let (local_name, def) = imports[0];
+        assert_eq!(local_name, "FK");
+        assert_eq!(r.defs().name(def), "FieldKind");
+        assert_eq!(r.defs().module(def), &other);
+        // The variant's cases reach value position without entering this tier.
+        assert!(r.value_named(&entry, "Leaf").is_some());
+    }
+
+    /// A namespace import enters its members under the qualification the
+    /// module can name them by, which is the local name the tier records.
+    #[test]
+    fn imports_in_records_a_namespace_member_qualified() {
+        let (r, entry, _) = resolve(
+            r#"use ns from "./other.wado";"#,
+            "pub struct Widget { a: i32 }",
+        );
+        let names: Vec<&str> = r.imports_in(&entry).map(|(name, _)| name).collect();
+        assert!(names.contains(&"ns$Widget"), "{names:?}");
+    }
+
     /// A `struct` declared in a function body shadows a module-level one of
     /// the same name for the rest of that body, and nowhere else.
     #[test]

--- a/wado-compiler/src/resolve.rs
+++ b/wado-compiler/src/resolve.rs
@@ -742,10 +742,8 @@ mod tests {
         assert_eq!(r.defs().module(list), &entry);
     }
 
-    /// An alias names what it aliases, not itself, and the import tier answers
-    /// under the name the module wrote. It holds no cases — those ride a tier
-    /// of their own — so a visibility set read off this tier answers for type
-    /// position alone.
+    /// The import tier answers under the name the module wrote, and holds no
+    /// cases — those ride a tier only value position consults.
     #[test]
     fn imports_in_answers_under_the_local_name_and_holds_no_cases() {
         let (r, entry, other) = resolve(
@@ -763,7 +761,7 @@ mod tests {
     }
 
     /// A namespace import enters its members under the qualification the
-    /// module can name them by, which is the local name the tier records.
+    /// module can name them by.
     #[test]
     fn imports_in_records_a_namespace_member_qualified() {
         let (r, entry, _) = resolve(

--- a/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
+++ b/wado-compiler/src/synthesis/cm_binding/type_fixup.rs
@@ -298,7 +298,6 @@ fn replace_type_in_adapter_with_names(
 /// identity — needed for a monomorphized `List<T>::with_capacity` whose `T` is
 /// WASI-derived. Traversal rides `TirMutVisitor`, so the swap reaches every
 /// expression position.
-
 struct TypeReplacer<'a> {
     old_type: TypeId,
     new_type: TypeId,


### PR DESCRIPTION
`module_visible_types` enumerates each module's import tier through the new `Resolutions::imports_in`, under the local name the module wrote — an alias where it wrote one, and the `ns$member` name a namespace import registers. Cases sit on a tier only `resolve_value` consults, so the import tier holds exactly the type-position names this set answers for.

`trait_env` keeps the one import fact the symbol table does not record: which module a namespace alias stands for. `namespace_imports_of` answers that alone, and `NamespaceImports` is an `IndexMap<String, ModuleSource>`. `SymbolTable` is a parameter of neither it nor `TraitEnv::build`.

`build_tir_from_state` reads each module's aliases from the map `TraitEnv::build` pre-computes over every loaded module, so one compile walks the `use` declarations for this fact once.

Two unit tests pin the import tier: an alias answers under the name the module wrote and carries no cases, and a namespace import registers its members qualified.

Closes the `module_import_scope` item in `docs/wep-2026-08-12-declaration-identity.md`, whose design section now names what survives that function.

Carries one unrelated fix: `TypeReplacer`'s doc comment was separated from the struct by a blank line, which `clippy::empty_line_after_doc_comments` rejects under `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)