### PR TITLE
docs: add a Principles section and document black_box for fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ This document describes how to develop the Wado compiler toolchain.
 
 Note: `CLAUDE.md` is a symlink to `AGENTS.md`.
 
+## Principles
+
+- Succinctly — say and write the least that fully conveys the point.
+- Fix-forward — fix the cause of a defect and move forward; never backtrack.
+
 ## Development
 
 This project uses [mise](https://mise.jdx.dev/) to manage dev tools. Project tasks are defined in `mise.toml`. Run `mise tasks` to discover available tasks.

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -29,3 +29,5 @@ section whose fields are the `serde` structs in `tests/e2e.rs`.
   `WADO_FULL_TEST`. `datatest_mini` resolves fixtures at macro-expansion time and
   an incremental `cargo test` will not re-expand on its own.
 - `wado dump [-O0|-O2] file.wado` is how you find `wir_expect:Ox` patterns.
+- `builtin::black_box(value)` returns `value` opaquely, keeping a fixture's input
+  off the constant-folding path.


### PR DESCRIPTION
`AGENTS.md` opens with a `Principles` section stating two behavioral principles that the concrete rules below it specialize:

- Succinctly — say and write the least that fully conveys the point.
- Fix-forward — fix the cause of a defect and move forward; never backtrack.

`wado-compiler/AGENTS.md` records `builtin::black_box(value)` in its E2E Tests notes, so a fixture author finds the optimization barrier where fixtures are described rather than only in `docs/spec.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeE2GRVLjqvgZBas9bhu6w)_