### PR TITLE
fix(lsp): correct URI handling, diagnostic scoping, and hover resolution

### DIFF
--- a/wado-cli/src/compiler_host.rs
+++ b/wado-cli/src/compiler_host.rs
@@ -2,7 +2,7 @@
 //! [`wado_lsp::FilesystemCompilerHost`] with CLI decorations: phase-tracking
 //! timestamps, log-level filtering, and stderr printing.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
@@ -185,7 +185,7 @@ impl FilesystemCompilerHost {
         self.inner.has_errors()
     }
 
-    pub fn base_path(&self) -> &PathBuf {
+    pub fn base_path(&self) -> &Path {
         self.inner.base_path()
     }
 

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -34,9 +34,6 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<LspOptions, CliExit> {
 }
 
 pub async fn run(_opts: LspOptions) -> Result<(), CliExit> {
-    // The server owns the exit code (LSP 3.18 §exit: `exit` without a prior
-    // `shutdown` is an error). Route it through the CLI's exit path rather
-    // than terminating from inside the message loop.
     match wado_lsp::server::run_stdio().await {
         0 => Ok(()),
         code => Err(CliExit::silent_failure(code)),

--- a/wado-cli/src/lsp.rs
+++ b/wado-cli/src/lsp.rs
@@ -34,6 +34,11 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<LspOptions, CliExit> {
 }
 
 pub async fn run(_opts: LspOptions) -> Result<(), CliExit> {
-    wado_lsp::server::run_stdio().await;
-    Ok(())
+    // The server owns the exit code (LSP 3.18 §exit: `exit` without a prior
+    // `shutdown` is an error). Route it through the CLI's exit path rather
+    // than terminating from inside the message loop.
+    match wado_lsp::server::run_stdio().await {
+        0 => Ok(()),
+        code => Err(CliExit::silent_failure(code)),
+    }
 }

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -44,7 +44,9 @@ async fn prepare_query(filename: &str) -> Result<PreparedQuery, CliExit> {
     )
     .await
     .map_err(CliExit::error)?;
-    let uri = format!("file://{}", canonical.display());
+    let uri = wado_lsp::Uri::from_file_path(&canonical)
+        .as_str()
+        .to_string();
 
     let mut engine = wado_lsp::Engine::new();
     match run_generators_for(&canonical, &host, manifest_pair).await {
@@ -217,7 +219,9 @@ async fn symbol_env(notation: &str, base: &str) -> Result<SymbolEnv, CliExit> {
     )
     .await
     .map_err(CliExit::error)?;
-    let uri = format!("file://{}", entry_path.display());
+    let uri = wado_lsp::Uri::from_file_path(&entry_path)
+        .as_str()
+        .to_string();
     Ok(SymbolEnv {
         parsed,
         host,
@@ -355,7 +359,9 @@ fn imports_with_target(target: &str, extra: &[String]) -> Vec<String> {
 
 /// Whether `spec` analyzes on its own (imported into a throwaway entry).
 async fn file_analyzes(base_dir: &Path, host: &FilesystemCompilerHost, spec: &str) -> bool {
-    let uri = format!("file://{}", base_dir.join("__wado_probe__.wado").display());
+    let uri = wado_lsp::Uri::from_file_path(&base_dir.join("__wado_probe__.wado"))
+        .as_str()
+        .to_string();
     let mut engine = wado_lsp::Engine::new();
     engine.open_document(&uri, format!("use __p from \"{spec}\";\n"));
     engine.analyzes(&uri, host).await
@@ -531,7 +537,7 @@ pub async fn run_document_highlight_by_symbol(
             if json_output {
                 print_highlights_json(&highlights);
             } else {
-                print_highlights_text(uri_to_display(&def_uri), &highlights);
+                print_highlights_text(&uri_to_display(&def_uri), &highlights);
             }
         },
         || {
@@ -698,8 +704,10 @@ fn print_diagnostics_text(filename: &str, diagnostics: &[wado_lsp::Diagnostic]) 
     }
 }
 
-fn uri_to_display(uri: &str) -> &str {
-    uri.strip_prefix("file://").unwrap_or(uri)
+/// The path a URI names, for human-readable output. Decodes percent-escapes
+/// so the printed path matches what the user would type, not the wire form.
+fn uri_to_display(uri: &str) -> String {
+    wado_lsp::Uri::new(uri).to_filename()
 }
 
 fn print_references_json(refs: &[ReferenceLocation]) {

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -14,7 +14,7 @@ Language service engine for the Wado compiler toolchain.
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `src/lib.rs`                | `Engine` struct: document state + per-document `Semantics` snapshot cache + query dispatch                                                                                                       |
 | `src/host.rs`               | `FilesystemCompilerHost`: default `CompilerHost` for disk-backed source loading                                                                                                                  |
-| `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting; percent-decodes `file:` paths                                          |
+| `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting; percent-decodes and re-encodes `file:` paths                            |
 | `src/text.rs`               | `PositionEncoding`, LSP `Position` ↔ compiler 1-based codepoint `(line, col)` conversion, and the `LineIndex` every batch conversion shares                                                      |
 | `src/diagnostics.rs`        | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion (re-encodes spans in the negotiated position encoding; tags unused / dead-code lints with `DiagnosticTag::Unnecessary`)          |
 | `src/semantic_tokens.rs`    | Semantic token computation. Classifies identifiers by resolved `SymbolKind` from the `Semantics` snapshot, falling back to lexer + AST heuristics. Re-encodes start/length at delta-encode time. |
@@ -123,6 +123,12 @@ Clients send rfc3986-encoded URIs, so `Uri::to_filename` percent-decodes
 decoding, a workspace under `my project/` resolved nothing at all.
 Non-`file:` schemes are compiler-minted and never encoded, so they pass
 through verbatim.
+
+The inverse holds on the way out: `location::filename_to_uri` percent-encodes
+via `uri::percent_encode_path` before wrapping a path as `file://…`. The
+paths it receives are decoded — from `to_filename`, or from the compiler,
+which speaks in real paths — and a URI emitted without re-encoding does not
+string-match the document the client already has open.
 
 Relative imports are normalised lexically (`../lib/x.wado` off
 `file:///a/b/foo.wado` is `file:///a/lib/x.wado`, not

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -14,7 +14,7 @@ Language service engine for the Wado compiler toolchain.
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `src/lib.rs`                | `Engine` struct: document state + per-document `Semantics` snapshot cache + query dispatch                                                                                                       |
 | `src/host.rs`               | `FilesystemCompilerHost`: default `CompilerHost` for disk-backed source loading                                                                                                                  |
-| `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting; percent-decodes and re-encodes `file:` paths                            |
+| `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting; percent-decodes and re-encodes `file:` paths                           |
 | `src/text.rs`               | `PositionEncoding`, LSP `Position` ↔ compiler 1-based codepoint `(line, col)` conversion, and the `LineIndex` every batch conversion shares                                                      |
 | `src/diagnostics.rs`        | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion (re-encodes spans in the negotiated position encoding; tags unused / dead-code lints with `DiagnosticTag::Unnecessary`)          |
 | `src/semantic_tokens.rs`    | Semantic token computation. Classifies identifiers by resolved `SymbolKind` from the `Semantics` snapshot, falling back to lexer + AST heuristics. Re-encodes start/length at delta-encode time. |
@@ -99,7 +99,7 @@ conversion lives in `text.rs` and routes through
 `Engine::diagnostics` returns only the diagnostics belonging to the
 requested document. LSP publishes per URI, so a diagnostic whose
 `span.file` names an imported module cannot be reported on the importer:
-its line and column are the *imported* file's, and painting them onto the
+its line and column are the _imported_ file's, and painting them onto the
 open document draws the squiggle over unrelated code. The imported file
 reports its own errors when the client opens it.
 

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -14,8 +14,8 @@ Language service engine for the Wado compiler toolchain.
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `src/lib.rs`                | `Engine` struct: document state + per-document `Semantics` snapshot cache + query dispatch                                                                                                       |
 | `src/host.rs`               | `FilesystemCompilerHost`: default `CompilerHost` for disk-backed source loading                                                                                                                  |
-| `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting                                                                         |
-| `src/text.rs`               | `PositionEncoding` and LSP `Position` ↔ compiler 1-based codepoint `(line, col)` conversion                                                                                                      |
+| `src/uri.rs`                | Typed `Uri` + `UriScheme` for parsing `file:` / `core:` / `wasi:` / `kiln:` URIs once instead of inline string splitting; percent-decodes `file:` paths                                          |
+| `src/text.rs`               | `PositionEncoding`, LSP `Position` ↔ compiler 1-based codepoint `(line, col)` conversion, and the `LineIndex` every batch conversion shares                                                      |
 | `src/diagnostics.rs`        | Compiler `Diagnostic` to LSP-compatible `Diagnostic` conversion (re-encodes spans in the negotiated position encoding; tags unused / dead-code lints with `DiagnosticTag::Unnecessary`)          |
 | `src/semantic_tokens.rs`    | Semantic token computation. Classifies identifiers by resolved `SymbolKind` from the `Semantics` snapshot, falling back to lexer + AST heuristics. Re-encodes start/length at delta-encode time. |
 | `src/definition.rs`         | Go-to-definition via `Cursor::{def_key, def_span}` and a file-path matcher for `use`/`#include` paths                                                                                            |
@@ -23,9 +23,9 @@ Language service engine for the Wado compiler toolchain.
 | `src/inlay_hints.rs`        | Inlay hints: inferred-type hints on `let` / closure / `for-of` bindings, plus parameter-name hints at call sites                                                                                 |
 | `src/references.rs`         | Find-references via `Cursor::references_to_def`                                                                                                                                                  |
 | `src/document_highlight.rs` | Document highlight; Read/Write classification consults `Semantics::is_write_target`                                                                                                              |
-| `src/location.rs`           | URI / span helpers for translating compiler `ModuleSource` to LSP URIs                                                                                                                           |
+| `src/location.rs`           | `ModuleSource` → LSP URI translation, including lexical `.`/`..` normalisation of relative imports                                                                                               |
 | `src/query.rs`              | `QueryContext`: per-query bundle (`&Semantics` + source + URI + encoding) consumed by every position-bearing feature                                                                             |
-| `src/server.rs`             | `run_stdio()`: blocking stdin/stdout loop feeding the async dispatcher                                                                                                                           |
+| `src/server.rs`             | `run_stdio()`: blocking stdin/stdout loop feeding the async dispatcher; returns the LSP exit code                                                                                                |
 | `src/server/transport.rs`   | Content-Length framing + typed JSON-RPC send/receive helpers                                                                                                                                     |
 | `src/server/dispatch.rs`    | LSP method routing, position-encoding negotiation, and server-lifecycle enforcement                                                                                                              |
 | `src/server/rpc.rs`         | LSP wire types (params, capabilities, notifications)                                                                                                                                             |
@@ -94,13 +94,48 @@ scalar value, not per byte and not per UTF-16 code unit. Every
 conversion lives in `text.rs` and routes through
 `codepoint_offset_to_character` / `character_to_codepoint_offset`.
 
+### Diagnostics
+
+`Engine::diagnostics` returns only the diagnostics belonging to the
+requested document. LSP publishes per URI, so a diagnostic whose
+`span.file` names an imported module cannot be reported on the importer:
+its line and column are the *imported* file's, and painting them onto the
+open document draws the squiggle over unrelated code. The imported file
+reports its own errors when the client opens it.
+
+A diagnostic with no span is kept and anchored at the document start.
+The loader reports its hard failures — `ModuleNotFound` above all —
+without one, and the same failure returns `Semantics::empty`, silencing
+every position query. Dropping the diagnostic left a file that looked
+clean and answered nothing.
+
+The Design-B semantic checks (effect / stores / default-purity / resource
+moves) are derived from the snapshot lazily, on the first `diagnostics`
+call, and cached on the `Snapshot`. Every other query reuses the same
+snapshot without paying for them.
+
+### URIs
+
+Clients send rfc3986-encoded URIs, so `Uri::to_filename` percent-decodes
+`file:` paths. Everything this crate derives from a URI — the
+`FilesystemCompilerHost` base path, the kiln manifest walk-up, the
+`span.file` match in `Engine::diagnostics` — depends on it: without
+decoding, a workspace under `my project/` resolved nothing at all.
+Non-`file:` schemes are compiler-minted and never encoded, so they pass
+through verbatim.
+
+Relative imports are normalised lexically (`../lib/x.wado` off
+`file:///a/b/foo.wado` is `file:///a/lib/x.wado`, not
+`file:///a/b/../lib/x.wado`). Clients key open documents by URI string, so
+the un-normalised form opened a duplicate tab for an already-open file.
+
 ### DiagnosticCollector
 
 `DiagnosticCollector` in `lib.rs` wraps any `CompilerHost`, delegating `load_source` while silently collecting all emitted diagnostics. This avoids modifying or depending on a specific host implementation.
 
 ### Stdio server
 
-`server::run_stdio` is the binary's only entrypoint and is also re-used by `wado-cli/src/lsp.rs`. I/O is synchronous (`std::io`) so the crate builds for `wasm32-wasip2`, where tokio's `io-std` is unavailable; the dispatcher still awaits `Engine` futures between messages. Async is driven by `futures::executor::block_on` — the crate does not depend on tokio.
+`server::run_stdio` is the binary's only entrypoint and is also re-used by `wado-cli/src/lsp.rs`. It returns the process exit code (LSP 3.18 §exit) rather than calling `std::process::exit`: `dispatch` records the client's `exit` on `Lifecycle::exit_code` and the loop returns it, so `wado lsp` routes it through the CLI's own exit path and the loop stays testable. I/O is synchronous (`std::io`) so the crate builds for `wasm32-wasip2`, where tokio's `io-std` is unavailable; the dispatcher still awaits `Engine` futures between messages. Async is driven by `futures::executor::block_on` — the crate does not depend on tokio.
 
 ### Bundled stdlib content
 
@@ -187,6 +222,11 @@ Progress tracker for LSP 3.18 feature kinds. Each item represents a protocol kin
 - [ ] `workspace/didChangeConfiguration`
 - [ ] `workspace/workspaceFolders` / `workspace/didChangeWorkspaceFolders`
 - [ ] `workspace/didChangeWatchedFiles`
+      Also the prerequisite for caching `FilesystemCompilerHost::dependency_index`
+      across requests: the walk-up + `wado.toml` + `wado.lock` parse currently
+      re-runs once per document version (the loader asks for the index exactly
+      once, when it is constructed). Caching it without watching the manifest
+      would serve a stale dependency set after an edit to `wado.toml`.
 - [ ] `workspace/executeCommand`
 - [ ] `workspace/applyEdit`
 - [ ] File operations (`willCreateFiles` / `didCreateFiles` / `willRenameFiles` / `didRenameFiles` / `willDeleteFiles` / `didDeleteFiles`)

--- a/wado-lsp/src/bin/wado-lsp.rs
+++ b/wado-lsp/src/bin/wado-lsp.rs
@@ -1,5 +1,5 @@
 //! Stdio LSP server entrypoint. Builds for both native and `wasm32-wasip2`.
 
 fn main() {
-    futures::executor::block_on(wado_lsp::server::run_stdio());
+    std::process::exit(futures::executor::block_on(wado_lsp::server::run_stdio()));
 }

--- a/wado-lsp/src/definition.rs
+++ b/wado-lsp/src/definition.rs
@@ -14,7 +14,7 @@ use wado_compiler::name::resolve_import_with_entry;
 use wado_compiler::token::Span;
 
 use crate::diagnostics::{Position, Range};
-use crate::location::{module_uri, span_to_range, symbol_uri};
+use crate::location::{module_uri, symbol_uri};
 use crate::query::QueryContext;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -68,7 +68,7 @@ pub(crate) fn find_definition(ctx: &QueryContext, position: Position) -> Option<
     };
     Some(DefinitionResult {
         uri: def_uri,
-        range: span_to_range(&span, ctx.source_for_id(def_key), ctx.encoding),
+        range: ctx.range_of(&span, def_key),
     })
 }
 

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -73,7 +73,6 @@ fn span_to_range(
     lines: Option<&LineIndex>,
     encoding: PositionEncoding,
 ) -> Range {
-    // Compiler uses 1-based line/codepoint column; LSP uses 0-based.
     let start_line = span.line.saturating_sub(1) as u32;
     let end_line = span
         .end_line

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -52,10 +52,71 @@ pub struct Diagnostic {
     pub tags: Vec<DiagnosticTag>,
 }
 
+/// Anchor for a diagnostic the compiler reported without a source location.
+const DOCUMENT_START: Range = Range {
+    start: Position {
+        line: 0,
+        character: 0,
+    },
+    end: Position {
+        line: 0,
+        character: 0,
+    },
+};
+
+/// Convert a [`DiagnosticSpan`](wado_compiler::DiagnosticSpan) to an LSP
+/// [`Range`], re-expressing the compiler's 1-based codepoint columns in
+/// `encoding`. `source` is the text the span points into; `None` passes the
+/// codepoint columns through (correct for ASCII / UTF-32).
+fn span_to_range(
+    span: &wado_compiler::DiagnosticSpan,
+    source: Option<&str>,
+    encoding: PositionEncoding,
+) -> Range {
+    // Compiler uses 1-based line/codepoint column; LSP uses 0-based.
+    let start_line = span.line.saturating_sub(1) as u32;
+    let end_line = span
+        .end_line
+        .map_or(start_line, |l| l.saturating_sub(1) as u32);
+    let start_codepoint = span.column.saturating_sub(1) as u32;
+    let end_codepoint = span
+        .end_column
+        .map_or(start_codepoint.saturating_add(1), |c| {
+            c.saturating_sub(1) as u32
+        });
+
+    let (start_char, end_char) = match source {
+        Some(src) => (
+            codepoint_offset_to_character(src, start_line, start_codepoint, encoding),
+            codepoint_offset_to_character(src, end_line, end_codepoint, encoding),
+        ),
+        None => (start_codepoint, end_codepoint),
+    };
+
+    Range {
+        start: Position {
+            line: start_line,
+            character: start_char,
+        },
+        end: Position {
+            line: end_line,
+            character: end_char,
+        },
+    }
+}
+
 /// Convert a compiler diagnostic to an LSP-compatible diagnostic.
 ///
 /// Returns `None` for diagnostics that should not be shown to the user
-/// (span tracking, log messages, diagnostics without source location).
+/// (span tracking, log messages, `Debug`-severity output).
+///
+/// A diagnostic with no span is anchored at the start of the document
+/// rather than dropped. The loader reports its hard failures — a missing
+/// or unreadable import (`ModuleNotFound`) above all — without a span, and
+/// those are exactly the failures that also blank out every position query
+/// for the document. Dropping them left the editor showing a file with no
+/// errors, no hover, and no navigation, with nothing on screen to explain
+/// why.
 ///
 /// `source` and `encoding` are used to re-express the compiler's
 /// codepoint columns in the negotiated position encoding. Pass
@@ -89,39 +150,13 @@ pub fn from_compiler_diagnostic(
         Vec::new()
     };
 
-    let span = diag.span.as_ref()?;
-
-    // Compiler uses 1-based line/codepoint column; LSP uses 0-based.
-    let start_line = span.line.saturating_sub(1) as u32;
-    let end_line = span
-        .end_line
-        .map_or(start_line, |l| l.saturating_sub(1) as u32);
-    let start_codepoint = span.column.saturating_sub(1) as u32;
-    let end_codepoint = span
-        .end_column
-        .map_or(start_codepoint.saturating_add(1), |c| {
-            c.saturating_sub(1) as u32
-        });
-
-    let (start_char, end_char) = match source {
-        Some(src) => (
-            codepoint_offset_to_character(src, start_line, start_codepoint, encoding),
-            codepoint_offset_to_character(src, end_line, end_codepoint, encoding),
-        ),
-        None => (start_codepoint, end_codepoint),
+    let range = match diag.span.as_ref() {
+        Some(span) => span_to_range(span, source, encoding),
+        None => DOCUMENT_START,
     };
 
     Some(Diagnostic {
-        range: Range {
-            start: Position {
-                line: start_line,
-                character: start_char,
-            },
-            end: Position {
-                line: end_line,
-                character: end_char,
-            },
-        },
+        range,
         severity,
         code: format!("{}", diag.code),
         source: Some("wado".to_string()),
@@ -240,22 +275,25 @@ mod tests {
     }
 
     #[test]
-    fn test_skip_no_span() {
+    fn span_less_diagnostic_anchors_at_document_start() {
+        // The loader reports `ModuleNotFound` without a span, and that same
+        // failure empties the `Semantics` so every position query goes quiet.
+        // Dropping it left the user with a silently dead file.
         let compiler_diag = CompilerDiagnostic {
             severity: CompilerSeverity::Error,
-            code: Code::CodegenError,
-            message: "internal error".to_string(),
+            code: Code::ModuleNotFound,
+            message: "module not found: ./missing.wado".to_string(),
             span: None,
         };
-        assert!(
-            from_compiler_diagnostic(
-                &compiler_diag,
-                "file:///test.wado",
-                None,
-                PositionEncoding::Utf16
-            )
-            .is_none()
-        );
+        let diag = from_compiler_diagnostic(
+            &compiler_diag,
+            "file:///test.wado",
+            None,
+            PositionEncoding::Utf16,
+        )
+        .expect("a span-less error must still reach the editor");
+        assert_eq!(diag.range, DOCUMENT_START);
+        assert_eq!(diag.severity, Severity::Error);
     }
 
     #[test]

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -110,22 +110,15 @@ fn span_to_range(
 /// Returns `None` for diagnostics that should not be shown to the user
 /// (span tracking, log messages, `Debug`-severity output).
 ///
-/// A diagnostic with no span is anchored at the start of the document
-/// rather than dropped. The loader reports its hard failures — a missing
-/// or unreadable import (`ModuleNotFound`) above all — without a span, and
-/// those are exactly the failures that also blank out every position query
-/// for the document. Dropping them left the editor showing a file with no
-/// errors, no hover, and no navigation, with nothing on screen to explain
-/// why.
+/// A diagnostic with no span is anchored at the document start rather than
+/// dropped: the loader reports its hard failures that way, and those are the
+/// same failures that silence every position query, so dropping them leaves
+/// nothing on screen to explain the silence.
 ///
-/// `lines` and `encoding` are used to re-express the compiler's
-/// codepoint columns in the negotiated position encoding. Pass
-/// `None` for diagnostics whose `span.file` is not the request
-/// document — the result will still be valid for ASCII source but may
-/// drift the column for non-ASCII codepoints (the spec's UTF-16
-/// default). For the request document itself the caller should always
-/// provide the index. It is built once per `textDocument/publishDiagnostics`
-/// and shared across every diagnostic in it — see [`LineIndex`].
+/// `lines` re-expresses the compiler's codepoint columns in `encoding`. Pass
+/// `None` for a span outside the request document — the columns then hold
+/// for ASCII and UTF-32 but may drift under UTF-16. One index is built per
+/// batch and shared; see [`LineIndex`].
 pub(crate) fn from_compiler_diagnostic(
     diag: &CompilerDiagnostic,
     _uri: &str,
@@ -277,9 +270,8 @@ mod tests {
 
     #[test]
     fn span_less_diagnostic_anchors_at_document_start() {
-        // The loader reports `ModuleNotFound` without a span, and that same
-        // failure empties the `Semantics` so every position query goes quiet.
-        // Dropping it left the user with a silently dead file.
+        // `ModuleNotFound` carries no span, and the same failure empties the
+        // `Semantics` — dropping it leaves a silently dead file.
         let compiler_diag = CompilerDiagnostic {
             severity: CompilerSeverity::Error,
             code: Code::ModuleNotFound,

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -121,7 +121,6 @@ fn span_to_range(
 /// batch and shared; see [`LineIndex`].
 pub(crate) fn from_compiler_diagnostic(
     diag: &CompilerDiagnostic,
-    _uri: &str,
     lines: Option<&LineIndex>,
     encoding: PositionEncoding,
 ) -> Option<Diagnostic> {
@@ -180,13 +179,7 @@ mod tests {
             }),
         };
 
-        let diag = from_compiler_diagnostic(
-            &compiler_diag,
-            "file:///test.wado",
-            None,
-            PositionEncoding::Utf16,
-        )
-        .unwrap();
+        let diag = from_compiler_diagnostic(&compiler_diag, None, PositionEncoding::Utf16).unwrap();
         assert_eq!(diag.severity, Severity::Error);
         assert_eq!(diag.code, "TYPE_MISMATCH");
         assert_eq!(diag.message, "expected i32, found String");
@@ -208,13 +201,7 @@ mod tests {
                 end_column: Some(10),
             }),
         };
-        let diag = from_compiler_diagnostic(
-            &compiler_diag,
-            "file:///test.wado",
-            None,
-            PositionEncoding::Utf16,
-        )
-        .unwrap();
+        let diag = from_compiler_diagnostic(&compiler_diag, None, PositionEncoding::Utf16).unwrap();
         assert_eq!(diag.tags, vec![DiagnosticTag::Unnecessary]);
         let json = serde_json::to_string(&diag).unwrap();
         assert!(json.contains("\"tags\":[1]"), "got {json}");
@@ -234,13 +221,7 @@ mod tests {
                 end_column: Some(2),
             }),
         };
-        let diag = from_compiler_diagnostic(
-            &compiler_diag,
-            "file:///test.wado",
-            None,
-            PositionEncoding::Utf16,
-        )
-        .unwrap();
+        let diag = from_compiler_diagnostic(&compiler_diag, None, PositionEncoding::Utf16).unwrap();
         assert!(diag.tags.is_empty());
         let json = serde_json::to_string(&diag).unwrap();
         assert!(
@@ -257,15 +238,7 @@ mod tests {
             message: "parse".to_string(),
             span: None,
         };
-        assert!(
-            from_compiler_diagnostic(
-                &compiler_diag,
-                "file:///test.wado",
-                None,
-                PositionEncoding::Utf16
-            )
-            .is_none()
-        );
+        assert!(from_compiler_diagnostic(&compiler_diag, None, PositionEncoding::Utf16).is_none());
     }
 
     #[test]
@@ -278,13 +251,8 @@ mod tests {
             message: "module not found: ./missing.wado".to_string(),
             span: None,
         };
-        let diag = from_compiler_diagnostic(
-            &compiler_diag,
-            "file:///test.wado",
-            None,
-            PositionEncoding::Utf16,
-        )
-        .expect("a span-less error must still reach the editor");
+        let diag = from_compiler_diagnostic(&compiler_diag, None, PositionEncoding::Utf16)
+            .expect("a span-less error must still reach the editor");
         assert_eq!(diag.range, DOCUMENT_START);
         assert_eq!(diag.severity, Severity::Error);
     }
@@ -303,13 +271,7 @@ mod tests {
                 end_column: None,
             }),
         };
-        let diag = from_compiler_diagnostic(
-            &compiler_diag,
-            "file:///test.wado",
-            None,
-            PositionEncoding::Utf16,
-        )
-        .unwrap();
+        let diag = from_compiler_diagnostic(&compiler_diag, None, PositionEncoding::Utf16).unwrap();
         assert_eq!(diag.severity, Severity::Warning);
     }
 
@@ -335,7 +297,6 @@ mod tests {
         };
         let diag = from_compiler_diagnostic(
             &compiler_diag,
-            "file:///entry.wado",
             None, // cross-file: no source on hand
             PositionEncoding::Utf16,
         )
@@ -367,7 +328,6 @@ mod tests {
         };
         let diag = from_compiler_diagnostic(
             &compiler_diag,
-            "file:///entry.wado",
             Some(&LineIndex::new(src)),
             PositionEncoding::Utf16,
         )
@@ -393,13 +353,7 @@ mod tests {
                 end_column: Some(15),
             }),
         };
-        let diag = from_compiler_diagnostic(
-            &compiler_diag,
-            "file:///test.wado",
-            None,
-            PositionEncoding::Utf16,
-        )
-        .unwrap();
+        let diag = from_compiler_diagnostic(&compiler_diag, None, PositionEncoding::Utf16).unwrap();
         assert_eq!(
             diag.range,
             Range {

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use wado_compiler::{Code, Diagnostic as CompilerDiagnostic, Severity as CompilerSeverity};
 
 use crate::macros::lsp_repr_u32_enum;
-use crate::text::{PositionEncoding, codepoint_offset_to_character};
+use crate::text::{LineIndex, PositionEncoding};
 
 lsp_repr_u32_enum!(
     /// LSP-compatible diagnostic severity. Serializes as the 1..=4 integer
@@ -66,11 +66,11 @@ const DOCUMENT_START: Range = Range {
 
 /// Convert a [`DiagnosticSpan`](wado_compiler::DiagnosticSpan) to an LSP
 /// [`Range`], re-expressing the compiler's 1-based codepoint columns in
-/// `encoding`. `source` is the text the span points into; `None` passes the
-/// codepoint columns through (correct for ASCII / UTF-32).
+/// `encoding`. `lines` indexes the text the span points into; `None` passes
+/// the codepoint columns through (correct for ASCII / UTF-32).
 fn span_to_range(
     span: &wado_compiler::DiagnosticSpan,
-    source: Option<&str>,
+    lines: Option<&LineIndex>,
     encoding: PositionEncoding,
 ) -> Range {
     // Compiler uses 1-based line/codepoint column; LSP uses 0-based.
@@ -85,10 +85,10 @@ fn span_to_range(
             c.saturating_sub(1) as u32
         });
 
-    let (start_char, end_char) = match source {
-        Some(src) => (
-            codepoint_offset_to_character(src, start_line, start_codepoint, encoding),
-            codepoint_offset_to_character(src, end_line, end_codepoint, encoding),
+    let (start_char, end_char) = match lines {
+        Some(lines) => (
+            lines.to_character(start_line, start_codepoint, encoding),
+            lines.to_character(end_line, end_codepoint, encoding),
         ),
         None => (start_codepoint, end_codepoint),
     };
@@ -118,17 +118,18 @@ fn span_to_range(
 /// errors, no hover, and no navigation, with nothing on screen to explain
 /// why.
 ///
-/// `source` and `encoding` are used to re-express the compiler's
+/// `lines` and `encoding` are used to re-express the compiler's
 /// codepoint columns in the negotiated position encoding. Pass
 /// `None` for diagnostics whose `span.file` is not the request
 /// document — the result will still be valid for ASCII source but may
 /// drift the column for non-ASCII codepoints (the spec's UTF-16
 /// default). For the request document itself the caller should always
-/// provide `Some(source)`.
-pub fn from_compiler_diagnostic(
+/// provide the index. It is built once per `textDocument/publishDiagnostics`
+/// and shared across every diagnostic in it — see [`LineIndex`].
+pub(crate) fn from_compiler_diagnostic(
     diag: &CompilerDiagnostic,
     _uri: &str,
-    source: Option<&str>,
+    lines: Option<&LineIndex>,
     encoding: PositionEncoding,
 ) -> Option<Diagnostic> {
     // Skip internal span tracking and log messages
@@ -151,7 +152,7 @@ pub fn from_compiler_diagnostic(
     };
 
     let range = match diag.span.as_ref() {
-        Some(span) => span_to_range(span, source, encoding),
+        Some(span) => span_to_range(span, lines, encoding),
         None => DOCUMENT_START,
     };
 
@@ -375,7 +376,7 @@ mod tests {
         let diag = from_compiler_diagnostic(
             &compiler_diag,
             "file:///entry.wado",
-            Some(src),
+            Some(&LineIndex::new(src)),
             PositionEncoding::Utf16,
         )
         .unwrap();

--- a/wado-lsp/src/document_highlight.rs
+++ b/wado-lsp/src/document_highlight.rs
@@ -18,7 +18,6 @@ use wado_compiler::ast::AstId;
 use wado_compiler::module_source::ModuleSource;
 
 use crate::diagnostics::{Position, Range};
-use crate::location::span_to_range;
 use crate::macros::lsp_repr_u32_enum;
 use crate::query::QueryContext;
 
@@ -40,14 +39,13 @@ pub struct DocumentHighlight {
 
 #[must_use]
 pub(crate) fn document_highlight(ctx: &QueryContext, position: Position) -> Vec<DocumentHighlight> {
-    let entry = ctx.entry().clone();
     let Some(cursor) = ctx.cursor_at(position) else {
         return Vec::new();
     };
     let Some(def_key) = cursor.def_key() else {
         return Vec::new();
     };
-    highlights_for_def(ctx, def_key, &entry)
+    highlights_for_def(ctx, def_key, ctx.entry())
 }
 
 /// Highlight every occurrence of `def_key` that lives in `target_module`,
@@ -69,7 +67,7 @@ pub(crate) fn highlights_for_def(
             .or_else(|| ctx.sem.symbol_at(def_key).and_then(|s| s.span))
     {
         out.push(DocumentHighlight {
-            range: span_to_range(&span, ctx.source_for_id(def_key), ctx.encoding),
+            range: ctx.range_of(&span, def_key),
             kind: HighlightKind::Write,
         });
     }
@@ -87,7 +85,7 @@ pub(crate) fn highlights_for_def(
             HighlightKind::Read
         };
         out.push(DocumentHighlight {
-            range: span_to_range(&span, ctx.source_for_id(use_id), ctx.encoding),
+            range: ctx.range_of(&span, use_id),
             kind,
         });
     }
@@ -108,12 +106,7 @@ mod tests {
         let uri = format!("file://{path}");
         let host = MapHost::single(path, source);
         let sem = wado_compiler::semantics(source, &host, Some(path)).await;
-        let ctx = QueryContext {
-            sem: &sem,
-            source,
-            uri: &uri,
-            encoding: PositionEncoding::Utf16,
-        };
+        let ctx = QueryContext::new(&sem, source, &uri, PositionEncoding::Utf16);
         document_highlight(&ctx, Position { line, character })
     }
 

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -39,7 +39,7 @@ impl FilesystemCompilerHost {
         }
     }
 
-    pub fn base_path(&self) -> &PathBuf {
+    pub fn base_path(&self) -> &Path {
         &self.base_path
     }
 

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -43,16 +43,26 @@ impl FilesystemCompilerHost {
         &self.base_path
     }
 
+    /// The collected buffer, recovering from a poisoned lock.
+    ///
+    /// A panic anywhere under the compiler pipeline while this lock is held
+    /// poisons it for the rest of the process. `unwrap()` would then turn
+    /// one recoverable panic into a permanently dead language server: every
+    /// later query re-panics on the same lock. The buffer's contents are
+    /// plain data — a partially-written `Vec` is still a valid `Vec` — so
+    /// recovering is safe. Matches `DiagnosticCollector` in `lib.rs`.
+    fn buffer(&self) -> std::sync::MutexGuard<'_, Vec<Diagnostic>> {
+        self.diagnostics
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     pub fn diagnostics(&self) -> Vec<Diagnostic> {
-        self.diagnostics.lock().unwrap().clone()
+        self.buffer().clone()
     }
 
     pub fn has_errors(&self) -> bool {
-        self.diagnostics
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|d| d.severity == Severity::Error)
+        self.buffer().iter().any(|d| d.severity == Severity::Error)
     }
 
     /// Append a diagnostic to the collected buffer without emitting it.
@@ -61,7 +71,7 @@ impl FilesystemCompilerHost {
     /// printing) so the buffer remains the single source of truth for
     /// `has_errors` / `diagnostics()`.
     pub fn collect_diagnostic(&self, diagnostic: Diagnostic) {
-        self.diagnostics.lock().unwrap().push(diagnostic);
+        self.buffer().push(diagnostic);
     }
 }
 
@@ -113,8 +123,20 @@ pub fn registry_component_needs(
     manifest: &wado_manifest::Manifest,
     manifest_dir: &Path,
 ) -> Vec<Result<RegistryComponentNeed, (String, String)>> {
+    let locked = read_lock(manifest_dir)
+        .as_ref()
+        .map(registry_pins)
+        .unwrap_or_default();
+    registry_component_needs_locked(manifest, &locked)
+}
+
+/// [`registry_component_needs`] against an already-parsed lock, so a caller
+/// resolving several dependency kinds reads `wado.lock` once.
+fn registry_component_needs_locked(
+    manifest: &wado_manifest::Manifest,
+    locked: &std::collections::BTreeMap<String, String>,
+) -> Vec<Result<RegistryComponentNeed, (String, String)>> {
     let root = cache_root();
-    let locked = locked_registry_versions(manifest_dir);
     manifest
         .dependencies
         .iter()
@@ -127,7 +149,7 @@ pub fn registry_component_needs(
                     name,
                     registry.as_deref(),
                     package,
-                    &locked,
+                    locked,
                     root.as_deref(),
                 )
                 .map_err(|reason| (name.clone(), reason)),
@@ -186,7 +208,14 @@ pub fn dependency_index_from(
     base: &Path,
 ) -> DependencyIndex {
     let mut index = DependencyIndex::default();
-    let base_abs = absolutize(base);
+    let base_abs = crate::workspace::absolutize(base);
+    // `wado.lock` is read and parsed exactly once here. Both dependency kinds
+    // that consult it — git worktrees and registry components — take their
+    // pins from this one parse; the git path used to re-read the file per
+    // dependency.
+    let lock = read_lock(manifest_dir);
+    let git_pins = lock.clone().map(git_pins).unwrap_or_default();
+    let registry_pins = lock.as_ref().map(registry_pins).unwrap_or_default();
     for (name, dep) in &manifest.dependencies {
         match &dep.source {
             DependencySource::Path { path, .. } => {
@@ -194,7 +223,7 @@ pub fn dependency_index_from(
                     Ok(entry) => {
                         index
                             .resolved
-                            .insert(name.clone(), relative_path(&base_abs, &absolutize(&entry)));
+                            .insert(name.clone(), relative_path(&base_abs, &crate::workspace::absolutize(&entry)));
                     }
                     Err(reason) => {
                         index.unresolved.insert(name.clone(), reason);
@@ -202,11 +231,11 @@ pub fn dependency_index_from(
                 }
             }
             DependencySource::Git { url, directory, .. } => {
-                match git_dependency_entry(manifest_dir, name, url, directory.as_deref()) {
+                match git_dependency_entry(&git_pins, name, url, directory.as_deref()) {
                     Ok(entry) => {
                         index
                             .resolved
-                            .insert(name.clone(), relative_path(&base_abs, &absolutize(&entry)));
+                            .insert(name.clone(), relative_path(&base_abs, &crate::workspace::absolutize(&entry)));
                     }
                     Err(reason) => {
                         index.unresolved.insert(name.clone(), reason);
@@ -214,12 +243,11 @@ pub fn dependency_index_from(
                 }
             }
             DependencySource::Workspace => {}
-            // Registry deps are indexed from `registry_component_needs` below,
-            // so the lock is read once for the whole manifest.
+            // Registry deps are indexed from the needs list below.
             DependencySource::Registry { .. } => {}
         }
     }
-    for need in registry_component_needs(manifest, manifest_dir) {
+    for need in registry_component_needs_locked(manifest, &registry_pins) {
         match need {
             Ok(need) if need.cache_path.is_file() => {
                 index
@@ -245,18 +273,18 @@ pub fn dependency_index_from(
 /// `directory`); `Err(reason)` explains why it cannot be placed (no lock pin, no
 /// cache root, or a cold worktree pointing the user at `wado fetch`).
 fn git_dependency_entry(
-    manifest_dir: &Path,
+    locked: &std::collections::BTreeMap<String, (String, String)>,
     name: &str,
     url: &str,
     directory: Option<&str>,
 ) -> Result<PathBuf, String> {
     let id = format!("git+{url}/{name}");
-    let (version, resolved_ref) = locked_git_packages(manifest_dir)
-        .remove(&id)
+    let (version, resolved_ref) = locked
+        .get(&id)
         .ok_or_else(|| format!("no `wado.lock` entry for {name:?}; run `wado update`"))?;
     let root =
         cache_root().ok_or_else(|| format!("no cache root for {name:?}; set `WADO_ROOT`"))?;
-    let relative = wado_manifest::cache::git_worktree_relative(url, &version, &resolved_ref)
+    let relative = wado_manifest::cache::git_worktree_relative(url, version, resolved_ref)
         .ok_or_else(|| format!("cannot place {name:?} in the cache (bad git url {url:?})"))?;
     let worktree_root = root.join(relative);
     // The `.ready` completion marker (written last by `wado-cli`'s materializer)
@@ -274,6 +302,15 @@ fn git_dependency_entry(
     package_lib_entry(&pkg_dir)
 }
 
+/// Parse `manifest_dir`'s `wado.lock`, or `None` when it is absent or
+/// malformed (a cold checkout reads as "nothing pinned").
+fn read_lock(manifest_dir: &Path) -> Option<wado_manifest::LockFile> {
+    std::fs::read_to_string(manifest_dir.join("wado.lock"))
+        .ok()?
+        .parse::<wado_manifest::LockFile>()
+        .ok()
+}
+
 /// `lock id -> (version, resolved-ref)` for every git `[[package]]` in
 /// `manifest_dir`'s `wado.lock`. Empty when no lock is present. Shared so the CLI
 /// can materialize the same worktrees the offline index resolves against.
@@ -281,36 +318,23 @@ fn git_dependency_entry(
 pub fn locked_git_packages(
     manifest_dir: &Path,
 ) -> std::collections::BTreeMap<String, (String, String)> {
-    let mut out = std::collections::BTreeMap::new();
-    let Ok(text) = std::fs::read_to_string(manifest_dir.join("wado.lock")) else {
-        return out;
-    };
-    let Ok(lock) = text.parse::<wado_manifest::LockFile>() else {
-        return out;
-    };
-    for pkg in &lock.packages {
-        if let Some(sha) = &pkg.resolved_ref {
-            out.insert(pkg.id.clone(), (pkg.version.clone(), sha.clone()));
-        }
-    }
-    out
+    read_lock(manifest_dir).map(git_pins).unwrap_or_default()
 }
 
-/// `lock id -> version` for every registry `[[package]]` in `manifest_dir`'s
-/// `wado.lock`. Keyed by the full id so distinct registries never collide.
-/// Empty when no lock is present (a cold checkout).
-fn locked_registry_versions(manifest_dir: &Path) -> std::collections::BTreeMap<String, String> {
-    let mut out = std::collections::BTreeMap::new();
-    let Ok(text) = std::fs::read_to_string(manifest_dir.join("wado.lock")) else {
-        return out;
-    };
-    let Ok(lock) = text.parse::<wado_manifest::LockFile>() else {
-        return out;
-    };
-    for pkg in &lock.packages {
-        out.insert(pkg.id.clone(), pkg.version.clone());
-    }
-    out
+fn git_pins(lock: wado_manifest::LockFile) -> std::collections::BTreeMap<String, (String, String)> {
+    lock.packages
+        .into_iter()
+        .filter_map(|pkg| Some((pkg.id, (pkg.version, pkg.resolved_ref?))))
+        .collect()
+}
+
+/// `lock id -> version` for every registry `[[package]]`. Keyed by the full id
+/// so distinct registries never collide.
+fn registry_pins(lock: &wado_manifest::LockFile) -> std::collections::BTreeMap<String, String> {
+    lock.packages
+        .iter()
+        .map(|pkg| (pkg.id.clone(), pkg.version.clone()))
+        .collect()
 }
 
 /// The Wado root (dependency cache): `$WADO_ROOT`, else `~/wado` (`$HOME/wado`).
@@ -333,21 +357,12 @@ pub fn cache_root() -> Option<PathBuf> {
         .map(|home| PathBuf::from(home).join("wado"))
 }
 
-/// Walk up from `start` to find the nearest `wado.toml`, returning the parsed
-/// manifest and its directory.
+/// The nearest `wado.toml` at or above `start`, parsed, with its directory.
 fn nearest_manifest(start: &Path) -> Option<(wado_manifest::Manifest, PathBuf)> {
-    let mut dir = absolutize(start);
-    loop {
-        let candidate = dir.join("wado.toml");
-        if candidate.is_file() {
-            let text = std::fs::read_to_string(&candidate).ok()?;
-            let manifest = crate::workspace::resolve_member_manifest(&dir, &text).ok()?;
-            return Some((manifest, dir));
-        }
-        if !dir.pop() {
-            return None;
-        }
-    }
+    let dir = crate::workspace::nearest_manifest_dir(start)?;
+    let text = std::fs::read_to_string(dir.join(crate::workspace::MANIFEST_FILENAME)).ok()?;
+    let manifest = crate::workspace::resolve_member_manifest(&dir, &text).ok()?;
+    Some((manifest, dir))
 }
 
 /// The entry module file of a source dependency: the file itself when the path
@@ -373,16 +388,6 @@ pub fn package_lib_entry(dep_path: &Path) -> Result<PathBuf, String> {
         )
     })?;
     Ok(dep_path.join(lib))
-}
-
-fn absolutize(p: &Path) -> PathBuf {
-    if p.is_absolute() {
-        p.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .map(|cwd| cwd.join(p))
-            .unwrap_or_else(|_| p.to_path_buf())
-    }
 }
 
 /// Lexical relative path from directory `from_dir` to file `to_file`. Both

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -45,12 +45,9 @@ impl FilesystemCompilerHost {
 
     /// The collected buffer, recovering from a poisoned lock.
     ///
-    /// A panic anywhere under the compiler pipeline while this lock is held
-    /// poisons it for the rest of the process. `unwrap()` would then turn
-    /// one recoverable panic into a permanently dead language server: every
-    /// later query re-panics on the same lock. The buffer's contents are
-    /// plain data — a partially-written `Vec` is still a valid `Vec` — so
-    /// recovering is safe. Matches `DiagnosticCollector` in `lib.rs`.
+    /// One panic under the compiler pipeline would otherwise leave every
+    /// later query panicking on the same lock. The contents are plain data,
+    /// so recovery is safe. Matches `DiagnosticCollector` in `lib.rs`.
     fn buffer(&self) -> std::sync::MutexGuard<'_, Vec<Diagnostic>> {
         self.diagnostics
             .lock()
@@ -130,8 +127,7 @@ pub fn registry_component_needs(
     registry_component_needs_locked(manifest, &locked)
 }
 
-/// [`registry_component_needs`] against an already-parsed lock, so a caller
-/// resolving several dependency kinds reads `wado.lock` once.
+/// [`registry_component_needs`] against an already-parsed lock.
 fn registry_component_needs_locked(
     manifest: &wado_manifest::Manifest,
     locked: &std::collections::BTreeMap<String, String>,
@@ -209,10 +205,7 @@ pub fn dependency_index_from(
 ) -> DependencyIndex {
     let mut index = DependencyIndex::default();
     let base_abs = crate::workspace::absolutize(base);
-    // `wado.lock` is read and parsed exactly once here. Both dependency kinds
-    // that consult it — git worktrees and registry components — take their
-    // pins from this one parse; the git path used to re-read the file per
-    // dependency.
+    // One parse of `wado.lock` for both dependency kinds that consult it.
     let lock = read_lock(manifest_dir);
     let git_pins = lock.clone().map(git_pins).unwrap_or_default();
     let registry_pins = lock.as_ref().map(registry_pins).unwrap_or_default();

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -221,9 +221,10 @@ pub fn dependency_index_from(
             DependencySource::Path { path, .. } => {
                 match package_lib_entry(&manifest_dir.join(path)) {
                     Ok(entry) => {
-                        index
-                            .resolved
-                            .insert(name.clone(), relative_path(&base_abs, &crate::workspace::absolutize(&entry)));
+                        index.resolved.insert(
+                            name.clone(),
+                            relative_path(&base_abs, &crate::workspace::absolutize(&entry)),
+                        );
                     }
                     Err(reason) => {
                         index.unresolved.insert(name.clone(), reason);
@@ -233,9 +234,10 @@ pub fn dependency_index_from(
             DependencySource::Git { url, directory, .. } => {
                 match git_dependency_entry(&git_pins, name, url, directory.as_deref()) {
                     Ok(entry) => {
-                        index
-                            .resolved
-                            .insert(name.clone(), relative_path(&base_abs, &crate::workspace::absolutize(&entry)));
+                        index.resolved.insert(
+                            name.clone(),
+                            relative_path(&base_abs, &crate::workspace::absolutize(&entry)),
+                        );
                     }
                     Err(reason) => {
                         index.unresolved.insert(name.clone(), reason);

--- a/wado-lsp/src/host.rs
+++ b/wado-lsp/src/host.rs
@@ -205,7 +205,6 @@ pub fn dependency_index_from(
 ) -> DependencyIndex {
     let mut index = DependencyIndex::default();
     let base_abs = crate::workspace::absolutize(base);
-    // One parse of `wado.lock` for both dependency kinds that consult it.
     let lock = read_lock(manifest_dir);
     let git_pins = lock.clone().map(git_pins).unwrap_or_default();
     let registry_pins = lock.as_ref().map(registry_pins).unwrap_or_default();

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -319,9 +319,7 @@ fn pattern_binds(pattern: &ast::Pattern, target: AstId) -> bool {
 /// shares a name with `target`.
 fn item_info(item: &Item, target: AstId, public_only: bool) -> Option<String> {
     match item {
-        Item::Function(f) => {
-            (f.id == target).then(|| unparse::unparse_function_signature(f))
-        }
+        Item::Function(f) => (f.id == target).then(|| unparse::unparse_function_signature(f)),
         // Struct fields follow `public_only` (matching `wado doc`'s `..`
         // elision when set); enum cases are always public.
         Item::Struct(s) => {
@@ -657,7 +655,8 @@ mod tests {
                 "    return apply(|n: i32| -> i32 { let doubled = n * 2; return doubled; });\n",
                 "}\n",
             );
-            let line = "    return apply(|n: i32| -> i32 { let doubled = n * 2; return doubled; });";
+            let line =
+                "    return apply(|n: i32| -> i32 { let doubled = n * 2; return doubled; });";
             let col = line.rfind("doubled").unwrap() as u32;
             let result = hover_at(source, 2, col).await.expect("hover on doubled");
             assert_eq!(result.contents.value, "```wado\nlet doubled\n```");

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -137,11 +137,9 @@ fn fenced_hover(signature: String) -> HoverResult {
 
 /// Render a signature for the given item-level symbol.
 ///
-/// Matching is by [`AstId`] identity, never by name: a module may hold
-/// several declarations sharing one name (a struct field and a free function,
-/// an enum case and a method), and a name scan returns whichever the parser
-/// happened to place first — `struct Wrap { helper: i32 }` used to shadow
-/// `fn helper()` on hover. `Symbol::defined_at` names exactly one node.
+/// Matching is by [`AstId`], never by name: a module may declare one name
+/// twice — a struct field beside a free function, an enum case beside a
+/// method — and only `Symbol::defined_at` picks out which one.
 fn render_item_signature(sem: &Semantics, symbol: &Symbol, public_only: bool) -> Option<String> {
     let module = sem.modules.get(symbol.module_source())?;
     let target = symbol.defined_at;
@@ -170,15 +168,11 @@ fn render_local_binding(sem: &Semantics, def_id: AstId, name: &str) -> Option<St
 
 /// Locates the AST node that binds `target` and renders its declaration.
 ///
-/// Traversal is [`AstVisitor`]'s, not hand-rolled. The previous hand-rolled
-/// walker only descended through the statement and expression shapes someone
-/// had thought to list, so a binding one level off that path — a `let` inside
-/// a closure passed as a call argument, say — resolved to a symbol whose
-/// declaration hover could not find, and hover silently returned nothing.
-/// `walk_*` covers every shape by construction, including impl constants,
-/// resource methods, and items nested in statements.
+/// Traversal is [`AstVisitor`]'s rather than hand-rolled, so every shape that
+/// can hold a binding is reached by construction — a `let` inside a closure
+/// passed as a call argument as readily as one at the top of a function body.
 ///
-/// Only the shapes that carry extra syntax are intercepted: `Stmt::Let` (for
+/// Only the shapes carrying extra syntax are intercepted: `Stmt::Let` (for
 /// `mut` and the type annotation), function and closure parameters. Every
 /// other binding site — match arms, `if let` / `while let`, `for … of` —
 /// reaches [`Self::visit_pattern`] and renders as a bare `let name`.
@@ -250,9 +244,8 @@ impl AstVisitor for LocalRenderer<'_> {
         }
         self.result = self.render_param(&method.params);
         if self.result.is_none() {
-            // An interface method has no body today, so this walk finds
-            // nothing — but not walking is how the previous implementation
-            // grew its blind spots.
+            // No body to search today; walk anyway so a future one is not
+            // silently missed.
             ast::walk_interface_method(self, method);
         }
     }
@@ -314,9 +307,7 @@ fn pattern_binds(pattern: &ast::Pattern, target: AstId) -> bool {
 }
 
 /// Render `item` when it — or one of its members — is the declaration
-/// identified by `target`. Each arm compares the declaring node's own
-/// [`AstId`], so a member arm can never be reached by an item that merely
-/// shares a name with `target`.
+/// identified by `target`.
 fn item_info(item: &Item, target: AstId, public_only: bool) -> Option<String> {
     match item {
         Item::Function(f) => (f.id == target).then(|| unparse::unparse_function_signature(f)),
@@ -629,9 +620,7 @@ mod tests {
 
     #[test]
     fn item_hover_ignores_a_member_sharing_the_name() {
-        // `render_item_signature` used to scan the module by name, so the
-        // struct field `helper` — declared first — answered a hover on the
-        // free function `helper`. Resolution is by `AstId` now.
+        // A name scan would answer with the struct field, declared first.
         futures::executor::block_on(async {
             let source = concat!(
                 "struct Wrap { helper: i32 }\n",
@@ -645,9 +634,7 @@ mod tests {
 
     #[test]
     fn hover_on_local_inside_a_closure_call_argument() {
-        // The hand-rolled walker bottomed out at `Expr::Call`, so a binding
-        // inside a closure passed as an argument was unreachable: the cursor
-        // resolved to the symbol, and hover returned nothing.
+        // A binding reachable only through a call argument.
         futures::executor::block_on(async {
             let source = concat!(
                 "fn apply(f: fn(i32) -> i32) -> i32 { return f(1); }\n",
@@ -665,8 +652,8 @@ mod tests {
 
     #[test]
     fn hover_on_local_inside_a_nested_call_argument_block() {
-        // Same gap, one shape further out: a labeled block nested in a
-        // binary operand inside a call argument.
+        // One shape further out: a labeled block in a binary operand in a
+        // call argument.
         futures::executor::block_on(async {
             let source = concat!(
                 "fn take(v: i32) -> i32 { return v; }\n",
@@ -683,8 +670,7 @@ mod tests {
 
     #[test]
     fn hover_on_local_inside_a_test_block_closure() {
-        // `Item::Test` bodies were covered before, but only down the same
-        // hand-listed path — a binding inside a closure there was not.
+        // A `test` block body, through a closure.
         futures::executor::block_on(async {
             let source = concat!(
                 "fn apply(f: fn(i32) -> i32) -> i32 { return f(1); }\n",

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -168,9 +168,8 @@ fn render_local_binding(sem: &Semantics, def_id: AstId, name: &str) -> Option<St
 
 /// Locates the AST node that binds `target` and renders its declaration.
 ///
-/// Traversal is [`AstVisitor`]'s rather than hand-rolled, so every shape that
-/// can hold a binding is reached by construction — a `let` inside a closure
-/// passed as a call argument as readily as one at the top of a function body.
+/// Traversal is [`AstVisitor`]'s, so every shape that can hold a binding is
+/// reached by construction.
 ///
 /// Only the shapes carrying extra syntax are intercepted: `Stmt::Let` (for
 /// `mut` and the type annotation), function and closure parameters. Every
@@ -634,7 +633,6 @@ mod tests {
 
     #[test]
     fn hover_on_local_inside_a_closure_call_argument() {
-        // A binding reachable only through a call argument.
         futures::executor::block_on(async {
             let source = concat!(
                 "fn apply(f: fn(i32) -> i32) -> i32 { return f(1); }\n",
@@ -652,8 +650,6 @@ mod tests {
 
     #[test]
     fn hover_on_local_inside_a_nested_call_argument_block() {
-        // One shape further out: a labeled block in a binary operand in a
-        // call argument.
         futures::executor::block_on(async {
             let source = concat!(
                 "fn take(v: i32) -> i32 { return v; }\n",
@@ -670,7 +666,6 @@ mod tests {
 
     #[test]
     fn hover_on_local_inside_a_test_block_closure() {
-        // A `test` block body, through a closure.
         futures::executor::block_on(async {
             let source = concat!(
                 "fn apply(f: fn(i32) -> i32) -> i32 { return f(1); }\n",

--- a/wado-lsp/src/hover.rs
+++ b/wado-lsp/src/hover.rs
@@ -8,13 +8,12 @@
 //! `wado_compiler::unparse`.
 
 use serde::{Deserialize, Serialize};
-use wado_compiler::ast::{self, AstId, Expr, Item, Module, Stmt};
+use wado_compiler::ast::{self, AstId, AstVisitor, Expr, Item, Stmt};
 use wado_compiler::semantics::Semantics;
 use wado_compiler::symbol::{Symbol, SymbolKind};
 use wado_compiler::unparse;
 
 use crate::diagnostics::{Position, Range};
-use crate::location::span_to_range;
 use crate::query::QueryContext;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -58,7 +57,7 @@ pub(crate) fn find_hover_opts(
             kind: MarkupKind::Markdown,
             value: format!("```wado\n{signature}\n```"),
         },
-        range: Some(span_to_range(&cursor_span, Some(ctx.source), ctx.encoding)),
+        range: Some(ctx.range_in_document(&cursor_span)),
     })
 }
 
@@ -137,318 +136,248 @@ fn fenced_hover(signature: String) -> HoverResult {
 }
 
 /// Render a signature for the given item-level symbol.
+///
+/// Matching is by [`AstId`] identity, never by name: a module may hold
+/// several declarations sharing one name (a struct field and a free function,
+/// an enum case and a method), and a name scan returns whichever the parser
+/// happened to place first — `struct Wrap { helper: i32 }` used to shadow
+/// `fn helper()` on hover. `Symbol::defined_at` names exactly one node.
 fn render_item_signature(sem: &Semantics, symbol: &Symbol, public_only: bool) -> Option<String> {
     let module = sem.modules.get(symbol.module_source())?;
-    for item in &module.items {
-        if let Some(rendered) = item_info(item, &symbol.name, public_only) {
-            return Some(rendered);
-        }
-    }
-    None
+    let target = symbol.defined_at;
+    module
+        .items
+        .iter()
+        .find_map(|item| item_info(item, target, public_only))
 }
 
 /// Render a hover line for a local binding (`let x: T` / `fn f(x: T)`).
 fn render_local_binding(sem: &Semantics, def_id: AstId, name: &str) -> Option<String> {
     let module = sem.modules.get(sem.module_of_id(def_id)?)?;
-    render_local_in_module(module, def_id, name)
-}
-
-fn render_local_in_module(module: &Module, target: AstId, name: &str) -> Option<String> {
+    let mut renderer = LocalRenderer {
+        target: def_id,
+        name,
+        result: None,
+    };
     for item in &module.items {
-        if let Some(s) = render_local_in_item(item, target, name) {
-            return Some(s);
+        renderer.visit_item(item);
+        if renderer.result.is_some() {
+            break;
         }
     }
-    None
+    renderer.result
 }
 
-fn render_local_in_item(item: &Item, target: AstId, name: &str) -> Option<String> {
-    match item {
-        Item::Function(f) => {
-            for p in &f.params {
-                if p.id == target {
-                    let mut out = String::new();
-                    unparse::unparse_param_into(p, &mut out);
-                    return Some(out);
-                }
-            }
-            if let Some(body) = &f.body {
-                return find_let_in_block(body, target, name);
-            }
-            None
-        }
-        Item::Impl(imp) => {
-            for m in &imp.methods {
-                for p in &m.params {
-                    if p.id == target {
-                        let mut out = String::new();
-                        unparse::unparse_param_into(p, &mut out);
-                        return Some(out);
-                    }
-                }
-                if let Some(body) = &m.body
-                    && let Some(s) = find_let_in_block(body, target, name)
-                {
-                    return Some(s);
-                }
-            }
-            None
-        }
-        Item::Trait(t) => {
-            for m in &t.methods {
-                for p in &m.params {
-                    if p.id == target {
-                        let mut out = String::new();
-                        unparse::unparse_param_into(p, &mut out);
-                        return Some(out);
-                    }
-                }
-                if let Some(body) = &m.body
-                    && let Some(s) = find_let_in_block(body, target, name)
-                {
-                    return Some(s);
-                }
-            }
-            None
-        }
-        Item::Test(t) => find_let_in_block(&t.body, target, name),
-        Item::Global(g) => find_let_in_expr(&g.initializer, target, name),
-        _ => None,
+/// Locates the AST node that binds `target` and renders its declaration.
+///
+/// Traversal is [`AstVisitor`]'s, not hand-rolled. The previous hand-rolled
+/// walker only descended through the statement and expression shapes someone
+/// had thought to list, so a binding one level off that path — a `let` inside
+/// a closure passed as a call argument, say — resolved to a symbol whose
+/// declaration hover could not find, and hover silently returned nothing.
+/// `walk_*` covers every shape by construction, including impl constants,
+/// resource methods, and items nested in statements.
+///
+/// Only the shapes that carry extra syntax are intercepted: `Stmt::Let` (for
+/// `mut` and the type annotation), function and closure parameters. Every
+/// other binding site — match arms, `if let` / `while let`, `for … of` —
+/// reaches [`Self::visit_pattern`] and renders as a bare `let name`.
+struct LocalRenderer<'a> {
+    target: AstId,
+    name: &'a str,
+    result: Option<String>,
+}
+
+impl LocalRenderer<'_> {
+    /// The declaring param of `params`, rendered as `name: T`.
+    fn render_param(&self, params: &[ast::Param]) -> Option<String> {
+        let param = params.iter().find(|p| p.id == self.target)?;
+        let mut out = String::new();
+        unparse::unparse_param_into(param, &mut out);
+        Some(out)
     }
-}
 
-fn find_let_in_block(block: &ast::Block, target: AstId, name: &str) -> Option<String> {
-    for stmt in &block.stmts {
-        if let Some(s) = find_let_in_stmt(stmt, target, name) {
-            return Some(s);
+    /// `let [mut ]name[: T]`. The annotation is shown only for a simple
+    /// binding — for a destructuring pattern the annotation describes the
+    /// whole scrutinee, not the leaf the cursor sits on.
+    fn render_let(&self, l: &ast::LetStmt) -> Option<String> {
+        if !pattern_binds(&l.pattern, self.target) {
+            return None;
         }
+        let mut out = String::new();
+        out.push_str(if l.is_mut { "let mut " } else { "let " });
+        out.push_str(self.name);
+        if let Some(ty) = &l.ty
+            && matches!(
+                &l.pattern,
+                ast::Pattern::Ident { .. } | ast::Pattern::MutIdent { .. }
+            )
+        {
+            out.push_str(": ");
+            unparse::unparse_type_into(ty, &mut out);
+        }
+        Some(out)
     }
-    None
-}
 
-fn format_binding_name(name: &str) -> String {
-    format!("let {name}")
-}
-
-fn find_let_in_condition(cond: &ast::Condition, target: AstId, name: &str) -> Option<String> {
-    use ast::{Condition, ConditionElement};
-    match cond {
-        Condition::Expr(e) => find_let_in_expr(e, target, name),
-        Condition::LetChain { elements, .. } => {
-            for el in elements {
-                match el {
-                    ConditionElement::Let { pattern, expr, .. } => {
-                        if pattern_contains_ident(pattern, target) {
-                            return Some(format_binding_name(name));
-                        }
-                        if let Some(r) = find_let_in_expr(expr, target, name) {
-                            return Some(r);
-                        }
-                    }
-                    ConditionElement::Expr(e) => {
-                        if let Some(r) = find_let_in_expr(e, target, name) {
-                            return Some(r);
-                        }
-                    }
-                }
-            }
-            None
+    /// `|name: T|` for the closure parameter declaring `target`.
+    fn render_closure_param(&self, params: &[ast::ClosureParam]) -> Option<String> {
+        let param = params.iter().find(|p| p.id == self.target)?;
+        let mut out = String::from("|");
+        out.push_str(&param.name);
+        if let Some(ty) = &param.ty {
+            out.push_str(": ");
+            unparse::unparse_type_into(ty, &mut out);
         }
+        out.push('|');
+        Some(out)
     }
 }
 
-fn pattern_contains_ident(pattern: &ast::Pattern, target: AstId) -> bool {
+impl AstVisitor for LocalRenderer<'_> {
+    fn visit_function(&mut self, func: &ast::Function) {
+        if self.result.is_some() {
+            return;
+        }
+        self.result = self.render_param(&func.params);
+        if self.result.is_none() {
+            ast::walk_function(self, func);
+        }
+    }
+
+    fn visit_interface_method(&mut self, method: &ast::InterfaceMethod) {
+        if self.result.is_some() {
+            return;
+        }
+        self.result = self.render_param(&method.params);
+        if self.result.is_none() {
+            // An interface method has no body today, so this walk finds
+            // nothing — but not walking is how the previous implementation
+            // grew its blind spots.
+            ast::walk_interface_method(self, method);
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if self.result.is_some() {
+            return;
+        }
+        // `Stmt::Let` is intercepted before `walk_stmt` would hand its
+        // pattern to `visit_pattern`, which renders the annotation-less form.
+        if let Stmt::Let(l) = stmt
+            && let Some(rendered) = self.render_let(l)
+        {
+            self.result = Some(rendered);
+            return;
+        }
+        ast::walk_stmt(self, stmt);
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        if self.result.is_some() {
+            return;
+        }
+        if let Expr::Closure(c) = expr
+            && let Some(rendered) = self.render_closure_param(&c.params)
+        {
+            self.result = Some(rendered);
+            return;
+        }
+        ast::walk_expr(self, expr);
+    }
+
+    fn visit_pattern(&mut self, pat: &ast::Pattern) {
+        if self.result.is_some() {
+            return;
+        }
+        if pattern_binds(pat, self.target) {
+            self.result = Some(format!("let {}", self.name));
+            return;
+        }
+        ast::walk_pattern(self, pat);
+    }
+}
+
+/// Whether `pattern` itself is the identifier leaf binding `target`.
+/// Recursion into sub-patterns is [`ast::walk_pattern`]'s job.
+fn pattern_binds(pattern: &ast::Pattern, target: AstId) -> bool {
     match pattern {
         ast::Pattern::Ident { id, .. } | ast::Pattern::MutIdent { id, .. } => *id == target,
-        ast::Pattern::Tuple(ps, _) | ast::Pattern::Or(ps) => {
-            ps.iter().any(|p| pattern_contains_ident(p, target))
-        }
-        ast::Pattern::Struct { fields, .. } => fields
-            .iter()
-            .any(|f| pattern_contains_ident(&f.pattern, target)),
-        ast::Pattern::Variant { bindings, .. } => {
-            bindings.iter().any(|p| pattern_contains_ident(p, target))
-        }
-        _ => false,
+        ast::Pattern::Tuple(..)
+        | ast::Pattern::Or(_)
+        | ast::Pattern::Struct { .. }
+        | ast::Pattern::Variant { .. }
+        | ast::Pattern::Range { .. }
+        | ast::Pattern::Literal(_)
+        | ast::Pattern::Wildcard
+        | ast::Pattern::Error(_) => false,
     }
 }
 
-fn find_let_in_stmt(stmt: &Stmt, target: AstId, name: &str) -> Option<String> {
-    match stmt {
-        Stmt::Let(l) => {
-            if pattern_contains_ident(&l.pattern, target) {
-                let mut out = String::new();
-                out.push_str(if l.is_mut { "let mut " } else { "let " });
-                out.push_str(name);
-                if let Some(ty) = &l.ty
-                    && matches!(
-                        &l.pattern,
-                        ast::Pattern::Ident { .. } | ast::Pattern::MutIdent { .. }
-                    )
-                {
-                    out.push_str(": ");
-                    unparse::unparse_type_into(ty, &mut out);
-                }
-                return Some(out);
-            }
-            l.value
-                .as_ref()
-                .and_then(|v| find_let_in_expr(v, target, name))
-                .or_else(|| {
-                    l.else_block
-                        .as_ref()
-                        .and_then(|b| find_let_in_block(b, target, name))
-                })
-        }
-        Stmt::Expr(s) => find_let_in_expr(&s.expr, target, name),
-        Stmt::Return(s) => s
-            .value
-            .as_ref()
-            .and_then(|v| find_let_in_expr(v, target, name)),
-        Stmt::TaskReturn(s) => find_let_in_expr(&s.value, target, name),
-        Stmt::If(s) => find_let_in_condition(&s.condition, target, name)
-            .or_else(|| find_let_in_block(&s.then_block, target, name))
-            .or_else(|| {
-                s.else_block
-                    .as_ref()
-                    .and_then(|b| find_let_in_block(b, target, name))
-            }),
-        Stmt::While(s) => find_let_in_condition(&s.condition, target, name)
-            .or_else(|| find_let_in_block(&s.body, target, name)),
-        Stmt::For(s) => {
-            if let Some(init) = &s.init
-                && let Some(r) = find_let_in_stmt(init, target, name)
-            {
-                return Some(r);
-            }
-            find_let_in_block(&s.body, target, name)
-        }
-        Stmt::ForOf(s) => {
-            if pattern_contains_ident(&s.binding, target) {
-                return Some(format_binding_name(name));
-            }
-            find_let_in_block(&s.body, target, name)
-        }
-        Stmt::Loop(s) => find_let_in_block(&s.body, target, name),
-        Stmt::Match(m) => {
-            for arm in &m.arms {
-                if pattern_contains_ident(&arm.pattern, target) {
-                    return Some(format_binding_name(name));
-                }
-                if let Some(r) = find_let_in_expr(&arm.body, target, name) {
-                    return Some(r);
-                }
-            }
-            None
-        }
-        Stmt::Break(_) | Stmt::Continue(_) => None,
-        Stmt::Assert(_) => None,
-        Stmt::LabeledBlock(s) => find_let_in_block(&s.block, target, name),
-        // A local item's methods have their own local variables, unrelated
-        // to the enclosing function's — never the source of `target`.
-        Stmt::Item(_) => None,
-        Stmt::Error(_) => None,
-    }
-}
-
-fn find_let_in_expr(expr: &Expr, target: AstId, name: &str) -> Option<String> {
-    match expr {
-        Expr::Block(b) => find_let_in_block(b, target, name),
-        Expr::If(e) => find_let_in_block(&e.then_block, target, name).or_else(|| {
-            e.else_block
-                .as_ref()
-                .and_then(|b| find_let_in_block(b, target, name))
-        }),
-        Expr::Closure(c) => {
-            for p in &c.params {
-                if p.id == target {
-                    let mut out = String::from("|");
-                    out.push_str(&p.name);
-                    if let Some(ty) = &p.ty {
-                        out.push_str(": ");
-                        unparse::unparse_type_into(ty, &mut out);
-                    }
-                    out.push('|');
-                    return Some(out);
-                }
-            }
-            find_let_in_expr(&c.body, target, name)
-        }
-        Expr::LabeledBlock(lb) => find_let_in_block(&lb.block, target, name),
-        Expr::Match(m) => {
-            for arm in &m.arms {
-                if pattern_contains_ident(&arm.pattern, target) {
-                    return Some(format_binding_name(name));
-                }
-                if let Some(r) = find_let_in_expr(&arm.body, target, name) {
-                    return Some(r);
-                }
-            }
-            None
-        }
-        Expr::Matches(m) => {
-            if pattern_contains_ident(&m.pattern, target) {
-                return Some(format_binding_name(name));
-            }
-            if let Some(g) = &m.guard {
-                return find_let_in_expr(g, target, name);
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-fn item_info(item: &Item, name: &str, public_only: bool) -> Option<String> {
+/// Render `item` when it — or one of its members — is the declaration
+/// identified by `target`. Each arm compares the declaring node's own
+/// [`AstId`], so a member arm can never be reached by an item that merely
+/// shares a name with `target`.
+fn item_info(item: &Item, target: AstId, public_only: bool) -> Option<String> {
     match item {
-        Item::Function(f) if f.name == name => Some(unparse::unparse_function_signature(f)),
+        Item::Function(f) => {
+            (f.id == target).then(|| unparse::unparse_function_signature(f))
+        }
         // Struct fields follow `public_only` (matching `wado doc`'s `..`
         // elision when set); enum cases are always public.
-        Item::Struct(s) if s.name == name => {
-            Some(unparse::unparse_struct_signature(s, public_only))
-        }
-        Item::Enum(e) if e.name == name => Some(unparse::unparse_enum_signature(e)),
-        Item::Variant(v) if v.name == name => Some(unparse::unparse_variant_header(v)),
-        Item::Flags(fl) if fl.name == name => Some(unparse::unparse_flags_header(fl)),
-        Item::Trait(t) if t.name == name => Some(unparse::unparse_trait_header(t)),
-        Item::Newtype(n) if n.name == name => Some(unparse::unparse_newtype_signature(n)),
-        Item::BuiltinTypeDecl(d) if d.name == name => {
-            Some(unparse::unparse_builtin_type_decl_signature(d))
-        }
-        Item::Interface(e) if e.name == name => Some(format!("interface {name}")),
-        Item::Global(g) if g.name == name => Some(unparse::unparse_global_signature(g)),
-        Item::Impl(imp) => {
-            for method in &imp.methods {
-                if method.name == name {
-                    return Some(unparse::unparse_function_signature(method));
-                }
+        Item::Struct(s) => {
+            if s.id == target {
+                return Some(unparse::unparse_struct_signature(s, public_only));
             }
-            None
+            s.fields
+                .iter()
+                .find(|f| f.id == target)
+                .map(|f| unparse::unparse_struct_field(&s.name, f))
         }
-        Item::Enum(e) => e
-            .cases
-            .iter()
-            .find(|c| c.name == name)
-            .map(|c| unparse::unparse_enum_case(&e.name, c)),
-        Item::Variant(v) => v
-            .cases
-            .iter()
-            .find(|c| c.name == name)
-            .map(|c| unparse::unparse_variant_case(&v.name, c)),
-        Item::Struct(s) => s
-            .fields
-            .iter()
-            .find(|f| f.name == name)
-            .map(|f| unparse::unparse_struct_field(&s.name, f)),
+        Item::Enum(e) => {
+            if e.id == target {
+                return Some(unparse::unparse_enum_signature(e));
+            }
+            e.cases
+                .iter()
+                .find(|c| c.id == target)
+                .map(|c| unparse::unparse_enum_case(&e.name, c))
+        }
+        Item::Variant(v) => {
+            if v.id == target {
+                return Some(unparse::unparse_variant_header(v));
+            }
+            v.cases
+                .iter()
+                .find(|c| c.id == target)
+                .map(|c| unparse::unparse_variant_case(&v.name, c))
+        }
         Item::Trait(t) => {
-            for method in &t.methods {
-                if method.name == name {
-                    return Some(unparse::unparse_function_signature(method));
-                }
+            if t.id == target {
+                return Some(unparse::unparse_trait_header(t));
             }
-            None
+            t.methods
+                .iter()
+                .find(|m| m.id == target)
+                .map(unparse::unparse_function_signature)
         }
-        _ => None,
+        Item::Impl(imp) => imp
+            .methods
+            .iter()
+            .find(|m| m.id == target)
+            .map(unparse::unparse_function_signature),
+        Item::Flags(fl) => (fl.id == target).then(|| unparse::unparse_flags_header(fl)),
+        Item::Newtype(n) => (n.id == target).then(|| unparse::unparse_newtype_signature(n)),
+        Item::BuiltinTypeDecl(d) => {
+            (d.id == target).then(|| unparse::unparse_builtin_type_decl_signature(d))
+        }
+        Item::Interface(e) => (e.id == target).then(|| format!("interface {}", e.name)),
+        Item::Global(g) => (g.id == target).then(|| unparse::unparse_global_signature(g)),
+        Item::Use(_)
+        | Item::Resource(_)
+        | Item::World(_)
+        | Item::Test(_)
+        | Item::TupleTypeDecl(_)
+        | Item::Error(_) => None,
     }
 }
 
@@ -628,12 +557,7 @@ mod tests {
         let uri = format!("file://{path}");
         let host = MapHost::single(path, source);
         let sem = wado_compiler::semantics(source, &host, Some(path)).await;
-        let ctx = QueryContext {
-            sem: &sem,
-            source,
-            uri: &uri,
-            encoding,
-        };
+        let ctx = QueryContext::new(&sem, source, &uri, encoding);
         find_hover_opts(&ctx, Position { line, character }, true)
     }
 
@@ -702,6 +626,78 @@ mod tests {
                 "got: {}",
                 result.contents.value,
             );
+        });
+    }
+
+    #[test]
+    fn item_hover_ignores_a_member_sharing_the_name() {
+        // `render_item_signature` used to scan the module by name, so the
+        // struct field `helper` — declared first — answered a hover on the
+        // free function `helper`. Resolution is by `AstId` now.
+        futures::executor::block_on(async {
+            let source = concat!(
+                "struct Wrap { helper: i32 }\n",
+                "fn helper() -> i32 { return 1; }\n",
+                "fn run() -> i32 { return helper(); }\n",
+            );
+            let result = hover_at(source, 2, 26).await.expect("hover on helper()");
+            assert_eq!(result.contents.value, "```wado\nfn helper() -> i32\n```");
+        });
+    }
+
+    #[test]
+    fn hover_on_local_inside_a_closure_call_argument() {
+        // The hand-rolled walker bottomed out at `Expr::Call`, so a binding
+        // inside a closure passed as an argument was unreachable: the cursor
+        // resolved to the symbol, and hover returned nothing.
+        futures::executor::block_on(async {
+            let source = concat!(
+                "fn apply(f: fn(i32) -> i32) -> i32 { return f(1); }\n",
+                "fn run() -> i32 {\n",
+                "    return apply(|n: i32| -> i32 { let doubled = n * 2; return doubled; });\n",
+                "}\n",
+            );
+            let line = "    return apply(|n: i32| -> i32 { let doubled = n * 2; return doubled; });";
+            let col = line.rfind("doubled").unwrap() as u32;
+            let result = hover_at(source, 2, col).await.expect("hover on doubled");
+            assert_eq!(result.contents.value, "```wado\nlet doubled\n```");
+        });
+    }
+
+    #[test]
+    fn hover_on_local_inside_a_nested_call_argument_block() {
+        // Same gap, one shape further out: a labeled block nested in a
+        // binary operand inside a call argument.
+        futures::executor::block_on(async {
+            let source = concat!(
+                "fn take(v: i32) -> i32 { return v; }\n",
+                "fn run() -> i32 {\n",
+                "    return take(1 + b: { let inner: i32 = 2; break b: inner; });\n",
+                "}\n",
+            );
+            let line = "    return take(1 + b: { let inner: i32 = 2; break b: inner; });";
+            let col = line.rfind("inner").unwrap() as u32;
+            let result = hover_at(source, 2, col).await.expect("hover on inner");
+            assert_eq!(result.contents.value, "```wado\nlet inner: i32\n```");
+        });
+    }
+
+    #[test]
+    fn hover_on_local_inside_a_test_block_closure() {
+        // `Item::Test` bodies were covered before, but only down the same
+        // hand-listed path — a binding inside a closure there was not.
+        futures::executor::block_on(async {
+            let source = concat!(
+                "fn apply(f: fn(i32) -> i32) -> i32 { return f(1); }\n",
+                "fn run() {}\n",
+                "test \"t\" {\n",
+                "    let _ = apply(|n: i32| -> i32 { let scaled = n * 3; return scaled; });\n",
+                "}\n",
+            );
+            let line = "    let _ = apply(|n: i32| -> i32 { let scaled = n * 3; return scaled; });";
+            let col = line.rfind("scaled").unwrap() as u32;
+            let result = hover_at(source, 3, col).await.expect("hover on scaled");
+            assert_eq!(result.contents.value, "```wado\nlet scaled\n```");
         });
     }
 

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -107,7 +107,6 @@ impl HintCollector<'_> {
     }
 
     fn position(&self, line: u32, codepoint_col: u32) -> Position {
-        // The line table lives on the context, built once per query.
         self.ctx.position_at(line, codepoint_col)
     }
 

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -32,7 +32,6 @@ use wado_compiler::token::Span;
 use crate::diagnostics::{Position, Range};
 use crate::macros::lsp_repr_u32_enum;
 use crate::query::QueryContext;
-use crate::text::codepoint_offset_to_character;
 
 lsp_repr_u32_enum!(
     /// LSP inlay-hint kind. Serializes as the wire integer.
@@ -93,20 +92,23 @@ struct HintCollector<'a> {
 impl HintCollector<'_> {
     /// Position immediately after `span` ends — where a `: T` label is anchored.
     fn position_after(&self, span: Span) -> Position {
-        let line = span.end_line.saturating_sub(1) as u32;
-        let codepoint_col = span.end_column.saturating_sub(1) as u32;
-        let character =
-            codepoint_offset_to_character(self.ctx.source, line, codepoint_col, self.ctx.encoding);
-        Position { line, character }
+        self.position(
+            span.end_line.saturating_sub(1) as u32,
+            span.end_column.saturating_sub(1) as u32,
+        )
     }
 
     /// Position at the start of `span` — where a `name:` parameter label is anchored.
     fn position_before(&self, span: Span) -> Position {
-        let line = span.line.saturating_sub(1) as u32;
-        let codepoint_col = span.column.saturating_sub(1) as u32;
-        let character =
-            codepoint_offset_to_character(self.ctx.source, line, codepoint_col, self.ctx.encoding);
-        Position { line, character }
+        self.position(
+            span.line.saturating_sub(1) as u32,
+            span.column.saturating_sub(1) as u32,
+        )
+    }
+
+    fn position(&self, line: u32, codepoint_col: u32) -> Position {
+        // The line table lives on the context, built once per query.
+        self.ctx.position_at(line, codepoint_col)
     }
 
     /// Emit a `: T` hint anchored at the end of `name_span` for a binding
@@ -353,12 +355,7 @@ mod tests {
         let uri = format!("file://{path}");
         let host = MapHost::single(path, source);
         let sem = wado_compiler::semantics(source, &host, Some(path)).await;
-        let ctx = QueryContext {
-            sem: &sem,
-            source,
-            uri: &uri,
-            encoding: PositionEncoding::Utf16,
-        };
+        let ctx = QueryContext::new(&sem, source, &uri, PositionEncoding::Utf16);
         let max_range = Range {
             start: Position {
                 line: 0,
@@ -511,12 +508,7 @@ mod tests {
             let uri = format!("file://{path}");
             let host = MapHost::single(path, src);
             let sem = wado_compiler::semantics(src, &host, Some(path)).await;
-            let ctx = QueryContext {
-                sem: &sem,
-                source: src,
-                uri: &uri,
-                encoding: PositionEncoding::Utf16,
-            };
+            let ctx = QueryContext::new(&sem, src, &uri, PositionEncoding::Utf16);
             // Restrict to line 1 only — `let x = 1` is on line 1 (0-based),
             // `let y = 2` is on line 2. Filter must drop the line-2 hint.
             let range = Range {
@@ -771,12 +763,7 @@ mod tests {
         let uri = format!("file://{path}");
         let host = MapHost::single(path, src);
         let sem = futures::executor::block_on(wado_compiler::semantics(src, &host, Some(path)));
-        let ctx = QueryContext {
-            sem: &sem,
-            source: src,
-            uri: &uri,
-            encoding: PositionEncoding::Utf16,
-        };
+        let ctx = QueryContext::new(&sem, src, &uri, PositionEncoding::Utf16);
         let max_range = Range {
             start: Position {
                 line: 0,
@@ -850,12 +837,7 @@ mod tests {
             // `./lib.wado`, not its eventual absolute path.
             let host = MapHost::with_files(&[("./other.wado", other), (path, entry)]);
             let sem = wado_compiler::semantics(entry, &host, Some(path)).await;
-            let ctx = QueryContext {
-                sem: &sem,
-                source: entry,
-                uri: &uri,
-                encoding: PositionEncoding::Utf16,
-            };
+            let ctx = QueryContext::new(&sem, entry, &uri, PositionEncoding::Utf16);
             let max_range = Range {
                 start: Position {
                     line: 0,

--- a/wado-lsp/src/kiln.rs
+++ b/wado-lsp/src/kiln.rs
@@ -64,7 +64,7 @@ pub fn prepare_invocations<H: CompilerHost>(
     host: &H,
 ) -> InvocationIndex {
     let entry_path = Path::new(entry_filename);
-    let Some(manifest_root) = find_manifest_root(entry_path) else {
+    let Some(manifest_root) = crate::workspace::nearest_manifest_dir(entry_path) else {
         return InvocationIndex::new();
     };
 
@@ -246,27 +246,6 @@ fn safe_join(manifest_root: &Path, rel: &str) -> Option<PathBuf> {
         return None;
     }
     Some(joined)
-}
-
-/// Walk up from `entry_path`'s directory looking for the nearest
-/// `wado.toml`. Returns the directory that contains it — the kiln
-/// pipeline's `manifest_root`.
-fn find_manifest_root(entry_path: &Path) -> Option<PathBuf> {
-    let mut dir = entry_path
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
-    if dir.as_os_str().is_empty() {
-        dir = PathBuf::from(".");
-    }
-    loop {
-        if dir.join("wado.toml").is_file() {
-            return Some(dir);
-        }
-        if !dir.pop() {
-            return None;
-        }
-    }
 }
 
 /// Compose the `kiln:` redirect URI used by [`InvocationIndex`].

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -615,16 +615,22 @@ impl Engine {
     ///
     /// Reads from the snapshot cache populated by [`Engine::snapshot`].
     /// The semantics pipeline runs at most once per document version
-    /// regardless of which queries the client issued first. Each
-    /// diagnostic's column is re-encoded against the source whose file
-    /// matches its
-    /// `span.file` — cross-file diagnostics keep the compiler's codepoint
-    /// columns, the entry document is re-expressed in the negotiated
-    /// position encoding.
+    /// regardless of which queries the client issued first.
+    ///
+    /// Only diagnostics belonging to `uri` are returned. LSP publishes
+    /// diagnostics per document, so a diagnostic whose `span.file` names an
+    /// imported module cannot be reported here: it would draw a squiggle at
+    /// the *imported* file's line and column inside the document the user
+    /// has open. The importing document sees the loader's own failures
+    /// instead, and the imported file reports its errors when the client
+    /// opens it. A span-less diagnostic is about the request itself (a
+    /// loader hard failure) and is always kept.
+    ///
+    /// Columns of the kept diagnostics are re-encoded against the document
+    /// text in the negotiated position encoding.
     ///
     /// Unused / dead-code warnings are applied here (not baked into the
-    /// snapshot, so [`Engine::set_unused_diagnostics`] stays live) and are
-    /// kept only for the entry document.
+    /// snapshot, so [`Engine::set_unused_diagnostics`] stays live).
     pub async fn diagnostics<H: CompilerHost>(&self, uri: &str, host: &H) -> Vec<Diagnostic> {
         let Some(snapshot) = self.snapshot(uri, host).await else {
             return Vec::new();
@@ -632,23 +638,19 @@ impl Engine {
         let filename = Uri::new(uri).to_filename();
         let encoding = self.position_encoding;
         let entry_text = self.documents.get(uri).map(|d| d.text.as_str());
-        let reencode = |d: &CompilerDiagnostic| {
-            // Re-encode against the entry text only when the diagnostic points
-            // at it; imported-module spans keep raw codepoint columns.
-            let source = d
-                .span
-                .as_ref()
-                .filter(|s| s.file == filename)
-                .and(entry_text);
-            diagnostics::from_compiler_diagnostic(d, uri, source, encoding)
+        let convert = |d: &CompilerDiagnostic| {
+            let span = d.span.as_ref();
+            if span.is_some_and(|s| s.file != filename) {
+                return None;
+            }
+            diagnostics::from_compiler_diagnostic(d, uri, entry_text, encoding)
         };
-        let mut out: Vec<Diagnostic> = snapshot.diagnostics.iter().filter_map(&reencode).collect();
+        let mut out: Vec<Diagnostic> = snapshot.diagnostics.iter().filter_map(&convert).collect();
         if self.unused_diagnostics {
             out.extend(
                 wado_compiler::unused_diagnostics(&snapshot.sem, false)
                     .iter()
-                    .filter(|d| d.span.as_ref().is_some_and(|s| s.file == filename))
-                    .filter_map(&reencode),
+                    .filter_map(&convert),
             );
         }
         out

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -107,17 +107,14 @@ pub struct Engine {
 /// `hover`, …) rather than the raw bundle.
 pub(crate) struct Snapshot {
     pub(crate) sem: Semantics,
-    /// Diagnostics the compiler host emitted while the pass ran — lex, parse,
-    /// load, and analysis errors. Produced as a side effect of building
-    /// `sem`, so they cost nothing to keep.
+    /// Lex, parse, load, and analysis errors the host emitted while the pass
+    /// ran — a side effect of building `sem`.
     pub(crate) diagnostics: Vec<CompilerDiagnostic>,
     /// Design-B semantic diagnostics (effect / stores / default-purity /
-    /// resource moves), derived from `sem` on first request and cached.
+    /// resource moves), derived on first request and cached.
     ///
-    /// Deriving them is a separate pass over the whole module graph, and
-    /// only `Engine::diagnostics` consumes them — hover, definition,
-    /// references, highlights, semantic tokens, and inlay hints all used to
-    /// pay for it on the keystroke that first touched a document.
+    /// Deriving them walks the whole module graph again, and only
+    /// `Engine::diagnostics` reads them.
     semantic: RefCell<Option<Rc<Vec<CompilerDiagnostic>>>>,
 }
 
@@ -127,8 +124,7 @@ impl Snapshot {
         if let Some(cached) = self.semantic.borrow().clone() {
             return cached;
         }
-        // `check_semantics` builds the shared effect index once and runs all
-        // three of its checks off it.
+        // One shared effect index drives all three checks.
         let checked =
             wado_compiler::check_semantics(&self.sem, wado_compiler::hashmap::IndexSet::default());
         let mut out: Vec<CompilerDiagnostic> = checked
@@ -316,10 +312,8 @@ impl Engine {
         // InvocationIndex through without the LSP having to know the
         // loader's source-based entry point.
         let sem = build_semantics(&doc.text, &filename, invocations, &collecting_host).await;
-        // The Design-B semantic diagnostics are derived lazily — see
-        // `Snapshot::semantic_diagnostics`. Only `Engine::diagnostics` needs
-        // them, and the LSP builds no TIR, so this snapshot is the only place
-        // they can surface in the editor.
+        // Semantic diagnostics are derived lazily; see
+        // `Snapshot::semantic_diagnostics`.
         let snapshot = Rc::new(Snapshot {
             sem,
             diagnostics: collecting_host.take_diagnostics(),
@@ -640,17 +634,13 @@ impl Engine {
     /// The semantics pipeline runs at most once per document version
     /// regardless of which queries the client issued first.
     ///
-    /// Only diagnostics belonging to `uri` are returned. LSP publishes
-    /// diagnostics per document, so a diagnostic whose `span.file` names an
-    /// imported module cannot be reported here: it would draw a squiggle at
-    /// the *imported* file's line and column inside the document the user
-    /// has open. The importing document sees the loader's own failures
-    /// instead, and the imported file reports its errors when the client
-    /// opens it. A span-less diagnostic is about the request itself (a
-    /// loader hard failure) and is always kept.
+    /// Only diagnostics belonging to `uri` are returned. LSP publishes per
+    /// document, so one whose `span.file` names an imported module would draw
+    /// its squiggle at that file's line and column inside the open one; the
+    /// imported file reports its own errors when the client opens it. A
+    /// span-less diagnostic is about the request itself and is always kept.
     ///
-    /// Columns of the kept diagnostics are re-encoded against the document
-    /// text in the negotiated position encoding.
+    /// Kept columns are re-encoded in the negotiated position encoding.
     ///
     /// Unused / dead-code warnings are applied here (not baked into the
     /// snapshot, so [`Engine::set_unused_diagnostics`] stays live).
@@ -660,8 +650,7 @@ impl Engine {
         };
         let filename = Uri::new(uri).to_filename();
         let encoding = self.position_encoding;
-        // One line table for the whole batch: every diagnostic re-encodes two
-        // columns against this same text.
+        // One line table for the batch.
         let lines = self
             .documents
             .get(uri)

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -107,7 +107,46 @@ pub struct Engine {
 /// `hover`, …) rather than the raw bundle.
 pub(crate) struct Snapshot {
     pub(crate) sem: Semantics,
+    /// Diagnostics the compiler host emitted while the pass ran — lex, parse,
+    /// load, and analysis errors. Produced as a side effect of building
+    /// `sem`, so they cost nothing to keep.
     pub(crate) diagnostics: Vec<CompilerDiagnostic>,
+    /// Design-B semantic diagnostics (effect / stores / default-purity /
+    /// resource moves), derived from `sem` on first request and cached.
+    ///
+    /// Deriving them is a separate pass over the whole module graph, and
+    /// only `Engine::diagnostics` consumes them — hover, definition,
+    /// references, highlights, semantic tokens, and inlay hints all used to
+    /// pay for it on the keystroke that first touched a document.
+    semantic: RefCell<Option<Rc<Vec<CompilerDiagnostic>>>>,
+}
+
+impl Snapshot {
+    fn semantic_diagnostics(&self) -> Rc<Vec<CompilerDiagnostic>> {
+        // Drop the borrow before computing — see `Engine::snapshot`.
+        if let Some(cached) = self.semantic.borrow().clone() {
+            return cached;
+        }
+        // `check_semantics` builds the shared effect index once and runs all
+        // three of its checks off it.
+        let checked =
+            wado_compiler::check_semantics(&self.sem, wado_compiler::hashmap::IndexSet::default());
+        let mut out: Vec<CompilerDiagnostic> = checked
+            .effects
+            .into_iter()
+            .map(Into::into)
+            .chain(checked.stores.into_iter().map(Into::into))
+            .chain(checked.purity.into_iter().map(Into::into))
+            .collect();
+        out.extend(
+            wado_compiler::check_resource_moves_semantic(&self.sem)
+                .into_iter()
+                .map(Into::into),
+        );
+        let computed = Rc::new(out);
+        *self.semantic.borrow_mut() = Some(Rc::clone(&computed));
+        computed
+    }
 }
 
 struct Document {
@@ -277,26 +316,15 @@ impl Engine {
         // InvocationIndex through without the LSP having to know the
         // loader's source-based entry point.
         let sem = build_semantics(&doc.text, &filename, invocations, &collecting_host).await;
-        // The Design-B semantic diagnostics (effect / stores / default-purity)
-        // are produced from `Semantics`; the LSP builds no TIR, so this is the
-        // only place they surface in the editor. `check_semantics` builds the
-        // shared effect index once and runs all three.
-        let mut diagnostics = collecting_host.take_diagnostics();
-        let semantic =
-            wado_compiler::check_semantics(&sem, wado_compiler::hashmap::IndexSet::default());
-        for error in semantic.effects {
-            diagnostics.push(error.into());
-        }
-        for error in semantic.stores {
-            diagnostics.push(error.into());
-        }
-        for error in semantic.purity {
-            diagnostics.push(error.into());
-        }
-        for error in wado_compiler::check_resource_moves_semantic(&sem) {
-            diagnostics.push(error.into());
-        }
-        let snapshot = Rc::new(Snapshot { sem, diagnostics });
+        // The Design-B semantic diagnostics are derived lazily — see
+        // `Snapshot::semantic_diagnostics`. Only `Engine::diagnostics` needs
+        // them, and the LSP builds no TIR, so this snapshot is the only place
+        // they can surface in the editor.
+        let snapshot = Rc::new(Snapshot {
+            sem,
+            diagnostics: collecting_host.take_diagnostics(),
+            semantic: RefCell::new(None),
+        });
         *doc.snapshot.borrow_mut() = Some(snapshot.clone());
         Some(snapshot)
     }
@@ -321,12 +349,7 @@ impl Engine {
         let Some(doc_text) = self.documents.get(uri).map(|d| d.text.as_str()) else {
             return default;
         };
-        let ctx = QueryContext {
-            sem: &snapshot.sem,
-            source: doc_text,
-            uri,
-            encoding: self.position_encoding,
-        };
+        let ctx = QueryContext::new(&snapshot.sem, doc_text, uri, self.position_encoding);
         f(&ctx)
     }
 
@@ -385,12 +408,7 @@ impl Engine {
     /// Build a [`QueryContext`] over `uri`'s cached snapshot. The caller owns
     /// the `Rc<Snapshot>` so the borrow outlives the context.
     fn query_ctx_over<'a>(&'a self, snapshot: &'a Snapshot, uri: &'a str) -> QueryContext<'a> {
-        QueryContext {
-            sem: &snapshot.sem,
-            source: self.documents.get(uri).map_or("", |d| d.text.as_str()),
-            uri,
-            encoding: self.position_encoding,
-        }
+        QueryContext::new(&snapshot.sem, self.documents.get(uri).map_or("", |d| d.text.as_str()), uri, self.position_encoding)
     }
 
     /// Resolve a symbol notation to a definition location. `public_only` only
@@ -417,7 +435,7 @@ impl Engine {
         .ok_or(SymbolQueryError::NoLocation)?;
         Ok(DefinitionResult {
             uri: def_uri,
-            range: location::span_to_range(&span, None, self.position_encoding),
+            range: text::span_to_range(&span, None, self.position_encoding),
         })
     }
 
@@ -637,15 +655,26 @@ impl Engine {
         };
         let filename = Uri::new(uri).to_filename();
         let encoding = self.position_encoding;
-        let entry_text = self.documents.get(uri).map(|d| d.text.as_str());
+        // One line table for the whole batch: every diagnostic re-encodes two
+        // columns against this same text.
+        let lines = self
+            .documents
+            .get(uri)
+            .map(|d| text::LineIndex::new(&d.text));
         let convert = |d: &CompilerDiagnostic| {
             let span = d.span.as_ref();
             if span.is_some_and(|s| s.file != filename) {
                 return None;
             }
-            diagnostics::from_compiler_diagnostic(d, uri, entry_text, encoding)
+            diagnostics::from_compiler_diagnostic(d, uri, lines.as_ref(), encoding)
         };
-        let mut out: Vec<Diagnostic> = snapshot.diagnostics.iter().filter_map(&convert).collect();
+        let semantic = snapshot.semantic_diagnostics();
+        let mut out: Vec<Diagnostic> = snapshot
+            .diagnostics
+            .iter()
+            .chain(semantic.iter())
+            .filter_map(&convert)
+            .collect();
         if self.unused_diagnostics {
             out.extend(
                 wado_compiler::unused_diagnostics(&snapshot.sem, false)

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -660,7 +660,7 @@ impl Engine {
             if span.is_some_and(|s| s.file != filename) {
                 return None;
             }
-            diagnostics::from_compiler_diagnostic(d, uri, lines.as_ref(), encoding)
+            diagnostics::from_compiler_diagnostic(d, lines.as_ref(), encoding)
         };
         let semantic = snapshot.semantic_diagnostics();
         let mut out: Vec<Diagnostic> = snapshot

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -124,7 +124,6 @@ impl Snapshot {
         if let Some(cached) = self.semantic.borrow().clone() {
             return cached;
         }
-        // One shared effect index drives all three checks.
         let checked =
             wado_compiler::check_semantics(&self.sem, wado_compiler::hashmap::IndexSet::default());
         let mut out: Vec<CompilerDiagnostic> = checked
@@ -312,8 +311,6 @@ impl Engine {
         // InvocationIndex through without the LSP having to know the
         // loader's source-based entry point.
         let sem = build_semantics(&doc.text, &filename, invocations, &collecting_host).await;
-        // Semantic diagnostics are derived lazily; see
-        // `Snapshot::semantic_diagnostics`.
         let snapshot = Rc::new(Snapshot {
             sem,
             diagnostics: collecting_host.take_diagnostics(),
@@ -650,7 +647,6 @@ impl Engine {
         };
         let filename = Uri::new(uri).to_filename();
         let encoding = self.position_encoding;
-        // One line table for the batch.
         let lines = self
             .documents
             .get(uri)

--- a/wado-lsp/src/lib.rs
+++ b/wado-lsp/src/lib.rs
@@ -408,7 +408,12 @@ impl Engine {
     /// Build a [`QueryContext`] over `uri`'s cached snapshot. The caller owns
     /// the `Rc<Snapshot>` so the borrow outlives the context.
     fn query_ctx_over<'a>(&'a self, snapshot: &'a Snapshot, uri: &'a str) -> QueryContext<'a> {
-        QueryContext::new(&snapshot.sem, self.documents.get(uri).map_or("", |d| d.text.as_str()), uri, self.position_encoding)
+        QueryContext::new(
+            &snapshot.sem,
+            self.documents.get(uri).map_or("", |d| d.text.as_str()),
+            uri,
+            self.position_encoding,
+        )
     }
 
     /// Resolve a symbol notation to a definition location. `public_only` only

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -43,12 +43,10 @@ pub(crate) fn module_uri(
     }
 }
 
-/// Wrap an absolute path as a `file:` URI, percent-encoding it on the way out.
-///
-/// The path reaching here is decoded — it came through `Uri::to_filename`, or
-/// from the compiler, which speaks in real paths. A string that is already a
-/// URI (`file://…`) is left alone, as is a relative path or a non-`file:`
-/// scheme, neither of which this function is in a position to complete.
+/// Wrap an absolute path as a `file:` URI, percent-encoding on the way out —
+/// the paths reaching here are decoded, from `Uri::to_filename` or from the
+/// compiler. A string that is already a URI is left alone, as is a relative
+/// path or a non-`file:` scheme.
 fn filename_to_uri(filename: &str) -> String {
     if filename.starts_with("file://") {
         filename.to_string()
@@ -92,21 +90,17 @@ fn resolve_local_uri(module_path: &str, request_uri: &str) -> String {
 
 /// Collapse `.` and `..` segments lexically.
 ///
-/// A parent-relative import (`use … from "../lib/x.wado"`) otherwise produced
-/// `file:///a/b/../lib/x.wado`. LSP clients key open documents by URI string,
-/// so that names a *different* document than the canonical
-/// `file:///a/lib/x.wado` the same file gets when opened any other way —
-/// jump-to-definition opened a second, duplicate editor tab.
+/// Clients key open documents by URI string, so `file:///a/b/../lib/x.wado`
+/// names a different document than the canonical `file:///a/lib/x.wado` the
+/// same file gets when opened any other way.
 ///
-/// Lexical only: symlinks are not resolved (the LSP has no filesystem on the
-/// wasm target). A leading `..` that cannot be collapsed — the path escapes
-/// its own root — is kept, since dropping it would silently retarget the URI.
+/// Lexical only — symlinks are not resolved, the wasm target has no
+/// filesystem. A `..` that escapes its own root is kept rather than dropped,
+/// which would silently retarget the URI.
 fn normalize_dot_segments(path: &str) -> String {
     if !path.contains("./") && !path.ends_with("/.") && !path.ends_with("/..") {
         return path.to_string();
     }
-    // Split the scheme off first so `..` can never eat it: an opaque URI's
-    // first segment (`kiln:`, `wasi:filesystem`) is not a directory.
     let (prefix, rest) = split_scheme(path);
     let rooted = rest.starts_with('/');
     let mut out: Vec<&str> = Vec::new();
@@ -130,11 +124,8 @@ fn normalize_dot_segments(path: &str) -> String {
     }
 }
 
-/// Split `path` into its scheme prefix and the path body `..` may rewrite.
-///
-/// `file://` URIs keep the authority-less `//`; an opaque URI (`kiln:/abs/x`,
-/// `wasi:filesystem/types.wado`) keeps everything through the `:`. A bare
-/// filesystem path has no prefix.
+/// Split `path` into its scheme prefix and the body `..` may rewrite, so a
+/// `..` can never eat the scheme. A bare filesystem path has no prefix.
 fn split_scheme(path: &str) -> (&str, &str) {
     if let Some(rest) = path.strip_prefix("file://") {
         return ("file://", rest);
@@ -196,9 +187,6 @@ mod tests {
 
     #[test]
     fn parent_relative_import_collapses_dot_dot() {
-        // `file:///home/user/../lib/x.wado` is a different URI *string* than
-        // the canonical form, and LSP clients key documents by URI string —
-        // jumping there opened a duplicate tab for a file already open.
         let resolved = resolve_local_uri("../lib/x.wado", "file:///home/user/foo.wado");
         assert_eq!(resolved, "file:///home/lib/x.wado");
     }
@@ -217,7 +205,7 @@ mod tests {
 
     #[test]
     fn parent_escape_of_root_is_clamped() {
-        // `/..` is `/`; refusing to walk above the root keeps the URI valid.
+        // `/..` is `/`.
         let resolved = resolve_local_uri("../../../x.wado", "file:///a/foo.wado");
         assert_eq!(resolved, "file:///x.wado");
     }
@@ -230,10 +218,8 @@ mod tests {
 
     #[test]
     fn sibling_of_an_encoded_request_uri_stays_encoded() {
-        // `Uri::to_filename` decodes, so the base directory we join against is
-        // a real path. Emitting it back without re-encoding hands the client a
-        // URI string that does not match the document it already has open —
-        // the duplicate-tab failure `normalize_dot_segments` exists to avoid.
+        // The base directory we join against is decoded, so the join has to
+        // be re-encoded on the way back out.
         let resolved = resolve_local_uri("./other.wado", "file:///home/user/my%20project/foo.wado");
         assert_eq!(resolved, "file:///home/user/my%20project/other.wado");
     }
@@ -246,8 +232,7 @@ mod tests {
 
     #[test]
     fn a_literal_percent_survives_the_round_trip() {
-        // `100%` decodes from `100%25`; re-encoding must restore the escape,
-        // not emit a bare `%` that the client would decode a second time.
+        // A bare `%` would be decoded a second time by the client.
         let resolved = resolve_local_uri("./x.wado", "file:///home/100%25/foo.wado");
         assert_eq!(resolved, "file:///home/100%25/x.wado");
         assert_eq!(
@@ -259,16 +244,13 @@ mod tests {
 
     #[test]
     fn path_separators_and_sub_delims_are_not_escaped() {
-        // Over-encoding is as wrong as under-encoding: `/` and `:` are legal
-        // path characters and clients do not escape them.
+        // Over-encoding is as wrong as under-encoding.
         let resolved = resolve_local_uri("./a+b,c.wado", "file:///home/user/foo.wado");
         assert_eq!(resolved, "file:///home/user/a+b,c.wado");
     }
 
     #[test]
     fn parent_segments_never_consume_the_scheme() {
-        // Walking above a scheme's root must clamp at the root, not eat
-        // `kiln:` and emit a scheme-less relative URI.
         let resolved = resolve_local_uri("../../../x.wado", "kiln:/a/foo.wado");
         assert_eq!(resolved, "kiln:/x.wado");
     }

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -239,7 +239,6 @@ mod tests {
 
     #[test]
     fn path_separators_and_sub_delims_are_not_escaped() {
-        // Over-encoding is as wrong as under-encoding.
         let resolved = resolve_local_uri("./a+b,c.wado", "file:///home/user/foo.wado");
         assert_eq!(resolved, "file:///home/user/a+b,c.wado");
     }

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -43,11 +43,17 @@ pub(crate) fn module_uri(
     }
 }
 
+/// Wrap an absolute path as a `file:` URI, percent-encoding it on the way out.
+///
+/// The path reaching here is decoded — it came through `Uri::to_filename`, or
+/// from the compiler, which speaks in real paths. A string that is already a
+/// URI (`file://…`) is left alone, as is a relative path or a non-`file:`
+/// scheme, neither of which this function is in a position to complete.
 fn filename_to_uri(filename: &str) -> String {
     if filename.starts_with("file://") {
         filename.to_string()
     } else if filename.starts_with('/') {
-        format!("file://{filename}")
+        format!("file://{}", crate::uri::percent_encode_path(filename))
     } else {
         filename.to_string()
     }
@@ -220,6 +226,43 @@ mod tests {
     fn parent_relative_import_off_kiln_uri_collapses_too() {
         let resolved = resolve_local_uri("../gen/x.wado", "kiln:/abs/path/foo.wado");
         assert_eq!(resolved, "kiln:/abs/gen/x.wado");
+    }
+
+    #[test]
+    fn sibling_of_an_encoded_request_uri_stays_encoded() {
+        // `Uri::to_filename` decodes, so the base directory we join against is
+        // a real path. Emitting it back without re-encoding hands the client a
+        // URI string that does not match the document it already has open —
+        // the duplicate-tab failure `normalize_dot_segments` exists to avoid.
+        let resolved = resolve_local_uri("./other.wado", "file:///home/user/my%20project/foo.wado");
+        assert_eq!(resolved, "file:///home/user/my%20project/other.wado");
+    }
+
+    #[test]
+    fn non_ascii_path_segments_are_re_encoded() {
+        let resolved = resolve_local_uri("./types.wado", "file:///home/%E3%81%82/foo.wado");
+        assert_eq!(resolved, "file:///home/%E3%81%82/types.wado");
+    }
+
+    #[test]
+    fn a_literal_percent_survives_the_round_trip() {
+        // `100%` decodes from `100%25`; re-encoding must restore the escape,
+        // not emit a bare `%` that the client would decode a second time.
+        let resolved = resolve_local_uri("./x.wado", "file:///home/100%25/foo.wado");
+        assert_eq!(resolved, "file:///home/100%25/x.wado");
+        assert_eq!(
+            Uri::new(&resolved).to_filename(),
+            "/home/100%/x.wado",
+            "the emitted URI must decode back to the real path",
+        );
+    }
+
+    #[test]
+    fn path_separators_and_sub_delims_are_not_escaped() {
+        // Over-encoding is as wrong as under-encoding: `/` and `:` are legal
+        // path characters and clients do not escape them.
+        let resolved = resolve_local_uri("./a+b,c.wado", "file:///home/user/foo.wado");
+        assert_eq!(resolved, "file:///home/user/a+b,c.wado");
     }
 
     #[test]

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -68,7 +68,7 @@ fn resolve_local_uri(module_path: &str, request_uri: &str) -> String {
     // path component (`core:cli`, `wasi:filesystem/types.wado` *with*
     // a path, `untitled:1`), `rsplit_once` either returns the right
     // thing or yields an empty `base_dir` and we fall back to the bare
-    // module path. Matches the pre-refactor string-based behaviour.
+    // module path.
     let request_path = Uri::new(request_uri).to_filename();
     let base_dir = request_path
         .rsplit_once('/')
@@ -153,13 +153,8 @@ mod tests {
 
     #[test]
     fn relative_import_off_kiln_uri_preserves_parent_directory() {
-        // Regression test for the Layer-2 refactor: the typed-Uri
-        // rewrite of `resolve_local_uri` short-circuited every
-        // non-`file:` scheme to `filename_to_uri(normalized)`,
-        // dropping the parent directory of kiln-redirected modules.
-        // For `kiln:/abs/path/foo.wado` importing `./sibling.wado` the
-        // result must remain `kiln:/abs/path/sibling.wado`, not the
-        // unanchored `sibling.wado`.
+        // A kiln-redirected module's siblings anchor under its directory,
+        // not at the scheme root.
         let resolved = resolve_local_uri("./sibling.wado", "kiln:/abs/path/foo.wado");
         assert_eq!(resolved, "kiln:/abs/path/sibling.wado");
     }

--- a/wado-lsp/src/location.rs
+++ b/wado-lsp/src/location.rs
@@ -8,10 +8,7 @@
 
 use wado_compiler::module_source::ModuleSource;
 use wado_compiler::symbol::Symbol;
-use wado_compiler::token::Span;
 
-use crate::diagnostics::Range;
-use crate::text::PositionEncoding;
 use crate::uri::Uri;
 
 /// Resolve the URI of a module relative to the requesting document's URI.
@@ -58,9 +55,8 @@ fn filename_to_uri(filename: &str) -> String {
 
 fn resolve_local_uri(module_path: &str, request_uri: &str) -> String {
     if module_path.starts_with('/') || module_path.starts_with("file://") {
-        return filename_to_uri(module_path);
+        return filename_to_uri(&normalize_dot_segments(module_path));
     }
-    let normalized = module_path.strip_prefix("./").unwrap_or(module_path);
     // String-based parent extraction. `Uri::to_filename` is a passthrough
     // for non-`file:` schemes, so for `kiln:/abs/path/foo.wado` we get
     // `kiln:/abs/path/foo.wado` back and `rsplit_once('/')` yields the
@@ -68,7 +64,7 @@ fn resolve_local_uri(module_path: &str, request_uri: &str) -> String {
     // path component (`core:cli`, `wasi:filesystem/types.wado` *with*
     // a path, `untitled:1`), `rsplit_once` either returns the right
     // thing or yields an empty `base_dir` and we fall back to the bare
-    // normalized path. Matches the pre-refactor string-based behaviour.
+    // module path. Matches the pre-refactor string-based behaviour.
     let request_path = Uri::new(request_uri).to_filename();
     let base_dir = request_path
         .rsplit_once('/')
@@ -76,14 +72,72 @@ fn resolve_local_uri(module_path: &str, request_uri: &str) -> String {
         .unwrap_or("");
     // When the request path is rooted at "/" (e.g. "/test.wado"), rsplit_once
     // yields an empty base_dir, so preserve the leading slash explicitly.
-    if base_dir.is_empty() {
+    let joined = if base_dir.is_empty() {
         if request_path.starts_with('/') {
-            filename_to_uri(&format!("/{normalized}"))
+            format!("/{module_path}")
         } else {
-            filename_to_uri(normalized)
+            module_path.to_string()
         }
     } else {
-        filename_to_uri(&format!("{base_dir}/{normalized}"))
+        format!("{base_dir}/{module_path}")
+    };
+    filename_to_uri(&normalize_dot_segments(&joined))
+}
+
+/// Collapse `.` and `..` segments lexically.
+///
+/// A parent-relative import (`use … from "../lib/x.wado"`) otherwise produced
+/// `file:///a/b/../lib/x.wado`. LSP clients key open documents by URI string,
+/// so that names a *different* document than the canonical
+/// `file:///a/lib/x.wado` the same file gets when opened any other way —
+/// jump-to-definition opened a second, duplicate editor tab.
+///
+/// Lexical only: symlinks are not resolved (the LSP has no filesystem on the
+/// wasm target). A leading `..` that cannot be collapsed — the path escapes
+/// its own root — is kept, since dropping it would silently retarget the URI.
+fn normalize_dot_segments(path: &str) -> String {
+    if !path.contains("./") && !path.ends_with("/.") && !path.ends_with("/..") {
+        return path.to_string();
+    }
+    // Split the scheme off first so `..` can never eat it: an opaque URI's
+    // first segment (`kiln:`, `wasi:filesystem`) is not a directory.
+    let (prefix, rest) = split_scheme(path);
+    let rooted = rest.starts_with('/');
+    let mut out: Vec<&str> = Vec::new();
+    for segment in rest.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." if matches!(out.last(), Some(&last) if last != "..") => {
+                out.pop();
+            }
+            // An unmatched `..` is only droppable when the path is rooted:
+            // `/..` is `/`, but `../x` names a real sibling directory.
+            ".." if rooted => {}
+            _ => out.push(segment),
+        }
+    }
+    let body = out.join("/");
+    if rooted {
+        format!("{prefix}/{body}")
+    } else {
+        format!("{prefix}{body}")
+    }
+}
+
+/// Split `path` into its scheme prefix and the path body `..` may rewrite.
+///
+/// `file://` URIs keep the authority-less `//`; an opaque URI (`kiln:/abs/x`,
+/// `wasi:filesystem/types.wado`) keeps everything through the `:`. A bare
+/// filesystem path has no prefix.
+fn split_scheme(path: &str) -> (&str, &str) {
+    if let Some(rest) = path.strip_prefix("file://") {
+        return ("file://", rest);
+    }
+    match path.find(':') {
+        // Only a real scheme, never a stray colon inside a filename: the
+        // schemes reaching here are the compiler's own.
+        Some(colon) if colon > 0 && !path[..colon].contains('/') => path.split_at(colon + 1),
+        _ => ("", path),
     }
 }
 
@@ -94,20 +148,6 @@ pub(crate) fn symbol_uri(
     request_uri: &str,
 ) -> Option<String> {
     module_uri(entry, symbol.module_source(), request_uri)
-}
-
-/// Convert a compiler `Span` (1-based byte column) to an LSP `Range` in
-/// the negotiated `encoding`. Pass `Some(source)` for spans inside the
-/// request document so non-ASCII columns survive the round-trip; pass
-/// `None` only when the source text is not available for the span's
-/// module (cross-file references), and accept the ASCII-only correctness
-/// implied by that.
-pub(crate) fn span_to_range(
-    span: &Span,
-    source: Option<&str>,
-    encoding: PositionEncoding,
-) -> Range {
-    crate::text::span_to_range(span, source, encoding)
 }
 
 #[cfg(test)]
@@ -145,6 +185,60 @@ mod tests {
     #[test]
     fn absolute_module_path_is_passed_through() {
         let resolved = resolve_local_uri("/abs/x.wado", "file:///home/user/foo.wado");
+        assert_eq!(resolved, "file:///abs/x.wado");
+    }
+
+    #[test]
+    fn parent_relative_import_collapses_dot_dot() {
+        // `file:///home/user/../lib/x.wado` is a different URI *string* than
+        // the canonical form, and LSP clients key documents by URI string —
+        // jumping there opened a duplicate tab for a file already open.
+        let resolved = resolve_local_uri("../lib/x.wado", "file:///home/user/foo.wado");
+        assert_eq!(resolved, "file:///home/lib/x.wado");
+    }
+
+    #[test]
+    fn repeated_parent_segments_collapse() {
+        let resolved = resolve_local_uri("../../lib/x.wado", "file:///a/b/c/foo.wado");
+        assert_eq!(resolved, "file:///a/lib/x.wado");
+    }
+
+    #[test]
+    fn interior_dot_segments_collapse() {
+        let resolved = resolve_local_uri("./sub/./x.wado", "file:///home/user/foo.wado");
+        assert_eq!(resolved, "file:///home/user/sub/x.wado");
+    }
+
+    #[test]
+    fn parent_escape_of_root_is_clamped() {
+        // `/..` is `/`; refusing to walk above the root keeps the URI valid.
+        let resolved = resolve_local_uri("../../../x.wado", "file:///a/foo.wado");
+        assert_eq!(resolved, "file:///x.wado");
+    }
+
+    #[test]
+    fn parent_relative_import_off_kiln_uri_collapses_too() {
+        let resolved = resolve_local_uri("../gen/x.wado", "kiln:/abs/path/foo.wado");
+        assert_eq!(resolved, "kiln:/abs/gen/x.wado");
+    }
+
+    #[test]
+    fn parent_segments_never_consume_the_scheme() {
+        // Walking above a scheme's root must clamp at the root, not eat
+        // `kiln:` and emit a scheme-less relative URI.
+        let resolved = resolve_local_uri("../../../x.wado", "kiln:/a/foo.wado");
+        assert_eq!(resolved, "kiln:/x.wado");
+    }
+
+    #[test]
+    fn colon_in_a_filename_is_not_mistaken_for_a_scheme() {
+        let resolved = resolve_local_uri("../x.wado", "file:///a/we:ird/foo.wado");
+        assert_eq!(resolved, "file:///a/x.wado");
+    }
+
+    #[test]
+    fn absolute_module_path_with_dot_dot_is_normalized() {
+        let resolved = resolve_local_uri("/abs/sub/../x.wado", "file:///home/user/foo.wado");
         assert_eq!(resolved, "file:///abs/x.wado");
     }
 }

--- a/wado-lsp/src/macros.rs
+++ b/wado-lsp/src/macros.rs
@@ -2,20 +2,21 @@
 
 /// Declare a `pub` enum whose LSP wire form is a small `u32` discriminant.
 ///
-/// Generates the same `serde` plumbing (`#[serde(into = "u32", try_from
-/// = "u32")]`), the `From<Self> for u32` cast, and a `TryFrom<u32>`
-/// impl whose `Err` is a human-readable diagnostic. The LSP wire types
-/// `Severity` (1..=4) and `HighlightKind` (1..=3) used to spell these
-/// impls out by hand — identical shape, drifty when one side gets a new
-/// variant.
+/// Generates the `serde` plumbing (`#[serde(into = "u32", try_from =
+/// "u32")]`), the `From<Self> for u32` cast, and a `TryFrom<u32>` impl whose
+/// `Err` is a human-readable diagnostic. Spelled out by hand per enum, the
+/// `TryFrom` arm drifts as soon as one of them gains a variant.
 ///
 /// Usage:
 ///
 /// ```ignore
-/// lsp_repr_u32_enum!(Severity {
-///     Error = 1,
-///     Warning = 2,
-/// });
+/// lsp_repr_u32_enum!(
+///     /// Doc comment, forwarded to the generated enum.
+///     pub enum Severity {
+///         Error = 1,
+///         Warning = 2,
+///     }
+/// );
 /// ```
 macro_rules! lsp_repr_u32_enum {
     (

--- a/wado-lsp/src/query.rs
+++ b/wado-lsp/src/query.rs
@@ -8,7 +8,9 @@
 //! - the document text,
 //! - the document URI (for relative-import URI resolution),
 //! - the negotiated [`PositionEncoding`],
-//! - a way to land an LSP [`Position`] on a compiler [`Cursor`].
+//! - a way to land an LSP [`Position`] on a compiler [`Cursor`],
+//! - a [`LineIndex`] over the document, so the many spans one query
+//!   answers share a single scan.
 //!
 //! [`QueryContext`] bundles them so feature functions take a single
 //! argument instead of threading the tuple by hand at every call site.
@@ -17,9 +19,10 @@ use wado_compiler::Cursor;
 use wado_compiler::ast::AstId;
 use wado_compiler::module_source::ModuleSource;
 use wado_compiler::semantics::Semantics;
+use wado_compiler::token::Span;
 
-use crate::diagnostics::Position;
-use crate::text::{PositionEncoding, lsp_position_to_line_col};
+use crate::diagnostics::{Position, Range};
+use crate::text::{self, LineIndex, PositionEncoding, lsp_position_to_line_col};
 
 /// Constant inputs to one LSP query against an open document.
 ///
@@ -38,9 +41,59 @@ pub(crate) struct QueryContext<'a> {
     pub(crate) source: &'a str,
     pub(crate) uri: &'a str,
     pub(crate) encoding: PositionEncoding,
+    /// Line table over `source`, built once per query.
+    ///
+    /// A query answers many spans — every reference, every highlight — and
+    /// each one converts two columns. Rebuilding the table per span put the
+    /// document scan back in the inner loop that [`LineIndex`] exists to take
+    /// it out of.
+    lines: LineIndex<'a>,
 }
 
 impl<'a> QueryContext<'a> {
+    pub fn new(
+        sem: &'a Semantics,
+        source: &'a str,
+        uri: &'a str,
+        encoding: PositionEncoding,
+    ) -> Self {
+        Self {
+            sem,
+            source,
+            uri,
+            encoding,
+            lines: LineIndex::new(source),
+        }
+    }
+
+    /// Convert `span` — belonging to node `id` — to an LSP [`Range`].
+    ///
+    /// Spans in the entry document are re-encoded against its text; spans in
+    /// other modules keep the compiler's codepoint columns, since their
+    /// source is not on hand (correct under UTF-32 / ASCII).
+    pub fn range_of(&self, span: &Span, id: AstId) -> Range {
+        match self.source_for_id(id) {
+            Some(_) => text::span_to_range_indexed(span, &self.lines, self.encoding),
+            None => text::span_to_range(span, None, self.encoding),
+        }
+    }
+
+    /// [`Self::range_of`] for a span already known to be in the entry
+    /// document (a cursor's own span).
+    pub fn range_in_document(&self, span: &Span) -> Range {
+        text::span_to_range_indexed(span, &self.lines, self.encoding)
+    }
+
+    /// An LSP [`Position`] from a 0-based line and 0-based codepoint column
+    /// in the entry document, in the negotiated encoding. Inlay hints anchor
+    /// at one edge of a span rather than converting a whole range.
+    pub fn position_at(&self, line: u32, codepoint_col: u32) -> Position {
+        Position {
+            line,
+            character: self.lines.to_character(line, codepoint_col, self.encoding),
+        }
+    }
+
     /// The entry module — the one whose source text lives in `self.source`.
     pub fn entry(&self) -> &'a ModuleSource {
         &self.sem.entry_module_source
@@ -69,11 +122,10 @@ impl<'a> QueryContext<'a> {
         self.sem.cursor_at(self.entry(), line, col)
     }
 
-    /// Source text to feed [`crate::location::span_to_range`] when
-    /// re-encoding a span at node `id`. `Some(self.source)` for spans
-    /// inside the entry document; `None` for spans in other modules (their
-    /// source isn't available here, and `span_to_range` falls back to
-    /// "codepoint columns as code units" — correct under UTF-32 / ASCII).
+    /// Whether node `id` lives in the entry document, carrying its source
+    /// when so. `None` for spans in other modules: their text is not
+    /// available here, so [`Self::range_of`] emits the compiler's codepoint
+    /// columns verbatim (correct under UTF-32 / ASCII).
     pub fn source_for_id(&self, id: AstId) -> Option<&'a str> {
         (self.sem.module_of_id(id) == Some(self.entry())).then_some(self.source)
     }

--- a/wado-lsp/src/query.rs
+++ b/wado-lsp/src/query.rs
@@ -9,8 +9,7 @@
 //! - the document URI (for relative-import URI resolution),
 //! - the negotiated [`PositionEncoding`],
 //! - a way to land an LSP [`Position`] on a compiler [`Cursor`],
-//! - a [`LineIndex`] over the document, so the many spans one query
-//!   answers share a single scan.
+//! - a [`LineIndex`] shared by every span the query answers.
 //!
 //! [`QueryContext`] bundles them so feature functions take a single
 //! argument instead of threading the tuple by hand at every call site.
@@ -41,8 +40,7 @@ pub(crate) struct QueryContext<'a> {
     pub(crate) source: &'a str,
     pub(crate) uri: &'a str,
     pub(crate) encoding: PositionEncoding,
-    /// Line table over `source`, built once per query — a query answers many
-    /// spans and each converts two columns.
+    /// Line table over `source`, built once per query.
     lines: LineIndex<'a>,
 }
 
@@ -117,10 +115,8 @@ impl<'a> QueryContext<'a> {
         self.sem.cursor_at(self.entry(), line, col)
     }
 
-    /// Whether node `id` lives in the entry document, carrying its source
-    /// when so. `None` for spans in other modules: their text is not
-    /// available here, so [`Self::range_of`] emits the compiler's codepoint
-    /// columns verbatim (correct under UTF-32 / ASCII).
+    /// The entry document's source when node `id` lives in it, `None`
+    /// otherwise — no other module's text is available here.
     pub fn source_for_id(&self, id: AstId) -> Option<&'a str> {
         (self.sem.module_of_id(id) == Some(self.entry())).then_some(self.source)
     }

--- a/wado-lsp/src/query.rs
+++ b/wado-lsp/src/query.rs
@@ -41,12 +41,8 @@ pub(crate) struct QueryContext<'a> {
     pub(crate) source: &'a str,
     pub(crate) uri: &'a str,
     pub(crate) encoding: PositionEncoding,
-    /// Line table over `source`, built once per query.
-    ///
-    /// A query answers many spans — every reference, every highlight — and
-    /// each one converts two columns. Rebuilding the table per span put the
-    /// document scan back in the inner loop that [`LineIndex`] exists to take
-    /// it out of.
+    /// Line table over `source`, built once per query — a query answers many
+    /// spans and each converts two columns.
     lines: LineIndex<'a>,
 }
 
@@ -84,9 +80,8 @@ impl<'a> QueryContext<'a> {
         text::span_to_range_indexed(span, &self.lines, self.encoding)
     }
 
-    /// An LSP [`Position`] from a 0-based line and 0-based codepoint column
-    /// in the entry document, in the negotiated encoding. Inlay hints anchor
-    /// at one edge of a span rather than converting a whole range.
+    /// An LSP [`Position`] from a 0-based line and codepoint column in the
+    /// entry document. For anchors that are one edge of a span, not a range.
     pub fn position_at(&self, line: u32, codepoint_col: u32) -> Position {
         Position {
             line,

--- a/wado-lsp/src/references.rs
+++ b/wado-lsp/src/references.rs
@@ -11,7 +11,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::diagnostics::{Position, Range};
-use crate::location::{module_uri, span_to_range, symbol_uri};
+use crate::location::{module_uri, symbol_uri};
 use crate::query::QueryContext;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -86,7 +86,7 @@ pub(crate) fn declaration_location(
     };
     Some(ReferenceLocation {
         uri,
-        range: span_to_range(&span, ctx.source_for_id(def_id), ctx.encoding),
+        range: ctx.range_of(&span, def_id),
     })
 }
 
@@ -98,7 +98,7 @@ pub(crate) fn use_site_location(
     let uri = module_uri(ctx.entry(), ctx.sem.module_of_id(use_id)?, ctx.uri)?;
     Some(ReferenceLocation {
         uri,
-        range: span_to_range(&span, ctx.source_for_id(use_id), ctx.encoding),
+        range: ctx.range_of(&span, use_id),
     })
 }
 
@@ -118,12 +118,7 @@ mod tests {
         let uri = format!("file://{path}");
         let host = MapHost::single(path, source);
         let sem = wado_compiler::semantics(source, &host, Some(path)).await;
-        let ctx = QueryContext {
-            sem: &sem,
-            source,
-            uri: &uri,
-            encoding: PositionEncoding::Utf16,
-        };
+        let ctx = QueryContext::new(&sem, source, &uri, PositionEncoding::Utf16);
         find_references(&ctx, Position { line, character }, include_declaration)
     }
 

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -167,7 +167,6 @@ pub fn delta_encode(
     source: &str,
     encoding: PositionEncoding,
 ) -> Vec<u32> {
-    // Two conversions per token, so the line table is built up front.
     let lines = LineIndex::new(source);
 
     let mut data = Vec::with_capacity(tokens.len() * 5);
@@ -996,10 +995,7 @@ mod tests {
 
     #[test]
     fn multi_line_tokens_are_skipped() {
-        // LSP semantic tokens MUST NOT span lines — a partially encoded
-        // one renders worse than none. The fixture crosses a newline with a
-        // `/* */` block comment: no COMMENT token may be produced, and the
-        // single-line tokens around it must still appear.
+        // A partially encoded token renders worse than none.
         let src = "fn f() {\n    /* multi\n    line */\n    let _ = 1;\n}\n";
         let tokens = compute(src, None);
         // "Must not span lines", expressed against a start and a length.

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -867,7 +867,11 @@ mod tests {
         ];
         assert_eq!(expected.len(), TOKEN_MODIFIERS.len());
         for (bit, name) in expected {
-            assert_eq!(bit.count_ones(), 1, "{name} must be a single bit, got {bit}");
+            assert_eq!(
+                bit.count_ones(),
+                1,
+                "{name} must be a single bit, got {bit}"
+            );
             assert_eq!(
                 TOKEN_MODIFIERS.get(bit.trailing_zeros() as usize),
                 Some(&name),

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -6,9 +6,13 @@ use wado_compiler::semantics::Semantics;
 use wado_compiler::symbol::{Symbol, SymbolKind};
 use wado_compiler::token::{Token, TokenKind};
 
-use crate::text::{PositionEncoding, codepoints_to_code_units, line_without_terminator};
+use crate::text::{LineIndex, PositionEncoding};
 
-/// LSP semantic token type indices (must match `TOKEN_TYPES` order).
+/// LSP semantic token type indices — positions into [`TOKEN_TYPES`], the
+/// legend the server advertises at `initialize`. The correspondence is
+/// asserted by `legend_matches_token_type_indices`, not merely documented:
+/// a constant that drifts from its legend entry mis-colours every token of
+/// that kind, silently and in the client only.
 ///
 /// Indices `0..=13` are append-only history: keep them stable so the legend
 /// stays comparable across versions. New kinds (`14..`) map Wado-specific
@@ -56,7 +60,8 @@ pub const TOKEN_TYPES: &[&str] = &[
     "class",
 ];
 
-/// LSP semantic token modifier bit positions (must match `TOKEN_MODIFIERS`).
+/// LSP semantic token modifier bits — bit `n` is [`TOKEN_MODIFIERS`]`[n]`.
+/// Asserted by `legend_matches_token_modifier_bits`.
 pub mod token_modifier {
     pub const DECLARATION: u32 = 1 << 0;
     pub const DEFINITION: u32 = 1 << 1;
@@ -164,35 +169,18 @@ pub fn delta_encode(
     source: &str,
     encoding: PositionEncoding,
 ) -> Vec<u32> {
-    // Pre-split lines once with their codepoint count cached alongside.
-    // The hot loop converts twice per token (start and end). Without
-    // this cache each call would recompute `line.chars().count()`, so
-    // delta_encode would be O(tokens × line_codepoints); with the cache
-    // it's O(total_codepoints + tokens × min(token_codepoints, line)).
-    // UTF-32 short-circuits to a single `min`.
-    let lines: Vec<(&str, u32)> = source
-        .split_inclusive('\n')
-        .map(|line| {
-            let text = line_without_terminator(line);
-            (text, text.chars().count() as u32)
-        })
-        .collect();
+    // The hot loop converts twice per token (start and end), so the line
+    // table is built once up front — see [`LineIndex`]. UTF-32 short-circuits
+    // to a single `min`.
+    let lines = LineIndex::new(source);
 
     let mut data = Vec::with_capacity(tokens.len() * 5);
     let mut prev_line = 0u32;
     let mut prev_start = 0u32;
 
     for token in tokens {
-        let (line_text, line_codepoints) =
-            lines.get(token.line as usize).copied().unwrap_or(("", 0));
-        let start_char =
-            codepoints_to_code_units(line_text, line_codepoints, token.start_char, encoding);
-        let end_char = codepoints_to_code_units(
-            line_text,
-            line_codepoints,
-            token.start_char + token.length,
-            encoding,
-        );
+        let start_char = lines.to_character(token.line, token.start_char, encoding);
+        let end_char = lines.to_character(token.line, token.start_char + token.length, encoding);
         let length_in_encoding = end_char.saturating_sub(start_char);
 
         let delta_line = token.line - prev_line;
@@ -826,6 +814,68 @@ mod tests {
         futures::executor::block_on(wado_compiler::semantics(source, &host, Some("/test.wado")))
     }
 
+    /// Every `token_type` constant must index its own name in the legend.
+    ///
+    /// The two lists were kept in sync by a comment. A constant pointing one
+    /// slot off does not fail to compile, does not fail any behavioural test
+    /// (the tokens still carry *a* type), and shows up only as wrongly
+    /// coloured code in the editor.
+    #[test]
+    fn legend_matches_token_type_indices() {
+        let expected = [
+            (token_type::NAMESPACE, "namespace"),
+            (token_type::TYPE, "type"),
+            (token_type::TYPE_PARAMETER, "typeParameter"),
+            (token_type::PARAMETER, "parameter"),
+            (token_type::VARIABLE, "variable"),
+            (token_type::PROPERTY, "property"),
+            (token_type::ENUM_MEMBER, "enumMember"),
+            (token_type::FUNCTION, "function"),
+            (token_type::METHOD, "method"),
+            (token_type::KEYWORD, "keyword"),
+            (token_type::COMMENT, "comment"),
+            (token_type::STRING, "string"),
+            (token_type::NUMBER, "number"),
+            (token_type::OPERATOR, "operator"),
+            (token_type::STRUCT, "struct"),
+            (token_type::ENUM, "enum"),
+            (token_type::INTERFACE, "interface"),
+            (token_type::CLASS, "class"),
+        ];
+        assert_eq!(
+            expected.len(),
+            TOKEN_TYPES.len(),
+            "every legend entry needs a named constant (and vice versa)",
+        );
+        for (index, name) in expected {
+            assert_eq!(
+                TOKEN_TYPES.get(index as usize),
+                Some(&name),
+                "token type {index} should be {name:?}",
+            );
+        }
+    }
+
+    /// Each modifier constant is a single bit whose position indexes its own
+    /// legend name.
+    #[test]
+    fn legend_matches_token_modifier_bits() {
+        let expected = [
+            (token_modifier::DECLARATION, "declaration"),
+            (token_modifier::DEFINITION, "definition"),
+            (token_modifier::READONLY, "readonly"),
+        ];
+        assert_eq!(expected.len(), TOKEN_MODIFIERS.len());
+        for (bit, name) in expected {
+            assert_eq!(bit.count_ones(), 1, "{name} must be a single bit, got {bit}");
+            assert_eq!(
+                TOKEN_MODIFIERS.get(bit.trailing_zeros() as usize),
+                Some(&name),
+                "modifier bit {bit} should be {name:?}",
+            );
+        }
+    }
+
     #[test]
     fn test_empty_source() {
         let tokens = compute("", None);
@@ -958,11 +1008,22 @@ mod tests {
         // but no COMMENT token may be produced.
         let src = "fn f() {\n    /* multi\n    line */\n    let _ = 1;\n}\n";
         let tokens = compute(src, None);
+        // No token may extend past the end of the line it starts on — that is
+        // what "must not span lines" means once the token carries only a
+        // start and a length.
+        let line_lengths: Vec<u32> = src
+            .split_inclusive('\n')
+            .map(|l| crate::text::line_without_terminator(l).chars().count() as u32)
+            .collect();
         for tok in &tokens {
-            // No token may span lines under any circumstances.
-            assert_eq!(
-                tok.length,
-                tok.length, // pin for the assertion structure
+            let line_len = line_lengths
+                .get(tok.line as usize)
+                .copied()
+                .unwrap_or_else(|| panic!("token on a line past EOF: {tok:?}"));
+            assert!(
+                tok.start_char + tok.length <= line_len,
+                "token runs past the end of line {}: {tok:?} (line is {line_len} codepoints)",
+                tok.line,
             );
         }
         assert!(

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -10,9 +10,7 @@ use crate::text::{LineIndex, PositionEncoding};
 
 /// LSP semantic token type indices — positions into [`TOKEN_TYPES`], the
 /// legend the server advertises at `initialize`. The correspondence is
-/// asserted by `legend_matches_token_type_indices`, not merely documented:
-/// a constant that drifts from its legend entry mis-colours every token of
-/// that kind, silently and in the client only.
+/// asserted by `legend_matches_token_type_indices`.
 ///
 /// Indices `0..=13` are append-only history: keep them stable so the legend
 /// stays comparable across versions. New kinds (`14..`) map Wado-specific
@@ -169,9 +167,7 @@ pub fn delta_encode(
     source: &str,
     encoding: PositionEncoding,
 ) -> Vec<u32> {
-    // The hot loop converts twice per token (start and end), so the line
-    // table is built once up front — see [`LineIndex`]. UTF-32 short-circuits
-    // to a single `min`.
+    // Two conversions per token, so the line table is built up front.
     let lines = LineIndex::new(source);
 
     let mut data = Vec::with_capacity(tokens.len() * 5);
@@ -814,12 +810,11 @@ mod tests {
         futures::executor::block_on(wado_compiler::semantics(source, &host, Some("/test.wado")))
     }
 
-    /// Every `token_type` constant must index its own name in the legend.
+    /// Every `token_type` constant indexes its own name in the legend.
     ///
-    /// The two lists were kept in sync by a comment. A constant pointing one
-    /// slot off does not fail to compile, does not fail any behavioural test
-    /// (the tokens still carry *a* type), and shows up only as wrongly
-    /// coloured code in the editor.
+    /// A constant one slot off still compiles and still carries *a* type
+    /// through every behavioural test; it shows up only as wrongly coloured
+    /// code in the editor.
     #[test]
     fn legend_matches_token_type_indices() {
         let expected = [
@@ -856,8 +851,7 @@ mod tests {
         }
     }
 
-    /// Each modifier constant is a single bit whose position indexes its own
-    /// legend name.
+    /// Each modifier constant is one bit, positioned at its legend name.
     #[test]
     fn legend_matches_token_modifier_bits() {
         let expected = [
@@ -1012,9 +1006,7 @@ mod tests {
         // but no COMMENT token may be produced.
         let src = "fn f() {\n    /* multi\n    line */\n    let _ = 1;\n}\n";
         let tokens = compute(src, None);
-        // No token may extend past the end of the line it starts on — that is
-        // what "must not span lines" means once the token carries only a
-        // start and a length.
+        // "Must not span lines", expressed against a start and a length.
         let line_lengths: Vec<u32> = src
             .split_inclusive('\n')
             .map(|l| crate::text::line_without_terminator(l).chars().count() as u32)

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -996,14 +996,10 @@ mod tests {
 
     #[test]
     fn multi_line_tokens_are_skipped() {
-        // LSP semantic tokens MUST NOT span lines. Both lexer-emitted
-        // tokens (raw-newline string literals, doc/block comments) and
-        // the comment list path used to silently slip through and
-        // produce wrong-length entries that delta_encode then clipped
-        // to end-of-start-line. The fixture below uses a `/* */` block
-        // comment that crosses a newline; the parse-emitted single-
-        // line tokens around it (`fn`, `f`, etc.) must still appear,
-        // but no COMMENT token may be produced.
+        // LSP semantic tokens MUST NOT span lines — a partially encoded
+        // one renders worse than none. The fixture crosses a newline with a
+        // `/* */` block comment: no COMMENT token may be produced, and the
+        // single-line tokens around it must still appear.
         let src = "fn f() {\n    /* multi\n    line */\n    let _ = 1;\n}\n";
         let tokens = compute(src, None);
         // "Must not span lines", expressed against a start and a length.

--- a/wado-lsp/src/server.rs
+++ b/wado-lsp/src/server.rs
@@ -26,10 +26,7 @@ use crate::server::transport::ReadError;
 ///
 /// Returns the process exit code LSP 3.18 §exit prescribes — `0` when the
 /// client ran `shutdown` first or the transport closed cleanly, `1` when it
-/// exited without shutting down. Returning it, rather than calling
-/// `std::process::exit` from inside the loop, leaves the decision with the
-/// caller: `wado lsp` routes it through the CLI's own exit path, and the
-/// loop stays testable.
+/// exited without shutting down. See [`Lifecycle::exit_code`].
 pub async fn run_stdio() -> i32 {
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();

--- a/wado-lsp/src/server.rs
+++ b/wado-lsp/src/server.rs
@@ -21,8 +21,16 @@ use crate::server::dispatch::Lifecycle;
 use crate::server::rpc::error_codes;
 use crate::server::transport::ReadError;
 
-/// Run the LSP server over stdio until the client disconnects.
-pub async fn run_stdio() {
+/// Run the LSP server over stdio until the client disconnects or sends
+/// `exit`.
+///
+/// Returns the process exit code LSP 3.18 §exit prescribes — `0` when the
+/// client ran `shutdown` first or the transport closed cleanly, `1` when it
+/// exited without shutting down. Returning it, rather than calling
+/// `std::process::exit` from inside the loop, leaves the decision with the
+/// caller: `wado lsp` routes it through the CLI's own exit path, and the
+/// loop stays testable.
+pub async fn run_stdio() -> i32 {
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let mut reader = BufReader::new(stdin.lock());
@@ -61,5 +69,9 @@ pub async fn run_stdio() {
             eprintln!("wado-lsp: {e}");
             break;
         }
+        if let Some(code) = lifecycle.exit_code {
+            return code;
+        }
     }
+    0
 }

--- a/wado-lsp/src/server/dispatch.rs
+++ b/wado-lsp/src/server/dispatch.rs
@@ -20,12 +20,8 @@ use crate::text::PositionEncoding;
 
 const STDLIB_SCHEMES: &[&str] = &["core", "wasi"];
 
-/// The document a request targets.
-///
-/// Every document-scoped request names it the same way, and the dispatcher
-/// needs it *before* the handler runs so it can root the request's
-/// [`FilesystemCompilerHost`] at the document's directory. Naming it once
-/// here is what lets [`query`] be shared by all six arms.
+/// The document a request targets. [`query`] needs it before the handler
+/// runs, to root the request's [`FilesystemCompilerHost`].
 trait TargetDocument {
     fn uri(&self) -> &str;
 }
@@ -85,11 +81,8 @@ where
 ///   `shutdown`. After that, every request except `exit` must fail with
 ///   `InvalidRequest` and every notification except `exit` must be dropped.
 /// - `exit_code` is set by the `exit` notification. `dispatch` never calls
-///   `std::process::exit` itself: it is a library function that
-///   `wado lsp` invokes inside a longer-lived process, and terminating from
-///   inside it skips every destructor between here and `main` — besides
-///   making the exit path untestable. The owning loop reads this and
-///   returns.
+///   `std::process::exit` itself — `wado lsp` invokes it inside a
+///   longer-lived process — so the owning loop reads this and returns.
 #[derive(Default)]
 pub struct Lifecycle {
     pub initialized: bool,

--- a/wado-lsp/src/server/dispatch.rs
+++ b/wado-lsp/src/server/dispatch.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 use serde_json::Value;
 
 use crate::Engine;
+use crate::host::FilesystemCompilerHost;
 use crate::server::rpc::{
     DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
     InitializeParams, InitializeResult, InlayHintParams, JsonRpcRequest, PublishDiagnosticsParams,
@@ -19,6 +20,62 @@ use crate::text::PositionEncoding;
 
 const STDLIB_SCHEMES: &[&str] = &["core", "wasi"];
 
+/// The document a request targets.
+///
+/// Every document-scoped request names it the same way, and the dispatcher
+/// needs it *before* the handler runs so it can root the request's
+/// [`FilesystemCompilerHost`] at the document's directory. Naming it once
+/// here is what lets [`query`] be shared by all six arms.
+trait TargetDocument {
+    fn uri(&self) -> &str;
+}
+
+impl TargetDocument for TextDocumentPositionParams {
+    fn uri(&self) -> &str {
+        &self.text_document.uri
+    }
+}
+
+impl TargetDocument for ReferenceParams {
+    fn uri(&self) -> &str {
+        &self.text_document.uri
+    }
+}
+
+impl TargetDocument for SemanticTokensParams {
+    fn uri(&self) -> &str {
+        &self.text_document.uri
+    }
+}
+
+impl TargetDocument for InlayHintParams {
+    fn uri(&self) -> &str {
+        &self.text_document.uri
+    }
+}
+
+/// Run a document-scoped query: decode the params, build the host for the
+/// document they name, hand both to `handler`, and reply with its result.
+async fn query<P, R, W, F>(
+    engine: &Engine,
+    writer: &mut W,
+    id: Option<&Value>,
+    params: Value,
+    handler: F,
+) -> Result<(), String>
+where
+    P: serde::de::DeserializeOwned + TargetDocument,
+    R: serde::Serialize,
+    W: Write,
+    F: AsyncFnOnce(&Engine, P, &FilesystemCompilerHost) -> R,
+{
+    transport::typed_request(writer, id, params, async |p: P| {
+        let host = transport::host_for_uri(p.uri());
+        handler(engine, p, &host).await
+    })
+    .await
+}
+
 /// Tracks server lifecycle per LSP 3.18 §Server lifecycle.
 ///
 /// - `initialized` flips to `true` once the server has *responded* to
@@ -27,10 +84,17 @@ const STDLIB_SCHEMES: &[&str] = &["core", "wasi"];
 /// - `shutdown_requested` flips to `true` once the server has responded to
 ///   `shutdown`. After that, every request except `exit` must fail with
 ///   `InvalidRequest` and every notification except `exit` must be dropped.
+/// - `exit_code` is set by the `exit` notification. `dispatch` never calls
+///   `std::process::exit` itself: it is a library function that
+///   `wado lsp` invokes inside a longer-lived process, and terminating from
+///   inside it skips every destructor between here and `main` — besides
+///   making the exit path untestable. The owning loop reads this and
+///   returns.
 #[derive(Default)]
 pub struct Lifecycle {
     pub initialized: bool,
     pub shutdown_requested: bool,
+    pub exit_code: Option<i32>,
 }
 
 pub async fn dispatch<W: Write>(
@@ -44,7 +108,9 @@ pub async fn dispatch<W: Write>(
     let params = request.params;
 
     if method == "exit" {
-        std::process::exit(i32::from(!lifecycle.shutdown_requested));
+        // LSP 3.18 §exit: 0 when `shutdown` was requested first, else 1.
+        lifecycle.exit_code = Some(i32::from(!lifecycle.shutdown_requested));
+        return Ok(());
     }
 
     if !lifecycle.initialized && method != "initialize" {
@@ -152,65 +218,47 @@ pub async fn dispatch<W: Write>(
             }
         }
         "textDocument/definition" => {
-            let engine = &*engine;
-            transport::typed_request(writer, id, params, async |p: TextDocumentPositionParams| {
-                let host = transport::host_for_uri(&p.text_document.uri);
-                engine
-                    .definition(&p.text_document.uri, p.position, &host)
-                    .await
+            query(engine, writer, id, params, async |e, p: TextDocumentPositionParams, host| {
+                e.definition(&p.text_document.uri, p.position, host).await
             })
             .await?;
         }
         "textDocument/hover" => {
-            let engine = &*engine;
-            transport::typed_request(writer, id, params, async |p: TextDocumentPositionParams| {
-                let host = transport::host_for_uri(&p.text_document.uri);
-                engine.hover(&p.text_document.uri, p.position, &host).await
+            query(engine, writer, id, params, async |e, p: TextDocumentPositionParams, host| {
+                e.hover(&p.text_document.uri, p.position, host).await
             })
             .await?;
         }
         "textDocument/references" => {
-            let engine = &*engine;
-            transport::typed_request(writer, id, params, async |p: ReferenceParams| {
-                let host = transport::host_for_uri(&p.text_document.uri);
-                engine
-                    .references(
-                        &p.text_document.uri,
-                        p.position,
-                        p.context.include_declaration,
-                        &host,
-                    )
-                    .await
+            query(engine, writer, id, params, async |e, p: ReferenceParams, host| {
+                e.references(
+                    &p.text_document.uri,
+                    p.position,
+                    p.context.include_declaration,
+                    host,
+                )
+                .await
             })
             .await?;
         }
         "textDocument/documentHighlight" => {
-            let engine = &*engine;
-            transport::typed_request(writer, id, params, async |p: TextDocumentPositionParams| {
-                let host = transport::host_for_uri(&p.text_document.uri);
-                engine
-                    .document_highlight(&p.text_document.uri, p.position, &host)
+            query(engine, writer, id, params, async |e, p: TextDocumentPositionParams, host| {
+                e.document_highlight(&p.text_document.uri, p.position, host)
                     .await
             })
             .await?;
         }
         "textDocument/semanticTokens/full" => {
-            let engine = &*engine;
-            transport::typed_request(writer, id, params, async |p: SemanticTokensParams| {
-                let host = transport::host_for_uri(&p.text_document.uri);
+            query(engine, writer, id, params, async |e, p: SemanticTokensParams, host| {
                 SemanticTokens {
-                    data: engine.semantic_tokens(&p.text_document.uri, &host).await,
+                    data: e.semantic_tokens(&p.text_document.uri, host).await,
                 }
             })
             .await?;
         }
         "textDocument/inlayHint" => {
-            let engine = &*engine;
-            transport::typed_request(writer, id, params, async |p: InlayHintParams| {
-                let host = transport::host_for_uri(&p.text_document.uri);
-                engine
-                    .inlay_hints(&p.text_document.uri, p.range, &host)
-                    .await
+            query(engine, writer, id, params, async |e, p: InlayHintParams, host| {
+                e.inlay_hints(&p.text_document.uri, p.range, host).await
             })
             .await?;
         }

--- a/wado-lsp/src/server/dispatch.rs
+++ b/wado-lsp/src/server/dispatch.rs
@@ -218,48 +218,82 @@ pub async fn dispatch<W: Write>(
             }
         }
         "textDocument/definition" => {
-            query(engine, writer, id, params, async |e, p: TextDocumentPositionParams, host| {
-                e.definition(&p.text_document.uri, p.position, host).await
-            })
+            query(
+                engine,
+                writer,
+                id,
+                params,
+                async |e, p: TextDocumentPositionParams, host| {
+                    e.definition(&p.text_document.uri, p.position, host).await
+                },
+            )
             .await?;
         }
         "textDocument/hover" => {
-            query(engine, writer, id, params, async |e, p: TextDocumentPositionParams, host| {
-                e.hover(&p.text_document.uri, p.position, host).await
-            })
+            query(
+                engine,
+                writer,
+                id,
+                params,
+                async |e, p: TextDocumentPositionParams, host| {
+                    e.hover(&p.text_document.uri, p.position, host).await
+                },
+            )
             .await?;
         }
         "textDocument/references" => {
-            query(engine, writer, id, params, async |e, p: ReferenceParams, host| {
-                e.references(
-                    &p.text_document.uri,
-                    p.position,
-                    p.context.include_declaration,
-                    host,
-                )
-                .await
-            })
+            query(
+                engine,
+                writer,
+                id,
+                params,
+                async |e, p: ReferenceParams, host| {
+                    e.references(
+                        &p.text_document.uri,
+                        p.position,
+                        p.context.include_declaration,
+                        host,
+                    )
+                    .await
+                },
+            )
             .await?;
         }
         "textDocument/documentHighlight" => {
-            query(engine, writer, id, params, async |e, p: TextDocumentPositionParams, host| {
-                e.document_highlight(&p.text_document.uri, p.position, host)
-                    .await
-            })
+            query(
+                engine,
+                writer,
+                id,
+                params,
+                async |e, p: TextDocumentPositionParams, host| {
+                    e.document_highlight(&p.text_document.uri, p.position, host)
+                        .await
+                },
+            )
             .await?;
         }
         "textDocument/semanticTokens/full" => {
-            query(engine, writer, id, params, async |e, p: SemanticTokensParams, host| {
-                SemanticTokens {
+            query(
+                engine,
+                writer,
+                id,
+                params,
+                async |e, p: SemanticTokensParams, host| SemanticTokens {
                     data: e.semantic_tokens(&p.text_document.uri, host).await,
-                }
-            })
+                },
+            )
             .await?;
         }
         "textDocument/inlayHint" => {
-            query(engine, writer, id, params, async |e, p: InlayHintParams, host| {
-                e.inlay_hints(&p.text_document.uri, p.range, host).await
-            })
+            query(
+                engine,
+                writer,
+                id,
+                params,
+                async |e, p: InlayHintParams, host| {
+                    e.inlay_hints(&p.text_document.uri, p.range, host).await
+                },
+            )
             .await?;
         }
         "workspace/textDocumentContent" => {

--- a/wado-lsp/src/server/rpc.rs
+++ b/wado-lsp/src/server/rpc.rs
@@ -200,6 +200,9 @@ pub struct TextDocumentSyncOptions {
     pub change: u32,
 }
 
+/// LSP `TextDocumentSyncKind`, mirrored whole so the value the server
+/// advertises reads against its alternatives. Only `FULL` is served today;
+/// `INCREMENTAL` is on the roadmap.
 pub mod text_document_sync_kind {
     pub const NONE: u32 = 0;
     pub const FULL: u32 = 1;

--- a/wado-lsp/src/server/transport.rs
+++ b/wado-lsp/src/server/transport.rs
@@ -34,12 +34,16 @@ const MAX_CONTENT_LENGTH: usize = 64 * 1024 * 1024;
 
 /// Failure mode of [`read_message`].
 ///
-/// `Parse` errors are recoverable: per LSP 3.18 (JSON-RPC 2.0 §5.1), the
-/// server should respond with `-32700 ParseError` and keep processing. `Io`
-/// errors are unrecoverable — the transport is broken, or the frame boundary
-/// is lost and no amount of further reading finds it again (an oversized
-/// `Content-Length` names a body we refuse to consume, so every subsequent
-/// byte would be read at the wrong offset).
+/// `Parse` errors are recoverable: the frame was consumed whole and only its
+/// contents were bad, so per LSP 3.18 (JSON-RPC 2.0 §5.1) the server answers
+/// `-32700 ParseError` and keeps processing.
+///
+/// `Io` errors are unrecoverable — the transport is broken, or the frame
+/// boundary is lost and no amount of further reading finds it again. A
+/// `Content-Length` we cannot parse or refuse to honour leaves a body we
+/// never consumed, so every subsequent byte would be read at the wrong
+/// offset; answering and looping would re-read that body as headers and spin
+/// on the same error.
 #[derive(Debug)]
 pub enum ReadError {
     Parse(String),
@@ -48,8 +52,9 @@ pub enum ReadError {
 
 /// Read one JSON-RPC message (Content-Length framed).
 ///
-/// Returns `Ok(None)` on clean EOF, `Err(ReadError::Parse)` for malformed
-/// framing or JSON bodies, and `Err(ReadError::Io)` for transport failures.
+/// Returns `Ok(None)` on clean EOF, `Err(ReadError::Parse)` for a body that
+/// was read but is not valid JSON, and `Err(ReadError::Io)` for transport
+/// failures and for framing we cannot recover from.
 pub fn read_message<R: BufRead>(reader: &mut R) -> Result<Option<JsonRpcRequest>, ReadError> {
     let mut content_length: Option<usize> = None;
     loop {
@@ -70,10 +75,15 @@ pub fn read_message<R: BufRead>(reader: &mut R) -> Result<Option<JsonRpcRequest>
             && name.eq_ignore_ascii_case("Content-Length")
         {
             let value = value.trim();
+            // Fatal, like the over-limit case below and for the same reason:
+            // an unparseable length leaves us unable to say where this
+            // message's body ends, so every later read starts at an offset we
+            // cannot recover. Answering `-32700` and looping would re-read
+            // the body as headers and spin on the error forever.
             content_length = Some(
                 value
                     .parse()
-                    .map_err(|_| ReadError::Parse(format!("invalid Content-Length: {value}")))?,
+                    .map_err(|_| ReadError::Io(format!("invalid Content-Length: {value}")))?,
             );
         }
     }
@@ -280,6 +290,30 @@ mod tests {
         assert!(
             matches!(&err, ReadError::Io(m) if m.contains("exceeds")),
             "expected a fatal transport error, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn unparseable_content_length_is_fatal_not_recoverable() {
+        // Classifying it `Parse` made `run_stdio` answer `-32700` and loop —
+        // but the body was never consumed, so the next "header" it read came
+        // from mid-body and the server spun on the same error forever.
+        let raw = "Content-Length: not-a-number\r\n\r\n{}";
+        let err = read(raw.as_bytes()).expect_err("an unparseable length must be refused");
+        assert!(
+            matches!(&err, ReadError::Io(m) if m.contains("invalid Content-Length")),
+            "expected a fatal transport error, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn malformed_json_body_stays_recoverable() {
+        // The counter-case: the body *was* consumed, so the stream is still
+        // framed and JSON-RPC 2.0 §5.1's `-32700`-and-continue applies.
+        let err = read(&frame("not json")).expect_err("malformed JSON must be reported");
+        assert!(
+            matches!(&err, ReadError::Parse(m) if m.contains("invalid JSON")),
+            "expected a recoverable parse error, got {err:?}",
         );
     }
 

--- a/wado-lsp/src/server/transport.rs
+++ b/wado-lsp/src/server/transport.rs
@@ -182,8 +182,7 @@ where
 ///
 /// Skips the body when `id` is `None` (notification-shaped envelope on
 /// a request method), and bails after sending an `InvalidParams` error
-/// when the params don't deserialize. This shell is what every
-/// query-style handler in `dispatch.rs` used to inline by hand.
+/// when the params don't deserialize.
 pub async fn typed_request<P, R, W, F, Fut>(
     writer: &mut W,
     id: Option<&Value>,

--- a/wado-lsp/src/server/transport.rs
+++ b/wado-lsp/src/server/transport.rs
@@ -22,11 +22,24 @@ use crate::uri::Uri;
 
 const JSONRPC_VERSION: &str = "2.0";
 
+/// Largest message body accepted from the client, in bytes.
+///
+/// `Content-Length` is attacker-controlled in the sense that matters here: a
+/// buggy client (or a desynchronised stream after a malformed frame) can name
+/// any length, and the body buffer was allocated eagerly at that size. 64 MiB
+/// is far above any real LSP message — a `didOpen` carries one source file —
+/// and far below a length that would take the editor's language server down
+/// with an allocation failure.
+const MAX_CONTENT_LENGTH: usize = 64 * 1024 * 1024;
+
 /// Failure mode of [`read_message`].
 ///
 /// `Parse` errors are recoverable: per LSP 3.18 (JSON-RPC 2.0 §5.1), the
 /// server should respond with `-32700 ParseError` and keep processing. `Io`
-/// errors are unrecoverable — the transport is broken.
+/// errors are unrecoverable — the transport is broken, or the frame boundary
+/// is lost and no amount of further reading finds it again (an oversized
+/// `Content-Length` names a body we refuse to consume, so every subsequent
+/// byte would be read at the wrong offset).
 #[derive(Debug)]
 pub enum ReadError {
     Parse(String),
@@ -51,17 +64,29 @@ pub fn read_message<R: BufRead>(reader: &mut R) -> Result<Option<JsonRpcRequest>
         if trimmed.is_empty() {
             break;
         }
-        if let Some(len_str) = trimmed.strip_prefix("Content-Length: ") {
+        // Header names are case-insensitive and the space after the colon is
+        // optional (LSP 3.18 §baseProtocol defers to the HTTP header grammar).
+        if let Some((name, value)) = trimmed.split_once(':')
+            && name.eq_ignore_ascii_case("Content-Length")
+        {
+            let value = value.trim();
             content_length = Some(
-                len_str
+                value
                     .parse()
-                    .map_err(|_| ReadError::Parse(format!("invalid Content-Length: {len_str}")))?,
+                    .map_err(|_| ReadError::Parse(format!("invalid Content-Length: {value}")))?,
             );
         }
     }
 
     let length = content_length
         .ok_or_else(|| ReadError::Parse("missing Content-Length header".to_string()))?;
+    if length > MAX_CONTENT_LENGTH {
+        // Fatal, not recoverable: the declared body is never consumed, so the
+        // stream stays framed at an offset we cannot find our way back from.
+        return Err(ReadError::Io(format!(
+            "Content-Length {length} exceeds the {MAX_CONTENT_LENGTH}-byte limit",
+        )));
+    }
     let mut body = vec![0u8; length];
     reader
         .read_exact(&mut body)
@@ -211,4 +236,55 @@ pub async fn publish_diagnostics<W: Write>(
         diagnostics,
     };
     send_notification(writer, "textDocument/publishDiagnostics", params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read(input: &[u8]) -> Result<Option<JsonRpcRequest>, ReadError> {
+        read_message(&mut std::io::BufReader::new(input))
+    }
+
+    fn frame(body: &str) -> Vec<u8> {
+        format!("Content-Length: {}\r\n\r\n{body}", body.len()).into_bytes()
+    }
+
+    #[test]
+    fn reads_a_well_formed_frame() {
+        let msg = read(&frame(r#"{"jsonrpc":"2.0","id":1,"method":"shutdown"}"#))
+            .expect("read")
+            .expect("message");
+        assert_eq!(msg.method, "shutdown");
+    }
+
+    #[test]
+    fn content_length_header_is_case_insensitive_and_space_optional() {
+        // LSP defers to the HTTP header grammar: the name is case-insensitive
+        // and the space after the colon is optional. Matching the literal
+        // `"Content-Length: "` silently dropped such a frame into
+        // "missing Content-Length header".
+        let body = r#"{"jsonrpc":"2.0","id":1,"method":"shutdown"}"#;
+        let raw = format!("content-length:{}\r\n\r\n{body}", body.len());
+        let msg = read(raw.as_bytes()).expect("read").expect("message");
+        assert_eq!(msg.method, "shutdown");
+    }
+
+    #[test]
+    fn oversized_content_length_is_refused_without_allocating() {
+        // The body buffer was allocated eagerly at the declared size, so a
+        // bogus length took the server down with an allocation failure
+        // instead of an error.
+        let raw = format!("Content-Length: {}\r\n\r\n", MAX_CONTENT_LENGTH + 1);
+        let err = read(raw.as_bytes()).expect_err("oversized length must be refused");
+        assert!(
+            matches!(&err, ReadError::Io(m) if m.contains("exceeds")),
+            "expected a fatal transport error, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn clean_eof_is_not_an_error() {
+        assert!(read(b"").expect("read").is_none());
+    }
 }

--- a/wado-lsp/src/server/transport.rs
+++ b/wado-lsp/src/server/transport.rs
@@ -24,26 +24,20 @@ const JSONRPC_VERSION: &str = "2.0";
 
 /// Largest message body accepted from the client, in bytes.
 ///
-/// `Content-Length` is attacker-controlled in the sense that matters here: a
-/// buggy client (or a desynchronised stream after a malformed frame) can name
-/// any length, and the body buffer was allocated eagerly at that size. 64 MiB
-/// is far above any real LSP message — a `didOpen` carries one source file —
-/// and far below a length that would take the editor's language server down
-/// with an allocation failure.
+/// The body buffer is allocated eagerly at the declared length, and a buggy
+/// client or a desynchronised stream can name any. 64 MiB sits far above a
+/// real message and far below an allocation failure.
 const MAX_CONTENT_LENGTH: usize = 64 * 1024 * 1024;
 
 /// Failure mode of [`read_message`].
 ///
-/// `Parse` errors are recoverable: the frame was consumed whole and only its
-/// contents were bad, so per LSP 3.18 (JSON-RPC 2.0 §5.1) the server answers
-/// `-32700 ParseError` and keeps processing.
+/// `Parse` is recoverable: the frame was consumed whole and only its contents
+/// were bad, so per LSP 3.18 (JSON-RPC 2.0 §5.1) the server answers
+/// `-32700 ParseError` and keeps going.
 ///
-/// `Io` errors are unrecoverable — the transport is broken, or the frame
-/// boundary is lost and no amount of further reading finds it again. A
+/// `Io` is not: the transport is broken, or the frame boundary is lost. A
 /// `Content-Length` we cannot parse or refuse to honour leaves a body we
-/// never consumed, so every subsequent byte would be read at the wrong
-/// offset; answering and looping would re-read that body as headers and spin
-/// on the same error.
+/// never consumed, so answering and looping would read that body as headers.
 #[derive(Debug)]
 pub enum ReadError {
     Parse(String),
@@ -75,11 +69,8 @@ pub fn read_message<R: BufRead>(reader: &mut R) -> Result<Option<JsonRpcRequest>
             && name.eq_ignore_ascii_case("Content-Length")
         {
             let value = value.trim();
-            // Fatal, like the over-limit case below and for the same reason:
-            // an unparseable length leaves us unable to say where this
-            // message's body ends, so every later read starts at an offset we
-            // cannot recover. Answering `-32700` and looping would re-read
-            // the body as headers and spin on the error forever.
+            // Fatal: without a length we cannot say where this body ends,
+            // so every later read starts at an unrecoverable offset.
             content_length = Some(
                 value
                     .parse()
@@ -91,8 +82,7 @@ pub fn read_message<R: BufRead>(reader: &mut R) -> Result<Option<JsonRpcRequest>
     let length = content_length
         .ok_or_else(|| ReadError::Parse("missing Content-Length header".to_string()))?;
     if length > MAX_CONTENT_LENGTH {
-        // Fatal, not recoverable: the declared body is never consumed, so the
-        // stream stays framed at an offset we cannot find our way back from.
+        // Fatal for the same reason: the declared body is never consumed.
         return Err(ReadError::Io(format!(
             "Content-Length {length} exceeds the {MAX_CONTENT_LENGTH}-byte limit",
         )));
@@ -270,10 +260,6 @@ mod tests {
 
     #[test]
     fn content_length_header_is_case_insensitive_and_space_optional() {
-        // LSP defers to the HTTP header grammar: the name is case-insensitive
-        // and the space after the colon is optional. Matching the literal
-        // `"Content-Length: "` silently dropped such a frame into
-        // "missing Content-Length header".
         let body = r#"{"jsonrpc":"2.0","id":1,"method":"shutdown"}"#;
         let raw = format!("content-length:{}\r\n\r\n{body}", body.len());
         let msg = read(raw.as_bytes()).expect("read").expect("message");
@@ -282,9 +268,7 @@ mod tests {
 
     #[test]
     fn oversized_content_length_is_refused_without_allocating() {
-        // The body buffer was allocated eagerly at the declared size, so a
-        // bogus length took the server down with an allocation failure
-        // instead of an error.
+        // The buffer is allocated eagerly at the declared size.
         let raw = format!("Content-Length: {}\r\n\r\n", MAX_CONTENT_LENGTH + 1);
         let err = read(raw.as_bytes()).expect_err("oversized length must be refused");
         assert!(
@@ -295,9 +279,7 @@ mod tests {
 
     #[test]
     fn unparseable_content_length_is_fatal_not_recoverable() {
-        // Classifying it `Parse` made `run_stdio` answer `-32700` and loop —
-        // but the body was never consumed, so the next "header" it read came
-        // from mid-body and the server spun on the same error forever.
+        // Recovering here would read the unconsumed body as headers.
         let raw = "Content-Length: not-a-number\r\n\r\n{}";
         let err = read(raw.as_bytes()).expect_err("an unparseable length must be refused");
         assert!(
@@ -308,8 +290,7 @@ mod tests {
 
     #[test]
     fn malformed_json_body_stays_recoverable() {
-        // The counter-case: the body *was* consumed, so the stream is still
-        // framed and JSON-RPC 2.0 §5.1's `-32700`-and-continue applies.
+        // The counter-case: the body was consumed, so the stream stays framed.
         let err = read(&frame("not json")).expect_err("malformed JSON must be reported");
         assert!(
             matches!(&err, ReadError::Parse(m) if m.contains("invalid JSON")),

--- a/wado-lsp/src/test_support.rs
+++ b/wado-lsp/src/test_support.rs
@@ -1,15 +1,12 @@
 //! Shared test fixtures for `wado-lsp`.
 //!
-//! Centralises the in-memory `CompilerHost` implementation that every test
-//! file used to redeclare. The module is publicly exposed but marked
-//! `#[doc(hidden)]` so it is reachable from both unit tests (inside
-//! `src/`) and integration tests (`tests/*.rs`) without inflating the
-//! crate's documented surface.
+//! The one in-memory `CompilerHost` for the crate's tests. `#[doc(hidden)]
+//! pub` so both unit tests (inside `src/`) and integration tests
+//! (`tests/*.rs`) reach it without inflating the documented surface.
 //!
-//! Adding a new shared helper here is preferable to growing yet another
-//! `TestHost` per file — the previous duplication drifted across files
-//! (different constructor names, different diagnostic-capture behaviour)
-//! and made it easy to accidentally test against a non-canonical host.
+//! Add shared helpers here rather than growing a per-file `TestHost`: a
+//! second host drifts in constructor names and diagnostic-capture behaviour,
+//! and then a test silently asserts against the non-canonical one.
 //!
 //! Typical usage in tests:
 //!

--- a/wado-lsp/src/text.rs
+++ b/wado-lsp/src/text.rs
@@ -8,19 +8,8 @@
 //! scalar value, not per byte and not per UTF-16 code unit). The
 //! conversion lives here so every LSP query reaches the same compiler
 //! `(line, col)` for a given cursor regardless of which code-unit space
-//! the client speaks.
-//!
-//! Previously each query did
-//!
-//! ```ignore
-//! let line = position.line as usize + 1;
-//! let col = position.character as usize + 1;
-//! ```
-//!
-//! which silently assumed both 1-based-ness and ASCII. Non-ASCII source
-//! (multi-byte characters, multi-code-unit grapheme clusters) drifted
-//! the column by an unbounded amount, breaking hover / definition /
-//! references at every cursor past an emoji or a CJK character.
+//! the client speaks. Treating the two spaces as interchangeable drifts the
+//! column by an unbounded amount past any non-ASCII character.
 //!
 //! See LSP 3.18 §general.positionEncodings.
 
@@ -304,11 +293,9 @@ mod tests {
 
     #[test]
     fn past_eof_returns_out_of_range_sentinel() {
-        // A stale cursor (line beyond source) used to fall back to
-        // (1, 1) — a valid in-range position that silently bound LSP
-        // queries to the first AST node. The sentinel must be a line
-        // no real `Span` can have, so the compiler's `ast_id_at`
-        // returns `None` and the LSP query bails cleanly.
+        // The sentinel must be a line no real `Span` can have, so
+        // `ast_id_at` returns `None` and the query bails. An in-range
+        // fallback like (1, 1) would bind the cursor to the first AST node.
         let src = "fn f() {}\nfn g() {}\n";
         let (line, col) = lsp_position_to_line_col(src, pos(99, 0), PositionEncoding::Utf16);
         assert_eq!(

--- a/wado-lsp/src/text.rs
+++ b/wado-lsp/src/text.rs
@@ -158,9 +158,8 @@ pub fn span_to_range(span: &Span, source: Option<&str>, encoding: PositionEncodi
     }
 }
 
-/// [`span_to_range`] against an already-built line table. Callers converting
-/// more than one span per document — every position-bearing query does —
-/// share one index instead of rescanning the source per span.
+/// [`span_to_range`] against an already-built line table, for callers
+/// converting more than one span per document.
 #[must_use]
 pub(crate) fn span_to_range_indexed(
     span: &Span,
@@ -225,11 +224,10 @@ fn character_to_codepoint_offset(line: &str, character: u32, encoding: PositionE
 
 /// A document's lines, each paired with its codepoint count.
 ///
-/// Every codepoint→code-unit conversion needs the text of one line. Finding
-/// it with `source.split_inclusive('\n').nth(line)` re-scans the document
-/// from the top, so a caller converting once per diagnostic or once per inlay
-/// hint pays `O(hints × document length)`. Building this once is a single
-/// pass, and each conversion is then a slice index.
+/// Every codepoint→code-unit conversion needs one line's text. Looking it up
+/// with `split_inclusive('\n').nth(line)` rescans from the top, so a caller
+/// converting once per diagnostic or hint pays `O(items × document length)`.
+/// Built once, each conversion is a slice index.
 pub(crate) struct LineIndex<'a> {
     lines: Vec<(&'a str, u32)>,
 }

--- a/wado-lsp/src/text.rs
+++ b/wado-lsp/src/text.rs
@@ -143,22 +143,48 @@ pub fn span_to_range(span: &Span, source: Option<&str>, encoding: PositionEncodi
     let end_line = span.end_line.saturating_sub(1) as u32;
     let end_col_codepoints = span.end_column.saturating_sub(1) as u32;
 
-    let (start_char, end_char) = match source {
-        Some(src) => (
-            codepoint_offset_to_character(src, start_line, start_col_codepoints, encoding),
-            codepoint_offset_to_character(src, end_line, end_col_codepoints, encoding),
-        ),
-        None => (start_col_codepoints, end_col_codepoints),
-    };
+    match source {
+        Some(src) => span_to_range_indexed(span, &LineIndex::new(src), encoding),
+        None => Range {
+            start: Position {
+                line: start_line,
+                character: start_col_codepoints,
+            },
+            end: Position {
+                line: end_line,
+                character: end_col_codepoints,
+            },
+        },
+    }
+}
 
+/// [`span_to_range`] against an already-built line table. Callers converting
+/// more than one span per document — every position-bearing query does —
+/// share one index instead of rescanning the source per span.
+#[must_use]
+pub(crate) fn span_to_range_indexed(
+    span: &Span,
+    lines: &LineIndex<'_>,
+    encoding: PositionEncoding,
+) -> Range {
+    let start_line = span.line.saturating_sub(1) as u32;
+    let end_line = span.end_line.saturating_sub(1) as u32;
     Range {
         start: Position {
             line: start_line,
-            character: start_char,
+            character: lines.to_character(
+                start_line,
+                span.column.saturating_sub(1) as u32,
+                encoding,
+            ),
         },
         end: Position {
             line: end_line,
-            character: end_char,
+            character: lines.to_character(
+                end_line,
+                span.end_column.saturating_sub(1) as u32,
+                encoding,
+            ),
         },
     }
 }
@@ -197,24 +223,46 @@ fn character_to_codepoint_offset(line: &str, character: u32, encoding: PositionE
     }
 }
 
-/// Translate a 0-based codepoint offset at `line` (of `source`) into a
-/// 0-based `character` in `encoding` code units. Looks the line up in
-/// `source` on each call; callers that already have the line slice on
-/// hand (e.g. a delta-encoding loop) should use
-/// [`codepoints_to_code_units`] directly to skip the lookup.
-#[must_use]
-pub(crate) fn codepoint_offset_to_character(
-    source: &str,
-    line: u32,
-    codepoint_col: u32,
-    encoding: PositionEncoding,
-) -> u32 {
-    let Some(line_text) = source.split_inclusive('\n').nth(line as usize) else {
-        return codepoint_col;
-    };
-    let line_content = line_without_terminator(line_text);
-    let line_codepoints = line_content.chars().count() as u32;
-    codepoints_to_code_units(line_content, line_codepoints, codepoint_col, encoding)
+/// A document's lines, each paired with its codepoint count.
+///
+/// Every codepoint→code-unit conversion needs the text of one line. Finding
+/// it with `source.split_inclusive('\n').nth(line)` re-scans the document
+/// from the top, so a caller converting once per diagnostic or once per inlay
+/// hint pays `O(hints × document length)`. Building this once is a single
+/// pass, and each conversion is then a slice index.
+pub(crate) struct LineIndex<'a> {
+    lines: Vec<(&'a str, u32)>,
+}
+
+impl<'a> LineIndex<'a> {
+    #[must_use]
+    pub(crate) fn new(source: &'a str) -> Self {
+        Self {
+            lines: source
+                .split_inclusive('\n')
+                .map(|line| {
+                    let text = line_without_terminator(line);
+                    (text, text.chars().count() as u32)
+                })
+                .collect(),
+        }
+    }
+
+    /// Translate a 0-based codepoint offset at `line` into a 0-based
+    /// `character` in `encoding` code units. A line past the end of the
+    /// document passes the codepoint offset through unchanged.
+    #[must_use]
+    pub(crate) fn to_character(
+        &self,
+        line: u32,
+        codepoint_col: u32,
+        encoding: PositionEncoding,
+    ) -> u32 {
+        let Some(&(text, codepoints)) = self.lines.get(line as usize) else {
+            return codepoint_col;
+        };
+        codepoints_to_code_units(text, codepoints, codepoint_col, encoding)
+    }
 }
 
 /// Codepoint offset → LSP `character` (code-unit count) inside a single

--- a/wado-lsp/src/uri.rs
+++ b/wado-lsp/src/uri.rs
@@ -55,6 +55,21 @@ impl Uri {
         Self(s.into())
     }
 
+    /// A `file:` URI naming `path`, percent-encoded.
+    ///
+    /// The counterpart to [`Self::to_filename`], for callers that start from a
+    /// real path rather than from the wire — `wado query`, which opens a file
+    /// named on the command line. Building the URI by concatenation instead
+    /// leaves any `%` in the path unescaped, and `to_filename` then decodes it
+    /// into a different path than the one the user named.
+    #[must_use]
+    pub fn from_file_path(path: &Path) -> Self {
+        Self(format!(
+            "file://{}",
+            percent_encode_path(&path.to_string_lossy())
+        ))
+    }
+
     /// Raw URI string as received from the client.
     #[must_use]
     pub fn as_str(&self) -> &str {
@@ -169,6 +184,47 @@ fn percent_decode(s: &str) -> String {
         }
     }
     String::from_utf8(out).unwrap_or_else(|_| s.to_owned())
+}
+
+/// Percent-encode an absolute filesystem path for use as a `file:` URI body.
+///
+/// Prefer [`Uri::from_file_path`] when building a whole URI.
+///
+/// The inverse of [`percent_decode`], and the reason it must exist: this crate
+/// decodes a client URI down to a real path, joins relative imports onto it,
+/// and hands the result back as a URI. Skipping the re-encode emits a string
+/// the client cannot match against the document it already has open.
+///
+/// Unreserved characters, sub-delims, and the path-structural `/ : @` are kept
+/// verbatim (rfc3986 §3.3), matching what LSP clients emit. Everything else —
+/// space, `%`, `#`, `?`, `[`, `]`, and every non-ASCII byte — is escaped.
+/// Escaping `%` is what keeps the round trip exact for a path that really
+/// contains one.
+#[must_use]
+pub fn percent_encode_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        if is_path_safe(byte) {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push(HEX[usize::from(byte >> 4)] as char);
+            out.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+    }
+    out
+}
+
+const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+fn is_path_safe(b: u8) -> bool {
+    b.is_ascii_alphanumeric()
+        // unreserved
+        || matches!(b, b'-' | b'.' | b'_' | b'~')
+        // sub-delims
+        || matches!(b, b'!' | b'$' | b'&' | b'\'' | b'(' | b')' | b'*' | b'+' | b',' | b';' | b'=')
+        // path structure
+        || matches!(b, b'/' | b':' | b'@')
 }
 
 fn hex_pair(hi: u8, lo: u8) -> Option<u8> {
@@ -309,7 +365,37 @@ mod tests {
         // `core:` / `wasi:` / `kiln:` URIs are compiler-minted and never
         // percent-encoded; decoding would corrupt a literal `%` in a
         // generated path.
-        assert_eq!(Uri::new("kiln:/tmp/a%20b.wado").to_filename(), "kiln:/tmp/a%20b.wado");
+        assert_eq!(
+            Uri::new("kiln:/tmp/a%20b.wado").to_filename(),
+            "kiln:/tmp/a%20b.wado"
+        );
+    }
+
+    #[test]
+    fn encode_escapes_only_what_a_uri_needs() {
+        assert_eq!(
+            percent_encode_path("/home/my project"),
+            "/home/my%20project"
+        );
+        assert_eq!(percent_encode_path("/home/あ"), "/home/%E3%81%82");
+        assert_eq!(percent_encode_path("/home/100%"), "/home/100%25");
+        assert_eq!(percent_encode_path("/a?b#c[d]"), "/a%3Fb%23c%5Bd%5D");
+        // Path structure and sub-delims stay legible.
+        assert_eq!(percent_encode_path("/a/b:c@d+e,f"), "/a/b:c@d+e,f");
+    }
+
+    #[test]
+    fn encode_and_decode_round_trip() {
+        for path in [
+            "/plain/main.wado",
+            "/my project/main.wado",
+            "/あ/main.wado",
+            "/100%/main.wado",
+            "/weird ?#[]/main.wado",
+        ] {
+            let uri = Uri::new(format!("file://{}", percent_encode_path(path)));
+            assert_eq!(uri.to_filename(), path, "round trip failed for {path:?}");
+        }
     }
 
     #[test]

--- a/wado-lsp/src/uri.rs
+++ b/wado-lsp/src/uri.rs
@@ -11,11 +11,7 @@
 //!
 //! Centralising this lets `Engine`, the dispatcher, and
 //! `workspace/textDocumentContent` agree on what counts as a URI scheme
-//! rather than re-parsing strings inline. Previously the codebase had
-//! two copies of `uri_to_filename` (in `lib.rs` and in `location.rs`)
-//! plus ad-hoc `strip_prefix("file://")` calls scattered across
-//! `host_for_uri`, `text_document_content`, and the LSP query
-//! plumbing.
+//! rather than each re-parsing strings inline.
 
 use std::path::{Path, PathBuf};
 
@@ -106,10 +102,9 @@ impl Uri {
 
     /// Path / opaque component after the scheme delimiter `:`.
     ///
-    /// Returns `None` when the URI has no `:` (i.e. [`Self::scheme`]
-    /// returns [`UriScheme::Other`]). Callers that have already
-    /// classified the scheme as one of the known kinds may safely
-    /// `.expect()` on the result.
+    /// `None` only when the URI has no `:` at all — an unrecognised scheme
+    /// still yields its remainder. Callers that have already classified the
+    /// scheme as one of the known kinds may safely `.expect()`.
     #[must_use]
     pub fn rest(&self) -> Option<&str> {
         self.0.split_once(':').map(|(_, r)| r)
@@ -287,21 +282,15 @@ mod tests {
 
     #[test]
     fn file_uri_at_root_has_root_workspace() {
-        // Pre-existing bug class: `host_for_uri` for `file:///foo.wado`
-        // used to yield `PathBuf::from(".")` because `Path::parent` of
-        // `/foo.wado` returns `Some("/")` but the prior implementation
-        // treated the empty string oddly. Verify the typed accessor.
+        // `Path::parent` of `/foo.wado` is `Some("/")`, not the empty path.
         let u = Uri::new("file:///foo.wado");
         assert_eq!(u.workspace_root(), Some(PathBuf::from("/")));
     }
 
     #[test]
     fn malformed_file_uri_without_path_has_no_workspace_root() {
-        // `file://` (no path component) used to silently CWD-root the
-        // FilesystemCompilerHost. That let a buggy client read
-        // arbitrary files under the LSP process's cwd via relative
-        // imports off the bad URI. The typed accessor refuses such
-        // URIs.
+        // CWD-rooting this would let a buggy client read arbitrary files
+        // under the LSP process's cwd via relative imports off the bad URI.
         assert_eq!(Uri::new("file://").workspace_root(), None);
     }
 

--- a/wado-lsp/src/uri.rs
+++ b/wado-lsp/src/uri.rs
@@ -78,14 +78,24 @@ impl Uri {
     /// (`Logger::set_file`, `DiagnosticSpan::file`).
     ///
     /// For `file://` URIs returns the absolute path with the scheme
-    /// stripped. For every other scheme returns the raw URI — matching
+    /// stripped **and percent-escapes decoded** — LSP clients send
+    /// rfc3986-encoded URIs, so a workspace under `my project/` arrives as
+    /// `file:///…/my%20project/…`. Without decoding, every path this crate
+    /// derives from the URI (the `FilesystemCompilerHost` base path, the
+    /// kiln manifest walk-up, the `span.file` match in
+    /// `Engine::diagnostics`) names a directory that does not exist, and
+    /// the whole language service silently answers nothing.
+    ///
+    /// For every other scheme returns the raw URI — matching
     /// `ModuleSource::source_path` so cross-file diagnostic
-    /// rendering stays consistent.
+    /// rendering stays consistent. Non-`file:` schemes are compiler-minted
+    /// (`core:`, `wasi:`, `kiln:`) and never percent-encoded, so decoding
+    /// them would only corrupt a literal `%` in a generated path.
     #[must_use]
     pub fn to_filename(&self) -> String {
         self.0
             .strip_prefix("file://")
-            .map_or_else(|| self.0.clone(), str::to_owned)
+            .map_or_else(|| self.0.clone(), percent_decode)
     }
 
     /// Path / opaque component after the scheme delimiter `:`.
@@ -125,6 +135,52 @@ impl Uri {
                 .map(Path::to_path_buf)
                 .unwrap_or_else(|| PathBuf::from(".")),
         )
+    }
+}
+
+/// Decode rfc3986 percent-escapes (`%XX`) in `s`.
+///
+/// Decoding happens at the byte level and the result is re-validated as
+/// UTF-8, so a multi-byte character split across several escapes (`%E3%81%82`
+/// for `あ`) round-trips. A malformed escape — a `%` not followed by two hex
+/// digits, or a byte sequence that is not valid UTF-8 — leaves the input
+/// untouched rather than dropping characters: a path we cannot decode is
+/// better handed to the filesystem verbatim than silently mangled.
+fn percent_decode(s: &str) -> String {
+    if !s.contains('%') {
+        return s.to_owned();
+    }
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let Some(hex) = bytes.get(i + 1..i + 3) else {
+                return s.to_owned();
+            };
+            let Some(byte) = hex_pair(hex[0], hex[1]) else {
+                return s.to_owned();
+            };
+            out.push(byte);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| s.to_owned())
+}
+
+fn hex_pair(hi: u8, lo: u8) -> Option<u8> {
+    Some(hex_digit(hi)? << 4 | hex_digit(lo)?)
+}
+
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
     }
 }
 
@@ -209,6 +265,51 @@ mod tests {
         // imports off the bad URI. The typed accessor refuses such
         // URIs.
         assert_eq!(Uri::new("file://").workspace_root(), None);
+    }
+
+    #[test]
+    fn file_uri_percent_escapes_are_decoded() {
+        // LSP clients percent-encode every reserved character. Leaving the
+        // escapes in place pointed `FilesystemCompilerHost` at a directory
+        // that does not exist, so every cross-file query in a workspace whose
+        // path contains a space returned nothing — with no diagnostic.
+        let u = Uri::new("file:///home/user/my%20project/main.wado");
+        assert_eq!(u.to_filename(), "/home/user/my project/main.wado");
+        assert_eq!(
+            u.workspace_root(),
+            Some(PathBuf::from("/home/user/my project")),
+        );
+    }
+
+    #[test]
+    fn multi_byte_percent_escapes_decode_as_utf8() {
+        // A non-ASCII directory arrives as one escape per UTF-8 byte.
+        let u = Uri::new("file:///home/%E3%81%82/main.wado");
+        assert_eq!(u.to_filename(), "/home/あ/main.wado");
+    }
+
+    #[test]
+    fn encoded_percent_round_trips() {
+        let u = Uri::new("file:///home/100%25/main.wado");
+        assert_eq!(u.to_filename(), "/home/100%/main.wado");
+    }
+
+    #[test]
+    fn malformed_escape_is_left_verbatim() {
+        // `%zz` is not a valid escape. Dropping it (or the rest of the path)
+        // would be worse than handing the raw text to the filesystem.
+        let u = Uri::new("file:///home/%zz/main.wado");
+        assert_eq!(u.to_filename(), "/home/%zz/main.wado");
+        let truncated = Uri::new("file:///home/trailing%2");
+        assert_eq!(truncated.to_filename(), "/home/trailing%2");
+    }
+
+    #[test]
+    fn non_file_schemes_are_not_decoded() {
+        // `core:` / `wasi:` / `kiln:` URIs are compiler-minted and never
+        // percent-encoded; decoding would corrupt a literal `%` in a
+        // generated path.
+        assert_eq!(Uri::new("kiln:/tmp/a%20b.wado").to_filename(), "kiln:/tmp/a%20b.wado");
     }
 
     #[test]

--- a/wado-lsp/src/uri.rs
+++ b/wado-lsp/src/uri.rs
@@ -57,11 +57,9 @@ impl Uri {
 
     /// A `file:` URI naming `path`, percent-encoded.
     ///
-    /// The counterpart to [`Self::to_filename`], for callers that start from a
-    /// real path rather than from the wire — `wado query`, which opens a file
-    /// named on the command line. Building the URI by concatenation instead
-    /// leaves any `%` in the path unescaped, and `to_filename` then decodes it
-    /// into a different path than the one the user named.
+    /// The counterpart to [`Self::to_filename`], for callers holding a real
+    /// path rather than a wire URI — `wado query`, opening a file named on
+    /// the command line.
     #[must_use]
     pub fn from_file_path(path: &Path) -> Self {
         Self(format!(
@@ -89,23 +87,16 @@ impl Uri {
         }
     }
 
-    /// Filename string suitable for compiler-side diagnostics
-    /// (`Logger::set_file`, `DiagnosticSpan::file`).
+    /// Filename suitable for compiler-side diagnostics (`Logger::set_file`,
+    /// `DiagnosticSpan::file`).
     ///
-    /// For `file://` URIs returns the absolute path with the scheme
-    /// stripped **and percent-escapes decoded** — LSP clients send
-    /// rfc3986-encoded URIs, so a workspace under `my project/` arrives as
-    /// `file:///…/my%20project/…`. Without decoding, every path this crate
-    /// derives from the URI (the `FilesystemCompilerHost` base path, the
-    /// kiln manifest walk-up, the `span.file` match in
-    /// `Engine::diagnostics`) names a directory that does not exist, and
-    /// the whole language service silently answers nothing.
+    /// `file://` URIs lose the scheme and are percent-decoded: clients send
+    /// rfc3986-encoded URIs, and every path this crate derives from one has
+    /// to name a real directory.
     ///
-    /// For every other scheme returns the raw URI — matching
-    /// `ModuleSource::source_path` so cross-file diagnostic
-    /// rendering stays consistent. Non-`file:` schemes are compiler-minted
-    /// (`core:`, `wasi:`, `kiln:`) and never percent-encoded, so decoding
-    /// them would only corrupt a literal `%` in a generated path.
+    /// Every other scheme returns the raw URI, matching
+    /// `ModuleSource::source_path`. Those are compiler-minted and never
+    /// encoded, so decoding them would only corrupt a literal `%`.
     #[must_use]
     pub fn to_filename(&self) -> String {
         self.0
@@ -155,12 +146,10 @@ impl Uri {
 
 /// Decode rfc3986 percent-escapes (`%XX`) in `s`.
 ///
-/// Decoding happens at the byte level and the result is re-validated as
-/// UTF-8, so a multi-byte character split across several escapes (`%E3%81%82`
-/// for `あ`) round-trips. A malformed escape — a `%` not followed by two hex
-/// digits, or a byte sequence that is not valid UTF-8 — leaves the input
-/// untouched rather than dropping characters: a path we cannot decode is
-/// better handed to the filesystem verbatim than silently mangled.
+/// Decoding is byte-level with the result re-validated as UTF-8, so a
+/// character spread over several escapes (`%E3%81%82`) round-trips. A
+/// malformed escape or non-UTF-8 result leaves the input untouched: a path we
+/// cannot decode is better handed to the filesystem verbatim than mangled.
 fn percent_decode(s: &str) -> String {
     if !s.contains('%') {
         return s.to_owned();
@@ -186,20 +175,13 @@ fn percent_decode(s: &str) -> String {
     String::from_utf8(out).unwrap_or_else(|_| s.to_owned())
 }
 
-/// Percent-encode an absolute filesystem path for use as a `file:` URI body.
+/// Percent-encode a filesystem path for use as a `file:` URI body — the
+/// inverse of [`percent_decode`]. Prefer [`Uri::from_file_path`] when building
+/// a whole URI.
 ///
-/// Prefer [`Uri::from_file_path`] when building a whole URI.
-///
-/// The inverse of [`percent_decode`], and the reason it must exist: this crate
-/// decodes a client URI down to a real path, joins relative imports onto it,
-/// and hands the result back as a URI. Skipping the re-encode emits a string
-/// the client cannot match against the document it already has open.
-///
-/// Unreserved characters, sub-delims, and the path-structural `/ : @` are kept
-/// verbatim (rfc3986 §3.3), matching what LSP clients emit. Everything else —
-/// space, `%`, `#`, `?`, `[`, `]`, and every non-ASCII byte — is escaped.
-/// Escaping `%` is what keeps the round trip exact for a path that really
-/// contains one.
+/// Unreserved characters, sub-delims, and the path-structural `/ : @` stay
+/// verbatim (rfc3986 §3.3), matching what clients emit; everything else,
+/// including `%` itself, is escaped.
 #[must_use]
 pub fn percent_encode_path(path: &str) -> String {
     let mut out = String::with_capacity(path.len());
@@ -325,10 +307,7 @@ mod tests {
 
     #[test]
     fn file_uri_percent_escapes_are_decoded() {
-        // LSP clients percent-encode every reserved character. Leaving the
-        // escapes in place pointed `FilesystemCompilerHost` at a directory
-        // that does not exist, so every cross-file query in a workspace whose
-        // path contains a space returned nothing — with no diagnostic.
+        // Clients percent-encode every reserved character.
         let u = Uri::new("file:///home/user/my%20project/main.wado");
         assert_eq!(u.to_filename(), "/home/user/my project/main.wado");
         assert_eq!(
@@ -352,8 +331,6 @@ mod tests {
 
     #[test]
     fn malformed_escape_is_left_verbatim() {
-        // `%zz` is not a valid escape. Dropping it (or the rest of the path)
-        // would be worse than handing the raw text to the filesystem.
         let u = Uri::new("file:///home/%zz/main.wado");
         assert_eq!(u.to_filename(), "/home/%zz/main.wado");
         let truncated = Uri::new("file:///home/trailing%2");
@@ -362,9 +339,6 @@ mod tests {
 
     #[test]
     fn non_file_schemes_are_not_decoded() {
-        // `core:` / `wasi:` / `kiln:` URIs are compiler-minted and never
-        // percent-encoded; decoding would corrupt a literal `%` in a
-        // generated path.
         assert_eq!(
             Uri::new("kiln:/tmp/a%20b.wado").to_filename(),
             "kiln:/tmp/a%20b.wado"

--- a/wado-lsp/src/workspace.rs
+++ b/wado-lsp/src/workspace.rs
@@ -12,7 +12,45 @@ use std::path::{Path, PathBuf};
 use glob::{MatchOptions, Pattern};
 use wado_manifest::{Manifest, ManifestError, read_workspace_members};
 
-const MANIFEST_FILENAME: &str = "wado.toml";
+pub const MANIFEST_FILENAME: &str = "wado.toml";
+
+/// The nearest ancestor of `start` (inclusive) that contains a `wado.toml`.
+///
+/// `start` may name a file or a directory. It is absolutized first — a
+/// relative path's parent chain runs out after one `pop()`, so walking it
+/// as given would stop short of the real ancestry — and **the result is
+/// therefore always absolute**. Callers that re-anchor other paths against
+/// it must express those in the same frame; every current caller feeds it a
+/// path derived from an absolute `file:` URI, so they already do.
+///
+/// Both callers that need a manifest root go through here: the
+/// dependency-index builder (`host.rs`) and the kiln consume-only resolver
+/// (`kiln.rs`) previously each spelled this loop out, agreeing on the idea
+/// and disagreeing on exactly this detail.
+#[must_use]
+pub fn nearest_manifest_dir(start: &Path) -> Option<PathBuf> {
+    let mut dir = absolutize(start);
+    loop {
+        if dir.join(MANIFEST_FILENAME).is_file() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
+/// `p` resolved against the current directory when relative. Falls back to
+/// `p` itself when the process has no readable current directory.
+pub(crate) fn absolutize(p: &Path) -> PathBuf {
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(p))
+            .unwrap_or_else(|_| p.to_path_buf())
+    }
+}
 
 /// Glob match options shared by the file walker (`wado-cli`'s discover, which
 /// re-exports this) and workspace-member matching, so `members` globs and the

--- a/wado-lsp/src/workspace.rs
+++ b/wado-lsp/src/workspace.rs
@@ -15,18 +15,12 @@ use wado_manifest::{Manifest, ManifestError, read_workspace_members};
 pub const MANIFEST_FILENAME: &str = "wado.toml";
 
 /// The nearest ancestor of `start` (inclusive) that contains a `wado.toml`.
+/// `start` may name a file or a directory.
 ///
-/// `start` may name a file or a directory. It is absolutized first — a
-/// relative path's parent chain runs out after one `pop()`, so walking it
-/// as given would stop short of the real ancestry — and **the result is
-/// therefore always absolute**. Callers that re-anchor other paths against
-/// it must express those in the same frame; every current caller feeds it a
-/// path derived from an absolute `file:` URI, so they already do.
-///
-/// Both callers that need a manifest root go through here: the
-/// dependency-index builder (`host.rs`) and the kiln consume-only resolver
-/// (`kiln.rs`) previously each spelled this loop out, agreeing on the idea
-/// and disagreeing on exactly this detail.
+/// Absolutized first — a relative path's parent chain runs out after one
+/// `pop()` — so **the result is always absolute**. Callers re-anchoring other
+/// paths against it must express those in the same frame; every current
+/// caller derives its input from an absolute `file:` URI.
 #[must_use]
 pub fn nearest_manifest_dir(start: &Path) -> Option<PathBuf> {
     let mut dir = absolutize(start);
@@ -40,8 +34,8 @@ pub fn nearest_manifest_dir(start: &Path) -> Option<PathBuf> {
     }
 }
 
-/// `p` resolved against the current directory when relative. Falls back to
-/// `p` itself when the process has no readable current directory.
+/// `p` against the current directory when relative, or `p` itself when the
+/// process has no readable current directory.
 pub(crate) fn absolutize(p: &Path) -> PathBuf {
     if p.is_absolute() {
         p.to_path_buf()

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -174,7 +174,9 @@ fn imported_module_errors_stay_off_the_importer() {
 
         let foo_diags = engine.diagnostics("file:///work/foo.wado", &host).await;
         assert!(
-            !foo_diags.iter().any(|d| d.message.contains("type mismatch")),
+            !foo_diags
+                .iter()
+                .any(|d| d.message.contains("type mismatch")),
             "bar.wado's type error must not be published on foo.wado, got {foo_diags:#?}"
         );
 

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -155,12 +155,10 @@ fn imported_module_dead_code_stays_off_the_importer() {
     });
 }
 
-/// An *error* in an imported module is subject to the same rule as its dead
-/// code: it belongs to that module's document, not to the importer's.
-///
-/// Publishing it on the importer drew the squiggle at the imported file's
-/// line and column inside the file the user has open — an error message
-/// about `bar.wado` painted over an unrelated span of `foo.wado`.
+/// An *error* in an imported module follows the same rule as its dead code:
+/// it belongs to that module's document, not the importer's. Published on the
+/// importer it lands at the imported file's line and column, over unrelated
+/// code.
 #[test]
 fn imported_module_errors_stay_off_the_importer() {
     futures::executor::block_on(async {
@@ -192,10 +190,9 @@ fn imported_module_errors_stay_off_the_importer() {
 
 /// A broken import must surface as an error on the importing document.
 ///
-/// The loader reports `ModuleNotFound` without a span, and the same failure
-/// empties the `Semantics`, so hover / definition / references all go quiet
-/// for the document. Dropping the span-less diagnostic left the user with a
-/// file that looked clean and answered nothing.
+/// `ModuleNotFound` carries no span, and the same failure empties the
+/// `Semantics` — without the diagnostic the file looks clean and answers
+/// nothing.
 #[test]
 fn missing_import_is_reported_on_the_importer() {
     futures::executor::block_on(async {

--- a/wado-lsp/tests/diagnostics.rs
+++ b/wado-lsp/tests/diagnostics.rs
@@ -155,6 +155,62 @@ fn imported_module_dead_code_stays_off_the_importer() {
     });
 }
 
+/// An *error* in an imported module is subject to the same rule as its dead
+/// code: it belongs to that module's document, not to the importer's.
+///
+/// Publishing it on the importer drew the squiggle at the imported file's
+/// line and column inside the file the user has open — an error message
+/// about `bar.wado` painted over an unrelated span of `foo.wado`.
+#[test]
+fn imported_module_errors_stay_off_the_importer() {
+    futures::executor::block_on(async {
+        let bar = "pub fn boom() -> i32 {\n    return \"not an i32\";\n}\n";
+        let foo =
+            "use { boom } from \"./bar.wado\";\n\nexport fn run() {\n    let _ = boom();\n}\n";
+        let host = MapHost::with_files(&[("/work/bar.wado", bar)]);
+        let mut engine = Engine::new();
+        engine.open_document("file:///work/foo.wado", foo.to_string());
+        engine.open_document("file:///work/bar.wado", bar.to_string());
+
+        let foo_diags = engine.diagnostics("file:///work/foo.wado", &host).await;
+        assert!(
+            !foo_diags.iter().any(|d| d.message.contains("type mismatch")),
+            "bar.wado's type error must not be published on foo.wado, got {foo_diags:#?}"
+        );
+
+        let bar_diags = engine.diagnostics("file:///work/bar.wado", &host).await;
+        assert!(
+            errors(&bar_diags)
+                .iter()
+                .any(|d| d.message.contains("type mismatch")),
+            "bar.wado's own diagnostics must report its type error, got {bar_diags:#?}"
+        );
+    });
+}
+
+/// A broken import must surface as an error on the importing document.
+///
+/// The loader reports `ModuleNotFound` without a span, and the same failure
+/// empties the `Semantics`, so hover / definition / references all go quiet
+/// for the document. Dropping the span-less diagnostic left the user with a
+/// file that looked clean and answered nothing.
+#[test]
+fn missing_import_is_reported_on_the_importer() {
+    futures::executor::block_on(async {
+        let source = "use { nope } from \"./missing.wado\";\n\nexport fn run() {}\n";
+        let diags = diagnostics_for("/work/broken.wado", source).await;
+        let errs = errors(&diags);
+        assert!(
+            errs.iter().any(|d| d.message.contains("./missing.wado")),
+            "a broken import must be reported, got {diags:#?}"
+        );
+        assert!(
+            errs.iter().all(|d| d.range.start.line == 0),
+            "a span-less loader failure anchors at the document start, got {errs:#?}"
+        );
+    });
+}
+
 /// `set_unused_diagnostics(false)` takes effect at the next query, no edit.
 #[test]
 fn toggling_unused_diagnostics_takes_effect_without_reopen() {


### PR DESCRIPTION
A review pass over `wado-lsp`, fixing what it turned up.

## URIs

`Uri::to_filename` percent-decodes `file:` paths, and
`location::filename_to_uri` re-encodes on the way back out via
`uri::percent_encode_path`. Clients send rfc3986-encoded URIs, and every path
the crate derives from one — the `FilesystemCompilerHost` base path, the kiln
manifest walk-up, the `span.file` match in `Engine::diagnostics` — has to name
a real directory, so a workspace under `my project/` resolves. The URIs handed
back string-match the documents the client already has open. Non-`file:`
schemes are compiler-minted and pass through untouched.

`wado query` builds its URIs through `Uri::from_file_path` for the same reason,
and prints paths decoded.

Relative imports normalise their `.` and `..` segments lexically, clamping at
the root and never letting a `..` consume a scheme, so a parent-relative import
resolves to the canonical URI rather than a second name for an open document.

## Diagnostics

`Engine::diagnostics` returns only the diagnostics belonging to the requested
document. LSP publishes per URI, so one whose `span.file` names an imported
module would draw its squiggle at that file's line and column inside the open
one; the imported file reports its own errors when the client opens it.

A diagnostic with no span is anchored at the document start. The loader reports
its hard failures that way — `ModuleNotFound` above all — and the same failure
empties the `Semantics`, silencing every position query, so a broken import
that leaves the editor answering nothing at least says why.

## Hover

Items resolve by `AstId`, so a module declaring one name twice — a struct field
beside a free function — hovers the declaration the cursor actually names.

Locals resolve through an `ast::AstVisitor`, reaching every shape that can hold
a binding, including a `let` inside a closure passed as a call argument, an
impl block's associated constants, and items nested in statements.

## Server

`run_stdio` returns the process exit code LSP 3.18 §exit prescribes; `dispatch`
records the client's `exit` on `Lifecycle::exit_code` and the owning loop
returns it, so `wado lsp` routes it through the CLI's exit path. Document-scoped
requests share one `query` helper that roots each request's host at the
document it names.

`read_message` bounds `Content-Length` at 64 MiB and matches the header per the
HTTP grammar LSP defers to (case-insensitive name, optional space). A frame
whose length cannot be parsed or honoured is fatal — its body is never
consumed, so the stream cannot be resynchronised — while a body that was read
whole but is not valid JSON stays recoverable per JSON-RPC 2.0 §5.1.

`FilesystemCompilerHost` recovers from a poisoned diagnostics lock, matching
`DiagnosticCollector`.

## Performance

`LineIndex` holds a document's lines with their codepoint counts. `QueryContext`
carries one per query and `Engine::diagnostics` one per batch, so the many spans
a single request answers share one scan instead of rescanning the document per
column.

The Design-B semantic checks are derived from a `Snapshot` on first request and
cached, so hover, definition, references, highlights, tokens, and inlay hints do
not pay for a pass only `Engine::diagnostics` reads.

`wado.lock` is read once per manifest, shared by the git and registry
dependency paths.

## Structure

One `workspace::nearest_manifest_dir` serves both callers that need a manifest
root, with an absolute-path contract. Span conversion lives in `text`;
`location` keeps the `ModuleSource` → URI helpers.

The `token_type` / `TOKEN_TYPES` and `token_modifier` / `TOKEN_MODIFIERS`
correspondences are asserted — a constant one slot off still compiles and still
carries a type through every behavioural test, showing up only as wrongly
coloured code in the editor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLDTT4JuEMvhWcd2wy9CwC)_