### PR TITLE
fix(codegen): ICE on an unresolvable index instead of emitting wrong code

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -193,9 +193,9 @@ CM canonical operations (stream / future read + write, waitable-set, error-conte
 
 `codegen::emit_wasm` produces the final component bytes:
 
-1. `emit.rs` emits core Wasm bytes from WIR.
+1. `emit.rs` emits core Wasm bytes from WIR, including the branch-hint section.
 2. `component.rs` wraps the core module in a Component Model envelope (imports, exports, adapters, optional WIT bundling, embedded data).
-3. `postprocess.rs` adds branch-hint sections and other post-emission custom sections.
+3. `postprocess.rs` rewrites an embedded wasm asset's memory definition into an import and prunes it to its used exports.
 
 Output is validated with `wasmparser` unless `--no-validate` is set.
 

--- a/package-gale/tests/generated/action_arg_pred/wado_arg_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_arg_pred/wado_arg_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e80f819cb07676d0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_arg_pred.g4",
     "hash": "b6e9fd26f1e4936b34f10ed2108b0fad8b57c16b49f42707b509a9966ec692bc"

--- a/package-gale/tests/generated/action_atn_pred/wado_atn_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_atn_pred/wado_atn_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-873f523c716cd4d1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_atn_pred.g4",
     "hash": "418c3fffe47dbad329d0442fa2f8777413a3fd4fed06493c857d0d38f0f020a1"

--- a/package-gale/tests/generated/action_camel/wado_camel_label.g4.kiln.json
+++ b/package-gale/tests/generated/action_camel/wado_camel_label.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e3b09d9b3841e994",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_camel_label.g4",
     "hash": "8498bcbaa19080272d289cd209c4de583f2f2bc7468ffa60f79247b762cd8852"

--- a/package-gale/tests/generated/action_cross_vals/wado_cross_vals.g4.kiln.json
+++ b/package-gale/tests/generated/action_cross_vals/wado_cross_vals.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-557f17ff6595225c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_cross_vals.g4",
     "hash": "98795d9f5c50e06a8c68082c9d220847f581a7614e9cea6fd50bf6dd8d73132a"

--- a/package-gale/tests/generated/action_ctx_pred/wado_ctx_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_ctx_pred/wado_ctx_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b5e444fbba4fbca1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_ctx_pred.g4",
     "hash": "25ff008ab003885250e5bb1a6c782bef80b87dd900a7a23acedcdefd2af7484b"

--- a/package-gale/tests/generated/action_ctx_tree/wado_ctx_tree.g4.kiln.json
+++ b/package-gale/tests/generated/action_ctx_tree/wado_ctx_tree.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f37652fd7e23d882",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_ctx_tree.g4",
     "hash": "bcb7da72ec780de959259b673398a1c56cb4e35d4a11e5b25fefa7827c2a4913"

--- a/package-gale/tests/generated/action_dedup_ref/wado_dedup_ref.g4.kiln.json
+++ b/package-gale/tests/generated/action_dedup_ref/wado_dedup_ref.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8eb7c5c18c76387f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_dedup_ref.g4",
     "hash": "d16dd6277760ab027b3d0f4630ed12d9f5a1d6612d022118bbeaeeee369f5025"

--- a/package-gale/tests/generated/action_emit/wado_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_emit/wado_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0696ace5b552ad11",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_action.g4",
     "hash": "13474a9b2b58d0babd0bf8644fbe8a2650cff69c648085d555e0323f29ebb98d"

--- a/package-gale/tests/generated/action_label_group/wado_label_group.g4.kiln.json
+++ b/package-gale/tests/generated/action_label_group/wado_label_group.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-64e0b30a8a71683a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_label_group.g4",
     "hash": "b625e19198ee888d3e33ff93ed9b2d4fc576b8c12a02e693ea7d441d0fb307e6"

--- a/package-gale/tests/generated/action_lex_frag_boundary_pred/wado_lex_frag_boundary_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_frag_boundary_pred/wado_lex_frag_boundary_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6ff9d6857e2aa43d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_frag_boundary_pred.g4",
     "hash": "a200d6ef5d887eef3ea5c47a2054a03280630e8e3b99dae3e54c2ca625eb9501"

--- a/package-gale/tests/generated/action_lex_frag_pred/wado_lex_frag_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_frag_pred/wado_lex_frag_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b26118fdda96dd69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_frag_pred.g4",
     "hash": "4567851df78dbf2dcc1fc4f50d66ef802e82d3c506681dd9faa35124b689635d"

--- a/package-gale/tests/generated/action_lex_group_pred/wado_lex_group_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_group_pred/wado_lex_group_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c360f7b3051940c9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_group_pred.g4",
     "hash": "bd31f5842146ead0837f69ff2d604a8afcbb607d92c452604c1aacce7456dc90"

--- a/package-gale/tests/generated/action_lex_member_pred/wado_lex_member_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_member_pred/wado_lex_member_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-71784c1738352243",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_member_pred.g4",
     "hash": "3e1a6cad4066247558c47707dff05329142e67ab6e3853cb35ce080e49928242"

--- a/package-gale/tests/generated/action_lex_members/wado_lex_members.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_members/wado_lex_members.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e49a1ce2e5fb994a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_members.g4",
     "hash": "9b4e671154edbef1bcbb058cf26237353bb4f1354788f0e14c2030644beb903b"

--- a/package-gale/tests/generated/action_lex_mid_pred/wado_lex_mid_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_mid_pred/wado_lex_mid_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3ab4593ac7580568",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_mid_pred.g4",
     "hash": "ae3dd26483f7ec0f047be3dd69a9649fc3673220b97f0bf3a56b9099a88a28ea"

--- a/package-gale/tests/generated/action_lex_mode/wado_lex_mode_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_mode/wado_lex_mode_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3d897deac52ee7e1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_mode_action.g4",
     "hash": "372af2f3e08bc3c2b764a26c57d420015e4d7f6cbc3aace4924ae4cc47846873"

--- a/package-gale/tests/generated/action_lex_more/wado_lex_more_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_more/wado_lex_more_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fb0354ed22280e99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_more_action.g4",
     "hash": "5e5d47049ef97c1c4cc843998ca6043fe7d7555c1baf98a4eeeea3b87dc2b9c8"

--- a/package-gale/tests/generated/action_lex_multi_alt/wado_lex_multi_alt_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_multi_alt/wado_lex_multi_alt_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-be34d82bd565709f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_multi_alt_action.g4",
     "hash": "a793f4e07928b8d98d0da3cfd2815bf0052a2ffdbbc54d77027e1d596dcaf444"

--- a/package-gale/tests/generated/action_lex_multi_pred/wado_lex_multi_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_multi_pred/wado_lex_multi_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4e4cdc93c2365c95",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_multi_pred.g4",
     "hash": "659f190b659ccd3690641b96b4af14927661a54f47771f475d6537c5599d30a6"

--- a/package-gale/tests/generated/action_lex_pred/wado_lex_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_pred/wado_lex_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b82dd31e53ff5e74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_pred.g4",
     "hash": "19bcddb240cdfa316ea17d4e7ac8965373dfa3a342f3628402060b54b1c1be39"

--- a/package-gale/tests/generated/action_lex_pred_after_repeat/lexer_pred_after_repeat.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_pred_after_repeat/lexer_pred_after_repeat.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-75753fbc7532b41e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_pred_after_repeat.g4",
     "hash": "a7a78a9a05fc21a33aedf6fb99e992a6158aea69ef3549b781876d288320cf9e"

--- a/package-gale/tests/generated/action_lex_set_type/wado_lex_set_type.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_set_type/wado_lex_set_type.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3ea56cf86a7e4299",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_set_type.g4",
     "hash": "c5babd13837386bb10dacf1e98de9000a4de22a3c8fdbf23ad42d9e2b1694d54"

--- a/package-gale/tests/generated/action_lex_skip/wado_lex_skip_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_skip/wado_lex_skip_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-24a66e66599f85b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_skip_action.g4",
     "hash": "bbbceef0e868f1f13d72940c8e904e244e864fb83e7e923c2850edfceedf56ef"

--- a/package-gale/tests/generated/action_lex_stale/wado_lex_action_stale.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_stale/wado_lex_action_stale.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b21fd1c1b118d3f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_action_stale.g4",
     "hash": "fdbf31031e51700b89157611c714cb28140247461ed74b5c34d4403cc79c9f2d"

--- a/package-gale/tests/generated/action_lex_super/wado_lex_super.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_super/wado_lex_super.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4b3d155a05ff88f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_super.g4",
     "hash": "ac9b1263a10dbc4c6b60cb615957c369aec31ab0ead4cfd56917ca22c08c74d4"

--- a/package-gale/tests/generated/action_lex_super_action/wado_lex_super_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_super_action/wado_lex_super_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-576fcda56f4fcac2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_super_action.g4",
     "hash": "5ee340db380275fe8ff6688be9b89fefeb84c5fafa8b1bd4519fef632f444b64"

--- a/package-gale/tests/generated/action_lex_super_action_java/java_lex_super_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_super_action_java/java_lex_super_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e8f6bd89ef675de1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_lex_super_action.g4",
     "hash": "c97da5e6ff7cc1cb2deedd32548e75aee7b64c31b1a57d476d4b06baac76f974"

--- a/package-gale/tests/generated/action_lex_super_frag/wado_lex_super_frag.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_super_frag/wado_lex_super_frag.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-08705d0cfdc97cf0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_super_frag.g4",
     "hash": "1b70ddba1322ec488f8bdaa40f1d3bb82c48820a63c1f0e1300db22ed18816a1"

--- a/package-gale/tests/generated/action_lex_text_pred/wado_lex_text_pred.g4.kiln.json
+++ b/package-gale/tests/generated/action_lex_text_pred/wado_lex_text_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6d83ad91dbb14745",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lex_text_pred.g4",
     "hash": "a69c0307921fcc9d602b1e8e92f9a8f1be1607caf06a28221e9cab91b6838a3b"

--- a/package-gale/tests/generated/action_lit_alias/lit_alias_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lit_alias/lit_alias_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-75ebfb5e02e30aec",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lit_alias_action.g4",
     "hash": "0e69f203b65a0e57530682c7894771d4865c2827b16034c24db34ce637b5225f"

--- a/package-gale/tests/generated/action_lr_action/wado_lr_action.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_action/wado_lr_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8327f2775c781cc7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lr_action.g4",
     "hash": "3d2f91b83009b4016739d0262ee6c8bd68222e051ae64b25e9c386ad19ddcabb"

--- a/package-gale/tests/generated/action_lr_ctx_tree/wado_lr_ctx_tree.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_ctx_tree/wado_lr_ctx_tree.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-553398c1d1d9e0bb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lr_ctx_tree.g4",
     "hash": "1f32057e4c2a170bbb4b7002ec363b0b3bd3193d4a2a0131f72d770c7d1a8816"

--- a/package-gale/tests/generated/action_lr_p/wado_lr_p.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_p/wado_lr_p.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6eba93a643a5f281",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lr_p.g4",
     "hash": "e398cb5e5af3f995908f3d06ea557ebd8677bf3afa2b195f57b27c17c2eb0c48"

--- a/package-gale/tests/generated/action_lr_prequel/wado_lr_prequel.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_prequel/wado_lr_prequel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-dc6436677dc26e8c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lr_prequel.g4",
     "hash": "c47dff291ef192d4729e5199425295fe7b58748760498d02900876056f620b6f"

--- a/package-gale/tests/generated/action_lr_vals/wado_lr_vals.g4.kiln.json
+++ b/package-gale/tests/generated/action_lr_vals/wado_lr_vals.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6f7d2aaced992bf2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_lr_vals.g4",
     "hash": "ffe957d7d2cc0c1c80fab48acb2612bce6525946c668702c91de48d659df6819"

--- a/package-gale/tests/generated/action_multi_arg/wado_multi_arg.g4.kiln.json
+++ b/package-gale/tests/generated/action_multi_arg/wado_multi_arg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-650f92b8451f6b65",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_multi_arg.g4",
     "hash": "44b6db506425c5857807eb4f1159bf658496b591864e5d4237a9ef5ece27d1d2"

--- a/package-gale/tests/generated/action_multi_prequel/wado_multi_prequel.g4.kiln.json
+++ b/package-gale/tests/generated/action_multi_prequel/wado_multi_prequel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6e650f2542d1aa83",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_multi_prequel.g4",
     "hash": "a454c139fdc695536f883277eef5883c1ed967f9546ca5bd16aa64cdd1f3fcbb"

--- a/package-gale/tests/generated/action_multi_vals/wado_multi_vals.g4.kiln.json
+++ b/package-gale/tests/generated/action_multi_vals/wado_multi_vals.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-08075013495a9f85",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_multi_vals.g4",
     "hash": "ae2a31f802b37e095fe0ec164ef2b0ed11e7fc057372b7d0a45e9fbbd7d876d8"

--- a/package-gale/tests/generated/action_pred_direct/wado_pred_direct.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_direct/wado_pred_direct.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5e061c7be549197d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_pred_direct.g4",
     "hash": "e092f3749a943ddf550a6a71b95bd03cad20773c919e70783c1dd81231c86f40"

--- a/package-gale/tests/generated/action_pred_la/wado_pred_la.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_la/wado_pred_la.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-da1441b223e14727",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_pred_la.g4",
     "hash": "45c10f850f573ce0a566001e93626c9a530d9586cb4beb171f3a041330495569"

--- a/package-gale/tests/generated/action_pred_mixed/wado_pred_mixed.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_mixed/wado_pred_mixed.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ca54db1f2499f4bb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_pred_mixed.g4",
     "hash": "bbc420572b0acbfc0e53c8a6d2f79ed0fd1878634711e9c79fdfa5b5e5d294c4"

--- a/package-gale/tests/generated/action_pred_select/wado_pred_select.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_select/wado_pred_select.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b327e5a5e039ffee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_pred_select.g4",
     "hash": "84580d852a7a09a0c820d47fa8e4e2280ec070e3d98497b8f9513317a157f9db"

--- a/package-gale/tests/generated/action_pred_single/wado_pred_single.g4.kiln.json
+++ b/package-gale/tests/generated/action_pred_single/wado_pred_single.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-025f5de49e5ae1e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_pred_single.g4",
     "hash": "0d7912e38ff400aaca30b2461edcae7aca24336c4f6de5125244671c90146a87"

--- a/package-gale/tests/generated/action_predicate/wado_predicate.g4.kiln.json
+++ b/package-gale/tests/generated/action_predicate/wado_predicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0f6f2d45a8be8bf4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_predicate.g4",
     "hash": "d0d8e42a8c9fb83b9b4059ef6b880e28927e9b83ec9abdd7eaf9b3cf507b9a0a"

--- a/package-gale/tests/generated/action_prequel/wado_prequel.g4.kiln.json
+++ b/package-gale/tests/generated/action_prequel/wado_prequel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c4f501158f90b0c6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_prequel.g4",
     "hash": "0eefaa49185b6b001f981054b77cd117b340b2a1c20da6dfc25b8ec9275c6dd5"

--- a/package-gale/tests/generated/action_rule_arg/wado_rule_arg.g4.kiln.json
+++ b/package-gale/tests/generated/action_rule_arg/wado_rule_arg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-696b74c7625b82e8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_rule_arg.g4",
     "hash": "7be55c442df7e0e341c31c9a6d76870f675548d4aee16b05ab947af0fb0ab9d0"

--- a/package-gale/tests/generated/action_rule_text/wado_rule_text.g4.kiln.json
+++ b/package-gale/tests/generated/action_rule_text/wado_rule_text.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cb5561321a332653",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_rule_text.g4",
     "hash": "4b852c099e7d878056bbfeceac970ea29a8c24e2ebd431e5cd17530a7e47c215"

--- a/package-gale/tests/generated/action_start_stop/wado_start_stop.g4.kiln.json
+++ b/package-gale/tests/generated/action_start_stop/wado_start_stop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3249021442fd1f8b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_start_stop.g4",
     "hash": "a0358ce07a0d7c3e72d352eb6101b422a65047b0e07d664881ab2a95411223e8"

--- a/package-gale/tests/generated/action_tok_members/wado_tok_members.g4.kiln.json
+++ b/package-gale/tests/generated/action_tok_members/wado_tok_members.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ae6eaafe3479c391",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_tok_members.g4",
     "hash": "3422ef69b9b69e862e86e324a3a84e3782649e1454f0e2bc078a7db73cc70256"

--- a/package-gale/tests/generated/action_token_text/wado_token_text.g4.kiln.json
+++ b/package-gale/tests/generated/action_token_text/wado_token_text.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b4a5c6c2eb999ebd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_token_text.g4",
     "hash": "58d4f101e7b7394595c7b468d10766ad64ae00b1e41c5797e010b6f84016bc4e"

--- a/package-gale/tests/generated/action_vals/wado_vals.g4.kiln.json
+++ b/package-gale/tests/generated/action_vals/wado_vals.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e9ad6f91f8540f97",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/wado_vals.g4",
     "hash": "2bb1c64cf97d06ef0af9072915e81d1838d86251f92cdc93460d4ec66d544405"

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/AmbiguityNoLoop/AmbiguityNoLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/AmbiguityNoLoop/AmbiguityNoLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0809d2f7841463f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/AmbiguityNoLoop.g4",
     "hash": "4a5ea9400a16c409961ca654fbd830c7065473b123890f128d89c973c9f54116"

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-10862b0dddd3e3ce",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "3cef241a3f1aeefa4734eedc02294ff8d4e3b06d7b68b3bede9c69774c2b98f1"

--- a/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/LoopsSimulateTailRecursion/LoopsSimulateTailRecursion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/FullContextParsing/LoopsSimulateTailRecursion/LoopsSimulateTailRecursion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5692020f51c4cb8e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/LoopsSimulateTailRecursion.g4",
     "hash": "f110e04e7dbbeecd1db8bff0b481240c206c9744c0ae7e16332c80541090207d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_1/AmbigLR_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6dba95df275228d1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_1.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_2/AmbigLR_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c75e07f954524ebd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_2.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_3/AmbigLR_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-05c4a7a54efa10d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_3.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_4/AmbigLR_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-70c7ec0c9f713396",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_4.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/AmbigLR_5/AmbigLR_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-79a75dae3777f4e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/AmbigLR_5.g4",
     "hash": "24d8561b0961d6320b98bd4cfaff5fdf42796f8247fb92c253a205a5937f6edd"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-724c6291ef0ee955",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_1.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ec23e0d9aec1c2f6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_10.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8dcf81200324c571",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_2.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f313624ad6edc976",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_3.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1dc67c7db6d6d52f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_4.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-abe31a1d6808ce47",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_5.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-477f17c2463b8e96",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_6.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-10b57559aeaf3bcc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_7.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1d4098b0e07414b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_8.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e79fb0d29171ffdd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_9.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6f827f329afceaee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-defde4108f71c68b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b0bb19f34c7e7e99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5e0bb2a71cb18ef0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_1.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-792a24e4c5c84950",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_2.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5ddf90110c8adfd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_3.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a8c70cca85955bb7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_4.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b27749b045ce13de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_5.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8a5e49d006b9be98",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_6.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-10bdbb84da5c4d9d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_7.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-82c4f42335aded29",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bd15c85db4a62501",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6608e8be66945304",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-97f8a98ba183d09e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4f2e7c4ee02457ea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fdc5f8ecb1581ced",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9bd3774852624c48",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4e0b676e62be0622",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f3aeeff62f332d72",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-57aae01f9f5af6d6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a376df5b65f50eba",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6daa01c64eb48fd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-67fdb6e3085259fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-901da49e00dbf5c5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7ce86a56591743af",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4c875b19fd3b35fd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-237496525c89e858",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d2561963ef8e372e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-39985628aae4cb1b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0895caf4c8e2a330",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f7f208812b8635e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e3ef3f336d04e01a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c41367194dc3a19f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bfacbe6db622e778",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ab1af22394a68c5c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-dd789b61f267295f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0c8335b8ea486a97",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "2a585adcc4ff6452f8676164c5cc06d1193e60a1f365ced112583ade997878da"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9361b59d78a17c06",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "253110b6fce663add55c6e20a5eea61c026c00ba1848ed7ff547f6d5b46f0020"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2ed7a2793bc8bc6c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "253110b6fce663add55c6e20a5eea61c026c00ba1848ed7ff547f6d5b46f0020"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8542ba9833c00c8f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fc1d346535bb08d3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d08f41a3235744e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8f7bbbb71846d9a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6336653abd1152d9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fcae849bf6ee92c1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-420e0774837f8368",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fdde20ad6ee5b649",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d2b33966d9bec5b7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e4b4d8e09f55c8e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c7e4f03502e1969a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-59c158919da3896f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-63a6d0d25ef7c602",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bfda504c3fba4c04",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-95c0ae71c4e43bc6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-55dd948e9dc09b16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_1.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1ff0ff2b6b58c78e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_2.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4e6e02a58699299b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_3.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5752f12e23140fae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_4.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-62ff79f71482513f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPred.g4",
     "hash": "a106deb55eb2abfedaa31b38e5a85311ee1e2be76765ae4c41a8b133cd6b68f4"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9b11ca68a5374163",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_1.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d1e8b8611394f9c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_2.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-830fd21b47bd0c5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_3.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fa79ef279fbe7c3c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ea14c1a3e2e23694",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-abf3ff3cc2d5cf21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ed67d2b10520b3db",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-939c90efc705053a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b468c061e6f07b7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-74c3e1872ddbddd7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cd93634ca93fd5bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-52a1ecc107f43f69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e4c414946515e719",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-853182052d75cda1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-592ae0778a69b671",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2adf8f906040290b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b9bb4ab705fb304e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-82512f883620f99a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5c64b29f5282c291",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cc0f8b655e083ff4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-463eed3672b1a6ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_1/WhitespaceInfluence_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_1/WhitespaceInfluence_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-17276d278a535112",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/WhitespaceInfluence_1.g4",
     "hash": "eb2ee832bbd5bc64766c64a697b83e430bc397e5e3c51480f276099243202a4c"

--- a/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_2/WhitespaceInfluence_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LeftRecursion/WhitespaceInfluence_2/WhitespaceInfluence_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d0a000e3185c7b3b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/WhitespaceInfluence_2.g4",
     "hash": "eb2ee832bbd5bc64766c64a697b83e430bc397e5e3c51480f276099243202a4c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatFailsBackToDFA/DFAToATNThatFailsBackToDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f2f1422e8c0310b3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/DFAToATNThatFailsBackToDFA.g4",
     "hash": "48db67da6df9caa67f3e56b39408023058c363703e5eac58a74bea22a92f0066"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/DFAToATNThatMatchesThenFailsInATN/DFAToATNThatMatchesThenFailsInATN.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4dadcf88635a7676",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/DFAToATNThatMatchesThenFailsInATN.g4",
     "hash": "ce03131129eb8147280be2cb5319ce363f7a4184ab6b871b761128c49ce4edb3"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_1/EnforcedGreedyNestedBraces_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1ef8751859ed5604",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/EnforcedGreedyNestedBraces_1.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/EnforcedGreedyNestedBraces_2/EnforcedGreedyNestedBraces_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-78b62e31b94c4361",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/EnforcedGreedyNestedBraces_2.g4",
     "hash": "492b2ecee9f08f105799b38ff8e81a375902fbb29ec5d849b5f6459f2abc26a5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/ErrorInMiddle/ErrorInMiddle.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-93010c260c740be7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/ErrorInMiddle.g4",
     "hash": "ca5afb8c050f2d8b96fd19595dc603645d812846f62c9d767d56f7d0a0c5a0d9"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStart/InvalidCharAtStart.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-13d8ba3fca6a0ebd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharAtStart.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharAtStartAfterDFACache/InvalidCharAtStartAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-57106fa9edd42507",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharAtStartAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInToken/InvalidCharInToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-71000f947fddc067",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharInToken.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/InvalidCharInTokenAfterDFACache/InvalidCharInTokenAfterDFACache.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b09ad19d2b68620a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/InvalidCharInTokenAfterDFACache.g4",
     "hash": "97fcf7891b064a11fbcda1b83696ecfa795d3917c98f4efc47dfef9d8781364d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/LexerExecDFA/LexerExecDFA.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3de5a518e71a434f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/LexerExecDFA.g4",
     "hash": "9082786e9c7fc41aaf4fdfc2878c546039534e8b4ce83af668f95a9189b005d8"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_1/StringsEmbeddedInActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fa64fb074cffe6ab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/StringsEmbeddedInActions_1.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerErrors/StringsEmbeddedInActions_2/StringsEmbeddedInActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bdf529f43ece1728",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerErrors/StringsEmbeddedInActions_2.g4",
     "hash": "5e54d404efadb816a1078633ba2ec12083f375115c60fb0a60fab0de281a428e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ActionPlacement/ActionPlacement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c91fa185b6865077",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ActionPlacement.g4",
     "hash": "91771340407dde2b4532c24859aa784b279b79ac31c35b87f9e2fc4b13a628ee"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSet/CharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-aebed58c11eebec3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSet.g4",
     "hash": "7f0dc97864a229fb1ade2c9e6bb9c1e0a53992cf496e74170879deba7ac9be7e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetInSet/CharSetInSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f66b1b9b792de13d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetInSet.g4",
     "hash": "f181de0ae729e9b5f597000b968235effa143bdd7d29d6acbe87fcd5d8e06a6c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetNot/CharSetNot.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4e0e01a3e71a3fc0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetNot.g4",
     "hash": "0acfa451e3320feb7147da2dbed756195d32df523501c7f4955251641164eb53"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetPlus/CharSetPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2c0777939fa86890",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetPlus.g4",
     "hash": "68ed054fd1eb28b0376a5b2dd2fded19969077892161f56068df69cb754614e0"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetRange/CharSetRange.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-14995edf9a3a85af",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetRange.g4",
     "hash": "db0704abd79e9ce7c4f60ce25be1be804bdf07b6b994b85e1e6bb1e9d087ad94"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithEscapedChar/CharSetWithEscapedChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e42740b41f8491e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithEscapedChar.g4",
     "hash": "97dab8c7f42040028016a333b619486812b9eb6fc194367b3c531b4d52ea03c9"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithMissingEscapeChar/CharSetWithMissingEscapeChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1636fc5a0e2a7684",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithMissingEscapeChar.g4",
     "hash": "1100c51654e45fc483c6392018b186d6c7a62c40c10b5d9db7065209064605e1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote1/CharSetWithQuote1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-52cbf5a819a80b51",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithQuote1.g4",
     "hash": "f639d3e26e1a25fd463d1afe1f39069faa6a2fe61917ab0c7cae87457c52f21f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/CharSetWithQuote2/CharSetWithQuote2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7a4fe128d4e0713e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/CharSetWithQuote2.g4",
     "hash": "380857ab4bdd331efa9f3c0f6be2825bd53341c22505a2566a21f1bd1a557d72"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EOFSuffixInFirstRule_2/EOFSuffixInFirstRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e8ebde2e4a96043e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/EOFSuffixInFirstRule_2.g4",
     "hash": "441bbb7e472213eb37da15d9b0992d1c4d399644b0fa057762e0b579ae06e531"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/EscapedCharacters/EscapedCharacters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-186920fb399c84b8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/EscapedCharacters.g4",
     "hash": "88a4f34355fb87e7adbc718fcfe030c51f5c362d158b4cce6a5796189ba1cd4a"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyClosure/GreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d79c0f03bf29a36d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyClosure.g4",
     "hash": "d1458a9fc1db2a1bc64866ee5b621bdea6b8aca8fd321a6053f7b64c496bf279"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyConfigs/GreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4b2b773c85659db6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyConfigs.g4",
     "hash": "137ae29cb06b7b4e2019c66137635475ebb092d4adab59d505f39b6b398b94b5"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyOptional/GreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-59c03763c0684b73",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyOptional.g4",
     "hash": "0e2acf0a59884a4de77f9b74b30c2dc30770c78b1a11db4db50b1cea97df2d4d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/GreedyPositiveClosure/GreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-185f3b7faecee4ca",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/GreedyPositiveClosure.g4",
     "hash": "5d96b0c62fad69596130c0cfe142462b2dffa59bcc399e1decfd28cd0ad2ac03"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/HexVsID/HexVsID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cfe5f404fc84ed38",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/HexVsID.g4",
     "hash": "a1aa12f4fe19f66adc2b83628e3806eb535b11a974c9e7173202674b57eb3bf2"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/KeywordID/KeywordID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b878aaea220b7a7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/KeywordID.g4",
     "hash": "5eec334a6818219de3e310c919f6fa92ee282ea3d98561d1e53fa586df4b7645"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyClosure/NonGreedyClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3a1f814f024de92a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyClosure.g4",
     "hash": "919895cc80becbaa85e86b313156de11fb8cc30e641612bb47a295326f546a2c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyConfigs/NonGreedyConfigs.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-dba435445aaa5bbe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyConfigs.g4",
     "hash": "8d874c3637641d5e317e644b769d00acaf7ee045164ee9f5deafbd88677e2c0e"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyOptional/NonGreedyOptional.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bf45839c003aad34",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyOptional.g4",
     "hash": "611a3d559cf19bd50743e764270d813639b924662b03e7075f24f3ac3520ac9d"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyPositiveClosure/NonGreedyPositiveClosure.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e73ca4af79497afc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyPositiveClosure.g4",
     "hash": "a19bcb18c02be6721bf1028a7c1335d28291e3e247dbd8e5fa2fcbc88d716fe4"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination1/NonGreedyTermination1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1f5f43763cdcb57b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyTermination1.g4",
     "hash": "5841fcdcd5adf818f59bf6e0f6a29db4d1027ce77dcc476160b96079fcf35a8b"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/NonGreedyTermination2/NonGreedyTermination2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-78e4cbcd74e35bcf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/NonGreedyTermination2.g4",
     "hash": "9ea5e3f0fd959bb4a51b464e3c49d7f20e95f5189bab762287847163d70a5960"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Parentheses/Parentheses.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0b1b5a3c8b4b5713",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/Parentheses.g4",
     "hash": "10a47eed1b802ff2274c0d7ffffc1a145b6142f25340091ecdb1176446429acc"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/QuoteTranslation/QuoteTranslation.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d2d18fe86528ccbe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/QuoteTranslation.g4",
     "hash": "fd454e5ff551c86e4eab1e50e2375a62b8246aae8b700f386202c3fbc795225f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1/RecursiveLexerRuleRefWithWildcardPlus_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-978fdd26b14ef3bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RecursiveLexerRuleRefWithWildcardPlus_1.g4",
     "hash": "ccf3affeed08d41932ee1b94716d414b1bae3d229b6c7f3f4d17e62300e91492"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1/RecursiveLexerRuleRefWithWildcardStar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f12d192e2bc55a11",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RecursiveLexerRuleRefWithWildcardStar_1.g4",
     "hash": "7b6ed71096a57f601b91ad9c0bee2e6b2fc376dcf23c80eb7430b84c165be764"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother/RefToRuleDoesNotSetTokenNorEmitAnother.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c8cb897d1dcbcbbb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/RefToRuleDoesNotSetTokenNorEmitAnother.g4",
     "hash": "95a088465b495a7bfbf61a77ce9bb6ae79caa9288236175927e10273cca715f1"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-907d0bd38b8779aa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ReservedWordsEscaping.g4",
     "hash": "66600b7a97e9750d7527d65b8f6799e6e8f39806bf1a1bc70f349d2d79549d04"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ReservedWordsEscaping_NULL/ReservedWordsEscaping_NULL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d7a03811d0ce28e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ReservedWordsEscaping_NULL.g4",
     "hash": "c0512ddd17eb85b03ec5ee0bdfbd91e04bf5186ea196a43c6699b55bf350e582"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/Slashes/Slashes.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7ce50634698ad555",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/Slashes.g4",
     "hash": "8542b8d313ce35cd690e1408d548786844016931b7659852bbcb1af80919f7df"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/StackoverflowDueToNotEscapedHyphen/StackoverflowDueToNotEscapedHyphen.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e21ffc2e20097cda",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/StackoverflowDueToNotEscapedHyphen.g4",
     "hash": "8ac36d903f20ad5d1c01d8de6e7555e7095b62f80282b91c7309cb119f6e0e81"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/TokenType0xFFFF/TokenType0xFFFF.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/TokenType0xFFFF/TokenType0xFFFF.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f262d3761453c23c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/TokenType0xFFFF.g4",
     "hash": "510dfbf59b57e04442706e8d5ae998b7daa9bfb6e4ab2347959fcaf010e4793c"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/UnicodeCharSet/UnicodeCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a43c20a2765b5e78",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/UnicodeCharSet.g4",
     "hash": "be6380e8ca1f1838a7908f37fc269bbfe32d7522dff990274bfc144c90d5a73f"

--- a/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/LexerExec/ZeroLengthToken/ZeroLengthToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1dc63c416f1a1e13",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LexerExec/ZeroLengthToken.g4",
     "hash": "602fefbd71118c707ee514a7eb2d6eeac92032b2009e51b705b154429bffd5ea"

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b6011b9143d628c5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/Basic.g4",
     "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/LR/LR.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/LR/LR.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e56bd84efac1b634",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/LR.g4",
     "hash": "8f39eb58884a9c6d69675b6172d4948a5412a101e48acd93ca95d54dd694b322"

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/LRWithLabels/LRWithLabels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/LRWithLabels/LRWithLabels.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d6b05635f57067cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/LRWithLabels.g4",
     "hash": "1b70e6b955b2d400125149a5ba9a23c882c76eca3a7750a78ad34b015ff7addc"

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_1/RuleGetters_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_1/RuleGetters_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-30239be9065a102b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/RuleGetters_1.g4",
     "hash": "ddc38590f35a64a189e937c2aa4aa016a526e2decf03572af3c5ff26acb2d9e6"

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_2/RuleGetters_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/RuleGetters_2/RuleGetters_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-83dee48eed8ba5f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/RuleGetters_2.g4",
     "hash": "ddc38590f35a64a189e937c2aa4aa016a526e2decf03572af3c5ff26acb2d9e6"

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_1/TokenGetters_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_1/TokenGetters_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-84499a2abb159b25",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/TokenGetters_1.g4",
     "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"

--- a/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_2/TokenGetters_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Listeners/TokenGetters_2/TokenGetters_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-939d0f890cce06d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/TokenGetters_2.g4",
     "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/ExtraTokensAndAltLabels/ExtraTokensAndAltLabels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/ExtraTokensAndAltLabels/ExtraTokensAndAltLabels.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-38b66bd8122f6427",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/ExtraTokensAndAltLabels.g4",
     "hash": "307e9405ad7c575d0c7bc3fe8f69cef2aba30fe9afbc7a93336e689a9725c855"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6f9dec17daa020bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/RuleRef.g4",
     "hash": "d36f799562d5b5075bc37a123b6a6a2143de5376215c61781d2528fb20bfb872"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-12469ea38671fffb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Token2.g4",
     "hash": "6cd80a43bb370ffe5c24d939690ca5a01587d8722d37bcb6e7ef47465f4b3f28"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString/TokenAndRuleContextString.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TokenAndRuleContextString/TokenAndRuleContextString.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7200e3cc8fd5d741",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TokenAndRuleContextString.g4",
     "hash": "540d104df0edf2d66917d75620498573de808a49eedf7bd53a96b83c5a5efb11"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-500d88e92ed070c8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "a638aad22706396ab56c298fec81040d05225611bb2c1c55b5af65d0d5e6460f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7e035fc27b024880",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAlts.g4",
     "hash": "79b50c115868f434c423fbe49a9db89ec5ea12828b98d6cc90f1daef29b09b7a"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpToken/ConjuringUpToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0195fd565da9cb85",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ConjuringUpToken.g4",
     "hash": "204f0b6cd9b5dba20f999caaf203da12efff0cfb7192ae6ea579a39cc9bc55af"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ConjuringUpTokenFromSet/ConjuringUpTokenFromSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-485d99d36bf8253d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ConjuringUpTokenFromSet.g4",
     "hash": "adc51be2e2652ad8246b01a2be475f20cf314cc4614db7910f92807e4dbfa160"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7cb040514b4d8550",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ContextListGetters.g4",
     "hash": "5c0f1a3091c6de8a91d73791a7a55080a0ef042ad5b662b82d5947e976f700ab"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_1/DuplicatedLeftRecursiveCall_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f876fb4ea120fe24",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_1.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_2/DuplicatedLeftRecursiveCall_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4aeb64ac2f848ca2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_2.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_3/DuplicatedLeftRecursiveCall_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2852c8f877e16427",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_3.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/DuplicatedLeftRecursiveCall_4/DuplicatedLeftRecursiveCall_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2646e62a9bd34ea1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/DuplicatedLeftRecursiveCall_4.g4",
     "hash": "cb574c6c608fb07e3c875b5c7561874060c04e7a280293a55ab819142ffe274f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/ExtraneousInput/ExtraneousInput.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-19bb65344fed7a6d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ExtraneousInput.g4",
     "hash": "d65f706ca2451405802574364ae8d3d7abf995b07027e8a4625c575ee48c919b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/InvalidATNStateRemoval/InvalidATNStateRemoval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-971fd74760856567",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/InvalidATNStateRemoval.g4",
     "hash": "a61822facc746668e46fb82a4f967cebdfc94f80ed44bf9a14bb879c3fadc104"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-78b11d2968a7b9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "6fdb1536b5d50a39105a35527d0a8f63cff00a1682e45af84ee262aed25dec0f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL2/LL2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-da3662947095ba6c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL2.g4",
     "hash": "2aaa2b6a34f4a4348b34477ca85e32d712d0090ea04767439f00a52c9e369525"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LL3/LL3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e5f481f17edb72e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL3.g4",
     "hash": "c71f82724eba5c68a8618a7e086bdd6d4945e4a769695822a02a3e560fc12d76"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/LLStar/LLStar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-dff5a67e2d850dfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LLStar.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop/MultiTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5a21ceff6d015b8b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionBeforeLoop.g4",
     "hash": "e85e3274b80d9927fac0d6f6fd84f36c85e3495b5c8288e0dcb1117c16f07173"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionBeforeLoop2/MultiTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b354e50735f603f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionBeforeLoop2.g4",
     "hash": "fd6968e798351061bbc2284243713a2f29ffd06066cf5ff1f3ef91e3a0de79ff"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop/MultiTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c6de053fdca9cd20",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/MultiTokenDeletionDuringLoop2/MultiTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f59a4af78bfaa358",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/MultiTokenDeletionDuringLoop2.g4",
     "hash": "6b92671abb0fe47306019a2b498ff80170d85e888bbe48df128b882eee77731e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/NoViableAltAvoidance/NoViableAltAvoidance.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e2dc404a432bf2e8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/NoViableAltAvoidance.g4",
     "hash": "b28914eab8290e79724e3e1b2ac223e8b6c5021ac6ca3c564ee873762146bbfc"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertion/SingleSetInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-571104d65eeb7ea8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleSetInsertion.g4",
     "hash": "5c5213e807e10eac992c2dd076d8f12a8df33bb71c1803ee039588b15da2782b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertionConsumption/SingleSetInsertionConsumption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleSetInsertionConsumption/SingleSetInsertionConsumption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e2eef45b306a6e0c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleSetInsertionConsumption.g4",
     "hash": "be780fb891f1bbfbfaec2220da2248863f300e58833a1cfa9fb899655c53e0fe"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletion/SingleTokenDeletion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4295366fe9bdc424",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletion.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeAlt/SingleTokenDeletionBeforeAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9deeff3f59619bbb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeAlt.g4",
     "hash": "8620c2090497e410ec32e4c6556c760c41ffe1a00ca410ee8a598dfdd77baf3c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop/SingleTokenDeletionBeforeLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-88e54058582f681b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeLoop.g4",
     "hash": "981912e9f61c0e8e34da6607456532112011597125c30dcbddf0125401041f85"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforeLoop2/SingleTokenDeletionBeforeLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a8e7a747965f3e89",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforeLoop2.g4",
     "hash": "633635c9fdff3d0c984a8ceed258f6d51168ab8b4eef2f8f6250af32d225f19b"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionBeforePredict/SingleTokenDeletionBeforePredict.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2dd5808cf3e08083",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionBeforePredict.g4",
     "hash": "3e937ce2ce494c4be9f9c68d8901657bf961c2323261dd30954d25990d001418"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionConsumption/SingleTokenDeletionConsumption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionConsumption/SingleTokenDeletionConsumption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4d48d62113f3fee1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionConsumption.g4",
     "hash": "be780fb891f1bbfbfaec2220da2248863f300e58833a1cfa9fb899655c53e0fe"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop/SingleTokenDeletionDuringLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-77e75b00557857b6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionDuringLoop.g4",
     "hash": "bb77678589d1936b056f87c3eafaa90d32f55c9a10beee93b8160102affad30f"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionDuringLoop2/SingleTokenDeletionDuringLoop2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c7a1c76dcd0feb61",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionDuringLoop2.g4",
     "hash": "6b92671abb0fe47306019a2b498ff80170d85e888bbe48df128b882eee77731e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenDeletionExpectingSet/SingleTokenDeletionExpectingSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e70dcb6157b29f19",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenDeletionExpectingSet.g4",
     "hash": "82fab2ac95de6f83693cfada43a42fb29c81c33276e86a92c9ffe512e0619240"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/SingleTokenInsertion/SingleTokenInsertion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f9ecf857a1dda7fb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/SingleTokenInsertion.g4",
     "hash": "4153af41f9ffb8e3498f2f8624598a75ecb726bce94b85532bc26a2f9a553a93"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch/TokenMismatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-718adb9ff8473449",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/TokenMismatch.g4",
     "hash": "25554c7741a77a1d8537817aac67e64f061017ef4c7c06a01596c0279a6b03ec"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserErrors/TokenMismatch2/TokenMismatch2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-eeba7589f5d8a734",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/TokenMismatch2.g4",
     "hash": "4bd0badd70e068efac023f2f42dff67c8439fb46b31ad4ecffa908f2eb619d18"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0e768432ad217228",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/APlus.g4",
     "hash": "65afa725cbcac09fa8c5ef09b106193b0653e9a43d9f7dca8f80cfbdab0244cc"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bc656e8f273b5048",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AStar_2.g4",
     "hash": "32e20668bb74b32537e8ed784776ad010334047540356bf8e558bc448a1a4f1a"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e455fb79e0e760d5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAPlus.g4",
     "hash": "2d2f766470d77cd144a3c195c0abac3b491e9622212042e47a005e0cd803c497"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f0a4df9cad5ce7a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAStar_2.g4",
     "hash": "3373095cb5525150349456ff369eeabb2648d7369578d70344fa82843e4795fe"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0bf329c8c63c777b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorB.g4",
     "hash": "526a8a1a4c649b84d041ba7f0dd3f0d2dac2cd930858c7a432207f26448d0985"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a6fe4df601f8fb7e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBPlus.g4",
     "hash": "b24888c439f265999017b6c8d5cac646a8ea99c2c029f29bb49c9abcf813ea8e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-251c61a3417e52fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBStar_2.g4",
     "hash": "8ff040f2bd87b3c1cb83765d26a42f034fe40acabc9979cd9a48d3c4a4116786"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-25a70a6980012d9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Basic.g4",
     "hash": "2785b5f535bab4a06559235161609d47fcf9d752f82ddc5b44bf0fa197a87a5e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-81d548e32786ef7b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "eb2c2950e7f80585c973ffc612ea059eab4da91ea8fb7e50034dfb78e768fa87"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-90cfc510612af10b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "eb2c2950e7f80585c973ffc612ea059eab4da91ea8fb7e50034dfb78e768fa87"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-60f5a9a16604d6e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "440e59e87cf909864372e2572e161b8ac1102e2b33ca17024622c8cbd691c1f3"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0c64a9174f394f19",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "d57cdde3a5790f927f5bb3a08edc39254365cd598a989a331b50ad31d96b64f4"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8e7c2737b7b0f40b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding1.g4",
     "hash": "52c0d8947d2dad4eda6c969dded97b1e509ebabd582b34e4f1bd545fa7e3d98a"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3f270e9e32b462e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "c509006b579b65d3a2bb33cc73f2867396e0457f2e3caf43918c15fdf55f4ba7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-19a487ef9ab2d274",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_1.g4",
     "hash": "d67c4f8218be21f6104f600109218250c5738f3abd72780bffdd9c90a167b4d7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-53b24b4c4131b10c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_2.g4",
     "hash": "95b786e26fd0411bc4877c9ce220c361d43eef988f480687b4d8a2391b8c6c7d"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-108ee69dd95708f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_3.g4",
     "hash": "7bd91c8ffe4349c62fab43f7e24eccf0cb98ce10f96bb7fd8a4c18eb4c7288eb"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-316e47f9cb1bbc4b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_4.g4",
     "hash": "fc3f61392647c8ee0a4d42fa4d6935e257c040a5177fe7c9849988191e9be6da"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cbb5c83bd36dfc44",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_5.g4",
     "hash": "1b99bef44dff0f4b76fe9b8aaedb7fec1fd8c90e6fc6caec51a524204dc07b3d"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-97ad497ee3062dbe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_6.g4",
     "hash": "ff61271aca142ca5ce907d2f8c44c240da8b965be1a57bddafcf7e2389ed74de"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-993de6f9d029cdb3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "bec71119542848512f3dafd408fa0bbbe7279fa597ea3cfa8674dd7778424d5c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-19319eed76368793",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "63a8d3816100691a88d9aeff5c64ae599bf52dbf429c8972ae160de32b215a80"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Labels/Labels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Labels/Labels.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1abd98df9faa1037",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Labels.g4",
     "hash": "6263c0c263ff2e359d5ffe29f5156e36760ebc32acbd8fcae5cb2b94eea08fae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelForClosureContext/ListLabelForClosureContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3c9cf123dd4997d6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelForClosureContext.g4",
     "hash": "d564bc2775d8fa8ae1e3dd036aab81140f0ed275c2767d0211ff685752ac3ee7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnRuleRefStartOfAlt/ListLabelsOnRuleRefStartOfAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f5666f268c7aa0fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelsOnRuleRefStartOfAlt.g4",
     "hash": "3aa6084c13250ca71372eb09e5bc4d92097d46d3be5b3fc3df32760e0aa15708"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnSet/ListLabelsOnSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ListLabelsOnSet/ListLabelsOnSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-522a40a1b79a7b0e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ListLabelsOnSet.g4",
     "hash": "3e061c74b0839caf5d204be5aa58fad88f4a12eacb1a4b5987312548a5e87351"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/MultipleEOFHandling/MultipleEOFHandling.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ed45665f83f5726d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/MultipleEOFHandling.g4",
     "hash": "f1cb5bab46a024203403073ff94ae02fed6987c2e63b627edf697a7d299b08c6"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d6dcf4d3e116f36",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case1.g4",
     "hash": "150bd511e2898329b4a1be0d94cbab3775c9d762da1821db48a2acd09867e922"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7eaca01e9531e506",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case2.g4",
     "hash": "09b70ed5e0fe15e7bca784b725980f263bcfd0da3a8f9108d60bbeb4a7b7ef5c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ecedd277b785d87e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case3.g4",
     "hash": "09b70ed5e0fe15e7bca784b725980f263bcfd0da3a8f9108d60bbeb4a7b7ef5c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_1/Optional_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-799636ddb90c3b40",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_1.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_2/Optional_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-12013ce7871cd1fc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_2.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_3/Optional_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-493c6bc2ecc7d1c3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_3.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Optional_4/Optional_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e65be639da0c2871",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Optional_4.g4",
     "hash": "81da3d25df801643a2b8b428b72db781e2a8d51f46e90fe17e5c4d569460040c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/OrderingPredicates/OrderingPredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d1fe93a61add0269",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OrderingPredicates.g4",
     "hash": "9e1c1b5e4eb5492597f2e750d5935cb9a2fad092868471a4a1244f39f05c60e5"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredicatedIfIfElse/PredicatedIfIfElse.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-efdb61dfce95da1d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredicatedIfIfElse.g4",
     "hash": "84950f45715e14e61fd604dba5bdeb1168784e3abd7ed28dfe0f0433014fe90d"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c60a4d59c5c71db1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionIssue334.g4",
     "hash": "ef72aadf8f7a725e4784a4b40db3fd7131460bfd444256ed6fa7a6bc4804454c"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9319ef8088209c5e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "12bb5d21b00f7b51319887f14af975acc95a45ec6c8e2349c58d9e3036223dae"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_SLL/PredictionMode_SLL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/PredictionMode_SLL/PredictionMode_SLL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e3a408232a5ca722",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionMode_SLL.g4",
     "hash": "4b0ad60a0311866dd33a7bcd48ff62ddd3991c2f006b9b2f7489f3a221e32e6e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-05d54229af5ddb42",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "219dd0ab0de17f74119b2a502d847cef78f678320fb64cee55025e147beac015"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fe600c4e82ebbc18",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReservedWordsEscaping.g4",
     "hash": "1255013e85ee5370b81b22637b60dcc49fe82706c1f6a539154d35e5cd605b9e"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d3cbaec23431d82",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/TokenOffset.g4",
     "hash": "dfda12fb116e3c99f5f42c2618eb51727e857e5c05836e80bc1d2cc161fe42e7"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-79d73209896a1038",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Wildcard.g4",
     "hash": "11e95949cf96d6ef6495192ed616530367d1722b686f81d39a09e32761f3e9df"

--- a/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f4d3608d014cdf23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "807557a1c66b8ed1fbd0bd199253542faba1296ec9860f9e19a5aba35c7ffbc5"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_1/DropLoopEntryBranchInLRRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4c632dfbe56a6674",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_1.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_2/DropLoopEntryBranchInLRRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-78d170410f8aef16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_2.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_3/DropLoopEntryBranchInLRRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-23cbb08475e72322",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_3.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_4/DropLoopEntryBranchInLRRule_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-65001294d8797ce5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_4.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/DropLoopEntryBranchInLRRule_5/DropLoopEntryBranchInLRRule_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d7c66dbb7941b2ef",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/DropLoopEntryBranchInLRRule_5.g4",
     "hash": "b939eb6c32ee7ec29a924f62f15dbcc4185a8e719a264dc0f73c4b0abccc59bd"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_1/ExpressionGrammar_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_1/ExpressionGrammar_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4dfcb50ddd40cd9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/ExpressionGrammar_1.g4",
     "hash": "fdad284b75dbe1e75f3820211869d5d5e166b393077d55d5450945c644e77f47"

--- a/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_2/ExpressionGrammar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Performance/ExpressionGrammar_2/ExpressionGrammar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-361540f6d9ce9d5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Performance/ExpressionGrammar_2.g4",
     "hash": "fdad284b75dbe1e75f3820211869d5d5e166b393077d55d5450945c644e77f47"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/DisableRule/DisableRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-198077ec5ef4751f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/DisableRule.g4",
     "hash": "f62ea4e6c4d943b34fa987dcd883eff02bc0dbfcd3ad4663a81205e5955c7156"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/EnumNotID/EnumNotID.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d50d43a1aa9c0020",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/EnumNotID.g4",
     "hash": "9f0460d77a0406a03e0c63525201b2c910c1a708f8cf8fc2e8f20e39959436de"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDnotEnum/IDnotEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f4985c5a5f57ac6a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/IDnotEnum.g4",
     "hash": "d6fa9bfcf22626c43627cc5391f6c73765bcc1c3a43abcaf722875c4412a527d"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/IDvsEnum/IDvsEnum.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ef5f330af36bb529",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/IDvsEnum.g4",
     "hash": "10cb45c65ab65b1e015e3b7d691258acc911483ee369d6834593b6e8487afec5"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/Indent/Indent.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f2c9c5b2c6e6ef7e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/Indent.g4",
     "hash": "db8e01ca65078787390e766163db1dff28a8e88c2df734b8e396560fbca2ef7b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/LexerInputPositionSensitivePredicates/LexerInputPositionSensitivePredicates.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-167660d5e423e96d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/LexerInputPositionSensitivePredicates.g4",
     "hash": "3e09ac0de3a83ce4f5e42794587418e31bca2aa5c9f3e2e32d4bc05fd9d0a6cc"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/PredicatedKeywords/PredicatedKeywords.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-10e2afd27654c878",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/PredicatedKeywords.g4",
     "hash": "16010edac128bb7ff75a99600a5b7ffa8181e5a0a541a5e74ce1858f1a28abdc"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalLexer/RuleSempredFunction/RuleSempredFunction.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0cfe04ac4bfd6a3b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalLexer/RuleSempredFunction.g4",
     "hash": "3adb7a1189fb3d47c18f34bfccc6311ac16a3bb0caf93c623832feca744a6f8d"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a5be53022ad1b17b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "c4e01650ae90615c32bc3eee5f57f4d611342dcef12948a0907ea38cd714c377"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3abc78f1a1dd0875",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "952c48fb5ebd8dd1c896728f60456def84c4a80ed9f7b9b68b9e341308e04214"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/AtomWithClosureInTranslatedLRRule/AtomWithClosureInTranslatedLRRule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9327154feeb93d80",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/AtomWithClosureInTranslatedLRRule.g4",
     "hash": "92e1a1f0924ff1342f55dce399ac903cbd1ee449cb61b490823161e0100e84ea"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e80e63432313ae6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "f8449f4767b4dfdf52b6113a6c931ea0d5841a7b738c195bee631d4fba689b58"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e825ffff4663fe4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4",
     "hash": "8553bb8579e273475bec5dffac33d751cf4e86039144543bdd5a11d5cdf332a7"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/DisabledAlternative/DisabledAlternative.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-96fdf79d1d505df2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DisabledAlternative.g4",
     "hash": "a92a4c2ebf0d1f93e9d80589cf4ab3e9a3ecb8bf9e747044ca7d7d128634f8e2"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3ff9cd7f68432d91",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "3d7a2878f4652b70aa23384f57b762cf3ebdce090e6be47dc2c4f2e163ff581e"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e7b4b66c5c476d1e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Order.g4",
     "hash": "06ee6c74670bd951fc6adaa3d1d127d38db71c55a076074dacd031c2800e1d3b"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-67bda7c2024a7cf0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "46b96c8091c150c5c47391d69259f5ee245aa80438a275d7b1f0602531dc40ee"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5569f9327b68ba4f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "74c1616e4f0f48712c07b5aea8e8be5082e89184828d8814bf2ea1d6244abbcf"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-dcaf5cd43868245e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "95f0830d46eaa8d8d4b9472caa4fad3e5c7bfc6bc822a1098fca68853dd1ffec"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredicateDependentOnArg2/PredicateDependentOnArg2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-65c77736c57ae6ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg2.g4",
     "hash": "08f048b49e306837679757919e6037adfe1b956f0073cb05390d930c232415ab"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-061a749098f54759",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "435298930cbeb6acec547f5ac93d2d08c38a321dd7dea17a778829c1442580dd"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-05c8aabfff617ec3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "4c58b8b6fd28ccaa4a15af5461aba77078c476d7020ad07f9cb060eebc78d65e"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-18e0a54b0bb49e07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Simple.g4",
     "hash": "dbc4c1cffcd9badf83384d7de1fc39fdebea06e0ad0079703cf4e32c073c5fbd"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/SimpleValidate2/SimpleValidate2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/SimpleValidate2/SimpleValidate2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-42a1ed43266f78b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/SimpleValidate2.g4",
     "hash": "39fdd0ae989ec159c97e38ab22f5fab58507340c9aa482f8b14f7d621bcb60f0"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6fe3217ab933daf7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "79e26c081d50d8991394f673689871fc36a87b4f801191c773a77620c00db8b0"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-79f3ad75b455946b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "5510b13c3f52df41ab478b80a3d468d5676ff38c36d44e8a35630f43a95cd88c"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/TwoUnpredicatedAlts/TwoUnpredicatedAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/TwoUnpredicatedAlts/TwoUnpredicatedAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8f7c206dbca1f408",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/TwoUnpredicatedAlts.g4",
     "hash": "82b92d5ebdcc53619bd999f5abba8d32fd769b7e3ff402dbf35687bf66dd5312"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/TwoUnpredicatedAltsAndOneOrthogonalAlt/TwoUnpredicatedAltsAndOneOrthogonalAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/TwoUnpredicatedAltsAndOneOrthogonalAlt/TwoUnpredicatedAltsAndOneOrthogonalAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-12cc824da6958082",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/TwoUnpredicatedAltsAndOneOrthogonalAlt.g4",
     "hash": "e3b8e7c6478eb775308bb78d9dccb33851e6df630fbf97bf1a7ed3648e4e96b0"

--- a/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e9a29002fb60d256",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "998b2de4aa9e4153db9d16485ea2c6b528969989d99d0b2af7d9f991b544c2ec"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-55bcf562af70467b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/CharSetLiteral.g4",
     "hash": "1148556229dc59ef2626b0458399983d1636cc24e105edf123aa60544998e683"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1cd9f86e1018566f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerOptionalSet.g4",
     "hash": "9813ec122366d63be434989e2774116a84cf614ff88e6c06654e175e661cf1c2"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ff7d98a7d5e835b5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerPlusSet.g4",
     "hash": "527915ce7cd19bafdf7634fba06323a220718346e187aecd12df786c22a946b6"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-18ca170ffdb0afcc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerStarSet.g4",
     "hash": "c29a11128b93b442513fa85c5028140c2ffdcfa0caecb6a9ee9c91477d80b421"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-49fbc17fc2bfdbb3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotChar.g4",
     "hash": "8f2432be7a965cbd8766ca8e42dd247c40ee569d5381ece836d645269bd0ffec"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9f7b7f2dae37260f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSet.g4",
     "hash": "4155ec14531984facba34515b3ab2f63205dcc5122b43b35eb0e1a5f8d865653"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6d9f734b246f7ab7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "341497f02eb8299a891ed67de6b5ccf5d1a8370780d5dbf784f8e349d9a8255c"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cc4e7824c362636a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "065d4e9ed01354807c48b541794965b66c5acd0c3843a8d98456ff80114632d0"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e5a36297644ee691",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSet.g4",
     "hash": "dbe1e20ce85e9efb4ea176c99bdb5bc65e426a6abaafa504abb4741e796262da"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9a65cdd583df2656",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSingleElement.g4",
     "hash": "d8242b63e702bee096a3cd3349e04ca94491a4709e97f6db841bf985cf2ce3e7"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-55efb6463177bdd9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotSet.g4",
     "hash": "19c38d099171d47fd0f223833a56a33a3b346c3fefabd4d0ca5cd8cf901969d9"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f9d124d7634800b6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotToken.g4",
     "hash": "190c7d956b90644a68f1a9ea4b1f91ee074c37601d45aa4073cb67e8823ca048"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ed43933e5e98153d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "3ac7ed3d0bda73662f6ce22584ef8f716e5c346fbefa877fdb2fd6a51ea4df3c"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-497a997b7e1daa80",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserSet.g4",
     "hash": "3c4ccda24427c3e37b5dd041af7ef3c43dd3de617f05277385fdbdb7f7c2d87d"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d63d389009bdd4ec",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "a3312a0f61691f481f028a21631fdec86d8654463a35a1da7e3bfa8b677562f5"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9a13fd8981eecd43",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusSet.g4",
     "hash": "bc9bf5d4139930b8ac617486305b9a3a835c9215b5bd3d5a28a3a0e52511dcfd"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d706c00a4a6d9072",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/RuleAsSet.g4",
     "hash": "6d0cd361fe29b6aec92e7802b7d9a91db550efedd1556cc128dee78815f9a8cf"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2d064ae4884c1326",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "2a9008d9a05b1a7427be88356896cd2602f039c2ca9027d44353322d83acef51"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ee03249e2dda9d35",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "023ddbb1ca0f01a768584f1cc7c2264fa54660aa24f1c10eafa78239110f8b2e"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7a0fd6ccb94720da",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "023ddbb1ca0f01a768584f1cc7c2264fa54660aa24f1c10eafa78239110f8b2e"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d7b54423d6154fef",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarSet.g4",
     "hash": "60e149f889628a3731a1c6327c9b6637c87b12ba99154cfa59963e2b9849d755"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPRangeSet/UnicodeEscapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9ab0e2b39453cd74",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPRangeSet.g4",
     "hash": "17176bf7af0966bf96541f77aa167aa82c9f7378cdf13984ba9bbfbea2114fe8"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedBMPSet/UnicodeEscapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-377cf238ac1e2028",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedBMPSet.g4",
     "hash": "65b6fd8f5bf44b438979ad93c63cb50c3d5554a231063480c8847b9c28fe278e"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPRangeSet/UnicodeEscapedSMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-69887d620f56e26e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPRangeSet.g4",
     "hash": "564298c89ce6db1cc42e929274e9132c38d58c0a48edcdbf43f5fa20bbc5abbd"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeEscapedSMPSet/UnicodeEscapedSMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f9493b3cb4b64f24",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeEscapedSMPSet.g4",
     "hash": "44e7ffe1963a5eda267386f282dd10523ca29401f8dc76506453b3a2899b7651"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6c3d68741368e295",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedBMPSetIncludesSMPCodePoints.g4",
     "hash": "ca5ed0a5d7bdeeb899c3b35de97249046efdfe100ebc4182aa201fd3c878bdc8"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b82ad07daca60f42",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "e3d7399c4da29f3cebfa28d1e944e5dd5662c7f1246140332e66ecb63863194d"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPRangeSet/UnicodeUnescapedBMPRangeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e6753cbc42e76fec",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeUnescapedBMPRangeSet.g4",
     "hash": "7c48456074bd5ec29dc876af086e758b959f95fa5e0f0cbaa04c9b989d555027"

--- a/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_a/Sets/UnicodeUnescapedBMPSet/UnicodeUnescapedBMPSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ce398239e5d99754",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeUnescapedBMPSet.g4",
     "hash": "65cc6d65b95f981c34e00820029ab11e82d5108fc2799ad3608d49b421fcb984"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_1/ExprAmbiguity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3a16a4ff537f8c19",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/ExprAmbiguity_1.g4",
     "hash": "c5d1f3f3b41e83aed087813c0afe816ed99ae15b99daee412d3152ef47674096"

--- a/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/FullContextParsing/ExprAmbiguity_2/ExprAmbiguity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3b182b98fdaccc68",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/ExprAmbiguity_2.g4",
     "hash": "c5d1f3f3b41e83aed087813c0afe816ed99ae15b99daee412d3152ef47674096"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_1/Declarations_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-724c6291ef0ee955",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_1.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_10/Declarations_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ec23e0d9aec1c2f6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_10.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_2/Declarations_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8dcf81200324c571",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_2.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_3/Declarations_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f313624ad6edc976",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_3.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_4/Declarations_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1dc67c7db6d6d52f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_4.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_5/Declarations_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-abe31a1d6808ce47",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_5.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_6/Declarations_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-477f17c2463b8e96",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_6.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_7/Declarations_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-10b57559aeaf3bcc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_7.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_8/Declarations_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1d4098b0e07414b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_8.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Declarations_9/Declarations_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e79fb0d29171ffdd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Declarations_9.g4",
     "hash": "6fe031c9af32cf41a9deba7ddc2796b5dc2f94cfada0af08de807a136d116283"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_1/DirectCallToLeftRecursiveRule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6f827f329afceaee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_1.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_2/DirectCallToLeftRecursiveRule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-defde4108f71c68b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_2.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/DirectCallToLeftRecursiveRule_3/DirectCallToLeftRecursiveRule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b0bb19f34c7e7e99",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/DirectCallToLeftRecursiveRule_3.g4",
     "hash": "e659c64ca43d6586b157eae509cd40450f753464beeada97bcf011ed18a022be"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_1/Expressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5e0bb2a71cb18ef0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_1.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_2/Expressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-792a24e4c5c84950",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_2.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_3/Expressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5ddf90110c8adfd5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_3.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_4/Expressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a8c70cca85955bb7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_4.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_5/Expressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b27749b045ce13de",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_5.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_6/Expressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8a5e49d006b9be98",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_6.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Expressions_7/Expressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-10bdbb84da5c4d9d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Expressions_7.g4",
     "hash": "1ffa157c21b4269afb66d4e4ddbd09a0e4f3cc9a99c5e32d31856f4ec416f44f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_1/JavaExpressions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-82c4f42335aded29",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_1.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_10/JavaExpressions_10.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bd15c85db4a62501",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_10.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_11/JavaExpressions_11.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6608e8be66945304",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_11.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_12/JavaExpressions_12.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-97f8a98ba183d09e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_12.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_2/JavaExpressions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4f2e7c4ee02457ea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_2.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_5/JavaExpressions_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4e0b676e62be0622",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_5.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_6/JavaExpressions_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f3aeeff62f332d72",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_6.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_7/JavaExpressions_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-57aae01f9f5af6d6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_7.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_8/JavaExpressions_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a376df5b65f50eba",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_8.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/JavaExpressions_9/JavaExpressions_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6daa01c64eb48fd8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_9.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_1/LabelsOnOpSubrule_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-67fdb6e3085259fe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_1.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_2/LabelsOnOpSubrule_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-901da49e00dbf5c5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_2.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/LabelsOnOpSubrule_3/LabelsOnOpSubrule_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7ce86a56591743af",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/LabelsOnOpSubrule_3.g4",
     "hash": "7f7ca549b1f0f59da74f5e74a345196f489c983889a4790eec7ecdea0fe329e0"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_1/MultipleActionsPredicatesOptions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4c875b19fd3b35fd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_1.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_2/MultipleActionsPredicatesOptions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-237496525c89e858",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_2.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActionsPredicatesOptions_3/MultipleActionsPredicatesOptions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d2561963ef8e372e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActionsPredicatesOptions_3.g4",
     "hash": "942cd7e04ade02f64a77dcaf1b03ca284ac5c9360ed8ee8672c22d37c72fb401"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_1/MultipleActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-39985628aae4cb1b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_1.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_2/MultipleActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0895caf4c8e2a330",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_2.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/MultipleActions_3/MultipleActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f7f208812b8635e0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleActions_3.g4",
     "hash": "dadd48b41ab1728f1a4ac6227d245ed48162e27b4833e6155ac200eca84e5acf"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrecedenceFilterConsidersContext/PrecedenceFilterConsidersContext.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0c8335b8ea486a97",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrecedenceFilterConsidersContext.g4",
     "hash": "2a585adcc4ff6452f8676164c5cc06d1193e60a1f365ced112583ade997878da"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_1/PrefixAndOtherAlt_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9361b59d78a17c06",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_1.g4",
     "hash": "253110b6fce663add55c6e20a5eea61c026c00ba1848ed7ff547f6d5b46f0020"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/PrefixAndOtherAlt_2/PrefixAndOtherAlt_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2ed7a2793bc8bc6c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixAndOtherAlt_2.g4",
     "hash": "253110b6fce663add55c6e20a5eea61c026c00ba1848ed7ff547f6d5b46f0020"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_1/ReturnValueAndActionsList1_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fdde20ad6ee5b649",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_1.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList1_3/ReturnValueAndActionsList1_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e4b4d8e09f55c8e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_3.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_1/ReturnValueAndActionsList2_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-59c158919da3896f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_1.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/ReturnValueAndActionsList2_3/ReturnValueAndActionsList2_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bfda504c3fba4c04",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_3.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPred/SemPred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-62ff79f71482513f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPred.g4",
     "hash": "a106deb55eb2abfedaa31b38e5a85311ee1e2be76765ae4c41a8b133cd6b68f4"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/SemPredFailOption/SemPredFailOption.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-56b2f70e5a0e82f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/SemPredFailOption.g4",
     "hash": "d944920144fd0f2c268bce46eff79f339ec3e9991ef4598c6b7945c6c5e59a30"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_1/Simple_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9b11ca68a5374163",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_1.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_2/Simple_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d1e8b8611394f9c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_2.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/Simple_3/Simple_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-830fd21b47bd0c5b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/Simple_3.g4",
     "hash": "5252dc4fe277029b6d5bcdfe28b0eb9dc2621111d2b099a0a82b50d63f275eec"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_1/TernaryExprExplicitAssociativity_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fa79ef279fbe7c3c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_1.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_2/TernaryExprExplicitAssociativity_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ea14c1a3e2e23694",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_2.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_3/TernaryExprExplicitAssociativity_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-abf3ff3cc2d5cf21",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_3.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_4/TernaryExprExplicitAssociativity_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ed67d2b10520b3db",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_4.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_5/TernaryExprExplicitAssociativity_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-939c90efc705053a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_5.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_6/TernaryExprExplicitAssociativity_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b468c061e6f07b7d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_6.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_7/TernaryExprExplicitAssociativity_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-74c3e1872ddbddd7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_7.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_8/TernaryExprExplicitAssociativity_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cd93634ca93fd5bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_8.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExprExplicitAssociativity_9/TernaryExprExplicitAssociativity_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-52a1ecc107f43f69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExprExplicitAssociativity_9.g4",
     "hash": "9fc6e377b15602c97d9e8a926d61c6534ea8664f314fcabbd36e9e33906226c5"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_1/TernaryExpr_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e4c414946515e719",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_1.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_2/TernaryExpr_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-853182052d75cda1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_2.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_3/TernaryExpr_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-592ae0778a69b671",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_3.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_4/TernaryExpr_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2adf8f906040290b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_4.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_5/TernaryExpr_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b9bb4ab705fb304e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_5.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_6/TernaryExpr_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-82512f883620f99a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_6.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_7/TernaryExpr_7.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5c64b29f5282c291",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_7.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_8/TernaryExpr_8.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cc0f8b655e083ff4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_8.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/LeftRecursion/TernaryExpr_9/TernaryExpr_9.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-463eed3672b1a6ed",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/TernaryExpr_9.g4",
     "hash": "05c6ada6384336d96af692ed1c77a97dfcb7afad5dacce76f2f4f991422d8768"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/ExtraToken/ExtraToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-007ffa48d97e8593",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/ExtraToken.g4",
     "hash": "6c827abcee181be6a84c23d40dd7187d0cd9fd9ae188a58929cbf42ad2a3b6e3"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/NoViableAlt/NoViableAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2da31481e98ccb34",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/NoViableAlt.g4",
     "hash": "14de2839e69a1dea6c0c4927529aaffce7b01e72edef9233977ee146c24d798a"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/RuleRef/RuleRef.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6f9dec17daa020bf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/RuleRef.g4",
     "hash": "d36f799562d5b5075bc37a123b6a6a2143de5376215c61781d2528fb20bfb872"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Sync/Sync.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0de745acc394f91d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Sync.g4",
     "hash": "d7ee47c0c2239a7409d5fab7d5b4484e25cdee8675a516902627bdeee2af9562"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/Token2/Token2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-12469ea38671fffb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/Token2.g4",
     "hash": "6cd80a43bb370ffe5c24d939690ca5a01587d8722d37bcb6e7ef47465f4b3f28"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAltLoop/TwoAltLoop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-500d88e92ed070c8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAltLoop.g4",
     "hash": "a638aad22706396ab56c298fec81040d05225611bb2c1c55b5af65d0d5e6460f"

--- a/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParseTrees/TwoAlts/TwoAlts.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7e035fc27b024880",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TwoAlts.g4",
     "hash": "79b50c115868f434c423fbe49a9db89ec5ea12828b98d6cc90f1daef29b09b7a"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/BuildParseTree_TRUE/BuildParseTree_TRUE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-90cfc510612af10b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_TRUE.g4",
     "hash": "eb2c2950e7f80585c973ffc612ea059eab4da91ea8fb7e50034dfb78e768fa87"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionIssue334/PredictionIssue334.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c60a4d59c5c71db1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionIssue334.g4",
     "hash": "ef72aadf8f7a725e4784a4b40db3fd7131460bfd444256ed6fa7a6bc4804454c"

--- a/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/ParserExec/PredictionMode_LL/PredictionMode_LL.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9319ef8088209c5e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/PredictionMode_LL.g4",
     "hash": "12bb5d21b00f7b51319887f14af975acc95a45ec6c8e2349c58d9e3036223dae"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_1/PredFromAltTestedInLoopBack_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fb46a428b28ca3df",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_1.g4",
     "hash": "46b96c8091c150c5c47391d69259f5ee245aa80438a275d7b1f0602531dc40ee"

--- a/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b/SemPredEvalParser/PredFromAltTestedInLoopBack_2/PredFromAltTestedInLoopBack_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-67bda7c2024a7cf0",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredFromAltTestedInLoopBack_2.g4",
     "hash": "46b96c8091c150c5c47391d69259f5ee245aa80438a275d7b1f0602531dc40ee"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/FullContextParsing/FullContextIF_THEN_ELSEParse_1/FullContextIF_THEN_ELSEParse_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-10862b0dddd3e3ce",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/FullContextParsing/FullContextIF_THEN_ELSEParse_1.g4",
     "hash": "3cef241a3f1aeefa4734eedc02294ff8d4e3b06d7b68b3bede9c69774c2b98f1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_3/JavaExpressions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fdc5f8ecb1581ced",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_3.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/JavaExpressions_4/JavaExpressions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9bd3774852624c48",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/JavaExpressions_4.g4",
     "hash": "30284ff1b14ddd00914a4ff7d901fb4db5a3d192d35c9bd29707e972df321e2f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_1/MultipleAlternativesWithCommonLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e3ef3f336d04e01a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_1.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_2/MultipleAlternativesWithCommonLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c41367194dc3a19f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_2.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_3/MultipleAlternativesWithCommonLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bfacbe6db622e778",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_3.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_4/MultipleAlternativesWithCommonLabel_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ab1af22394a68c5c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_4.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/MultipleAlternativesWithCommonLabel_5/MultipleAlternativesWithCommonLabel_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-dd789b61f267295f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/MultipleAlternativesWithCommonLabel_5.g4",
     "hash": "8a4703658363db0a82cad9986e7664830fe78b613f9382c999035f6a1e1c7bb1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_1/PrefixOpWithActionAndLabel_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8542ba9833c00c8f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_1.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_2/PrefixOpWithActionAndLabel_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fc1d346535bb08d3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_2.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/PrefixOpWithActionAndLabel_3/PrefixOpWithActionAndLabel_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d08f41a3235744e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/PrefixOpWithActionAndLabel_3.g4",
     "hash": "c73ca2fd1eaf1e406081c476e0e9c7800795c1e0d746e80a1ede16154c08381a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_1/ReturnValueAndActionsAndLabels_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8f7bbbb71846d9a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_1.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_2/ReturnValueAndActionsAndLabels_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6336653abd1152d9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_2.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_3/ReturnValueAndActionsAndLabels_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fcae849bf6ee92c1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_3.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsAndLabels_4/ReturnValueAndActionsAndLabels_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-420e0774837f8368",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsAndLabels_4.g4",
     "hash": "27a10373cb1b48afe4543edaad07a879071b9b05a6db10a9def9c11569255fe8"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_2/ReturnValueAndActionsList1_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d2b33966d9bec5b7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_2.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList1_4/ReturnValueAndActionsList1_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c7e4f03502e1969a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList1_4.g4",
     "hash": "44d7ebbf392e4eb23c9292a268f01aed36d898128365c47e667e39a897d1b3e1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_2/ReturnValueAndActionsList2_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-63a6d0d25ef7c602",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_2.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActionsList2_4/ReturnValueAndActionsList2_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-95c0ae71c4e43bc6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActionsList2_4.g4",
     "hash": "bc0e2951a58fe049dbc312d9dad0c777cca4fbdab51e3c152e0ae312f5a5f6ad"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_1/ReturnValueAndActions_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-55dd948e9dc09b16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_1.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_2/ReturnValueAndActions_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1ff0ff2b6b58c78e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_2.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_3/ReturnValueAndActions_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4e6e02a58699299b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_3.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/LeftRecursion/ReturnValueAndActions_4/ReturnValueAndActions_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5752f12e23140fae",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/LeftRecursion/ReturnValueAndActions_4.g4",
     "hash": "b6f415b75e1aef86941057efe922c1859850f6a5a455942e559a9bd438bdf82d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b6011b9143d628c5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/Basic.g4",
     "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LR/LR.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LR/LR.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e56bd84efac1b634",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/LR.g4",
     "hash": "8f39eb58884a9c6d69675b6172d4948a5412a101e48acd93ca95d54dd694b322"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LRWithLabels/LRWithLabels.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/LRWithLabels/LRWithLabels.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d6b05635f57067cb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/LRWithLabels.g4",
     "hash": "1b70e6b955b2d400125149a5ba9a23c882c76eca3a7750a78ad34b015ff7addc"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_1/RuleGetters_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_1/RuleGetters_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-30239be9065a102b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/RuleGetters_1.g4",
     "hash": "ddc38590f35a64a189e937c2aa4aa016a526e2decf03572af3c5ff26acb2d9e6"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_2/RuleGetters_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/RuleGetters_2/RuleGetters_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-83dee48eed8ba5f7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/RuleGetters_2.g4",
     "hash": "ddc38590f35a64a189e937c2aa4aa016a526e2decf03572af3c5ff26acb2d9e6"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_1/TokenGetters_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_1/TokenGetters_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-84499a2abb159b25",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/TokenGetters_1.g4",
     "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_2/TokenGetters_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Listeners/TokenGetters_2/TokenGetters_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-939d0f890cce06d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Listeners/TokenGetters_2.g4",
     "hash": "5807c7704f305537c8db0e918ea0e3316a4f51bd97cd88ff8bd74c615992d3d1"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParseTrees/TokenAndRuleContextString/TokenAndRuleContextString.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParseTrees/TokenAndRuleContextString/TokenAndRuleContextString.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7200e3cc8fd5d741",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParseTrees/TokenAndRuleContextString.g4",
     "hash": "540d104df0edf2d66917d75620498573de808a49eedf7bd53a96b83c5a5efb11"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/ContextListGetters/ContextListGetters.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7cb040514b4d8550",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/ContextListGetters.g4",
     "hash": "5c0f1a3091c6de8a91d73791a7a55080a0ef042ad5b662b82d5947e976f700ab"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserErrors/LL1ErrorInfo/LL1ErrorInfo.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-78b11d2968a7b9bd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserErrors/LL1ErrorInfo.g4",
     "hash": "6fdb1536b5d50a39105a35527d0a8f63cff00a1682e45af84ee262aed25dec0f"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/APlus/APlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/APlus/APlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0e768432ad217228",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/APlus.g4",
     "hash": "65afa725cbcac09fa8c5ef09b106193b0653e9a43d9f7dca8f80cfbdab0244cc"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AStar_2/AStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AStar_2/AStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bc656e8f273b5048",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AStar_2.g4",
     "hash": "32e20668bb74b32537e8ed784776ad010334047540356bf8e558bc448a1a4f1a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAPlus/AorAPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e455fb79e0e760d5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAPlus.g4",
     "hash": "2d2f766470d77cd144a3c195c0abac3b491e9622212042e47a005e0cd803c497"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorAStar_2/AorAStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f0a4df9cad5ce7a3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorAStar_2.g4",
     "hash": "3373095cb5525150349456ff369eeabb2648d7369578d70344fa82843e4795fe"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorB/AorB.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorB/AorB.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0bf329c8c63c777b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorB.g4",
     "hash": "526a8a1a4c649b84d041ba7f0dd3f0d2dac2cd930858c7a432207f26448d0985"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBPlus/AorBPlus.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a6fe4df601f8fb7e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBPlus.g4",
     "hash": "b24888c439f265999017b6c8d5cac646a8ea99c2c029f29bb49c9abcf813ea8e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/AorBStar_2/AorBStar_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-251c61a3417e52fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/AorBStar_2.g4",
     "hash": "8ff040f2bd87b3c1cb83765d26a42f034fe40acabc9979cd9a48d3c4a4116786"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Basic/Basic.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Basic/Basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-25a70a6980012d9f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Basic.g4",
     "hash": "2785b5f535bab4a06559235161609d47fcf9d752f82ddc5b44bf0fa197a87a5e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/BuildParseTree_FALSE/BuildParseTree_FALSE.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-81d548e32786ef7b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/BuildParseTree_FALSE.g4",
     "hash": "eb2c2950e7f80585c973ffc612ea059eab4da91ea8fb7e50034dfb78e768fa87"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding1/IfIfElseGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-60f5a9a16604d6e9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding1.g4",
     "hash": "440e59e87cf909864372e2572e161b8ac1102e2b33ca17024622c8cbd691c1f3"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseGreedyBinding2/IfIfElseGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0c64a9174f394f19",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseGreedyBinding2.g4",
     "hash": "d57cdde3a5790f927f5bb3a08edc39254365cd598a989a331b50ad31d96b64f4"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding1/IfIfElseNonGreedyBinding1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8e7c2737b7b0f40b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding1.g4",
     "hash": "52c0d8947d2dad4eda6c969dded97b1e509ebabd582b34e4f1bd545fa7e3d98a"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/IfIfElseNonGreedyBinding2/IfIfElseNonGreedyBinding2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3f270e9e32b462e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/IfIfElseNonGreedyBinding2.g4",
     "hash": "c509006b579b65d3a2bb33cc73f2867396e0457f2e3caf43918c15fdf55f4ba7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_1/Keyword_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-19a487ef9ab2d274",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_1.g4",
     "hash": "d67c4f8218be21f6104f600109218250c5738f3abd72780bffdd9c90a167b4d7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_2/Keyword_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-53b24b4c4131b10c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_2.g4",
     "hash": "95b786e26fd0411bc4877c9ce220c361d43eef988f480687b4d8a2391b8c6c7d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_3/Keyword_3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-108ee69dd95708f3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_3.g4",
     "hash": "7bd91c8ffe4349c62fab43f7e24eccf0cb98ce10f96bb7fd8a4c18eb4c7288eb"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_4/Keyword_4.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-316e47f9cb1bbc4b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_4.g4",
     "hash": "fc3f61392647c8ee0a4d42fa4d6935e257c040a5177fe7c9849988191e9be6da"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_5/Keyword_5.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cbb5c83bd36dfc44",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_5.g4",
     "hash": "1b99bef44dff0f4b76fe9b8aaedb7fec1fd8c90e6fc6caec51a524204dc07b3d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Keyword_6/Keyword_6.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-97ad497ee3062dbe",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Keyword_6.g4",
     "hash": "ff61271aca142ca5ce907d2f8c44c240da8b965be1a57bddafcf7e2389ed74de"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LL1OptionalBlock_2/LL1OptionalBlock_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-993de6f9d029cdb3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LL1OptionalBlock_2.g4",
     "hash": "bec71119542848512f3dafd408fa0bbbe7279fa597ea3cfa8674dd7778424d5c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/LabelAliasingAcrossLabeledAlternatives/LabelAliasingAcrossLabeledAlternatives.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-19319eed76368793",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/LabelAliasingAcrossLabeledAlternatives.g4",
     "hash": "63a8d3816100691a88d9aeff5c64ae599bf52dbf429c8972ae160de32b215a80"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case1/OpenDeviceStatement_Case1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d6dcf4d3e116f36",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case1.g4",
     "hash": "150bd511e2898329b4a1be0d94cbab3775c9d762da1821db48a2acd09867e922"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case2/OpenDeviceStatement_Case2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7eaca01e9531e506",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case2.g4",
     "hash": "09b70ed5e0fe15e7bca784b725980f263bcfd0da3a8f9108d60bbeb4a7b7ef5c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/OpenDeviceStatement_Case3/OpenDeviceStatement_Case3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ecedd277b785d87e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/OpenDeviceStatement_Case3.g4",
     "hash": "09b70ed5e0fe15e7bca784b725980f263bcfd0da3a8f9108d60bbeb4a7b7ef5c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReferenceToATN_2/ReferenceToATN_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-05d54229af5ddb42",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReferenceToATN_2.g4",
     "hash": "219dd0ab0de17f74119b2a502d847cef78f678320fb64cee55025e147beac015"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/ReservedWordsEscaping/ReservedWordsEscaping.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fe600c4e82ebbc18",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/ReservedWordsEscaping.g4",
     "hash": "1255013e85ee5370b81b22637b60dcc49fe82706c1f6a539154d35e5cd605b9e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/TokenOffset/TokenOffset.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7d3cbaec23431d82",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/TokenOffset.g4",
     "hash": "dfda12fb116e3c99f5f42c2618eb51727e857e5c05836e80bc1d2cc161fe42e7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Wildcard/Wildcard.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/Wildcard/Wildcard.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-79d73209896a1038",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/Wildcard.g4",
     "hash": "11e95949cf96d6ef6495192ed616530367d1722b686f81d39a09e32761f3e9df"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f4d3608d014cdf23",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/ParserExec/uStartingCharDoesNotCauseIllegalUnicodeEscape.g4",
     "hash": "807557a1c66b8ed1fbd0bd199253542faba1296ec9860f9e19a5aba35c7ffbc5"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionHidesPreds/ActionHidesPreds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a5be53022ad1b17b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionHidesPreds.g4",
     "hash": "c4e01650ae90615c32bc3eee5f57f4d611342dcef12948a0907ea38cd714c377"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW/ActionsHidePredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3abc78f1a1dd0875",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ActionsHidePredsInGlobalFOLLOW.g4",
     "hash": "952c48fb5ebd8dd1c896728f60456def84c4a80ed9f7b9b68b9e341308e04214"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DepedentPredsInGlobalFOLLOW/DepedentPredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e80e63432313ae6e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DepedentPredsInGlobalFOLLOW.g4",
     "hash": "f8449f4767b4dfdf52b6113a6c931ea0d5841a7b738c195bee631d4fba689b58"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored/DependentPredNotInOuterCtxShouldBeIgnored.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e825ffff4663fe4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/DependentPredNotInOuterCtxShouldBeIgnored.g4",
     "hash": "8553bb8579e273475bec5dffac33d751cf4e86039144543bdd5a11d5cdf332a7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException/IndependentPredNotPassedOuterCtxToAvoidCastException.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3ff9cd7f68432d91",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/IndependentPredNotPassedOuterCtxToAvoidCastException.g4",
     "hash": "3d7a2878f4652b70aa23384f57b762cf3ebdce090e6be47dc2c4f2e163ff581e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Order/Order.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Order/Order.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e7b4b66c5c476d1e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Order.g4",
     "hash": "06ee6c74670bd951fc6adaa3d1d127d38db71c55a076074dacd031c2800e1d3b"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1/PredTestedEvenWhenUnAmbig_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5569f9327b68ba4f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredTestedEvenWhenUnAmbig_1.g4",
     "hash": "74c1616e4f0f48712c07b5aea8e8be5082e89184828d8814bf2ea1d6244abbcf"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredicateDependentOnArg/PredicateDependentOnArg.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-dcaf5cd43868245e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredicateDependentOnArg.g4",
     "hash": "95f0830d46eaa8d8d4b9472caa4fad3e5c7bfc6bc822a1098fca68853dd1ffec"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/PredsInGlobalFOLLOW/PredsInGlobalFOLLOW.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-061a749098f54759",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/PredsInGlobalFOLLOW.g4",
     "hash": "435298930cbeb6acec547f5ac93d2d08c38a321dd7dea17a778829c1442580dd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/RewindBeforePredEval/RewindBeforePredEval.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-05c8aabfff617ec3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/RewindBeforePredEval.g4",
     "hash": "4c58b8b6fd28ccaa4a15af5461aba77078c476d7020ad07f9cb060eebc78d65e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple/Simple.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/Simple/Simple.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-18e0a54b0bb49e07",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/Simple.g4",
     "hash": "dbc4c1cffcd9badf83384d7de1fc39fdebea06e0ad0079703cf4e32c073c5fbd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeft/ToLeft.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6fe3217ab933daf7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeft.g4",
     "hash": "79e26c081d50d8991394f673689871fc36a87b4f801191c773a77620c00db8b0"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/ToLeftWithVaryingPredicate/ToLeftWithVaryingPredicate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-79f3ad75b455946b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/ToLeftWithVaryingPredicate.g4",
     "hash": "5510b13c3f52df41ab478b80a3d468d5676ff38c36d44e8a35630f43a95cd88c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/SemPredEvalParser/UnpredicatedPathsInAlt/UnpredicatedPathsInAlt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e9a29002fb60d256",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/SemPredEvalParser/UnpredicatedPathsInAlt.g4",
     "hash": "998b2de4aa9e4153db9d16485ea2c6b528969989d99d0b2af7d9f991b544c2ec"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/CharSetLiteral/CharSetLiteral.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-55bcf562af70467b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/CharSetLiteral.g4",
     "hash": "1148556229dc59ef2626b0458399983d1636cc24e105edf123aa60544998e683"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerOptionalSet/LexerOptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1cd9f86e1018566f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerOptionalSet.g4",
     "hash": "9813ec122366d63be434989e2774116a84cf614ff88e6c06654e175e661cf1c2"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerPlusSet/LexerPlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ff7d98a7d5e835b5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerPlusSet.g4",
     "hash": "527915ce7cd19bafdf7634fba06323a220718346e187aecd12df786c22a946b6"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/LexerStarSet/LexerStarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-18ca170ffdb0afcc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/LexerStarSet.g4",
     "hash": "c29a11128b93b442513fa85c5028140c2ffdcfa0caecb6a9ee9c91477d80b421"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotChar/NotChar.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotChar/NotChar.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-49fbc17fc2bfdbb3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotChar.g4",
     "hash": "8f2432be7a965cbd8766ca8e42dd247c40ee569d5381ece836d645269bd0ffec"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSet/NotCharSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSet/NotCharSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9f7b7f2dae37260f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSet.g4",
     "hash": "4155ec14531984facba34515b3ab2f63205dcc5122b43b35eb0e1a5f8d865653"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/NotCharSetWithRuleRef3/NotCharSetWithRuleRef3.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6d9f734b246f7ab7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/NotCharSetWithRuleRef3.g4",
     "hash": "341497f02eb8299a891ed67de6b5ccf5d1a8370780d5dbf784f8e349d9a8255c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalLexerSingleElement/OptionalLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cc4e7824c362636a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalLexerSingleElement.g4",
     "hash": "065d4e9ed01354807c48b541794965b66c5acd0c3843a8d98456ff80114632d0"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSet/OptionalSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSet/OptionalSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e5a36297644ee691",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSet.g4",
     "hash": "dbe1e20ce85e9efb4ea176c99bdb5bc65e426a6abaafa504abb4741e796262da"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/OptionalSingleElement/OptionalSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9a65cdd583df2656",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/OptionalSingleElement.g4",
     "hash": "d8242b63e702bee096a3cd3349e04ca94491a4709e97f6db841bf985cf2ce3e7"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotSet/ParserNotSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-55efb6463177bdd9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotSet.g4",
     "hash": "19c38d099171d47fd0f223833a56a33a3b346c3fefabd4d0ca5cd8cf901969d9"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotToken/ParserNotToken.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f9d124d7634800b6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotToken.g4",
     "hash": "190c7d956b90644a68f1a9ea4b1f91ee074c37601d45aa4073cb67e8823ca048"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserNotTokenWithLabel/ParserNotTokenWithLabel.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ed43933e5e98153d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserNotTokenWithLabel.g4",
     "hash": "3ac7ed3d0bda73662f6ce22584ef8f716e5c346fbefa877fdb2fd6a51ea4df3c"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserSet/ParserSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/ParserSet/ParserSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-497a997b7e1daa80",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/ParserSet.g4",
     "hash": "3c4ccda24427c3e37b5dd041af7ef3c43dd3de617f05277385fdbdb7f7c2d87d"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusLexerSingleElement/PlusLexerSingleElement.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d63d389009bdd4ec",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusLexerSingleElement.g4",
     "hash": "a3312a0f61691f481f028a21631fdec86d8654463a35a1da7e3bfa8b677562f5"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusSet/PlusSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/PlusSet/PlusSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9a13fd8981eecd43",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/PlusSet.g4",
     "hash": "bc9bf5d4139930b8ac617486305b9a3a835c9215b5bd3d5a28a3a0e52511dcfd"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/RuleAsSet/RuleAsSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d706c00a4a6d9072",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/RuleAsSet.g4",
     "hash": "6d0cd361fe29b6aec92e7802b7d9a91db550efedd1556cc128dee78815f9a8cf"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/SeqDoesNotBecomeSet/SeqDoesNotBecomeSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2d064ae4884c1326",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/SeqDoesNotBecomeSet.g4",
     "hash": "2a9008d9a05b1a7427be88356896cd2602f039c2ca9027d44353322d83acef51"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_1/StarLexerSingleElement_1.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ee03249e2dda9d35",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_1.g4",
     "hash": "023ddbb1ca0f01a768584f1cc7c2264fa54660aa24f1c10eafa78239110f8b2e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarLexerSingleElement_2/StarLexerSingleElement_2.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-7a0fd6ccb94720da",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarLexerSingleElement_2.g4",
     "hash": "023ddbb1ca0f01a768584f1cc7c2264fa54660aa24f1c10eafa78239110f8b2e"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarSet/StarSet.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/StarSet/StarSet.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d7b54423d6154fef",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/StarSet.g4",
     "hash": "60e149f889628a3731a1c6327c9b6637c87b12ba99154cfa59963e2b9849d755"

--- a/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
+++ b/package-gale/tests/generated/antlr4_compat_b_oracle/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b82ad07daca60f42",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/antlr4-compat/grammars/Sets/UnicodeNegatedSMPSetIncludesBMPCodePoints.g4",
     "hash": "e3d7399c4da29f3cebfa28d1e944e5dd5662c7f1246140332e66ecb63863194d"

--- a/package-gale/tests/generated/cst_alt_option/alt_opt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_alt_option/alt_opt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-48b87baab8830ef8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/alt_opt.g4",
     "hash": "620ef772a707c22fe42276f8c87130ca600fbd64ce60520cac8fcd711135e1aa"

--- a/package-gale/tests/generated/cst_alt_shared_ident_prefix/alt_shared_ident_prefix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_alt_shared_ident_prefix/alt_shared_ident_prefix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f62bbf04d9ca5929",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/alt_shared_ident_prefix.g4",
     "hash": "61bb2be46f96c2c573f0cf8deb04193ba17af86139cf1e7d2ec8d3caedfa0518"

--- a/package-gale/tests/generated/cst_antlr4/ANTLRv4Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_antlr4/ANTLRv4Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1d86a4da709dfb8e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ANTLRv4Lexer.g4",
     "hash": "30bd52b58a5916a63041f501c2d45358431c5c379f1ed3e8a3fbbb311f3572bd"

--- a/package-gale/tests/generated/cst_at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_at_end_alt_gaps/at_end_alt_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a034c25435c8eab2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/at_end_alt_gaps.g4",
     "hash": "9cd47ca80f5762b4107f87ae05f1bce472bbfb8aca3c06ef0bdbf501ac519f82"

--- a/package-gale/tests/generated/cst_calc/calc_ll.g4.kiln.json
+++ b/package-gale/tests/generated/cst_calc/calc_ll.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f691f3794504d754",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/calc_ll.g4",
     "hash": "c482319990adba1a727e64e12ccf2a0547c6b46b236670971a827fba64a1067c"

--- a/package-gale/tests/generated/cst_calculator/calculator.g4.kiln.json
+++ b/package-gale/tests/generated/cst_calculator/calculator.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ae08d4663fb46310",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/calculator.g4",
     "hash": "67431dad6dcc459fea7d4c448fb04944de2c4cf61ecd75d546aeccd93b4564d7"

--- a/package-gale/tests/generated/cst_ci_rule_override/ci_rule_override.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ci_rule_override/ci_rule_override.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-303100b90d8385e6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ci_rule_override.g4",
     "hash": "6efdfe55ecb215bf526900a32a11c664a57c9e14d61c6a67758f870adc73d09b"

--- a/package-gale/tests/generated/cst_ci_sql/ci_sql.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ci_sql/ci_sql.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5e9f3f0dc36ada2e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ci_sql.g4",
     "hash": "41b72934417dd2f6fa0359722ce53ca05cd10cccde08fd9f3d0d58018f2137fe"

--- a/package-gale/tests/generated/cst_css3/css3Lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_css3/css3Lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-06e7a0a312ee3e01",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/css3Lexer.g4",
     "hash": "4733198f782344f0d3dbd2456ee9f6db955f53c688d14334fb403985551c963c"

--- a/package-gale/tests/generated/cst_diagnostics/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_diagnostics/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2ce82ddf83c467e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_error_recovery/error_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_error_recovery/error_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9d08a08dde09857c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/error_recovery.g4",
     "hash": "47911f94843fe38ff3fc4d77c7a5068a7d6f2104bd74a737a6a63423dd8dc5db"

--- a/package-gale/tests/generated/cst_follow/follow_gate.g4.kiln.json
+++ b/package-gale/tests/generated/cst_follow/follow_gate.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-8810c89269d88e2a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/follow_gate.g4",
     "hash": "524e44bc7007d56c2d229ad20e6c01bb033592fd8bcec53a7521325c564c5ee7"

--- a/package-gale/tests/generated/cst_fragment_entry_off/fragment_entry_off.g4.kiln.json
+++ b/package-gale/tests/generated/cst_fragment_entry_off/fragment_entry_off.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e4090c83d9e07612",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/fragment_entry_off.g4",
     "hash": "3a114028e66cb967d06ec2c1fd0616456cd3b3999da850a3c22dff4cb6d908cc"

--- a/package-gale/tests/generated/cst_fragment_entry_on/fragment_entry.g4.kiln.json
+++ b/package-gale/tests/generated/cst_fragment_entry_on/fragment_entry.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bbadbcf81bdff9be",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/fragment_entry.g4",
     "hash": "910ac9439654fbade1d3585a34e28aa7dbfe8f97d1425a9c2920887d9f0858a8"

--- a/package-gale/tests/generated/cst_group_recovery/group_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_group_recovery/group_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-213de2705ce984eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/group_recovery.g4",
     "hash": "721f7ec1f804bbfcbc0cf0222d5d50b90183eef3707e81b754f25b69d2fa792a"

--- a/package-gale/tests/generated/cst_group_tie/group_tie_catch_all.g4.kiln.json
+++ b/package-gale/tests/generated/cst_group_tie/group_tie_catch_all.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3b865f5d85ca8f31",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/group_tie_catch_all.g4",
     "hash": "8e99eec00af84b5d38a40182b5d45100aabcb4b7707f20c9c68f544b0d343af3"

--- a/package-gale/tests/generated/cst_html/HTMLLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_html/HTMLLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6ddf224e63e263ee",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/HTMLLexer.g4",
     "hash": "1d3b243228b182ddeca45bf2c7f9ec6512c176bcec126444bce7cbe7a8e93052"

--- a/package-gale/tests/generated/cst_json/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_json/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2ce82ddf83c467e3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_json_highlight/JSON.g4.kiln.json
+++ b/package-gale/tests/generated/cst_json_highlight/JSON.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e954ac3f3cbae5d3",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/JSON.g4",
     "hash": "6581bb5004eb2c80e9aeba923e5382f1022bf698c159df2bb16919902c128777"

--- a/package-gale/tests/generated/cst_label_list_collision/label_list_collision.g4.kiln.json
+++ b/package-gale/tests/generated/cst_label_list_collision/label_list_collision.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-db71f6f9596a3326",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/label_list_collision.g4",
     "hash": "239f1f60f63298c1365a8b13721d0d77d820a2eb318b86af02cd0a2879c26137"

--- a/package-gale/tests/generated/cst_labels/label_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_labels/label_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-21135d6356e2d08c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/label_gaps.g4",
     "hash": "8e2049cd7baf82750b8e242018ffdc1f8e684226f8e27fe8068ad7838d6da425"

--- a/package-gale/tests/generated/cst_lexer_alt_longest/lexer_alt_longest.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_alt_longest/lexer_alt_longest.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bc538278da0f4051",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_alt_longest.g4",
     "hash": "48e53769b4454a1717f8e5e90ae0b6e9b842c22c59694d4c5b48bf1090280757"

--- a/package-gale/tests/generated/cst_lexer_alt_longest_ref/lexer_alt_longest_ref.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_alt_longest_ref/lexer_alt_longest_ref.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5887207af5be0daf",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_alt_longest_ref.g4",
     "hash": "6400b5fce92c33b54f25da57bc3e2b096072cf1459b7eb4a8306639158fc1c84"

--- a/package-gale/tests/generated/cst_lexer_alt_suffix/lexer_alt_suffix_longest.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_alt_suffix/lexer_alt_suffix_longest.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-97655d304fba641c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_alt_suffix_longest.g4",
     "hash": "f4db8bc15d937ef14d02816932db096fd1b0966648ec9c25839182a606464009"

--- a/package-gale/tests/generated/cst_lexer_alt_suffix_shapes/lexer_alt_suffix_shapes.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_alt_suffix_shapes/lexer_alt_suffix_shapes.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e0ec25cce2ac653d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_alt_suffix_shapes.g4",
     "hash": "54b9139809068a2fff60b4dfb7ad8ac4d5820e4a37c2a74cc705856f71ff18c7"

--- a/package-gale/tests/generated/cst_lexer_catch_all/lexer_catch_all_reach.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_catch_all/lexer_catch_all_reach.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5eba8e4c5bb3cbd7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_catch_all_reach.g4",
     "hash": "0a95a6027d3bc2808023cac78c2081fd88cfdcd82add9be011f8cf66200dec49"

--- a/package-gale/tests/generated/cst_lexer_command_gaps/lexer_command_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_command_gaps/lexer_command_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-de78df534bdeb767",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_command_gaps.g4",
     "hash": "253a32f9908895a3ffaa23ac8e32eaa12f43998f25d7d2b73637ddf11a3cb3c9"

--- a/package-gale/tests/generated/cst_lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_greedy_suffix/lexer_greedy_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-004dc53ffad392b9",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_greedy_suffix.g4",
     "hash": "2286e1ce4403101b6a2c197a88b3ba06ef185d7c31e99ad55033185275953d1a"

--- a/package-gale/tests/generated/cst_lexer_keyword_carrier/lexer_keyword_carrier_len.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_keyword_carrier/lexer_keyword_carrier_len.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-502975c213d5d0e8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_keyword_carrier_len.g4",
     "hash": "d58555fabc71aa64702368e1aadb1576dc3cd1a9badc8d7c119cf64b7dc9a284"

--- a/package-gale/tests/generated/cst_lexer_lit_dup_ref/lexer_lit_dup_ref.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_lit_dup_ref/lexer_lit_dup_ref.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-51836fc564be4151",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_lit_dup_ref.g4",
     "hash": "77d63570d5295154f83f93f0f6f66fb946b648250bd14971caa3a98edf67d74f"

--- a/package-gale/tests/generated/cst_lexer_range_overlap/lexer_range_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_range_overlap/lexer_range_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9fce26ef24af3f40",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_range_overlap.g4",
     "hash": "2d74e86fdb70b8ab0b426fa090c54fb1d7dca984d52a7dab6985a437051fc89c"

--- a/package-gale/tests/generated/cst_lexer_suffix_peek_limits/lexer_suffix_peek_limits.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lexer_suffix_peek_limits/lexer_suffix_peek_limits.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-c796155083b3c2f1",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lexer_suffix_peek_limits.g4",
     "hash": "48639989c7218b51ed9165333066a6e293f5e731256414325085eda68531c0c4"

--- a/package-gale/tests/generated/cst_lit_alias_ref/lit_alias_ref.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lit_alias_ref/lit_alias_ref.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4a6cd43a21ee322d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lit_alias_ref.g4",
     "hash": "74fdfc200a5c94042a819ea5053396f4347b911336e33145b9f9ccf86dea7f76"

--- a/package-gale/tests/generated/cst_ll_at_end_follow_disjoint/ll_at_end_follow_disjoint.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_at_end_follow_disjoint/ll_at_end_follow_disjoint.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3dbaed505a04f3fa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_at_end_follow_disjoint.g4",
     "hash": "2d0b95b4fc43bafec2f89886d5aa864fb6bf5db735da6000d4c54d77f295ffeb"

--- a/package-gale/tests/generated/cst_ll_at_end_nullable_gap/ll_at_end_nullable_gap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_at_end_nullable_gap/ll_at_end_nullable_gap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f73feeaa819a13b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_at_end_nullable_gap.g4",
     "hash": "d0568cc42cc4a99cc19f7bae140369eb89606239f5dbd8519358d34a87812782"

--- a/package-gale/tests/generated/cst_ll_basic/ll_basic.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_basic/ll_basic.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-28d45bcf6d49d260",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_basic.g4",
     "hash": "f830d43f54bf58f877f51407f191785e0b519d8864d2e9cae12424dfb0c8ab3d"

--- a/package-gale/tests/generated/cst_ll_cascade_gaps/ll_cascade_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_cascade_gaps/ll_cascade_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-43e8b7a8395b9d16",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_cascade_gaps.g4",
     "hash": "616bce74e13f907b80276e8b0b084fbb8039e586ae8bfe47c48249c57148fa96"

--- a/package-gale/tests/generated/cst_ll_consume_group/ll_consume_group.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_consume_group/ll_consume_group.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d343579a322c6018",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_consume_group.g4",
     "hash": "9222485ca2ed6480753d84cef49f054d149fc919224051f99aa450f812b07a93"

--- a/package-gale/tests/generated/cst_ll_ctx_follow/ll_ctx_follow.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_ctx_follow/ll_ctx_follow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fe77ba0dc44c000e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_ctx_follow.g4",
     "hash": "c9dd4149b692de6c13dc9dd30cf96e276da36fd421349ed32aa772e16aa9a1ac"

--- a/package-gale/tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_empty_alt_group/ll_empty_alt_group.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-133e14bfde856446",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_empty_alt_group.g4",
     "hash": "2392939a3ceb27e919a24d1d6ad56e13cc613929c6374a340f75a03ae4ccacb7"

--- a/package-gale/tests/generated/cst_ll_eof_tie/ll_eof_tie.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_eof_tie/ll_eof_tie.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-df13935970e5dd7e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_eof_tie.g4",
     "hash": "67e380ea326c3d4481e98b723955acc7576bda48b8d99e2ade65883acfe529f7"

--- a/package-gale/tests/generated/cst_ll_k_prefix_cascade/ll_k_prefix_cascade.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_k_prefix_cascade/ll_k_prefix_cascade.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-659393a388bf8809",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_k_prefix_cascade.g4",
     "hash": "379589a434dcaabfbf33d2e739723b0deb2128a26b9bff77163d967e06b04d1a"

--- a/package-gale/tests/generated/cst_ll_longest_vs_context/ll_longest_vs_context.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_longest_vs_context/ll_longest_vs_context.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f19a5d1ac089a36f",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_longest_vs_context.g4",
     "hash": "6c586a8f3c0c3576e8147878ede717b11804253a90aac5b5ef82f21f4a883dd3"

--- a/package-gale/tests/generated/cst_ll_lr_atom/ll_lr_atom.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_lr_atom/ll_lr_atom.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b52f9769732455bc",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_lr_atom.g4",
     "hash": "d92f5f9744e5f022ce077b4e2237660b199a6ee15b00f94cc56387392f52823d"

--- a/package-gale/tests/generated/cst_ll_multi_alt/ll_multi_alt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_alt/ll_multi_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-39104ddc525a4300",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_multi_alt.g4",
     "hash": "b0e9035037ba8016d5020c5a34dd8743c2489ca12333f76ca51a9af81c4de25a"

--- a/package-gale/tests/generated/cst_ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_alt_overlap/ll_multi_alt_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-56a29edc4fc9d49a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_multi_alt_overlap.g4",
     "hash": "1c00866868c72e8b9c1da0332be534856dafa01dfc589ba1a985ff2fbb2affd6"

--- a/package-gale/tests/generated/cst_ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_multi_token_tail/ll_multi_token_tail.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-34d04cd5fb6544c4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_multi_token_tail.g4",
     "hash": "6dd40045f6bebef9292d9845d79c2befb5dddb0b81e2f22f6295dea6e16a7f55"

--- a/package-gale/tests/generated/cst_ll_non_greedy_plus_loop/ll_non_greedy_plus_loop.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_non_greedy_plus_loop/ll_non_greedy_plus_loop.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e4f5d10a095027d8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_non_greedy_plus_loop.g4",
     "hash": "92ab03384c2cc690eeeabed3d741c3ac9233d6e1b658a0a50575af241b185639"

--- a/package-gale/tests/generated/cst_ll_not_alt/ll_not_alt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_not_alt/ll_not_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4c282f20ed9be316",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_not_alt.g4",
     "hash": "a7da4a5edd109acee39d96e69a01535767c858ee5521d94519006f4661740a5c"

--- a/package-gale/tests/generated/cst_ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_nullable_suffix/ll_nullable_suffix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-01ae1a15ca7eec1c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_nullable_suffix.g4",
     "hash": "13724480e4e66b54852130604fc2ea866cc8ed7d6760c0524d9d72702eb42184"

--- a/package-gale/tests/generated/cst_ll_opaque_at_end_context/ll_opaque_at_end_context.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_opaque_at_end_context/ll_opaque_at_end_context.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5cbdda77d2b4ab52",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_opaque_at_end_context.g4",
     "hash": "51eb4c323abd96ce916da7b827332cfe1384635d4669124fcdb67153674b4a2a"

--- a/package-gale/tests/generated/cst_ll_opaque_at_end_gap/ll_opaque_at_end_gap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_opaque_at_end_gap/ll_opaque_at_end_gap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fd1bf04c50f680d2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_opaque_at_end_gap.g4",
     "hash": "51424855bdb2f387107c9580a46bf9626c09efdfbe996d787614d14443cd64be"

--- a/package-gale/tests/generated/cst_ll_opt_greedy_ambig/ll_opt_greedy_ambig.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_opt_greedy_ambig/ll_opt_greedy_ambig.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-06d178b3fe120483",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_opt_greedy_ambig.g4",
     "hash": "e0102fa1a38a042255e1e435e1ff742b2ecff654f74e675a0575200bbfaf8350"

--- a/package-gale/tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_optional_non_greedy/ll_optional_non_greedy.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-52e3330993884f82",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_optional_non_greedy.g4",
     "hash": "ba2d514d32e3c49ab408c6a2f5e9f1826c68843c9709dc34a5f55fd8e9bf81bf"

--- a/package-gale/tests/generated/cst_ll_optional_non_greedy_multi/ll_optional_non_greedy_multi.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_optional_non_greedy_multi/ll_optional_non_greedy_multi.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-65fa14e39599e00b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_optional_non_greedy_multi.g4",
     "hash": "841512abf6fd71dcd8ac9427c75c8f53c8e2860d0a1ca6e9cbe21625689e2558"

--- a/package-gale/tests/generated/cst_ll_repeat_alt_gap/ll_repeat_alt_gap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_repeat_alt_gap/ll_repeat_alt_gap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cde8a6d2235cbc80",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_repeat_alt_gap.g4",
     "hash": "cf47ee22f6dbadd515b4647f624ddddcec0ef6c217f51b2e4dd7341ab2221075"

--- a/package-gale/tests/generated/cst_ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_wildcard_alt/ll_wildcard_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-48257f3e59854dd7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_wildcard_alt.g4",
     "hash": "d1c18ea6b2be7b57df8d6ea77777c1de0e0c80ca8f86199e3c0183bcbaf325a8"

--- a/package-gale/tests/generated/cst_ll_wildcard_label_alt/ll_wildcard_label_alt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_ll_wildcard_label_alt/ll_wildcard_label_alt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-fb1439df5aed08eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_wildcard_label_alt.g4",
     "hash": "f6e6de060656df8a573e1c16a0e8f84c23a97f4772fbdba0f1c57927e53cecbf"

--- a/package-gale/tests/generated/cst_lr/arith_lr.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr/arith_lr.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ec7d464346065f78",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/arith_lr.g4",
     "hash": "26556f22f7a2c98d214fc95cb9ea81fb93d2abeeb84fb9b7c6c73a9086985b05"

--- a/package-gale/tests/generated/cst_lr_atn_mid_operand/lr_atn_mid_operand.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_atn_mid_operand/lr_atn_mid_operand.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b9bb1aeaf3ea4054",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_atn_mid_operand.g4",
     "hash": "29673a765b4455f493268af8b24fb88a86e0d6f6c9cd686b8e5b5f6d592cbde6"

--- a/package-gale/tests/generated/cst_lr_atn_shared_op/lr_atn_shared_op.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_atn_shared_op/lr_atn_shared_op.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a946348ff09adf85",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_atn_shared_op.g4",
     "hash": "e3424e9b810ff18f924003ef057e3e0b551c5a5ae545ac1aec150609ce9f870d"

--- a/package-gale/tests/generated/cst_lr_atom_probe/lr_atom_probe.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_atom_probe/lr_atom_probe.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e6fff343b6418bfa",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_atom_probe.g4",
     "hash": "a0c56096a3bdd1ffb1790dc789a2f5d82eaa35337739c38d8226fad41327f615"

--- a/package-gale/tests/generated/cst_lr_between/lr_between.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_between/lr_between.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-3ef64ca57aab7088",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_between.g4",
     "hash": "a1efd5682d5a41a5f4766db73e0bdcc06dc0afdf2e50ab4c403306441ffebe93"

--- a/package-gale/tests/generated/cst_lr_between_call/lr_between_call.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_between_call/lr_between_call.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f2c85fa95b494d46",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_between_call.g4",
     "hash": "55189d1a50844969b5054a4be88f80b4ef5ef1e00bdddafb98b8a24084eb682e"

--- a/package-gale/tests/generated/cst_lr_call/lr_call.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_call/lr_call.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-debe1fe586a61340",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_call.g4",
     "hash": "01e881ace397d3af62a29de281d1662a9e7ec86eb7fc2aa4637dea7e6bfe5fd8"

--- a/package-gale/tests/generated/cst_lr_complement_op/lr_complement_op.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_complement_op/lr_complement_op.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-909a229a6e3281f6",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_complement_op.g4",
     "hash": "501ba73a08ae31f00d1a310bdb79d4a51ef593ec71b3e6b5a01bae2ccb4eaee0"

--- a/package-gale/tests/generated/cst_lr_dangling_else/lr_dangling_else.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_dangling_else/lr_dangling_else.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-82cdfc1a9d2837b2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_dangling_else.g4",
     "hash": "676bce3fd8100375614484afd821174aa60a5a0759b5e46caaf7f2f3627296c2"

--- a/package-gale/tests/generated/cst_lr_mid_operand/lr_mid_operand.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_mid_operand/lr_mid_operand.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-9e5bbfd741eff4c8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_mid_operand.g4",
     "hash": "916a95cfe64062d900dead0ca2a1b49d5853465d84fecab8191d0a1e404d332e"

--- a/package-gale/tests/generated/cst_lr_opt_two_token/lr_opt_two_token.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_opt_two_token/lr_opt_two_token.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f22db0b3765cffea",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_opt_two_token.g4",
     "hash": "2c8efb339faba2009d6304a2fd57ab16891dbdfc889c0e67edffa12d64d1691b"

--- a/package-gale/tests/generated/cst_lr_overlap/lr_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_overlap/lr_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-30a70746c0b3246b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_overlap.g4",
     "hash": "5674c6a0f2f951dcbabbc831b2cb923c005d687276df03fea69d088cbae12c1a"

--- a/package-gale/tests/generated/cst_lr_paren/lr_paren.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_paren/lr_paren.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b4b015cf25dab035",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_paren.g4",
     "hash": "58cf6be3c20a432eab6caf7bd38be29f462578030956f800dce7b0d8eb96bea1"

--- a/package-gale/tests/generated/cst_lr_scan_caller/lr_scan_caller.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_scan_caller/lr_scan_caller.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-41bf694c80471b53",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_scan_caller.g4",
     "hash": "a5c160c8e20e4727da1e40c83d884d6f2658153bda5919e2431c5b8bee5f5648"

--- a/package-gale/tests/generated/cst_lr_suffix_non_greedy_opt/lr_suffix_non_greedy_opt.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_suffix_non_greedy_opt/lr_suffix_non_greedy_opt.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-398d5b6289817924",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_suffix_non_greedy_opt.g4",
     "hash": "3ca1bab068168073399fd5d15e86457a71d5b3ce364dfb98d7e60889c8184695"

--- a/package-gale/tests/generated/cst_lr_suffix_opt_shape/lr_suffix_opt_shape.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_suffix_opt_shape/lr_suffix_opt_shape.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-34db767121add53d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_suffix_opt_shape.g4",
     "hash": "fa19459fda7ac231a55652feeb2a8520627ea742fe0fc05fe5c13291c824df41"

--- a/package-gale/tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.g4.kiln.json
+++ b/package-gale/tests/generated/cst_lr_wildcard_postfix/lr_wildcard_postfix.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-764739b2433d7c87",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lr_wildcard_postfix.g4",
     "hash": "525afce18841d8fd1c19378727fb15e3e62e462ffa9202bfcc2253826c35bf98"

--- a/package-gale/tests/generated/cst_mode_gaps/mode_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_mode_gaps/mode_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d282af85b4f73af2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/mode_gaps.g4",
     "hash": "2129310ea345f84328b61531ce102c6306fda62ef4fa71d7c64d1dc4bb9f1d14"

--- a/package-gale/tests/generated/cst_multiple_eof/multiple_eof.g4.kiln.json
+++ b/package-gale/tests/generated/cst_multiple_eof/multiple_eof.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ed371b9e29e905eb",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/multiple_eof.g4",
     "hash": "2b097a4cde773ec14e56e4222cd34af3735931774e74c4c77ca7b37f41afaa43"

--- a/package-gale/tests/generated/cst_non_greedy/non_greedy.g4.kiln.json
+++ b/package-gale/tests/generated/cst_non_greedy/non_greedy.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-5a25ff4cea33619b",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/non_greedy.g4",
     "hash": "8df507b6ddb99d4381283f8a2b2af531696f43deadb3aa7e75f7a8d66990d1a0"

--- a/package-gale/tests/generated/cst_non_greedy_gaps/non_greedy_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_non_greedy_gaps/non_greedy_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4ee53b84b0328325",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/non_greedy_gaps.g4",
     "hash": "b7ebb6e1d962ee295bf43cc5a13f167cbd270ef3d9e15a052d2eb060eefb012c"

--- a/package-gale/tests/generated/cst_opt_sep_list/opt_sep_list.g4.kiln.json
+++ b/package-gale/tests/generated/cst_opt_sep_list/opt_sep_list.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-52e4d0f89320e047",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/opt_sep_list.g4",
     "hash": "c6a879a1e89a7a0cf4fddca366393412ec939a5579f079fab250cee7d8be33fd"

--- a/package-gale/tests/generated/cst_overlap_tournament/ll_overlap_tournament.g4.kiln.json
+++ b/package-gale/tests/generated/cst_overlap_tournament/ll_overlap_tournament.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-926c6460e2a9f76e",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_overlap_tournament.g4",
     "hash": "c6fd0821861f96cf907e2a88c796e161295e33bdc2a280ae9567fe31cbc15833"

--- a/package-gale/tests/generated/cst_parser_gaps/parser_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_parser_gaps/parser_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-f9257c59c3f549ab",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/parser_gaps.g4",
     "hash": "8262a9d7c10805db35e063564eaea6deb43e8de540af19d0969551d042b6d03a"

--- a/package-gale/tests/generated/cst_parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
+++ b/package-gale/tests/generated/cst_parser_set_group_dispatch/parser_set_group_dispatch.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1f7e16c027c1834d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/parser_set_group_dispatch.g4",
     "hash": "c36bfab5dcc4c7f598aa83ca22dca3fd716225387804db2223b3c47986b73355"

--- a/package-gale/tests/generated/cst_recursive_lexer/recursive_lexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_recursive_lexer/recursive_lexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b94286261fae4075",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/recursive_lexer.g4",
     "hash": "3bba2a980c91c247bfa081040a71e8349ebd29cec177d15cf69feb75f40e705f"

--- a/package-gale/tests/generated/cst_right_assoc_gaps/right_assoc_gaps.g4.kiln.json
+++ b/package-gale/tests/generated/cst_right_assoc_gaps/right_assoc_gaps.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-e22341b1badabb69",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/right_assoc_gaps.g4",
     "hash": "7632fce865fe8aa2c3c460beea14a27a0a020b9ccb2312fb59a2c980f12f639a"

--- a/package-gale/tests/generated/cst_rust/RustLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_rust/RustLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4450397ae11ad2b4",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/RustLexer.g4",
     "hash": "a9069b6b1a5650b0f5f115897eaa0edaddc42007b262c5096b59eb1de15323d3"

--- a/package-gale/tests/generated/cst_scan_group_recursion/scan_group_recursion.g4.kiln.json
+++ b/package-gale/tests/generated/cst_scan_group_recursion/scan_group_recursion.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-4ca966c1e5bc125d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/scan_group_recursion.g4",
     "hash": "f229196c13499c75802e3e8fc98dc1a05de5a89cd49a82c45b7e555d1e0647b9"

--- a/package-gale/tests/generated/cst_scan_optional_lookahead_restore/scan_optional_lookahead_restore.g4.kiln.json
+++ b/package-gale/tests/generated/cst_scan_optional_lookahead_restore/scan_optional_lookahead_restore.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-855acb5dc682584a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/scan_optional_lookahead_restore.g4",
     "hash": "0845415c21b8dc944fd50cc503542f1411e4f5a27740079037768febc0221b9a"

--- a/package-gale/tests/generated/cst_scan_zero_length_rule/scan_zero_length_rule.g4.kiln.json
+++ b/package-gale/tests/generated/cst_scan_zero_length_rule/scan_zero_length_rule.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b0aaaf4fe4f4c828",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/scan_zero_length_rule.g4",
     "hash": "d8ab86c23ffe0786f41fed0cef4fc6dfcc13f00af6ba0518445d19dd75fb1653"

--- a/package-gale/tests/generated/cst_sexpression/sexpression.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sexpression/sexpression.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-df217e695dae678d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/sexpression.g4",
     "hash": "74549e6167e186b754886880a5d473ad3361bee8440368f99e1b233e2c1c7bdb"

--- a/package-gale/tests/generated/cst_sqlite/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sqlite/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-a3cbf67768ad9029",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/cst_sqlite_highlight/SQLite.g4.kiln.json
+++ b/package-gale/tests/generated/cst_sqlite_highlight/SQLite.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-d0a8be96e4000de8",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/SQLite.g4",
     "hash": "72e3fa9877777afa5a4f9e8196d4cb194bb599e719d43b7b29d09eeed3e4c5e0"

--- a/package-gale/tests/generated/cst_tie_recovery/tie_recovery.g4.kiln.json
+++ b/package-gale/tests/generated/cst_tie_recovery/tie_recovery.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-af39119443379f30",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/tie_recovery.g4",
     "hash": "b424904a6f362db6e62af0d40479f785c71a19805baf47bc158037899a334ed1"

--- a/package-gale/tests/generated/cst_tour/amb_tour.g4.kiln.json
+++ b/package-gale/tests/generated/cst_tour/amb_tour.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-75a3fc62d79167d7",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/amb_tour.g4",
     "hash": "074f334123300f55a97b8103d93f22b02603c9fec0e734374e24472343645195"

--- a/package-gale/tests/generated/cst_trace/ll_multi_alt_overlap.g4.kiln.json
+++ b/package-gale/tests/generated/cst_trace/ll_multi_alt_overlap.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-56a29edc4fc9d49a",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/ll_multi_alt_overlap.g4",
     "hash": "1c00866868c72e8b9c1da0332be534856dafa01dfc589ba1a985ff2fbb2affd6"

--- a/package-gale/tests/generated/cst_typescript/TypeScriptLexer.g4.kiln.json
+++ b/package-gale/tests/generated/cst_typescript/TypeScriptLexer.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2e590d7f152dbc56",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/TypeScriptLexer.g4",
     "hash": "f7089740f7e82bbb90a6c4b13c75959b6ceaf3003be0dd0657c52b9eb6a594b7"

--- a/package-gale/tests/generated/cst_unicode_prop_kinds/unicode_prop_kinds.g4.kiln.json
+++ b/package-gale/tests/generated/cst_unicode_prop_kinds/unicode_prop_kinds.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2a936eba89a40cfd",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/unicode_prop_kinds.g4",
     "hash": "19b9847c46e11df3cbac626f7dae5254456cbc3e11071b525f85c2d4a83c4485"

--- a/package-gale/tests/generated/cst_unicode_props/unicode_props.g4.kiln.json
+++ b/package-gale/tests/generated/cst_unicode_props/unicode_props.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-2f56d5bf73d1b564",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/unicode_props.g4",
     "hash": "7559b99d20b67597cdc99b2e9e0eaeea1ad4b0931d40859c1dbb600e20d1c5c0"

--- a/package-gale/tests/generated/java_action/java_action.g4.kiln.json
+++ b/package-gale/tests/generated/java_action/java_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-cb827aca7a67f8e2",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_action.g4",
     "hash": "f5d358da2351263069770edb99fdfe68de2388fa9a694e14e48ca7c3a3404daf"

--- a/package-gale/tests/generated/java_group_binding/java_group_binding.g4.kiln.json
+++ b/package-gale/tests/generated/java_group_binding/java_group_binding.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1bb9f6f8391a3e94",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_group_binding.g4",
     "hash": "fff72f865338e84f221c3bb60ad9b4d15d86bccbcaac19541039869532c929eb"

--- a/package-gale/tests/generated/java_lex_action_pos/java_lex_action_pos.g4.kiln.json
+++ b/package-gale/tests/generated/java_lex_action_pos/java_lex_action_pos.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ca0ffe513e8e6c06",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_lex_action_pos.g4",
     "hash": "6c95d01525b010af847b701f35c4b5d4b622c3c5a0735435d812611b3b03af58"

--- a/package-gale/tests/generated/java_lex_pos/java_lex_pos.g4.kiln.json
+++ b/package-gale/tests/generated/java_lex_pos/java_lex_pos.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-0268db6955f2fa30",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_lex_pos.g4",
     "hash": "56cf067203a41dfbf0479db3ed120e2b72875b0700f18a5f4d96ec533836b1da"

--- a/package-gale/tests/generated/java_lex_print/java_lex_print.g4.kiln.json
+++ b/package-gale/tests/generated/java_lex_print/java_lex_print.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-975365b509499a70",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_lex_print.g4",
     "hash": "889295d992cd4cf8cc23936499cb2efaed3d38fcf9ed9eb8d40561cc12369ff1"

--- a/package-gale/tests/generated/java_members/java_members.g4.kiln.json
+++ b/package-gale/tests/generated/java_members/java_members.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-06da003e3a941c38",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_members.g4",
     "hash": "d0ef9eeb80b915011f89a5dc53c09c05002c2e273cfe9ad462b8c0f3d474f45a"

--- a/package-gale/tests/generated/java_pred/java_pred.g4.kiln.json
+++ b/package-gale/tests/generated/java_pred/java_pred.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-b0c3ac28e84fd109",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_pred.g4",
     "hash": "9b4d36f922a8bd958d74d5d704ebe7e5b682b5be0a8ec2eb8787052a479c9ebf"

--- a/package-gale/tests/generated/java_repeat_action/java_repeat_action.g4.kiln.json
+++ b/package-gale/tests/generated/java_repeat_action/java_repeat_action.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ce1f58073074df15",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_repeat_action.g4",
     "hash": "37e7291a07116f8977d07188fea05e7b8699f96834cf086f065dd1fd2cd9899e"

--- a/package-gale/tests/generated/java_rule_label_text/java_rule_label_text.g4.kiln.json
+++ b/package-gale/tests/generated/java_rule_label_text/java_rule_label_text.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-bf92bd3a7d779c2c",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/java_rule_label_text.g4",
     "hash": "f4ace4f889d348d84dc373f85e2180438cc9214a38ee083f4d431cc165e7e98e"

--- a/package-gale/tests/generated/lit_command_shadow/lit_command_shadow.g4.kiln.json
+++ b/package-gale/tests/generated/lit_command_shadow/lit_command_shadow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-ed7d841dd7fcb094",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/lit_command_shadow.g4",
     "hash": "c9ea9ffe565fe792998be96ebf60731bae11f4705da8e1862a09f33db4c495ac"

--- a/package-gale/tests/generated/mode_lit_shadow/mode_lit_shadow.g4.kiln.json
+++ b/package-gale/tests/generated/mode_lit_shadow/mode_lit_shadow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-6a675431ccc57bb5",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/mode_lit_shadow.g4",
     "hash": "5c60cce9b9ffec9ce6475e3c2c68304cf4608def43b1205523b3d30bad0fad84"

--- a/package-gale/tests/generated/nested_list_follow/nested_list_follow.g4.kiln.json
+++ b/package-gale/tests/generated/nested_list_follow/nested_list_follow.g4.kiln.json
@@ -2,7 +2,7 @@
   "version": 3,
   "invocation": "kiln-1add3cc04a11db4d",
   "generator": "local:src/generator.wado",
-  "generator_source_hash": "5c47fed8f9241e507e9388c893702745ecd981b3591d543c362322cd6ce13f46",
+  "generator_source_hash": "9dbcf2788fe72c2a8ef62f3782e227d252b4ec0a4195e081622b92d20f69e753",
   "primary": {
     "path": "tests/grammars/nested_list_follow.g4",
     "hash": "584493fc9fc1de92e1eea1934a4aec63d681c4c012c50a3f05a70b4f182c4360"

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -1265,7 +1265,7 @@ fn build_future_intrinsic_types(
     pkg: &str,
 ) -> (u32, u32) {
     let fields_resource_idx = ctx.type_idx(&format!("{pkg}-fields-resource"));
-    let error_code = CmTypeKey::Leaf(ctx.type_idx(&format!("{pkg}-error-code")));
+    let error_code = CmTypeKey::Leaf(ctx.type_idx(&error_code_key(pkg)));
 
     let fields = intern_cm_type(
         builder,
@@ -2898,7 +2898,7 @@ fn handler_result_key(ctx: &ComponentModelContext, pkg: &str) -> CmTypeKey {
             ctx.type_idx(&format!("{pkg}-response")),
         ))),
         err: Some(Box::new(CmTypeKey::Leaf(
-            ctx.type_idx(&format!("{pkg}-error-code")),
+            ctx.type_idx(&error_code_key(pkg)),
         ))),
     }
 }
@@ -3139,7 +3139,7 @@ fn import_resource_defining_interface(
                 .get_enum_cm_name_by_interface(types_fq, "ErrorCode")
         })
         .expect("ErrorCode CM name not found for the types interface");
-    ctx.register_type(&format!("{pkg}-error-code"));
+    ctx.register_type(&error_code_key(&pkg));
     builder.alias_export(
         ctx.instance_idx(&types_instance),
         http_error_code_cm,
@@ -3189,7 +3189,7 @@ fn import_resource_defining_interface(
     // Intern the `result<own<response>, error-code>` handler composite when this
     // interface provides both arms (the handler/world-export shape). The export
     // lift and any client interface resolve it by structure.
-    if ctx.has_type(&format!("{pkg}-response")) && ctx.has_type(&format!("{pkg}-error-code")) {
+    if ctx.has_type(&format!("{pkg}-response")) && ctx.has_type(&error_code_key(&pkg)) {
         let key = handler_result_key(ctx, &pkg);
         intern_cm_type(builder, ctx, &key, None);
     }

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -163,11 +163,8 @@ pub fn build_component(
                 ),
                 CmStreamPayload::Value(_) => unreachable!("handled above"),
                 CmStreamPayload::Record(name) => {
-                    // Alias the record type from the WASI interface that defines it.
-                    // WASI imports are already generated (generate_cm_imports runs first),
-                    // so we can alias the exported type from the interface instance.
-                    // No defining interface means the stream would silently become
-                    // `stream<u8>` — a different type at the component boundary.
+                    // WASI imports are generated first, so the defining
+                    // interface's instance is already available to alias from.
                     let interface_name = project
                         .cm_interface_registry
                         .find_interface_for_struct_cm_name(name)
@@ -425,10 +422,9 @@ pub fn build_component(
     )
 }
 
-/// Whether codegen emits `func` at all: the registry supports its signature and
-/// the program actually calls it. The two halves belong together — a supported
-/// but unused function drags resource types into the instance type that the
-/// world never imports.
+/// Whether codegen emits `func`: the registry supports its signature and the
+/// program calls it. Emitting a supported but unused function would drag
+/// resource types into the instance type that the world never imports.
 fn emits_function(project: &NirPackage, func: &CmFunctionInfo) -> bool {
     project.cm_interface_registry.is_function_supported(func)
         && project.used_wasi_functions.contains(&func.used_key())
@@ -935,9 +931,7 @@ fn build_transmission_future_type_for(
     source: &str,
 ) -> u32 {
     // `cli` is the shared `wasi:cli/types` error-code, aliased under the bare
-    // key by `generate_cm_imports`. Every other source must have aliased its own
-    // — substituting the CLI one, as this used to, gives the future a different
-    // error type than the host's.
+    // key by `generate_cm_imports`; every other source aliases its own.
     let key = if source == "cli" {
         "error-code".to_string()
     } else {
@@ -2857,23 +2851,20 @@ fn generate_cm_imports(
     import_interfaces_with_resources(builder, ctx, project, import_plan);
 }
 
-/// The outer-component-scope type key holding a resource type aliased out of
-/// the interface that defines it.
+/// Outer-scope type key for a resource aliased out of its defining interface.
 fn resource_type_key(cm_name: &str) -> String {
     format!("resource:{cm_name}")
 }
 
-/// The outer-component-scope type key holding a package's own `error-code`.
-/// `wasi:cli`'s is aliased under the bare `"error-code"` instead, as the shared
-/// fallback every interface without its own resolves to.
+/// Outer-scope type key for a package's own `error-code`. `wasi:cli`'s uses the
+/// bare `"error-code"` instead, being the shared one others resolve to.
 fn error_code_key(package: &str) -> String {
     format!("{package}-error-code")
 }
 
 /// Alias an interface's own `error-code` into the outer component scope, where
 /// transmission futures and composite results look it up. Idempotent: two
-/// interfaces of one package (`wasi:http/types` and `wasi:http/handler`) share
-/// the single alias.
+/// interfaces of one package share the single alias.
 fn alias_package_error_code(
     builder: &mut ComponentBuilder,
     ctx: &mut ComponentModelContext,
@@ -3552,9 +3543,6 @@ fn import_resource_source(
                 .filter(|(name, _, _)| *name == "ErrorCode")
                 .collect();
             if let Some((_, cm_name, cases)) = interface_variants.first() {
-                // Each case carries its declared payload type. Encoding them
-                // all as `option<string>`, as this used to, gives the host a
-                // variant whose arms have the wrong types.
                 let mut type_gen = CmTypeGen::with_interface_hint(source_path);
                 let no_resources: IndexMap<&str, u32> = IndexMap::default();
                 let cm_cases: Vec<(&str, Option<ComponentValType>)> = cases

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -166,18 +166,24 @@ pub fn build_component(
                     // Alias the record type from the WASI interface that defines it.
                     // WASI imports are already generated (generate_cm_imports runs first),
                     // so we can alias the exported type from the interface instance.
-                    let val = if let Some(interface_name) = project
+                    // No defining interface means the stream would silently become
+                    // `stream<u8>` — a different type at the component boundary.
+                    let interface_name = project
                         .cm_interface_registry
                         .find_interface_for_struct_cm_name(name)
-                    {
-                        let inst_idx = ctx.instance_idx(&interface_name);
-                        builder.alias_export(inst_idx, name, ComponentExportKind::Type);
-                        let aliased_idx = ctx.register_type(name);
-                        ComponentValType::Type(aliased_idx)
-                    } else {
-                        ComponentValType::Primitive(PrimitiveValType::U8)
-                    };
-                    (format!("stream-{name}"), val)
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "stream<{name}> has no interface defining the record `{name}` — \
+                                 the interface that declares it is not imported"
+                            )
+                        });
+                    let inst_idx = ctx.instance_idx(&interface_name);
+                    builder.alias_export(inst_idx, name, ComponentExportKind::Type);
+                    let aliased_idx = ctx.register_type(name);
+                    (
+                        format!("stream-{name}"),
+                        ComponentValType::Type(aliased_idx),
+                    )
                 }
             };
             ctx.register_type(&type_key);
@@ -921,17 +927,21 @@ fn build_transmission_future_type_for(
     ctx: &mut ComponentModelContext,
     source: &str,
 ) -> u32 {
+    // `cli` is the shared `wasi:cli/types` error-code, aliased under the bare
+    // key by `generate_cm_imports`. Every other source must have aliased its own
+    // — substituting the CLI one, as this used to, gives the future a different
+    // error type than the host's.
     let error_code_key = if source == "cli" {
         "error-code".to_string()
     } else {
         format!("{source}-error-code")
     };
-    let error_code_idx = if ctx.has_type(&error_code_key) {
-        ctx.type_idx(&error_code_key)
-    } else {
-        // Fallback to CLI error-code if package-specific one is not available
-        ctx.type_idx("error-code")
-    };
+    assert!(
+        ctx.has_type(&error_code_key),
+        "transmission future for `{source}` needs its error-code type `{error_code_key}`, \
+         which no imported interface aliased"
+    );
+    let error_code_idx = ctx.type_idx(&error_code_key);
 
     let result = intern_cm_type(
         builder,
@@ -3555,18 +3565,25 @@ fn import_resource_source(
                 .filter(|(name, _, _)| *name == "ErrorCode")
                 .collect();
             if let Some((_, cm_name, cases)) = interface_variants.first() {
+                // Each case carries its declared payload type. Encoding them
+                // all as `option<string>`, as this used to, gives the host a
+                // variant whose arms have the wrong types.
+                let mut type_gen = CmTypeGen::with_interface_hint(source_path);
+                let no_resources: IndexMap<&str, u32> = IndexMap::default();
                 let cm_cases: Vec<(&str, Option<ComponentValType>)> = cases
                     .iter()
                     .map(|c| {
-                        let payload = c.payload.as_ref().map(|_ty| {
-                            // For simplicity, all payloads are option<string>
-                            instance_type
-                                .ty()
-                                .defined_type()
-                                .option(ComponentValType::Primitive(PrimitiveValType::String));
-                            let option_idx = local_type_idx;
-                            local_type_idx += 1;
-                            ComponentValType::Type(option_idx)
+                        let payload = c.payload.as_ref().map(|ty| {
+                            let mut sink = crate::component_model::InstanceSink {
+                                it: &mut instance_type,
+                                next_idx: &mut local_type_idx,
+                            };
+                            type_gen.ast_type_to_cm(
+                                &mut sink,
+                                ty,
+                                &project.cm_interface_registry,
+                                &no_resources,
+                            )
                         });
                         (c.cm_name.as_str(), payload)
                     })

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -425,6 +425,15 @@ pub fn build_component(
     )
 }
 
+/// Whether codegen emits `func` at all: the registry supports its signature and
+/// the program actually calls it. The two halves belong together — a supported
+/// but unused function drags resource types into the instance type that the
+/// world never imports.
+fn emits_function(project: &NirPackage, func: &CmFunctionInfo) -> bool {
+    project.cm_interface_registry.is_function_supported(func)
+        && project.used_wasi_functions.contains(&func.used_key())
+}
+
 fn wado_type_to_cm_primitive(ty: &Type) -> ComponentValType {
     match ty {
         Type::Named(named) => {
@@ -765,10 +774,8 @@ fn collect_resources_in_type(
 }
 
 fn wado_type_to_cm_val_type(
-    _project: &NirPackage,
     ty: &Type,
     stream_type_idx: Option<u32>,
-    _error_code_idx: Option<u32>,
     result_param_type_idx: Option<u32>,
     enum_type_indices: &IndexMap<String, u32>,
     flags_type_indices: &IndexMap<String, u32>,
@@ -931,17 +938,17 @@ fn build_transmission_future_type_for(
     // key by `generate_cm_imports`. Every other source must have aliased its own
     // — substituting the CLI one, as this used to, gives the future a different
     // error type than the host's.
-    let error_code_key = if source == "cli" {
+    let key = if source == "cli" {
         "error-code".to_string()
     } else {
-        format!("{source}-error-code")
+        error_code_key(source)
     };
     assert!(
-        ctx.has_type(&error_code_key),
-        "transmission future for `{source}` needs its error-code type `{error_code_key}`, \
+        ctx.has_type(&key),
+        "transmission future for `{source}` needs its error-code type `{key}`, \
          which no imported interface aliased"
     );
-    let error_code_idx = ctx.type_idx(&error_code_key);
+    let error_code_idx = ctx.type_idx(&key);
 
     let result = intern_cm_type(
         builder,
@@ -983,16 +990,13 @@ fn expose_self_owned_resources(
         else {
             continue;
         };
-        let resource_type_name = format!("resource:{cm_name}");
+        let resource_type_name = resource_type_key(&cm_name);
         if ctx.has_type(&resource_type_name) {
             continue;
         }
         ctx.register_type(&resource_type_name);
         builder.alias_export(
-            ctx.instance_idx(&format!(
-                "{}-{}",
-                interface_info.package, interface_info.interface
-            )),
+            ctx.instance_idx(&interface_info.instance_key()),
             &cm_name,
             ComponentExportKind::Type,
         );
@@ -1379,7 +1383,7 @@ fn payload_type_to_cm_key(payload: &CmPayloadType, ctx: &ComponentModelContext) 
         ),
         CmPayloadType::Named(name) => CmTypeKey::Leaf(ctx.type_idx(name)),
         CmPayloadType::Resource(cm_name) => CmTypeKey::Own(Box::new(CmTypeKey::Leaf(
-            ctx.type_idx(&format!("resource:{cm_name}")),
+            ctx.type_idx(&resource_type_key(cm_name)),
         ))),
     }
 }
@@ -1429,7 +1433,7 @@ fn prebuild_resource_payload_types(
         }
     }
     for cm_name in cm_names {
-        if ctx.has_type(&format!("resource:{cm_name}")) {
+        if ctx.has_type(&resource_type_key(&cm_name)) {
             continue;
         }
         let Some(source) = project
@@ -1785,7 +1789,7 @@ fn emit_canonical_intrinsics(
                     .filter(|key| ctx.has_type(key));
                 let type_idx = match defining_key {
                     Some(key) => ctx.type_idx(&key),
-                    None => ctx.type_idx(&format!("resource:{cm_name}")),
+                    None => ctx.type_idx(&resource_type_key(cm_name)),
                 };
                 builder.resource_drop(type_idx);
             }
@@ -2324,13 +2328,7 @@ fn generate_cm_imports(
         let supported_functions: Vec<_> = interface_info
             .functions
             .iter()
-            .filter(|func| {
-                if !project.cm_interface_registry.is_function_supported(func) {
-                    return false;
-                }
-                let func_key = format!("{}::{}", func.interface_name, func.method_name);
-                project.used_wasi_functions.contains(&func_key)
-            })
+            .filter(|func| emits_function(project, func))
             .collect();
 
         // Collect resource types referenced in any function signature. The plan
@@ -2396,11 +2394,7 @@ fn generate_cm_imports(
             // ErrorCode may be an enum (cli/types) or a variant (filesystem/types, sockets/types).
             let has_local_error_code = project
                 .cm_interface_registry
-                .has_enum_in_interface(&interface_info.path, "ErrorCode")
-                || project
-                    .cm_interface_registry
-                    .variants_for_interface(&interface_info.path)
-                    .any(|(name, _, _)| name == "ErrorCode");
+                .declares_own_error_code(&interface_info.path);
 
             /// Recursively collect Named types from a type tree.
             fn collect_named_types(ty: &Type, out: &mut Vec<String>) {
@@ -2698,10 +2692,8 @@ fn generate_cm_imports(
                             )
                         } else {
                             wado_type_to_cm_val_type(
-                                project,
                                 ty,
                                 stream_type_idx,
-                                error_code_idx,
                                 result_param_type_idx,
                                 &enum_export_indices,
                                 &flags_export_indices,
@@ -2791,10 +2783,7 @@ fn generate_cm_imports(
             enc.instance(&instance_type);
         }
 
-        ctx.register_instance(&format!(
-            "{}-{}",
-            interface_info.package, interface_info.interface
-        ));
+        ctx.register_instance(&interface_info.instance_key());
         builder.import(
             &interface_info.path,
             wasm_encoder::ComponentTypeRef::Instance(instance_type_idx),
@@ -2811,14 +2800,11 @@ fn generate_cm_imports(
                     .cm_interface_registry
                     .get_resource_cm_name_by_source(source, resource_name)
             {
-                let resource_type_name = format!("resource:{cm_name}");
+                let resource_type_name = resource_type_key(cm_name);
                 if !ctx.has_type(&resource_type_name) {
                     ctx.register_type(&resource_type_name);
                     builder.alias_export(
-                        ctx.instance_idx(&format!(
-                            "{}-{}",
-                            interface_info.package, interface_info.interface
-                        )),
+                        ctx.instance_idx(&interface_info.instance_key()),
                         cm_name,
                         ComponentExportKind::Type,
                     );
@@ -2831,24 +2817,14 @@ fn generate_cm_imports(
         // We register them with source-qualified keys (e.g., "filesystem-error-code").
         let interface_has_error_code = project
             .cm_interface_registry
-            .has_enum_in_interface(&interface_info.path, "ErrorCode")
-            || project
-                .cm_interface_registry
-                .variants_for_interface(&interface_info.path)
-                .any(|(name, _, _)| name == "ErrorCode");
+            .declares_own_error_code(&interface_info.path);
         if interface_has_error_code {
-            let error_code_key = format!("{}-error-code", interface_info.package);
-            if !ctx.has_type(&error_code_key) {
-                ctx.register_type(&error_code_key);
-                builder.alias_export(
-                    ctx.instance_idx(&format!(
-                        "{}-{}",
-                        interface_info.package, interface_info.interface
-                    )),
-                    "error-code",
-                    ComponentExportKind::Type,
-                );
-            }
+            alias_package_error_code(
+                builder,
+                ctx,
+                &interface_info.package,
+                &interface_info.instance_key(),
+            );
         }
 
         for func in &supported_functions {
@@ -2860,10 +2836,7 @@ fn generate_cm_imports(
 
             ctx.register_comp_func(&local_name);
             builder.alias_export(
-                ctx.instance_idx(&format!(
-                    "{}-{}",
-                    interface_info.package, interface_info.interface
-                )),
+                ctx.instance_idx(&interface_info.instance_key()),
                 &func.wasi_func_name,
                 ComponentExportKind::Func,
             );
@@ -2882,6 +2855,41 @@ fn generate_cm_imports(
     }
 
     import_interfaces_with_resources(builder, ctx, project, import_plan);
+}
+
+/// The outer-component-scope type key holding a resource type aliased out of
+/// the interface that defines it.
+fn resource_type_key(cm_name: &str) -> String {
+    format!("resource:{cm_name}")
+}
+
+/// The outer-component-scope type key holding a package's own `error-code`.
+/// `wasi:cli`'s is aliased under the bare `"error-code"` instead, as the shared
+/// fallback every interface without its own resolves to.
+fn error_code_key(package: &str) -> String {
+    format!("{package}-error-code")
+}
+
+/// Alias an interface's own `error-code` into the outer component scope, where
+/// transmission futures and composite results look it up. Idempotent: two
+/// interfaces of one package (`wasi:http/types` and `wasi:http/handler`) share
+/// the single alias.
+fn alias_package_error_code(
+    builder: &mut ComponentBuilder,
+    ctx: &mut ComponentModelContext,
+    package: &str,
+    instance_key: &str,
+) {
+    let key = error_code_key(package);
+    if ctx.has_type(&key) {
+        return;
+    }
+    ctx.register_type(&key);
+    builder.alias_export(
+        ctx.instance_idx(instance_key),
+        "error-code",
+        ComponentExportKind::Type,
+    );
 }
 
 fn handler_result_key(ctx: &ComponentModelContext, pkg: &str) -> CmTypeKey {
@@ -3038,9 +3046,7 @@ fn import_resource_defining_interface(
                 }
                 // Only include functions that are actually used to avoid
                 // referencing unsupported resource types (e.g. RequestOptions).
-                project
-                    .used_wasi_functions
-                    .contains(&format!("{}::{}", f.interface_name, f.method_name))
+                project.used_wasi_functions.contains(&f.used_key())
             })
             .cloned()
             .collect();
@@ -3156,11 +3162,7 @@ fn import_resource_defining_interface(
                 let is_resource_func = f.wasi_func_name.starts_with("[constructor]")
                     || f.wasi_func_name.starts_with("[method]")
                     || f.wasi_func_name.starts_with("[static]");
-                is_resource_func
-                    && project.cm_interface_registry.is_function_supported(f)
-                    && project
-                        .used_wasi_functions
-                        .contains(&format!("{}::{}", f.interface_name, f.method_name))
+                is_resource_func && emits_function(project, f)
             })
             .map(|f| (f.wasi_func_name.clone(), f.local_alias_name()))
             .collect();
@@ -3279,12 +3281,7 @@ fn import_resource_using_composite_interface(
     let funcs: Vec<CmFunctionInfo> = iface
         .functions
         .iter()
-        .filter(|f| {
-            project.cm_interface_registry.is_function_supported(f)
-                && project
-                    .used_wasi_functions
-                    .contains(&format!("{}::{}", f.interface_name, f.method_name))
-        })
+        .filter(|f| emits_function(project, f))
         .cloned()
         .collect();
     if funcs.is_empty() {
@@ -3380,7 +3377,7 @@ fn import_resource_using_composite_interface(
         enc.instance(&instance_type);
     }
 
-    let instance_key = format!("{}-{}", iface.package, iface.interface);
+    let instance_key = iface.instance_key();
     ctx.register_instance(&instance_key);
     builder.import(
         iface_fq,
@@ -3419,7 +3416,7 @@ fn import_interface_with_resource(
         return;
     }
 
-    let outer_resource_type_name = format!("resource:{resource_cm_name}");
+    let outer_resource_type_name = resource_type_key(resource_cm_name);
     let has_outer_resource = ctx.has_type(&outer_resource_type_name);
 
     let instance_type_name = format!("{}-instance-type", interface_info.interface);
@@ -3462,10 +3459,7 @@ fn import_interface_with_resource(
         enc.instance(&instance_type);
     }
 
-    ctx.register_instance(&format!(
-        "{}-{}",
-        interface_info.package, interface_info.interface
-    ));
+    ctx.register_instance(&interface_info.instance_key());
     builder.import(
         &interface_info.path,
         wasm_encoder::ComponentTypeRef::Instance(instance_type_idx),
@@ -3475,13 +3469,10 @@ fn import_interface_with_resource(
     // expose the resource at the outer component scope so that other interfaces (like
     // wasi:filesystem/preopens) can alias it using `alias outer`.
     if !has_outer_resource {
-        let resource_type_name = format!("resource:{resource_cm_name}");
+        let resource_type_name = resource_type_key(resource_cm_name);
         ctx.register_type(&resource_type_name);
         builder.alias_export(
-            ctx.instance_idx(&format!(
-                "{}-{}",
-                interface_info.package, interface_info.interface
-            )),
+            ctx.instance_idx(&interface_info.instance_key()),
             resource_cm_name,
             ComponentExportKind::Type,
         );
@@ -3489,10 +3480,7 @@ fn import_interface_with_resource(
 
     ctx.register_comp_func(&local_name);
     builder.alias_export(
-        ctx.instance_idx(&format!(
-            "{}-{}",
-            interface_info.package, interface_info.interface
-        )),
+        ctx.instance_idx(&interface_info.instance_key()),
         &func.wasi_func_name,
         ComponentExportKind::Func,
     );
@@ -3518,7 +3506,10 @@ fn import_resource_source(
     // interface `types`). The instance-type name doubles as the idempotency key:
     // it is a real builder type, so reusing it never desyncs the ctx/builder
     // type-index counters the way a phantom marker type would.
-    let instance_name = format!("{}-{}", cm_import.package, cm_import.interface);
+    let instance_name = crate::component_model::cm_instance_key(
+        &cm_import.package,
+        &cm_import.interface,
+    );
     let instance_type_name = format!("{instance_name}-instance-type");
     if ctx.has_type(&instance_type_name) {
         return;
@@ -3537,11 +3528,7 @@ fn import_resource_source(
     // Does this source define its own ErrorCode (needed by transmission futures)?
     let source_has_error_code = project
         .cm_interface_registry
-        .variants_for_interface(source_path)
-        .any(|(name, _, _)| name == "ErrorCode")
-        || project
-            .cm_interface_registry
-            .has_enum_in_interface(source_path, "ErrorCode");
+        .declares_own_error_code(source_path);
 
     let instance_type_idx = ctx.register_type(&instance_type_name);
     let mut local_type_idx = 0u32;
@@ -3606,7 +3593,7 @@ fn import_resource_source(
     );
 
     for (_, cm_name) in &resources {
-        let resource_type_name = format!("resource:{cm_name}");
+        let resource_type_name = resource_type_key(cm_name);
         if !ctx.has_type(&resource_type_name) {
             ctx.register_type(&resource_type_name);
             builder.alias_export(
@@ -3618,15 +3605,7 @@ fn import_resource_source(
     }
 
     if source_has_error_code {
-        let error_code_key = format!("{}-error-code", cm_import.package);
-        if !ctx.has_type(&error_code_key) {
-            ctx.register_type(&error_code_key);
-            builder.alias_export(
-                ctx.instance_idx(&instance_name),
-                "error-code",
-                ComponentExportKind::Type,
-            );
-        }
+        alias_package_error_code(builder, ctx, &cm_import.package, &instance_name);
     }
 }
 
@@ -3696,21 +3675,9 @@ fn import_interfaces_with_resources(
         }
         let has_error_code = project
             .cm_interface_registry
-            .has_enum_in_interface(&interface_info.path, "ErrorCode")
-            || project
-                .cm_interface_registry
-                .variants_for_interface(&interface_info.path)
-                .any(|(name, _, _)| name == "ErrorCode");
+            .declares_own_error_code(&interface_info.path);
         if has_error_code {
-            let error_code_key = format!("{}-error-code", interface_info.package);
-            if !ctx.has_type(&error_code_key) {
-                ctx.register_type(&error_code_key);
-                builder.alias_export(
-                    ctx.instance_idx(&instance_key),
-                    "error-code",
-                    ComponentExportKind::Type,
-                );
-            }
+            alias_package_error_code(builder, ctx, &interface_info.package, &instance_key);
         }
     }
 
@@ -3736,8 +3703,7 @@ fn resource_using_references_defining_interface(
     };
     let mut resources: Vec<String> = Vec::new();
     for func in &iface.functions {
-        let key = format!("{}::{}", func.interface_name, func.method_name);
-        if !project.used_wasi_functions.contains(&key) || !registry.is_function_supported(func) {
+        if !emits_function(project, func) {
             continue;
         }
         if let Some(ret) = &func.return_type {
@@ -3801,13 +3767,7 @@ fn import_resource_using_interfaces(
         let supported_functions: Vec<_> = interface_info
             .functions
             .iter()
-            .filter(|func| {
-                if !project.cm_interface_registry.is_function_supported(func) {
-                    return false;
-                }
-                let func_key = format!("{}::{}", func.interface_name, func.method_name);
-                project.used_wasi_functions.contains(&func_key)
-            })
+            .filter(|func| emits_function(project, func))
             .collect();
 
         // Collect resources used in function signatures
@@ -3862,7 +3822,7 @@ fn import_resource_using_interfaces(
             else {
                 continue;
             };
-            if ctx.has_type(&format!("resource:{cm_name}")) {
+            if ctx.has_type(&resource_type_key(cm_name)) {
                 continue; // already imported (by the main loop or the source phase)
             }
             let Some(source_path) = project
@@ -3903,7 +3863,7 @@ fn import_resource_using_interfaces(
                         .cm_interface_registry
                         .get_resource_cm_name_by_source(source, resource_name)
                 {
-                    let outer_resource_type_name = format!("resource:{cm_name}");
+                    let outer_resource_type_name = resource_type_key(cm_name);
                     let source_is_self = project
                         .cm_interface_registry
                         .get_resource_source_interface(resource_name)
@@ -4044,10 +4004,7 @@ fn import_resource_using_interfaces(
             enc.instance(&instance_type);
         }
 
-        ctx.register_instance(&format!(
-            "{}-{}",
-            interface_info.package, interface_info.interface
-        ));
+        ctx.register_instance(&interface_info.instance_key());
         builder.import(
             &interface_info.path,
             wasm_encoder::ComponentTypeRef::Instance(instance_type_idx),
@@ -4067,10 +4024,7 @@ fn import_resource_using_interfaces(
 
             ctx.register_comp_func(&local_name);
             builder.alias_export(
-                ctx.instance_idx(&format!(
-                    "{}-{}",
-                    interface_info.package, interface_info.interface
-                )),
+                ctx.instance_idx(&interface_info.instance_key()),
                 &func.wasi_func_name,
                 ComponentExportKind::Func,
             );
@@ -4238,7 +4192,7 @@ fn generate_cm_world_func_imports(
             continue;
         }
         let val_type = |ty: &Type| {
-            wado_type_to_cm_val_type(project, ty, None, None, None, &empty, &empty, &empty)
+            wado_type_to_cm_val_type(ty, None, None, &empty, &empty, &empty)
         };
         let local_name = func.local_alias_name();
         let func_type_name = format!("world-func-type-{}", func.wasi_func_name);

--- a/wado-compiler/src/codegen/component.rs
+++ b/wado-compiler/src/codegen/component.rs
@@ -3497,10 +3497,8 @@ fn import_resource_source(
     // interface `types`). The instance-type name doubles as the idempotency key:
     // it is a real builder type, so reusing it never desyncs the ctx/builder
     // type-index counters the way a phantom marker type would.
-    let instance_name = crate::component_model::cm_instance_key(
-        &cm_import.package,
-        &cm_import.interface,
-    );
+    let instance_name =
+        crate::component_model::cm_instance_key(&cm_import.package, &cm_import.interface);
     let instance_type_name = format!("{instance_name}-instance-type");
     if ctx.has_type(&instance_type_name) {
         return;
@@ -4179,9 +4177,7 @@ fn generate_cm_world_func_imports(
         {
             continue;
         }
-        let val_type = |ty: &Type| {
-            wado_type_to_cm_val_type(ty, None, None, &empty, &empty, &empty)
-        };
+        let val_type = |ty: &Type| wado_type_to_cm_val_type(ty, None, None, &empty, &empty, &empty);
         let local_name = func.local_alias_name();
         let func_type_name = format!("world-func-type-{}", func.wasi_func_name);
 

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -572,11 +572,7 @@ impl<'a> WirEmitter<'a> {
         for import in &self.wir.imports {
             match &import.desc {
                 WirImportDesc::Func { type_id, .. } => {
-                    let wasm_type_idx = self
-                        .type_index_map
-                        .get(&type_id.index())
-                        .copied()
-                        .unwrap_or(0);
+                    let wasm_type_idx = self.resolve_type_index(type_id.index());
                     imports.import(
                         &import.module,
                         &import.field,
@@ -597,7 +593,16 @@ impl<'a> WirEmitter<'a> {
                         },
                     );
                 }
-                _ => {}
+                // No pass builds these; dropping one silently would leave the
+                // module's import index space out of step with the accesses.
+                WirImportDesc::Global { .. } => panic!(
+                    "[WIR emit] global import '{}::{}' is not implemented",
+                    import.module, import.field
+                ),
+                WirImportDesc::Table { .. } => panic!(
+                    "[WIR emit] table import '{}::{}' is not implemented",
+                    import.module, import.field
+                ),
             }
         }
 
@@ -611,18 +616,23 @@ impl<'a> WirEmitter<'a> {
             .any(|i| matches!(&i.desc, WirImportDesc::Memory { .. }))
     }
 
+    /// Memories in the module's index space: imported ones first, then defined.
+    fn memory_count(&self) -> usize {
+        self.wir
+            .imports
+            .iter()
+            .filter(|i| matches!(&i.desc, WirImportDesc::Memory { .. }))
+            .count()
+            + self.wir.memories.len()
+    }
+
     // === Function Section ===
 
     fn emit_function_section(&self) -> FunctionSection {
         let mut funcs = FunctionSection::new();
 
         for func in &self.wir.functions {
-            let wasm_type_idx = self
-                .type_index_map
-                .get(&func.type_id.index())
-                .copied()
-                .unwrap_or(0);
-            funcs.function(wasm_type_idx);
+            funcs.function(self.resolve_type_index(func.type_id.index()));
         }
 
         funcs
@@ -721,17 +731,19 @@ impl<'a> WirEmitter<'a> {
         for export in &self.wir.exports {
             match &export.desc {
                 WirExportDesc::Func { func_id } => {
-                    let wasm_idx = self
-                        .func_index_map
-                        .get(&func_id.index())
-                        .copied()
-                        .unwrap_or(func_id.index());
+                    let wasm_idx = self.resolve_func_index(func_id.index());
                     exports.export(&export.name, ExportKind::Func, wasm_idx);
                 }
                 WirExportDesc::Global { .. } => {
                     // TODO: global exports
                 }
                 WirExportDesc::Memory => {
+                    assert_eq!(
+                        self.memory_count(),
+                        1,
+                        "[WIR emit] memory export names index 0, so the module must hold \
+                         exactly one memory"
+                    );
                     exports.export(&export.name, ExportKind::Memory, 0);
                 }
                 WirExportDesc::Table { index } => {
@@ -878,11 +890,7 @@ impl<'a> WirEmitter<'a> {
                     locals.push((format!("__array_copy_i_{key}"), ValType::I32));
                 }
             }
-            WirInstr::ArrayClone {
-                type_id,
-                element_copy_mangle,
-                ..
-            } => {
+            WirInstr::ArrayClone { type_id, .. } => {
                 let arr_ref = RefType {
                     nullable: false,
                     heap_type: HeapType::Concrete(self.resolve_type_index(type_id.index())),
@@ -896,17 +904,13 @@ impl<'a> WirEmitter<'a> {
                     locals.push((format!("__copy_arr_dst_{idx}"), ValType::Ref(arr_ref)));
                     locals.push((format!("__copy_arr_len_{idx}"), ValType::I32));
                     locals.push((format!("__copy_arr_i_{idx}"), ValType::I32));
-                }
-                // The deep-clone loop's per-element nullability branch needs an
-                // element-typed temp; deduped independently, since a shallow
-                // `ArrayClone` of the same `type_id` claims `__copy_arr_src` but
-                // carries no element temp.
-                if element_copy_mangle.is_some()
-                    && let Some(elem_val) = self.array_element_val_type(idx)
-                    && self
-                        .scratch_local_names
-                        .insert(format!("__copy_arr_elem_{idx}"))
-                {
+                    // The clone loop's per-element nullability branch needs an
+                    // element-typed temp.
+                    let elem_val = self.array_element_val_type(idx).unwrap_or_else(|| {
+                        panic!("[WIR emit] ArrayClone on non-array WIR type {idx}")
+                    });
+                    self.scratch_local_names
+                        .insert(format!("__copy_arr_elem_{idx}"));
                     locals.push((format!("__copy_arr_elem_{idx}"), elem_val));
                 }
             }
@@ -2314,14 +2318,11 @@ impl<'a> WirEmitter<'a> {
                         f.instruction(&Instruction::ArrayGet(arr_wasm_idx));
                     }
                 }
-                let copy_mangle = element_copy_mangle
-                    .as_deref()
-                    .unwrap_or_else(|| panic!("WirInstr::ArrayClone with no element_copy_mangle"));
                 let func_idx = self
-                    .resolve_function_index_by_value_copy_mangle(copy_mangle)
+                    .resolve_function_index_by_value_copy_mangle(element_copy_mangle)
                     .unwrap_or_else(|| {
                         panic!(
-                            "WirInstr::ArrayClone references a value-copy helper for {copy_mangle} that was not synthesized"
+                            "WirInstr::ArrayClone references a value-copy helper for {element_copy_mangle} that was not synthesized"
                         )
                     });
                 // Wasm GC `array.get` produces `(ref null T)`; the
@@ -2337,7 +2338,7 @@ impl<'a> WirEmitter<'a> {
                 let elem_local = self.resolve_local(&elem_name);
                 let elem_val = self
                     .array_element_val_type(type_id.index())
-                    .expect("array element val type known when element_copy_type is set");
+                    .expect("collect_scratch_locals already resolved the element type");
                 f.instruction(&Instruction::LocalSet(elem_local));
                 f.instruction(&Instruction::LocalGet(elem_local));
                 f.instruction(&Instruction::RefIsNull);
@@ -2473,10 +2474,19 @@ impl<'a> WirEmitter<'a> {
                 }
             }
 
-            // Everything else - emit unreachable for unimplemented instructions
-            other => {
-                eprintln!("[WIR-EMIT] unhandled instruction: {other:?}");
-                f.instruction(&Instruction::Unreachable);
+            // Table
+            WirInstr::TableGet { table, index } => {
+                self.emit_instr(f, index);
+                f.instruction(&Instruction::TableGet(*table));
+            }
+            WirInstr::TableSet {
+                table,
+                index,
+                value,
+            } => {
+                self.emit_instr(f, index);
+                self.emit_instr(f, value);
+                f.instruction(&Instruction::TableSet(*table));
             }
         }
     }
@@ -2610,16 +2620,51 @@ impl<'a> WirEmitter<'a> {
             .unwrap_or_else(|| panic!("unresolved local: {name}"))
     }
 
+    /// The Wasm type index of a WIR type. An unmapped id is a bug upstream, not
+    /// a case to recover from: index 0 is some other type, so falling back to it
+    /// silently retargets the instruction — a `struct.new` builds the wrong
+    /// shape, a `ref.cast` tests the wrong class — and the module still
+    /// validates whenever the two shapes happen to agree.
     fn resolve_type_index(&self, wir_idx: u32) -> u32 {
-        self.type_index_map.get(&wir_idx).copied().unwrap_or(0)
+        self.type_index_map
+            .get(&wir_idx)
+            .copied()
+            .unwrap_or_else(|| {
+                panic!(
+                    "[WIR emit] WIR type {wir_idx} ({}) has no Wasm type index — either a pass \
+                     dropped the type while leaving a use behind, or the use names a type kind \
+                     that emits none (enum / flags)",
+                    self.describe_wir_type(wir_idx)
+                )
+            })
     }
 
+    /// The field index of `field_name` within a WIR struct. Falling back to 0
+    /// would read or write a *different* field of the same struct.
     fn resolve_field_index(&self, wir_type_idx: u32, field_name: &str) -> u32 {
         self.struct_field_map
             .get(&wir_type_idx)
             .and_then(|m| m.get(field_name))
             .copied()
-            .unwrap_or(0)
+            .unwrap_or_else(|| {
+                panic!(
+                    "[WIR emit] WIR type {wir_type_idx} ({}) has no field '{field_name}'",
+                    self.describe_wir_type(wir_type_idx)
+                )
+            })
+    }
+
+    /// A short description of a WIR type index, for ICE messages.
+    fn describe_wir_type(&self, wir_idx: u32) -> String {
+        match self.wir.types.get(wir_idx as usize) {
+            Some(WirTypeDef::Struct(s)) => format!("struct {}", s.name.fq),
+            Some(WirTypeDef::Variant(v)) => format!("variant {}", v.name.fq),
+            Some(WirTypeDef::Array(a)) => format!("array {}", a.name.fq),
+            Some(WirTypeDef::Func(_)) => "func type".to_string(),
+            Some(WirTypeDef::Enum(_)) => "enum".to_string(),
+            Some(WirTypeDef::Flags(_)) => "flags".to_string(),
+            None => "out of range".to_string(),
+        }
     }
 
     /// True when the array's Wado element type is a non-nullable reference. The
@@ -2667,11 +2712,21 @@ impl<'a> WirEmitter<'a> {
         None
     }
 
+    /// The Wasm index of a WIR function id. `build_func_index_map` maps every
+    /// import (identity) and every defined function, so a miss means a pass
+    /// dropped the callee while leaving the call behind. Passing the WIR id
+    /// through unchanged, as this used to, would call whatever function happens
+    /// to sit at that Wasm index.
     fn resolve_func_index(&self, wir_func_idx: u32) -> u32 {
         self.func_index_map
             .get(&wir_func_idx)
             .copied()
-            .unwrap_or(wir_func_idx) // fallback: use as-is (for imports)
+            .unwrap_or_else(|| {
+                panic!(
+                    "[WIR emit] WIR function id {wir_func_idx} has no Wasm index — a pass dropped \
+                     the function while leaving a reference to it behind"
+                )
+            })
     }
 
     /// Look up the (nullable) element `ValType` of a WIR array type by
@@ -2818,8 +2873,8 @@ mod tests {
     use super::emit_core_module;
     use crate::hashmap::{IndexMap, IndexSet};
     use crate::wir::{
-        WirComponent, WirField, WirGlobal, WirInstr, WirMeta, WirName, WirNames, WirPackage,
-        WirStructType, WirType, WirTypeDef, WirTypeId,
+        WirComponent, WirExport, WirExportDesc, WirField, WirFuncId, WirGlobal, WirInstr, WirMeta,
+        WirName, WirNames, WirPackage, WirStructType, WirType, WirTypeDef, WirTypeId,
     };
     use std::rc::Rc;
 
@@ -2853,13 +2908,9 @@ mod tests {
         v.validate_all(bytes).map(|_| ()).map_err(|e| e.to_string())
     }
 
-    /// A global whose initializer is a constant `struct.new` must be emitted as
-    /// a Wasm GC constant init expression — not the scalar `i32.const 0`
-    /// fallback, which leaves the `(ref $P)` global's init ill-typed.
-    #[test]
-    fn const_struct_global_init_validates() {
-        let tid = WirTypeId::new(0, Rc::from("test//P"));
-        let struct_ty = WirStructType {
+    /// A two-`i32`-field struct named `test//P`.
+    fn point_struct() -> WirStructType {
+        WirStructType {
             name: WirName {
                 fq: "test//P".to_string(),
             },
@@ -2879,7 +2930,16 @@ mod tests {
             generic_origin: None,
             newtype_origin: None,
             supertype: None,
-        };
+        }
+    }
+
+    /// A global whose initializer is a constant `struct.new` must be emitted as
+    /// a Wasm GC constant init expression — not the scalar `i32.const 0`
+    /// fallback, which leaves the `(ref $P)` global's init ill-typed.
+    #[test]
+    fn const_struct_global_init_validates() {
+        let tid = WirTypeId::new(0, Rc::from("test//P"));
+        let struct_ty = point_struct();
         let global = WirGlobal {
             name: WirName {
                 fq: "global:ORIGIN".to_string(),
@@ -2903,5 +2963,54 @@ mod tests {
 
         let bytes = emit_core_module(&pkg, false, crate::codegen_flags::CodegenFlags::default());
         validate(&bytes).expect("const struct global init should validate as Wasm");
+    }
+
+    /// An instruction naming a WIR type with no Wasm type index must ICE. The
+    /// emitter used to substitute index 0, which is a *different* type: here
+    /// `struct.new` would silently build a `test//P` instead of the missing
+    /// type, and the module still validates whenever the shapes agree.
+    #[test]
+    #[should_panic(expected = "has no Wasm type index")]
+    fn unmapped_type_index_is_an_ice() {
+        let known = WirTypeId::new(0, Rc::from("test//P"));
+        let missing = WirTypeId::new(1, Rc::from("test//Missing"));
+        let mut pkg = empty_package();
+        pkg.types.push(WirTypeDef::Struct(point_struct()));
+        pkg.globals.push(WirGlobal {
+            name: WirName {
+                fq: "global:G".to_string(),
+            },
+            ty: WirType::Ref {
+                type_id: known,
+                nullable: false,
+            },
+            mutable: false,
+            wado_mutable: false,
+            init: WirInstr::StructNew {
+                type_id: missing,
+                fields: vec![WirInstr::I32Const(3), WirInstr::I32Const(4)],
+            },
+            lazy_init: false,
+            meta: WirMeta::default(),
+        });
+
+        emit_core_module(&pkg, false, crate::codegen_flags::CodegenFlags::default());
+    }
+
+    /// Likewise for a function id with no Wasm index: exporting it used to fall
+    /// back to the raw WIR id, which names whatever function sits at that Wasm
+    /// index.
+    #[test]
+    #[should_panic(expected = "has no Wasm index")]
+    fn unmapped_func_index_is_an_ice() {
+        let mut pkg = empty_package();
+        pkg.exports.push(WirExport {
+            name: "gone".to_string(),
+            desc: WirExportDesc::Func {
+                func_id: WirFuncId::new(7, Rc::from("test//gone")),
+            },
+        });
+
+        emit_core_module(&pkg, false, crate::codegen_flags::CodegenFlags::default());
     }
 }

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -2236,7 +2236,8 @@ impl<'a> WirEmitter<'a> {
                 len,
             } => {
                 let arr_wasm_idx = self.resolve_type_index(type_id.index());
-                let slot = |role: &str| self.resolve_local(&array_clone_slot(role, type_id.index()));
+                let slot =
+                    |role: &str| self.resolve_local(&array_clone_slot(role, type_id.index()));
                 let src_local = slot("src");
                 let dst_local = slot("dst");
                 let len_local = slot("len");
@@ -2467,7 +2468,10 @@ impl<'a> WirEmitter<'a> {
             // Generate names from WIR functions using remapped Wasm indices
             let mut name_map = NameMap::new();
             for (i, func) in self.wir.functions.iter().enumerate() {
-                name_map.append(self.resolve_func_index(self.defined_func_id(i)), &func.name.fq);
+                name_map.append(
+                    self.resolve_func_index(self.defined_func_id(i)),
+                    &func.name.fq,
+                );
             }
             names.functions(&name_map);
         }

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -21,6 +21,31 @@ use wasm_encoder::{
 /// Software lowering of the wide-arithmetic ops for `-f no-wide-arithmetic`.
 mod wide_arith_downlevel;
 
+/// Name of a scratch slot for the `-f no-array-copy` loop. Keyed by the
+/// (dest, src) type pair, so sites of the same shape share slots. The single
+/// spelling shared by the declaring walker and the emitter — building the name
+/// twice lets the two drift, and a mismatch is an "unresolved local" ICE.
+fn array_copy_slot(role: &str, dest_type_idx: u32, src_type_idx: u32) -> String {
+    format!("__array_copy_{role}_{dest_type_idx}_{src_type_idx}")
+}
+
+/// Name of a scratch slot for the `ArrayClone` loop, keyed by array type.
+/// Shared by the declaring walker and the emitter, as [`array_copy_slot`].
+fn array_clone_slot(role: &str, type_idx: u32) -> String {
+    format!("__copy_arr_{role}_{type_idx}")
+}
+
+/// Whether a Wasm GC packed storage type reads back signed (`Some(true)`),
+/// unsigned (`Some(false)`), or is not packed at all (`None`) — the choice
+/// between `*.get_s`, `*.get_u` and plain `*.get`.
+fn packed_signedness(ty: &WirType) -> Option<bool> {
+    match ty {
+        WirType::I8 | WirType::I16 => Some(true),
+        WirType::U8 | WirType::U16 | WirType::Bool => Some(false),
+        _ => None,
+    }
+}
+
 /// Emit a core Wasm module from a `WirPackage`.
 pub fn emit_core_module(
     wir: &WirPackage,
@@ -212,10 +237,11 @@ impl<'a> WirEmitter<'a> {
         // This ensures `resolve_type_index` returns correct indices even for
         // forward references (e.g., array<Pair> referencing a Pair struct
         // that hasn't been emitted yet).
-        self.pre_assign_type_indices();
-
-        // Find func types that must go in the rec group (referenced from struct fields)
+        // Func types referenced from struct fields must join the rec group.
+        // Computed once and threaded into the pre-pass: the two walks assign
+        // and emit the same indices, so they must classify identically.
         let gc_func_types = self.find_gc_referenced_func_types();
+        self.pre_assign_type_indices(&gc_func_types);
 
         // Emit GC types (structs, arrays, variants) in a single `rec` group
         // so that forward references between them are allowed by the Wasm GC type system.
@@ -259,7 +285,7 @@ impl<'a> WirEmitter<'a> {
             if let WirTypeDef::Func(f) = typedef
                 && !gc_func_types.contains(&wir_idx)
             {
-                self.emit_standalone_func_type(&mut types, f, wir_idx);
+                self.emit_standalone_func_type(&mut types, f);
             }
         }
 
@@ -273,11 +299,8 @@ impl<'a> WirEmitter<'a> {
     ///
     /// Exception: func types referenced by struct fields (e.g., canonical closure func types)
     /// must also go in the rec group to avoid invalid forward references.
-    fn pre_assign_type_indices(&mut self) {
+    fn pre_assign_type_indices(&mut self, gc_func_types: &IndexSet<u32>) {
         let mut next_idx = 0u32;
-
-        // Find func types referenced from struct fields — these must go in the rec group
-        let gc_func_types = self.find_gc_referenced_func_types();
 
         // Pass 1: GC types (structs, arrays, variants) + func types referenced from GC types
         for (wir_idx, typedef) in self.wir.types.iter().enumerate() {
@@ -367,12 +390,7 @@ impl<'a> WirEmitter<'a> {
         gc_func_types
     }
 
-    fn emit_standalone_func_type(
-        &mut self,
-        types: &mut TypeSection,
-        f: &WirFuncType,
-        _wir_idx: u32,
-    ) {
+    fn emit_standalone_func_type(&mut self, types: &mut TypeSection, f: &WirFuncType) {
         let params: Vec<ValType> = f
             .params
             .iter()
@@ -704,12 +722,12 @@ impl<'a> WirEmitter<'a> {
         })
     }
 
+    /// Whether the global's declared slot type admits null. Resolved through
+    /// the name map rather than a scan: this runs once per `GlobalGet`.
     fn global_slot_is_nullable(&self, name: &str) -> bool {
-        self.wir
-            .globals
-            .iter()
-            .find(|g| g.name.fq == name)
-            .is_some_and(|g| !g.ty.is_nonnull_ref())
+        !self.wir.globals[self.resolve_global(name) as usize]
+            .ty
+            .is_nonnull_ref()
     }
 
     // === Global Section ===
@@ -884,41 +902,48 @@ impl<'a> WirEmitter<'a> {
                     nullable: false,
                     heap_type: HeapType::Concrete(self.resolve_type_index(src_type_id.index())),
                 };
-                let key = format!("{}_{}", dest_type_id.index(), src_type_id.index());
+                let (dest, src) = (dest_type_id.index(), src_type_id.index());
                 if self
                     .scratch_local_names
-                    .insert(format!("__array_copy_dst_{key}"))
+                    .insert(array_copy_slot("dst", dest, src))
                 {
-                    locals.push((format!("__array_copy_dst_{key}"), ValType::Ref(dst_ref)));
-                    locals.push((format!("__array_copy_src_{key}"), ValType::Ref(src_ref)));
-                    locals.push((format!("__array_copy_dst_off_{key}"), ValType::I32));
-                    locals.push((format!("__array_copy_src_off_{key}"), ValType::I32));
-                    locals.push((format!("__array_copy_len_{key}"), ValType::I32));
-                    locals.push((format!("__array_copy_i_{key}"), ValType::I32));
+                    for (role, ty) in [
+                        ("dst", ValType::Ref(dst_ref)),
+                        ("src", ValType::Ref(src_ref)),
+                        ("dst_off", ValType::I32),
+                        ("src_off", ValType::I32),
+                        ("len", ValType::I32),
+                        ("i", ValType::I32),
+                    ] {
+                        locals.push((array_copy_slot(role, dest, src), ty));
+                    }
                 }
             }
             WirInstr::ArrayClone { type_id, .. } => {
-                let arr_ref = RefType {
+                let arr = ValType::Ref(RefType {
                     nullable: false,
                     heap_type: HeapType::Concrete(self.resolve_type_index(type_id.index())),
-                };
+                });
                 let idx = type_id.index();
                 if self
                     .scratch_local_names
-                    .insert(format!("__copy_arr_src_{idx}"))
+                    .insert(array_clone_slot("src", idx))
                 {
-                    locals.push((format!("__copy_arr_src_{idx}"), ValType::Ref(arr_ref)));
-                    locals.push((format!("__copy_arr_dst_{idx}"), ValType::Ref(arr_ref)));
-                    locals.push((format!("__copy_arr_len_{idx}"), ValType::I32));
-                    locals.push((format!("__copy_arr_i_{idx}"), ValType::I32));
                     // The clone loop's per-element nullability branch needs an
-                    // element-typed temp.
+                    // element-typed temp alongside the cursor slots.
                     let elem_val = self.array_element_val_type(idx).unwrap_or_else(|| {
                         panic!("[WIR emit] ArrayClone on non-array WIR type {idx}")
                     });
-                    self.scratch_local_names
-                        .insert(format!("__copy_arr_elem_{idx}"));
-                    locals.push((format!("__copy_arr_elem_{idx}"), elem_val));
+                    for (role, ty) in [
+                        ("src", arr),
+                        ("dst", arr),
+                        ("len", ValType::I32),
+                        ("i", ValType::I32),
+                        ("elem", elem_val),
+                    ] {
+                        self.scratch_local_names.insert(array_clone_slot(role, idx));
+                        locals.push((array_clone_slot(role, idx), ty));
+                    }
                 }
             }
             WirInstr::I64MulWideU(..)
@@ -1677,12 +1702,7 @@ impl<'a> WirEmitter<'a> {
             } => {
                 self.emit_instr(f, array);
                 self.emit_instr(f, index);
-                let wasm_idx = self.resolve_type_index(type_id.index());
-                match self.is_array_packed(type_id.index()) {
-                    Some(true) => f.instruction(&Instruction::ArrayGetS(wasm_idx)),
-                    Some(false) => f.instruction(&Instruction::ArrayGetU(wasm_idx)),
-                    None => f.instruction(&Instruction::ArrayGet(wasm_idx)),
-                };
+                self.emit_array_get(f, type_id.index());
                 // Array elements are declared nullable in Wasm (for
                 // `array.new_default`), so `array.get` yields a nullable ref.
                 // Narrow back to non-null only when the Wado element type is
@@ -2107,43 +2127,14 @@ impl<'a> WirEmitter<'a> {
                 // per-element get/set. The native instruction (the arm above,
                 // now the default) is selected when `array_copy` is set.
                 let dst_wasm_idx = self.resolve_type_index(dest_type_id.index());
-                let src_wasm_idx = self.resolve_type_index(src_type_id.index());
-                let dst_name = format!(
-                    "__array_copy_dst_{}_{}",
-                    dest_type_id.index(),
-                    src_type_id.index()
-                );
-                let src_name = format!(
-                    "__array_copy_src_{}_{}",
-                    dest_type_id.index(),
-                    src_type_id.index()
-                );
-                let dst_off_name = format!(
-                    "__array_copy_dst_off_{}_{}",
-                    dest_type_id.index(),
-                    src_type_id.index()
-                );
-                let src_off_name = format!(
-                    "__array_copy_src_off_{}_{}",
-                    dest_type_id.index(),
-                    src_type_id.index()
-                );
-                let len_name = format!(
-                    "__array_copy_len_{}_{}",
-                    dest_type_id.index(),
-                    src_type_id.index()
-                );
-                let i_name = format!(
-                    "__array_copy_i_{}_{}",
-                    dest_type_id.index(),
-                    src_type_id.index()
-                );
-                let dst_local = self.resolve_local(&dst_name);
-                let src_local = self.resolve_local(&src_name);
-                let dst_off_local = self.resolve_local(&dst_off_name);
-                let src_off_local = self.resolve_local(&src_off_name);
-                let len_local = self.resolve_local(&len_name);
-                let i_local = self.resolve_local(&i_name);
+                let (dest_ty, src_ty) = (dest_type_id.index(), src_type_id.index());
+                let slot = |role: &str| self.resolve_local(&array_copy_slot(role, dest_ty, src_ty));
+                let dst_local = slot("dst");
+                let src_local = slot("src");
+                let dst_off_local = slot("dst_off");
+                let src_off_local = slot("src_off");
+                let len_local = slot("len");
+                let i_local = slot("i");
 
                 // Stash the five argument expressions into locals. The dst/src
                 // ref slots are declared non-null (init-tracking), so coerce
@@ -2196,17 +2187,7 @@ impl<'a> WirEmitter<'a> {
                 f.instruction(&Instruction::LocalGet(src_off_local));
                 f.instruction(&Instruction::LocalGet(i_local));
                 f.instruction(&Instruction::I32Add);
-                match self.is_array_packed(src_type_id.index()) {
-                    Some(true) => {
-                        f.instruction(&Instruction::ArrayGetS(src_wasm_idx));
-                    }
-                    Some(false) => {
-                        f.instruction(&Instruction::ArrayGetU(src_wasm_idx));
-                    }
-                    None => {
-                        f.instruction(&Instruction::ArrayGet(src_wasm_idx));
-                    }
-                }
+                self.emit_array_get(f, src_type_id.index());
                 f.instruction(&Instruction::ArraySet(dst_wasm_idx));
                 f.instruction(&Instruction::Br(0));
                 f.instruction(&Instruction::End);
@@ -2233,17 +2214,7 @@ impl<'a> WirEmitter<'a> {
                 f.instruction(&Instruction::LocalGet(src_off_local));
                 f.instruction(&Instruction::LocalGet(i_local));
                 f.instruction(&Instruction::I32Add);
-                match self.is_array_packed(src_type_id.index()) {
-                    Some(true) => {
-                        f.instruction(&Instruction::ArrayGetS(src_wasm_idx));
-                    }
-                    Some(false) => {
-                        f.instruction(&Instruction::ArrayGetU(src_wasm_idx));
-                    }
-                    None => {
-                        f.instruction(&Instruction::ArrayGet(src_wasm_idx));
-                    }
-                }
+                self.emit_array_get(f, src_type_id.index());
                 f.instruction(&Instruction::ArraySet(dst_wasm_idx));
                 // i += 1
                 f.instruction(&Instruction::LocalGet(i_local));
@@ -2277,14 +2248,12 @@ impl<'a> WirEmitter<'a> {
                 len,
             } => {
                 let arr_wasm_idx = self.resolve_type_index(type_id.index());
-                let src_name = format!("__copy_arr_src_{}", type_id.index());
-                let dst_name = format!("__copy_arr_dst_{}", type_id.index());
-                let len_name = format!("__copy_arr_len_{}", type_id.index());
-                let loop_idx_name = format!("__copy_arr_i_{}", type_id.index());
-                let src_local = self.resolve_local(&src_name);
-                let dst_local = self.resolve_local(&dst_name);
-                let len_local = self.resolve_local(&len_name);
-                let loop_idx_local = self.resolve_local(&loop_idx_name);
+                let slot = |role: &str| self.resolve_local(&array_clone_slot(role, type_id.index()));
+                let src_local = slot("src");
+                let dst_local = slot("dst");
+                let len_local = slot("len");
+                let loop_idx_local = slot("i");
+                let elem_local = slot("elem");
                 // Keep `src` on the operand stack while `len` is emitted: the
                 // scratch locals are shared per `type_id`, so a nested clone of
                 // the same array type inside the `len` subtree would clobber
@@ -2314,17 +2283,7 @@ impl<'a> WirEmitter<'a> {
                 f.instruction(&Instruction::LocalGet(loop_idx_local));
                 f.instruction(&Instruction::LocalGet(src_local));
                 f.instruction(&Instruction::LocalGet(loop_idx_local));
-                match self.is_array_packed(type_id.index()) {
-                    Some(true) => {
-                        f.instruction(&Instruction::ArrayGetS(arr_wasm_idx));
-                    }
-                    Some(false) => {
-                        f.instruction(&Instruction::ArrayGetU(arr_wasm_idx));
-                    }
-                    None => {
-                        f.instruction(&Instruction::ArrayGet(arr_wasm_idx));
-                    }
-                }
+                self.emit_array_get(f, type_id.index());
                 let func_idx = self
                     .resolve_function_index_by_value_copy_mangle(element_copy_mangle)
                     .unwrap_or_else(|| {
@@ -2341,8 +2300,6 @@ impl<'a> WirEmitter<'a> {
                 // the null in the destination — instead of
                 // unconditionally `ref.as_non_null` which would
                 // trap on every empty trailing slot.
-                let elem_name = format!("__copy_arr_elem_{}", type_id.index());
-                let elem_local = self.resolve_local(&elem_name);
                 let elem_val = self
                     .array_element_val_type(type_id.index())
                     .expect("collect_scratch_locals already resolved the element type");
@@ -2685,35 +2642,30 @@ impl<'a> WirEmitter<'a> {
     }
 
     fn is_array_packed(&self, wir_type_idx: u32) -> Option<bool> {
-        let idx = wir_type_idx as usize;
-        if idx < self.wir.types.len()
-            && let WirTypeDef::Array(ref arr) = self.wir.types[idx]
-        {
-            return match &arr.element_type {
-                WirType::I8 | WirType::I16 => Some(true),
-                WirType::U8 | WirType::U16 | WirType::Bool => Some(false),
-                _ => None,
-            };
+        match self.wir.types.get(wir_type_idx as usize) {
+            Some(WirTypeDef::Array(arr)) => packed_signedness(&arr.element_type),
+            _ => None,
         }
-        None
     }
 
     fn is_field_packed(&self, wir_type_idx: u32, field_name: &str) -> Option<bool> {
-        let idx = wir_type_idx as usize;
-        if idx < self.wir.types.len()
-            && let WirTypeDef::Struct(ref st) = self.wir.types[idx]
-        {
-            for field in &st.fields {
-                if field.name == field_name {
-                    return match &field.ty {
-                        WirType::I8 | WirType::I16 => Some(true),
-                        WirType::U8 | WirType::U16 | WirType::Bool => Some(false),
-                        _ => None,
-                    };
-                }
-            }
-        }
-        None
+        let Some(WirTypeDef::Struct(st)) = self.wir.types.get(wir_type_idx as usize) else {
+            return None;
+        };
+        let field = st.fields.iter().find(|f| f.name == field_name)?;
+        packed_signedness(&field.ty)
+    }
+
+    /// Emit the `array.get` flavour the element storage type calls for: the
+    /// signed or unsigned widening read for a packed element, the plain read
+    /// otherwise.
+    fn emit_array_get(&self, f: &mut Function, wir_type_idx: u32) {
+        let wasm_idx = self.resolve_type_index(wir_type_idx);
+        match self.is_array_packed(wir_type_idx) {
+            Some(true) => f.instruction(&Instruction::ArrayGetS(wasm_idx)),
+            Some(false) => f.instruction(&Instruction::ArrayGetU(wasm_idx)),
+            None => f.instruction(&Instruction::ArrayGet(wasm_idx)),
+        };
     }
 
     /// The Wasm index of a WIR function id. `build_func_index_map` maps every
@@ -2797,7 +2749,7 @@ impl<'a> WirEmitter<'a> {
                 heap_type,
                 nullable,
             } => {
-                let ht = self.wir_abstract_heap_to_wasm_heap(heap_type);
+                let ht = self.wir_abstract_heap_to_wasm(heap_type);
                 ValType::Ref(RefType {
                     nullable: *nullable,
                     heap_type: ht,
@@ -2836,10 +2788,6 @@ impl<'a> WirEmitter<'a> {
                 WirAbstractHeapType::Extern => AbstractHeapType::Extern,
             },
         }
-    }
-
-    fn wir_abstract_heap_to_wasm_heap(&self, ht: &WirAbstractHeapType) -> HeapType {
-        self.wir_abstract_heap_to_wasm(ht)
     }
 
     /// Collect all function indices referenced by `RefFunc` instructions.

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -21,23 +21,21 @@ use wasm_encoder::{
 /// Software lowering of the wide-arithmetic ops for `-f no-wide-arithmetic`.
 mod wide_arith_downlevel;
 
-/// Name of a scratch slot for the `-f no-array-copy` loop. Keyed by the
-/// (dest, src) type pair, so sites of the same shape share slots. The single
-/// spelling shared by the declaring walker and the emitter — building the name
-/// twice lets the two drift, and a mismatch is an "unresolved local" ICE.
+/// Scratch slot for the `-f no-array-copy` loop, keyed by the (dest, src) type
+/// pair so sites of the same shape share slots. The declaring walker and the
+/// emitter must spell these identically, so both come through here.
 fn array_copy_slot(role: &str, dest_type_idx: u32, src_type_idx: u32) -> String {
     format!("__array_copy_{role}_{dest_type_idx}_{src_type_idx}")
 }
 
-/// Name of a scratch slot for the `ArrayClone` loop, keyed by array type.
-/// Shared by the declaring walker and the emitter, as [`array_copy_slot`].
+/// Scratch slot for the `ArrayClone` loop, keyed by array type. As
+/// [`array_copy_slot`].
 fn array_clone_slot(role: &str, type_idx: u32) -> String {
     format!("__copy_arr_{role}_{type_idx}")
 }
 
-/// Whether a Wasm GC packed storage type reads back signed (`Some(true)`),
-/// unsigned (`Some(false)`), or is not packed at all (`None`) — the choice
-/// between `*.get_s`, `*.get_u` and plain `*.get`.
+/// Whether a packed storage type reads back signed (`Some(true)`), unsigned
+/// (`Some(false)`), or is not packed (`None`).
 fn packed_signedness(ty: &WirType) -> Option<bool> {
     match ty {
         WirType::I8 | WirType::I16 => Some(true),
@@ -238,8 +236,8 @@ impl<'a> WirEmitter<'a> {
         // forward references (e.g., array<Pair> referencing a Pair struct
         // that hasn't been emitted yet).
         // Func types referenced from struct fields must join the rec group.
-        // Computed once and threaded into the pre-pass: the two walks assign
-        // and emit the same indices, so they must classify identically.
+        // The assigning and emitting walks below must classify identically, so
+        // they share one set.
         let gc_func_types = self.find_gc_referenced_func_types();
         self.pre_assign_type_indices(&gc_func_types);
 
@@ -611,8 +609,6 @@ impl<'a> WirEmitter<'a> {
                         },
                     );
                 }
-                // No pass builds these; dropping one silently would leave the
-                // module's import index space out of step with the accesses.
                 WirImportDesc::Global { .. } => panic!(
                     "[WIR emit] global import '{}::{}' is not implemented",
                     import.module, import.field
@@ -634,7 +630,6 @@ impl<'a> WirEmitter<'a> {
             .any(|i| matches!(&i.desc, WirImportDesc::Memory { .. }))
     }
 
-    /// Memories in the module's index space: imported ones first, then defined.
     fn memory_count(&self) -> usize {
         self.wir
             .imports
@@ -670,11 +665,9 @@ impl<'a> WirEmitter<'a> {
         memories
     }
 
-    /// The `WirFuncId` of the `i`-th defined function. The base is the
-    /// package's own — `DEFINED_FUNC_BASE` for the GC module, `0` for the
-    /// import-less memory module — not a hard-coded constant, so both kinds of
-    /// package resolve. `defined_func_base` must clear the imports for the two
-    /// id spaces to stay disjoint.
+    /// The `WirFuncId` of the `i`-th defined function, over the package's own
+    /// base: `DEFINED_FUNC_BASE` for the GC module, `0` for the import-less
+    /// memory module.
     fn defined_func_id(&self, i: usize) -> u32 {
         debug_assert!(self.wir.defined_func_base >= self.func_index_offset);
         self.wir.defined_func_base + u32::try_from(i).unwrap()
@@ -685,7 +678,6 @@ impl<'a> WirEmitter<'a> {
         for i in 0..self.func_index_offset {
             self.func_index_map.insert(i, i);
         }
-        // Defined functions map onto Wasm indices starting after the imports.
         for (wasm_idx, (i, func)) in
             (self.func_index_offset..).zip(self.wir.functions.iter().enumerate())
         {
@@ -722,8 +714,6 @@ impl<'a> WirEmitter<'a> {
         })
     }
 
-    /// Whether the global's declared slot type admits null. Resolved through
-    /// the name map rather than a scan: this runs once per `GlobalGet`.
     fn global_slot_is_nullable(&self, name: &str) -> bool {
         !self.wir.globals[self.resolve_global(name) as usize]
             .ty
@@ -929,8 +919,6 @@ impl<'a> WirEmitter<'a> {
                     .scratch_local_names
                     .insert(array_clone_slot("src", idx))
                 {
-                    // The clone loop's per-element nullability branch needs an
-                    // element-typed temp alongside the cursor slots.
                     let elem_val = self.array_element_val_type(idx).unwrap_or_else(|| {
                         panic!("[WIR emit] ArrayClone on non-array WIR type {idx}")
                     });
@@ -2581,11 +2569,8 @@ impl<'a> WirEmitter<'a> {
             .unwrap_or_else(|| panic!("unresolved local: {name}"))
     }
 
-    /// The Wasm type index of a WIR type. An unmapped id is a bug upstream, not
-    /// a case to recover from: index 0 is some other type, so falling back to it
-    /// silently retargets the instruction — a `struct.new` builds the wrong
-    /// shape, a `ref.cast` tests the wrong class — and the module still
-    /// validates whenever the two shapes happen to agree.
+    /// The Wasm type index of a WIR type. Panics rather than substituting a
+    /// plausible index, which would retarget the instruction at another type.
     fn resolve_type_index(&self, wir_idx: u32) -> u32 {
         self.type_index_map
             .get(&wir_idx)
@@ -2600,8 +2585,6 @@ impl<'a> WirEmitter<'a> {
             })
     }
 
-    /// The field index of `field_name` within a WIR struct. Falling back to 0
-    /// would read or write a *different* field of the same struct.
     fn resolve_field_index(&self, wir_type_idx: u32, field_name: &str) -> u32 {
         self.struct_field_map
             .get(&wir_type_idx)
@@ -2656,9 +2639,7 @@ impl<'a> WirEmitter<'a> {
         packed_signedness(&field.ty)
     }
 
-    /// Emit the `array.get` flavour the element storage type calls for: the
-    /// signed or unsigned widening read for a packed element, the plain read
-    /// otherwise.
+    /// Emit the `array.get` flavour the element storage type calls for.
     fn emit_array_get(&self, f: &mut Function, wir_type_idx: u32) {
         let wasm_idx = self.resolve_type_index(wir_type_idx);
         match self.is_array_packed(wir_type_idx) {
@@ -2669,10 +2650,7 @@ impl<'a> WirEmitter<'a> {
     }
 
     /// The Wasm index of a WIR function id. `build_func_index_map` maps every
-    /// import (identity) and every defined function, so a miss means a pass
-    /// dropped the callee while leaving the call behind. Passing the WIR id
-    /// through unchanged, as this used to, would call whatever function happens
-    /// to sit at that Wasm index.
+    /// import and every defined function, so a miss is a dangling reference.
     fn resolve_func_index(&self, wir_func_idx: u32) -> u32 {
         self.func_index_map
             .get(&wir_func_idx)
@@ -2860,7 +2838,6 @@ mod tests {
         v.validate_all(bytes).map(|_| ()).map_err(|e| e.to_string())
     }
 
-    /// A two-`i32`-field struct named `test//P`.
     fn point_struct() -> WirStructType {
         WirStructType {
             name: WirName {
@@ -2917,10 +2894,9 @@ mod tests {
         validate(&bytes).expect("const struct global init should validate as Wasm");
     }
 
-    /// An instruction naming a WIR type with no Wasm type index must ICE. The
-    /// emitter used to substitute index 0, which is a *different* type: here
-    /// `struct.new` would silently build a `test//P` instead of the missing
-    /// type, and the module still validates whenever the shapes agree.
+    /// An instruction naming a WIR type with no Wasm type index must ICE, not
+    /// fall back to index 0 — a different type, whose `struct.new` still
+    /// validates whenever the two shapes agree.
     #[test]
     #[should_panic(expected = "has no Wasm type index")]
     fn unmapped_type_index_is_an_ice() {
@@ -2949,9 +2925,8 @@ mod tests {
         emit_core_module(&pkg, false, crate::codegen_flags::CodegenFlags::default());
     }
 
-    /// Likewise for a function id with no Wasm index: exporting it used to fall
-    /// back to the raw WIR id, which names whatever function sits at that Wasm
-    /// index.
+    /// Likewise for a function id with no Wasm index, where the raw WIR id
+    /// names whatever function sits at that Wasm index.
     #[test]
     #[should_panic(expected = "has no Wasm index")]
     fn unmapped_func_index_is_an_ice() {

--- a/wado-compiler/src/codegen/emit.rs
+++ b/wado-compiler/src/codegen/emit.rs
@@ -652,18 +652,26 @@ impl<'a> WirEmitter<'a> {
         memories
     }
 
+    /// The `WirFuncId` of the `i`-th defined function. The base is the
+    /// package's own — `DEFINED_FUNC_BASE` for the GC module, `0` for the
+    /// import-less memory module — not a hard-coded constant, so both kinds of
+    /// package resolve. `defined_func_base` must clear the imports for the two
+    /// id spaces to stay disjoint.
+    fn defined_func_id(&self, i: usize) -> u32 {
+        debug_assert!(self.wir.defined_func_base >= self.func_index_offset);
+        self.wir.defined_func_base + u32::try_from(i).unwrap()
+    }
+
     fn build_func_index_map(&mut self) {
-        use crate::wir_build::DEFINED_FUNC_BASE;
         // Import functions already have indices 0..import_func_count-1
         for i in 0..self.func_index_offset {
             self.func_index_map.insert(i, i);
         }
-        // Defined functions use DEFINED_FUNC_BASE + list_position as WirFuncId,
-        // mapped to actual Wasm indices starting after imports.
+        // Defined functions map onto Wasm indices starting after the imports.
         for (wasm_idx, (i, func)) in
             (self.func_index_offset..).zip(self.wir.functions.iter().enumerate())
         {
-            let wir_func_idx = DEFINED_FUNC_BASE + u32::try_from(i).unwrap();
+            let wir_func_idx = self.defined_func_id(i);
             self.func_index_map.insert(wir_func_idx, wasm_idx);
             // First-wins mirrors the previous linear scan (which returned the
             // first matching helper); after synthesis dedup each mangle is
@@ -765,8 +773,7 @@ impl<'a> WirEmitter<'a> {
             let wasm_func = self.emit_function(func);
             code.function(&wasm_func);
             if !self.current_branch_hints.is_empty() {
-                let wir_func_idx = crate::wir_build::DEFINED_FUNC_BASE + u32::try_from(i).unwrap();
-                let func_idx = self.func_index_map[&wir_func_idx];
+                let func_idx = self.resolve_func_index(self.defined_func_id(i));
                 self.all_branch_hints
                     .push((func_idx, std::mem::take(&mut self.current_branch_hints)));
             }
@@ -2515,10 +2522,7 @@ impl<'a> WirEmitter<'a> {
             // Generate names from WIR functions using remapped Wasm indices
             let mut name_map = NameMap::new();
             for (i, func) in self.wir.functions.iter().enumerate() {
-                let wir_func_idx = crate::wir_build::DEFINED_FUNC_BASE + u32::try_from(i).unwrap();
-                if let Some(&wasm_idx) = self.func_index_map.get(&wir_func_idx) {
-                    name_map.append(wasm_idx, &func.name.fq);
-                }
+                name_map.append(self.resolve_func_index(self.defined_func_id(i)), &func.name.fq);
             }
             names.functions(&name_map);
         }

--- a/wado-compiler/src/codegen/postprocess.rs
+++ b/wado-compiler/src/codegen/postprocess.rs
@@ -42,24 +42,37 @@ pub fn eliminate_dead_code(wasm_bytes: &[u8], keep_exports: &IndexSet<String>) -
 
 const IMPORT_SECTION_ID: u8 = 2;
 
-/// Rewrite a module that *defines* a memory into one that *imports* it, so it
-/// can share the component's memory with the other core modules.
+/// Rewrite a wasm asset so it takes the component's memory as an import rather
+/// than defining its own, letting it share memory with the other core modules.
 ///
-/// Every other section is carried over byte-for-byte, in its original order.
-/// Only three are touched: the memory definition is dropped, the memory export
-/// is dropped (the importer owns it now), and the import section gains the
-/// memory import — created if the module had none. This leaves every index
-/// space unchanged: a memory import takes slot 0, exactly where the dropped
-/// definition sat, and the memory space is disjoint from the function, global,
-/// and table spaces.
+/// Handles all three shapes `loader.rs` accepts (see [`MemorySource`]). Every
+/// section other than the memory definition, the memory export, and the import
+/// section is carried over byte-for-byte, in its original order. That leaves
+/// every index space unchanged: the memory import takes slot 0, exactly where
+/// the dropped definition sat, and the memory space is disjoint from the
+/// function, global, and table spaces.
 pub fn convert_memory_to_import(
     wasm_bytes: &[u8],
     import_module: &str,
     import_name: &str,
 ) -> Result<Vec<u8>, String> {
-    let memory = find_single_memory(wasm_bytes)?;
+    // `None` once the module already imports its memory: it needs no new one,
+    // and adding a second would be a duplicate.
+    let to_import: Option<MemoryType> = match find_memory_source(wasm_bytes)? {
+        MemorySource::AlreadyImported => None,
+        MemorySource::Defined(mem) => Some(mem),
+        MemorySource::Absent => Some(MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        }),
+    };
     let memory_import = |module: &mut Module, mut imports: ImportSection| {
-        imports.import(import_module, import_name, memory);
+        if let Some(mem) = to_import {
+            imports.import(import_module, import_name, mem);
+        }
         module.section(&imports);
     };
 
@@ -72,6 +85,7 @@ pub fn convert_memory_to_import(
         // import. When the module has none of its own, open one right before
         // the first such section (any id above the import section's own 2).
         if !memory_import_written
+            && to_import.is_some()
             && let Some((id, _)) = payload.as_section()
             && id > IMPORT_SECTION_ID
         {
@@ -134,27 +148,37 @@ pub fn convert_memory_to_import(
         }
     }
 
-    if !memory_import_written {
+    if !memory_import_written && to_import.is_some() {
         memory_import(&mut module, ImportSection::new());
     }
 
     Ok(module.finish())
 }
 
-/// The memory this module defines, as an import-ready [`MemoryType`]. The
-/// rewrite maps the definition onto import slot 0, so exactly one defined
-/// memory and no imported one is the only shape it can preserve.
-fn find_single_memory(wasm_bytes: &[u8]) -> Result<MemoryType, String> {
-    let mut found: Option<MemoryType> = None;
+/// Where a wasm asset's memory comes from. These are the shapes `loader.rs`
+/// admits: it rejects more than one memory, and `env.memory` is the only import
+/// it allows — so all three arms are ordinary inputs, not error cases.
+enum MemorySource {
+    /// Defines exactly one. The rewrite drops it and imports the same shape.
+    Defined(MemoryType),
+    /// Already written against the component's memory; nothing to convert.
+    AlreadyImported,
+    /// Neither defines nor imports one, so it cannot touch linear memory. It
+    /// still gets a minimal import, keeping every embedded module one shape.
+    Absent,
+}
+
+fn find_memory_source(wasm_bytes: &[u8]) -> Result<MemorySource, String> {
+    let mut defined: Option<MemoryType> = None;
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         match payload.map_err(|e| format!("Parse error: {e}"))? {
             Payload::MemorySection(reader) => {
                 for mem in reader {
                     let mem = mem.map_err(|e| format!("Parse error: {e}"))?;
-                    if found.is_some() {
+                    if defined.is_some() {
                         return Err("module defines more than one memory".to_string());
                     }
-                    found = Some(MemoryType {
+                    defined = Some(MemoryType {
                         minimum: mem.initial,
                         maximum: mem.maximum,
                         memory64: mem.memory64,
@@ -168,10 +192,7 @@ fn find_single_memory(wasm_bytes: &[u8]) -> Result<MemoryType, String> {
                     for entry in group.map_err(|e| format!("Parse error: {e}"))? {
                         let (_, import) = entry.map_err(|e| format!("Parse error: {e}"))?;
                         if matches!(import.ty, wasmparser::TypeRef::Memory(_)) {
-                            return Err(format!(
-                                "module already imports memory {}/{}",
-                                import.module, import.name
-                            ));
+                            return Ok(MemorySource::AlreadyImported);
                         }
                     }
                 }
@@ -179,7 +200,7 @@ fn find_single_memory(wasm_bytes: &[u8]) -> Result<MemoryType, String> {
             _ => {}
         }
     }
-    found.ok_or_else(|| "module defines no memory to convert".to_string())
+    Ok(defined.map_or(MemorySource::Absent, MemorySource::Defined))
 }
 
 fn entity_type(ty: wasmparser::TypeRef) -> Option<EntityType> {
@@ -237,6 +258,24 @@ mod tests {
             }
         }
         None
+    }
+
+    fn count_memory_imports(wasm: &[u8]) -> usize {
+        let mut n = 0;
+        for payload in Parser::new(0).parse_all(wasm) {
+            if let Ok(Payload::ImportSection(imports)) = payload {
+                for group in imports.into_iter().flatten() {
+                    for import in group {
+                        if let Ok((_, imp)) = import
+                            && matches!(imp.ty, wasmparser::TypeRef::Memory(_))
+                        {
+                            n += 1;
+                        }
+                    }
+                }
+            }
+        }
+        n
     }
 
     fn section_ids(wasm: &[u8]) -> Vec<u8> {
@@ -352,9 +391,37 @@ mod tests {
         assert!(memory_import_of(&converted).is_some());
     }
 
+    /// `loader.rs` accepts a wasm asset with no memory at all (it only rejects
+    /// more than one), so the rewrite must still hand it the component's
+    /// memory rather than refusing the module.
     #[test]
-    fn convert_memory_to_import_rejects_a_module_with_no_memory() {
-        let bytes = wat::parse_str("(module (func))").expect("fixture must parse");
+    fn convert_memory_to_import_accepts_a_module_with_no_memory() {
+        let bytes = wat::parse_str(r#"(module (func (export "add_one")))"#).expect("fixture");
+        let converted = convert_memory_to_import(&bytes, "env", "memory").expect("conversion");
+        validate(&converted).expect("converted module must validate");
+        assert!(memory_import_of(&converted).is_some(), "memory import");
+    }
+
+    /// `env.memory` is the one import `loader.rs` permits in a wasm asset, so a
+    /// module already written against it is a normal input, not an error — and
+    /// it must not come back with the import duplicated.
+    #[test]
+    fn convert_memory_to_import_passes_through_an_existing_memory_import() {
+        let source = r#"
+            (module
+              (import "env" "memory" (memory 1))
+              (func (export "load") (result i32) (i32.load (i32.const 0))))
+        "#;
+        let bytes = wat::parse_str(source).expect("fixture must parse");
+        let converted = convert_memory_to_import(&bytes, "env", "memory").expect("conversion");
+        validate(&converted).expect("converted module must validate");
+        assert!(memory_import_of(&converted).is_some(), "memory import");
+        assert_eq!(count_memory_imports(&converted), 1, "no duplicate import");
+    }
+
+    #[test]
+    fn convert_memory_to_import_rejects_more_than_one_memory() {
+        let bytes = wat::parse_str("(module (memory 1) (memory 1))").expect("fixture must parse");
         assert!(convert_memory_to_import(&bytes, "env", "memory").is_err());
     }
 }

--- a/wado-compiler/src/codegen/postprocess.rs
+++ b/wado-compiler/src/codegen/postprocess.rs
@@ -7,7 +7,7 @@ use crate::hashmap::IndexSet;
 
 use walrus::passes;
 use wasm_encoder::{
-    CodeSection, ExportKind, ExportSection, ImportSection, MemoryType, Module, RawSection,
+    EntityType, ExportKind, ExportSection, ImportSection, MemoryType, Module, RawSection,
 };
 use wasmparser::{Parser, Payload};
 
@@ -40,178 +40,171 @@ pub fn eliminate_dead_code(wasm_bytes: &[u8], keep_exports: &IndexSet<String>) -
     module.emit_wasm()
 }
 
-/// Convert a Wasm module that defines memory to one that imports memory
-/// This allows the module to share memory with other modules in a component
+const IMPORT_SECTION_ID: u8 = 2;
+
+/// Rewrite a module that *defines* a memory into one that *imports* it, so it
+/// can share the component's memory with the other core modules.
+///
+/// Every other section is carried over byte-for-byte, in its original order.
+/// Only three are touched: the memory definition is dropped, the memory export
+/// is dropped (the importer owns it now), and the import section gains the
+/// memory import — created if the module had none. This leaves every index
+/// space unchanged: a memory import takes slot 0, exactly where the dropped
+/// definition sat, and the memory space is disjoint from the function, global,
+/// and table spaces.
 pub fn convert_memory_to_import(
     wasm_bytes: &[u8],
     import_module: &str,
     import_name: &str,
 ) -> Result<Vec<u8>, String> {
-    let parser = Parser::new(0);
+    let memory = find_single_memory(wasm_bytes)?;
+    let memory_import = |module: &mut Module, mut imports: ImportSection| {
+        imports.import(import_module, import_name, memory);
+        module.section(&imports);
+    };
+
     let mut module = Module::new();
-
-    // Track what we find
-    let mut memory_pages: u64 = 1;
-    let mut type_bytes: Option<Vec<u8>> = None;
-    let mut function_bytes: Option<Vec<u8>> = None;
-    let mut global_bytes: Option<Vec<u8>> = None;
-    let mut export_section_data: Vec<(String, ExportKind, u32)> = Vec::new();
-    let mut data_bytes: Option<Vec<u8>> = None;
-
-    // First pass: collect sections
-    for payload in parser.parse_all(wasm_bytes) {
+    let mut memory_import_written = false;
+    for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.map_err(|e| format!("Parse error: {e}"))?;
+
+        // The import section must precede every section that can reference an
+        // import. When the module has none of its own, open one right before
+        // the first such section (any id above the import section's own 2).
+        if !memory_import_written
+            && let Some((id, _)) = payload.as_section()
+            && id > IMPORT_SECTION_ID
+        {
+            memory_import(&mut module, ImportSection::new());
+            memory_import_written = true;
+        }
 
         match &payload {
-            Payload::TypeSection(_) => {
-                // Get raw bytes for this section
-                if let Some(range) = get_section_range(&payload) {
-                    type_bytes = Some(wasm_bytes[range].to_vec());
-                }
-            }
-            Payload::FunctionSection(_) => {
-                if let Some(range) = get_section_range(&payload) {
-                    function_bytes = Some(wasm_bytes[range].to_vec());
-                }
-            }
-            Payload::MemorySection(mems) => {
-                for mem in mems.clone() {
-                    let mem = mem.map_err(|e| format!("{e}"))?;
-                    memory_pages = mem.initial;
-                }
-            }
-            Payload::GlobalSection(_) => {
-                if let Some(range) = get_section_range(&payload) {
-                    global_bytes = Some(wasm_bytes[range].to_vec());
-                }
-            }
-            Payload::ExportSection(exports) => {
-                for exp in exports.clone() {
-                    let exp = exp.map_err(|e| format!("{e}"))?;
-                    let kind = match exp.kind {
-                        wasmparser::ExternalKind::Func => ExportKind::Func,
-                        wasmparser::ExternalKind::Global => ExportKind::Global,
-                        wasmparser::ExternalKind::Memory => {
-                            continue; // Skip memory export
-                        }
-                        _ => continue,
-                    };
-                    export_section_data.push((exp.name.to_string(), kind, exp.index));
-                }
-            }
-            Payload::CodeSectionStart { .. } => {}
-            Payload::CodeSectionEntry(_) => {}
-            Payload::DataSection(_) => {
-                if let Some(range) = get_section_range(&payload) {
-                    data_bytes = Some(wasm_bytes[range].to_vec());
-                }
-            }
-            _ => {}
-        }
-    }
-
-    // Second pass: rebuild with memory import
-    let parser = Parser::new(0);
-    let mut code_entries: Vec<Vec<u8>> = Vec::new();
-
-    for payload in parser.parse_all(wasm_bytes) {
-        let payload = payload.map_err(|e| format!("Parse error: {e}"))?;
-
-        match payload {
-            Payload::TypeSection(_) => {
-                if let Some(bytes) = &type_bytes {
-                    module.section(&RawSection { id: 1, data: bytes });
-                }
-            }
-            Payload::ImportSection(_) => {
-                // Skip original imports, we'll add our own
-            }
-            Payload::FunctionSection(_) => {
-                // Add import section first (before function section)
+            Payload::ImportSection(reader) => {
                 let mut imports = ImportSection::new();
-                imports.import(
-                    import_module,
-                    import_name,
-                    MemoryType {
-                        minimum: memory_pages,
-                        maximum: None,
-                        memory64: false,
-                        shared: false,
-                        page_size_log2: None,
-                    },
-                );
-                module.section(&imports);
-
-                // Then add function section
-                if let Some(bytes) = &function_bytes {
-                    module.section(&RawSection { id: 3, data: bytes });
+                for group in reader.clone() {
+                    for entry in group.map_err(|e| format!("Parse error: {e}"))? {
+                        let (_, import) = entry.map_err(|e| format!("Parse error: {e}"))?;
+                        imports.import(
+                            import.module,
+                            import.name,
+                            entity_type(import.ty).ok_or_else(|| {
+                                format!(
+                                    "unsupported import kind in {}/{}",
+                                    import.module, import.name
+                                )
+                            })?,
+                        );
+                    }
                 }
+                memory_import(&mut module, imports);
+                memory_import_written = true;
             }
-            Payload::MemorySection(_) => {
-                // Skip - we're importing memory instead
-            }
-            Payload::GlobalSection(_) => {
-                if let Some(bytes) = &global_bytes {
-                    module.section(&RawSection { id: 6, data: bytes });
-                }
-            }
-            Payload::ExportSection(_) => {
+            // Replaced by the import above.
+            Payload::MemorySection(_) => {}
+            Payload::ExportSection(reader) => {
                 let mut exports = ExportSection::new();
-                for (name, kind, idx) in &export_section_data {
-                    exports.export(name, *kind, *idx);
+                for export in reader.clone() {
+                    let export = export.map_err(|e| format!("Parse error: {e}"))?;
+                    if export.kind == wasmparser::ExternalKind::Memory {
+                        continue;
+                    }
+                    exports.export(
+                        export.name,
+                        export_kind(export.kind)
+                            .ok_or_else(|| format!("unsupported export kind: {}", export.name))?,
+                        export.index,
+                    );
                 }
                 module.section(&exports);
             }
-            Payload::CodeSectionStart { .. } => {
-                // Start of code section
-            }
-            Payload::CodeSectionEntry(body) => {
-                // Collect code entries
-                let range = body.range();
-                code_entries.push(wasm_bytes[range].to_vec());
-            }
-            Payload::DataSection(_) => {
-                // Build code section before data section
-                if !code_entries.is_empty() {
-                    let mut code = CodeSection::new();
-                    for entry in &code_entries {
-                        code.raw(entry);
-                    }
-                    module.section(&code);
-                    code_entries.clear();
-                }
-
-                // Add data section
-                if let Some(bytes) = &data_bytes {
+            // Individual bodies arrive after `CodeSectionStart`, which already
+            // copied the whole section verbatim.
+            Payload::CodeSectionEntry(_) => {}
+            // Everything else — including sections this rewrite knows nothing
+            // about — is copied through rather than dropped.
+            other => {
+                if let Some((id, range)) = other.as_section() {
                     module.section(&RawSection {
-                        id: 11,
-                        data: bytes,
+                        id,
+                        data: &wasm_bytes[range],
                     });
                 }
             }
-            _ => {}
         }
     }
 
-    // If code section wasn't added before data, add it now
-    if !code_entries.is_empty() {
-        let mut code = CodeSection::new();
-        for entry in &code_entries {
-            code.raw(entry);
-        }
-        module.section(&code);
+    if !memory_import_written {
+        memory_import(&mut module, ImportSection::new());
     }
 
     Ok(module.finish())
 }
 
-fn get_section_range(payload: &Payload) -> Option<std::ops::Range<usize>> {
-    match payload {
-        Payload::TypeSection(reader) => Some(reader.range()),
-        Payload::FunctionSection(reader) => Some(reader.range()),
-        Payload::GlobalSection(reader) => Some(reader.range()),
-        Payload::DataSection(reader) => Some(reader.range()),
-        _ => None,
+/// The memory this module defines, as an import-ready [`MemoryType`]. The
+/// rewrite maps the definition onto import slot 0, so exactly one defined
+/// memory and no imported one is the only shape it can preserve.
+fn find_single_memory(wasm_bytes: &[u8]) -> Result<MemoryType, String> {
+    let mut found: Option<MemoryType> = None;
+    for payload in Parser::new(0).parse_all(wasm_bytes) {
+        match payload.map_err(|e| format!("Parse error: {e}"))? {
+            Payload::MemorySection(reader) => {
+                for mem in reader {
+                    let mem = mem.map_err(|e| format!("Parse error: {e}"))?;
+                    if found.is_some() {
+                        return Err("module defines more than one memory".to_string());
+                    }
+                    found = Some(MemoryType {
+                        minimum: mem.initial,
+                        maximum: mem.maximum,
+                        memory64: mem.memory64,
+                        shared: mem.shared,
+                        page_size_log2: mem.page_size_log2,
+                    });
+                }
+            }
+            Payload::ImportSection(reader) => {
+                for group in reader {
+                    for entry in group.map_err(|e| format!("Parse error: {e}"))? {
+                        let (_, import) = entry.map_err(|e| format!("Parse error: {e}"))?;
+                        if matches!(import.ty, wasmparser::TypeRef::Memory(_)) {
+                            return Err(format!(
+                                "module already imports memory {}/{}",
+                                import.module, import.name
+                            ));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    found.ok_or_else(|| "module defines no memory to convert".to_string())
+}
+
+fn entity_type(ty: wasmparser::TypeRef) -> Option<EntityType> {
+    use wasmparser::TypeRef;
+    match ty {
+        TypeRef::Func(idx) => Some(EntityType::Function(idx)),
+        TypeRef::Memory(mem) => Some(EntityType::Memory(MemoryType {
+            minimum: mem.initial,
+            maximum: mem.maximum,
+            memory64: mem.memory64,
+            shared: mem.shared,
+            page_size_log2: mem.page_size_log2,
+        })),
+        TypeRef::Global(_) | TypeRef::Table(_) | TypeRef::Tag(_) | TypeRef::FuncExact(_) => None,
+    }
+}
+
+fn export_kind(kind: wasmparser::ExternalKind) -> Option<ExportKind> {
+    use wasmparser::ExternalKind;
+    match kind {
+        ExternalKind::Func | ExternalKind::FuncExact => Some(ExportKind::Func),
+        ExternalKind::Table => Some(ExportKind::Table),
+        ExternalKind::Memory => Some(ExportKind::Memory),
+        ExternalKind::Global => Some(ExportKind::Global),
+        ExternalKind::Tag => Some(ExportKind::Tag),
     }
 }
 
@@ -228,43 +221,140 @@ mod tests {
             .into_owned()
     }
 
-    #[test]
-    fn test_convert_memory_to_import() {
-        let bytes = libm_core_wasm();
-        let result = convert_memory_to_import(&bytes, "env", "memory");
-        assert!(result.is_ok(), "Failed to convert: {result:?}");
-
-        let converted = result.unwrap();
-
-        // Verify it's valid Wasm
-        assert!(converted.starts_with(&[0, b'a', b's', b'm']));
-
-        // Parse and verify structure
-        let parser = Parser::new(0);
-        let mut has_memory_import = false;
-        let mut has_memory_definition = false;
-
-        for payload in parser.parse_all(&converted) {
-            match payload {
-                Ok(Payload::ImportSection(imports)) => {
-                    for group in imports.into_iter().flatten() {
-                        for import in group {
-                            if let Ok((_, imp)) = import
-                                && matches!(imp.ty, wasmparser::TypeRef::Memory(_))
-                            {
-                                has_memory_import = true;
-                            }
+    /// The imported memory type, if the module imports one.
+    fn memory_import_of(wasm: &[u8]) -> Option<wasmparser::MemoryType> {
+        for payload in Parser::new(0).parse_all(wasm) {
+            if let Ok(Payload::ImportSection(imports)) = payload {
+                for group in imports.into_iter().flatten() {
+                    for import in group {
+                        if let Ok((_, imp)) = import
+                            && let wasmparser::TypeRef::Memory(mem) = imp.ty
+                        {
+                            return Some(mem);
                         }
                     }
                 }
-                Ok(Payload::MemorySection(_)) => {
-                    has_memory_definition = true;
-                }
-                _ => {}
             }
         }
+        None
+    }
 
-        assert!(has_memory_import, "Should have memory import");
-        assert!(!has_memory_definition, "Should not have memory definition");
+    fn section_ids(wasm: &[u8]) -> Vec<u8> {
+        Parser::new(0)
+            .parse_all(wasm)
+            .filter_map(|p| p.ok().and_then(|p| p.as_section().map(|(id, _)| id)))
+            .collect()
+    }
+
+    fn export_names(wasm: &[u8]) -> Vec<String> {
+        let mut names = Vec::new();
+        for payload in Parser::new(0).parse_all(wasm) {
+            if let Ok(Payload::ExportSection(exports)) = payload {
+                for export in exports.into_iter().flatten() {
+                    names.push(export.name.to_string());
+                }
+            }
+        }
+        names
+    }
+
+    fn validate(wasm: &[u8]) -> Result<(), String> {
+        wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all())
+            .validate_all(wasm)
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn test_convert_memory_to_import() {
+        let bytes = libm_core_wasm();
+        let converted = convert_memory_to_import(&bytes, "env", "memory").expect("conversion");
+
+        assert!(memory_import_of(&converted).is_some(), "memory import");
+        assert!(
+            !section_ids(&converted).contains(&5),
+            "memory definition must be gone"
+        );
+        validate(&converted).expect("converted libm must validate");
+    }
+
+    /// The rewrite touches three sections; everything else must survive
+    /// byte-for-byte. It used to rebuild the module from a fixed list of
+    /// section kinds, so a table, element, start, or custom section was
+    /// silently dropped and the memory's `maximum` thrown away.
+    #[test]
+    fn convert_memory_to_import_preserves_other_sections() {
+        let source = r#"
+            (module
+              (type $void (func))
+              (type $get (func (result i32)))
+              (memory 2 4)
+              (table 1 funcref)
+              (global $g (mut i32) (i32.const 7))
+              (func $init (type $void))
+              (func $answer (type $get) (result i32) (i32.const 42))
+              (start $init)
+              (elem declare func $answer)
+              (data (i32.const 0) "hi")
+              (export "memory" (memory 0))
+              (export "answer" (func $answer))
+              (export "table" (table 0))
+              (export "g" (global $g)))
+        "#;
+        let bytes = wat::parse_str(source).expect("fixture must parse");
+        let converted = convert_memory_to_import(&bytes, "env", "memory").expect("conversion");
+
+        validate(&converted).expect("converted module must validate");
+
+        let mem = memory_import_of(&converted).expect("memory import");
+        assert_eq!(mem.initial, 2);
+        assert_eq!(mem.maximum, Some(4), "maximum must survive the rewrite");
+
+        let ids = section_ids(&converted);
+        assert!(!ids.contains(&5), "memory definition must be gone");
+        for (id, name) in [
+            (0u8, "custom"),
+            (1, "type"),
+            (2, "import"),
+            (3, "function"),
+            (4, "table"),
+            (6, "global"),
+            (7, "export"),
+            (8, "start"),
+            (9, "element"),
+            (10, "code"),
+            (11, "data"),
+        ] {
+            assert!(ids.contains(&id), "{name} section must survive");
+        }
+        // Custom sections (id 0) may sit anywhere; the rest must stay ordered.
+        let ordered: Vec<u8> = ids.iter().copied().filter(|id| *id != 0).collect();
+        assert_eq!(ordered, {
+            let mut sorted = ordered.clone();
+            sorted.sort_unstable();
+            sorted
+        });
+
+        let exports = export_names(&converted);
+        assert!(!exports.contains(&"memory".to_string()), "memory export");
+        for kept in ["answer", "table", "g"] {
+            assert!(exports.contains(&kept.to_string()), "{kept} export");
+        }
+    }
+
+    /// A module with no import section of its own still gets one, placed
+    /// before every section that could reference an import.
+    #[test]
+    fn convert_memory_to_import_inserts_import_section() {
+        let bytes = wat::parse_str("(module (memory 1) (func))").expect("fixture must parse");
+        let converted = convert_memory_to_import(&bytes, "env", "memory").expect("conversion");
+        validate(&converted).expect("converted module must validate");
+        assert!(memory_import_of(&converted).is_some());
+    }
+
+    #[test]
+    fn convert_memory_to_import_rejects_a_module_with_no_memory() {
+        let bytes = wat::parse_str("(module (func))").expect("fixture must parse");
+        assert!(convert_memory_to_import(&bytes, "env", "memory").is_err());
     }
 }

--- a/wado-compiler/src/codegen/postprocess.rs
+++ b/wado-compiler/src/codegen/postprocess.rs
@@ -1,7 +1,6 @@
-//! Post-processing for Wasm modules
-//!
-//! This module provides utilities to transform Wasm modules, such as
-//! converting memory definitions to imports and dead code elimination.
+//! Post-processing over finished core modules: rewriting an embedded wasm
+//! asset's memory definition into an import, and pruning it to its used
+//! exports.
 
 use crate::hashmap::IndexSet;
 
@@ -11,17 +10,12 @@ use wasm_encoder::{
 };
 use wasmparser::{Parser, Payload};
 
-/// Perform dead code elimination on a Wasm module, keeping only the specified exports.
-///
-/// This uses walrus to remove unused functions and other items from the module.
-/// The `keep_exports` set contains the names of exports that should be preserved.
-/// The gc pass automatically treats exports as roots, so we remove unwanted exports first.
+/// Drop everything not reachable from `keep_exports`. The gc pass roots at the
+/// exports, so the unwanted ones go first.
 pub fn eliminate_dead_code(wasm_bytes: &[u8], keep_exports: &IndexSet<String>) -> Vec<u8> {
     let mut module =
         walrus::Module::from_buffer(wasm_bytes).expect("bundled module should be valid");
 
-    // Remove exports that are not in the keep set
-    // The gc pass will treat remaining exports as roots
     let exports_to_remove: Vec<_> = module
         .exports
         .iter()
@@ -33,8 +27,6 @@ pub fn eliminate_dead_code(wasm_bytes: &[u8], keep_exports: &IndexSet<String>) -
         module.exports.delete(id);
     }
 
-    // Run garbage collection to remove unreferenced items
-    // (exports are automatically treated as roots)
     passes::gc::run(&mut module);
 
     module.emit_wasm()
@@ -45,19 +37,16 @@ const IMPORT_SECTION_ID: u8 = 2;
 /// Rewrite a wasm asset so it takes the component's memory as an import rather
 /// than defining its own, letting it share memory with the other core modules.
 ///
-/// Handles all three shapes `loader.rs` accepts (see [`MemorySource`]). Every
-/// section other than the memory definition, the memory export, and the import
-/// section is carried over byte-for-byte, in its original order. That leaves
-/// every index space unchanged: the memory import takes slot 0, exactly where
-/// the dropped definition sat, and the memory space is disjoint from the
-/// function, global, and table spaces.
+/// Every section but the memory definition, the memory export and the import
+/// section is copied through byte-for-byte, in order. Index spaces are
+/// therefore unchanged: the memory import takes slot 0, where the dropped
+/// definition sat.
 pub fn convert_memory_to_import(
     wasm_bytes: &[u8],
     import_module: &str,
     import_name: &str,
 ) -> Result<Vec<u8>, String> {
-    // `None` once the module already imports its memory: it needs no new one,
-    // and adding a second would be a duplicate.
+    // `None` when the module already imports its memory.
     let to_import: Option<MemoryType> = match find_memory_source(wasm_bytes)? {
         MemorySource::AlreadyImported => None,
         MemorySource::Defined(mem) => Some(mem),
@@ -81,9 +70,8 @@ pub fn convert_memory_to_import(
     for payload in Parser::new(0).parse_all(wasm_bytes) {
         let payload = payload.map_err(|e| format!("Parse error: {e}"))?;
 
-        // The import section must precede every section that can reference an
-        // import. When the module has none of its own, open one right before
-        // the first such section (any id above the import section's own 2).
+        // The import section must precede anything that can reference an
+        // import, so a module with none of its own gets one opened here.
         if !memory_import_written
             && to_import.is_some()
             && let Some((id, _)) = payload.as_section()
@@ -132,11 +120,10 @@ pub fn convert_memory_to_import(
                 }
                 module.section(&exports);
             }
-            // Individual bodies arrive after `CodeSectionStart`, which already
-            // copied the whole section verbatim.
+            // `CodeSectionStart` already copied the whole section.
             Payload::CodeSectionEntry(_) => {}
-            // Everything else — including sections this rewrite knows nothing
-            // about — is copied through rather than dropped.
+            // Everything else, including sections unknown here, is copied
+            // through rather than dropped.
             other => {
                 if let Some((id, range)) = other.as_section() {
                     module.section(&RawSection {
@@ -155,16 +142,15 @@ pub fn convert_memory_to_import(
     Ok(module.finish())
 }
 
-/// Where a wasm asset's memory comes from. These are the shapes `loader.rs`
-/// admits: it rejects more than one memory, and `env.memory` is the only import
-/// it allows — so all three arms are ordinary inputs, not error cases.
+/// Where a wasm asset's memory comes from. All three are shapes `loader.rs`
+/// admits, so none is an error case.
 enum MemorySource {
     /// Defines exactly one. The rewrite drops it and imports the same shape.
     Defined(MemoryType),
     /// Already written against the component's memory; nothing to convert.
     AlreadyImported,
-    /// Neither defines nor imports one, so it cannot touch linear memory. It
-    /// still gets a minimal import, keeping every embedded module one shape.
+    /// Cannot touch linear memory. Still gets a minimal import, so every
+    /// embedded module has one shape.
     Absent,
 }
 
@@ -242,7 +228,6 @@ mod tests {
             .into_owned()
     }
 
-    /// The imported memory type, if the module imports one.
     fn memory_import_of(wasm: &[u8]) -> Option<wasmparser::MemoryType> {
         for payload in Parser::new(0).parse_all(wasm) {
             if let Ok(Payload::ImportSection(imports)) = payload {
@@ -317,10 +302,8 @@ mod tests {
         validate(&converted).expect("converted libm must validate");
     }
 
-    /// The rewrite touches three sections; everything else must survive
-    /// byte-for-byte. It used to rebuild the module from a fixed list of
-    /// section kinds, so a table, element, start, or custom section was
-    /// silently dropped and the memory's `maximum` thrown away.
+    /// The rewrite touches three sections; every other one — table, element,
+    /// start, custom — and the memory's `maximum` must survive it.
     #[test]
     fn convert_memory_to_import_preserves_other_sections() {
         let source = r#"
@@ -391,9 +374,8 @@ mod tests {
         assert!(memory_import_of(&converted).is_some());
     }
 
-    /// `loader.rs` accepts a wasm asset with no memory at all (it only rejects
-    /// more than one), so the rewrite must still hand it the component's
-    /// memory rather than refusing the module.
+    /// `loader.rs` accepts an asset with no memory, so the rewrite must hand it
+    /// the component's rather than refuse the module.
     #[test]
     fn convert_memory_to_import_accepts_a_module_with_no_memory() {
         let bytes = wat::parse_str(r#"(module (func (export "add_one")))"#).expect("fixture");
@@ -402,9 +384,8 @@ mod tests {
         assert!(memory_import_of(&converted).is_some(), "memory import");
     }
 
-    /// `env.memory` is the one import `loader.rs` permits in a wasm asset, so a
-    /// module already written against it is a normal input, not an error — and
-    /// it must not come back with the import duplicated.
+    /// `env.memory` is the one import `loader.rs` permits, so an asset already
+    /// written against it is a normal input and must not gain a duplicate.
     #[test]
     fn convert_memory_to_import_passes_through_an_existing_memory_import() {
         let source = r#"

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -577,9 +577,8 @@ impl CmFunctionInfo {
         build_local_alias_name(&self.package, &self.interface_name, &self.method_name)
     }
 
-    /// The `"{interface}::{method}"` key that `NirPackage::used_wasi_functions`
-    /// is keyed by (e.g. `"Stdout::write_via_stream"`). The single spelling of
-    /// that format, so a lookup cannot drift from the recording side.
+    /// This function's key in `NirPackage::used_wasi_functions` (e.g.
+    /// `"Stdout::write_via_stream"`).
     #[must_use]
     pub fn used_key(&self) -> String {
         format!("{}::{}", self.interface_name, self.method_name)
@@ -741,11 +740,10 @@ pub struct CmInterfaceInfo {
 }
 
 /// The codegen component-instance key `"{package}-{interface}"` (e.g.
-/// `"http-types"`). The single source of truth for this format: a bare
-/// interface name would collide across packages (`wasi:cli/types` vs
-/// `wasi:http/types`), so every register/lookup pair builds the key here — from
-/// a [`CmInterfaceInfo`] or from a parsed [`crate::ast::CmImport`], which name
-/// the same instance and must agree.
+/// `"http-types"`). Package-qualified because a bare interface name collides
+/// across packages (`wasi:cli/types` vs `wasi:http/types`). Both
+/// [`CmInterfaceInfo`] and [`crate::ast::CmImport`] name the same instance, so
+/// both build the key here.
 #[must_use]
 pub fn cm_instance_key(package: &str, interface: &str) -> String {
     format!("{package}-{interface}")
@@ -2712,11 +2710,10 @@ impl CmInterfaceRegistry {
             .contains_key(&(interface_path.to_string(), name.to_string()))
     }
 
-    /// Whether `interface_path` declares its own `ErrorCode`, as either shape:
-    /// an enum in `wasi:cli/types`, a variant in `wasi:filesystem/types` and
-    /// `wasi:sockets/types`. Codegen asks this to decide between the
-    /// interface-local error type and an outer alias to the shared CLI one, so
-    /// both shapes must be checked together everywhere.
+    /// Whether `interface_path` declares its own `ErrorCode`, in either shape:
+    /// an enum (`wasi:cli/types`) or a variant (`wasi:filesystem/types`,
+    /// `wasi:sockets/types`). Codegen picks the interface-local error type over
+    /// an alias to the shared CLI one on this, so both shapes count.
     pub fn declares_own_error_code(&self, interface_path: &str) -> bool {
         self.has_enum_in_interface(interface_path, "ErrorCode")
             || self

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -577,6 +577,14 @@ impl CmFunctionInfo {
         build_local_alias_name(&self.package, &self.interface_name, &self.method_name)
     }
 
+    /// The `"{interface}::{method}"` key that `NirPackage::used_wasi_functions`
+    /// is keyed by (e.g. `"Stdout::write_via_stream"`). The single spelling of
+    /// that format, so a lookup cannot drift from the recording side.
+    #[must_use]
+    pub fn used_key(&self) -> String {
+        format!("{}::{}", self.interface_name, self.method_name)
+    }
+
     /// Whether `canon lower` requires the Memory canonical option.
     ///
     /// True when any parameter or return type involves linear memory
@@ -732,14 +740,22 @@ pub struct CmInterfaceInfo {
     pub resource_type: Option<(String, String)>,
 }
 
+/// The codegen component-instance key `"{package}-{interface}"` (e.g.
+/// `"http-types"`). The single source of truth for this format: a bare
+/// interface name would collide across packages (`wasi:cli/types` vs
+/// `wasi:http/types`), so every register/lookup pair builds the key here — from
+/// a [`CmInterfaceInfo`] or from a parsed [`crate::ast::CmImport`], which name
+/// the same instance and must agree.
+#[must_use]
+pub fn cm_instance_key(package: &str, interface: &str) -> String {
+    format!("{package}-{interface}")
+}
+
 impl CmInterfaceInfo {
-    /// The codegen component-instance key `"{package}-{interface}"` (e.g.
-    /// `"http-types"`). The single source of truth for this format: a bare
-    /// interface name would collide across packages (`wasi:cli/types` vs
-    /// `wasi:http/types`), so every register/lookup pair builds the key here.
+    /// This interface's [`cm_instance_key`].
     #[must_use]
     pub fn instance_key(&self) -> String {
-        format!("{}-{}", self.package, self.interface)
+        cm_instance_key(&self.package, &self.interface)
     }
 }
 
@@ -2694,6 +2710,18 @@ impl CmInterfaceRegistry {
     pub fn has_enum_in_interface(&self, interface_path: &str, name: &str) -> bool {
         self.enums
             .contains_key(&(interface_path.to_string(), name.to_string()))
+    }
+
+    /// Whether `interface_path` declares its own `ErrorCode`, as either shape:
+    /// an enum in `wasi:cli/types`, a variant in `wasi:filesystem/types` and
+    /// `wasi:sockets/types`. Codegen asks this to decide between the
+    /// interface-local error type and an outer alias to the shared CLI one, so
+    /// both shapes must be checked together everywhere.
+    pub fn declares_own_error_code(&self, interface_path: &str) -> bool {
+        self.has_enum_in_interface(interface_path, "ErrorCode")
+            || self
+                .variants_for_interface(interface_path)
+                .any(|(name, _, _)| name == "ErrorCode")
     }
 
     /// Get the variant cases scoped to a specific source interface. Falls back

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -1386,20 +1386,20 @@ pub enum WirInstr {
         value: Box<WirInstr>,
         len: Box<WirInstr>,
     },
-    /// Deep-copy an `Array<T>`: allocate one the length of `src` and copy every
-    /// element. `element_copy_type` is set when `T` is a value-typed struct
-    /// needing its own copy per element — a bare
-    /// `array.set(dst, i, array.get(src, i))` stores the *same* ref into both
-    /// arrays — and the loop then calls that type's `$value_copy$` helper.
+    /// Deep-copy an `Array<T>` whose `T` is a value-typed struct: allocate one
+    /// the length of `src` and copy every element through `T`'s `$value_copy$`
+    /// helper, since a bare `array.set(dst, i, array.get(src, i))` would store
+    /// the *same* ref into both arrays.
     ArrayClone {
         type_id: WirTypeId,
         src: Box<WirInstr>,
         /// The canonical mangle of the element type needing a per-element deep
-        /// copy, or `None` when a plain `array.set` already copies (primitive
-        /// elements). Codegen and DCE resolve this to the `$value_copy$` helper
-        /// by matching each helper's `value_copy_mangle` metadata — no name
+        /// copy. Codegen and DCE resolve this to the `$value_copy$` helper by
+        /// matching each helper's `value_copy_mangle` metadata — no name
         /// lookup, and robust to the same type being interned more than once.
-        element_copy_mangle: Option<String>,
+        /// A primitive element, for which a plain `array.set` already copies,
+        /// never reaches here: `wir_build` emits a bulk clone instead.
+        element_copy_mangle: String,
         /// Number of leading elements to copy — the destination's exact
         /// length. `None` clones the whole array (`array.len(src)`). Must
         /// evaluate to <= `array.len(src)`.

--- a/wado-compiler/src/wir.rs
+++ b/wado-compiler/src/wir.rs
@@ -1393,12 +1393,9 @@ pub enum WirInstr {
     ArrayClone {
         type_id: WirTypeId,
         src: Box<WirInstr>,
-        /// The canonical mangle of the element type needing a per-element deep
-        /// copy. Codegen and DCE resolve this to the `$value_copy$` helper by
-        /// matching each helper's `value_copy_mangle` metadata — no name
-        /// lookup, and robust to the same type being interned more than once.
-        /// A primitive element, for which a plain `array.set` already copies,
-        /// never reaches here: `wir_build` emits a bulk clone instead.
+        /// The element type's canonical mangle. Codegen and DCE resolve it to
+        /// the `$value_copy$` helper through each helper's `value_copy_mangle`,
+        /// so the same type interned twice still matches.
         element_copy_mangle: String,
         /// Number of leading elements to copy — the destination's exact
         /// length. `None` clones the whole array (`array.len(src)`). Must

--- a/wado-compiler/src/wir_build/calls.rs
+++ b/wado-compiler/src/wir_build/calls.rs
@@ -567,7 +567,7 @@ impl FunctionTranslator<'_, '_> {
                     Some(element_copy_mangle) => Some(WirInstr::ArrayClone {
                         type_id,
                         src: Box::new(src),
-                        element_copy_mangle: Some(element_copy_mangle),
+                        element_copy_mangle,
                         len: None,
                     }),
                     None => Some(self.build_bulk_array_clone(type_id, src, None)),
@@ -580,7 +580,7 @@ impl FunctionTranslator<'_, '_> {
                     Some(element_copy_mangle) => Some(WirInstr::ArrayClone {
                         type_id,
                         src: Box::new(src),
-                        element_copy_mangle: Some(element_copy_mangle),
+                        element_copy_mangle,
                         len: Some(Box::new(len)),
                     }),
                     None => Some(self.build_bulk_array_clone(type_id, src, Some(len))),

--- a/wado-compiler/src/wir_optimize/dce.rs
+++ b/wado-compiler/src/wir_optimize/dce.rs
@@ -42,7 +42,7 @@ fn collect_array_clone_helper_refs_recursive<F>(
     F: Fn(&str) -> Option<u32>,
 {
     if let WirInstr::ArrayClone {
-        element_copy_mangle: Some(copy_mangle),
+        element_copy_mangle: copy_mangle,
         ..
     } = instr
         && let Some(idx) = resolve(copy_mangle)

--- a/wado-compiler/src/wir_optimize/util.rs
+++ b/wado-compiler/src/wir_optimize/util.rs
@@ -71,7 +71,7 @@ fn collect_array_clone_helpers_instr(
     pinned: &mut IndexSet<u32>,
 ) {
     if let WirInstr::ArrayClone {
-        element_copy_mangle: Some(copy_mangle),
+        element_copy_mangle: copy_mangle,
         ..
     } = instr
         && let Some(idx) = helper_mangle_to_idx.get(copy_mangle.as_str())

--- a/wado-compiler/src/wir_unparse.rs
+++ b/wado-compiler/src/wir_unparse.rs
@@ -1514,17 +1514,12 @@ impl<'a> WirUnparser<'a> {
             WirInstr::ArrayClone {
                 type_id,
                 src,
-                element_copy_mangle,
+                element_copy_mangle: _,
                 len,
             } => {
                 let elem = self.array_elem_type_str(type_id);
-                let deep = if element_copy_mangle.is_some() {
-                    "_deep"
-                } else {
-                    ""
-                };
                 let prefix = if len.is_some() { "_prefix" } else { "" };
-                self.write(&format!("builtin::array_clone{deep}{prefix}<{elem}>("));
+                self.write(&format!("builtin::array_clone_deep{prefix}<{elem}>("));
                 self.unparse_instr_inline(src);
                 if let Some(len) = len {
                     self.write(", ");


### PR DESCRIPTION
Codegen resolves every index against a map that must contain it, and fails with a diagnostic when it does not.

## Index and type resolution

Each lookup in `emit.rs` that maps a WIR entity onto a Wasm index — type, struct field, function — panics naming the entity when the map has no entry. Any index standing in for a missing one denotes a different entity: `struct.new` builds another shape, `struct.get` reads another field, `call` targets another function. Such a module frequently still passes validation, so the defect surfaces as wrong runtime behaviour rather than as a compile error.

`emit_instr` covers every `WirInstr` variant, `table.get` and `table.set` included, so an instruction the emitter does not understand cannot become a bare `unreachable`.

Function ids resolve against `WirPackage::defined_func_base` — `DEFINED_FUNC_BASE` for the GC module, `0` for the import-less memory module. `build_func_index_map`, the branch-hint records and the name section all read that field, so both kinds of package resolve. A `debug_assert!` holds the base clear of the imports, keeping the two id spaces disjoint.

## Component Model boundary types

Three sites derive the type they emit from its declaration. A stream whose element is a record requires the interface defining that record to be imported. A transmission future requires the `error-code` alias of its own package. Each `ErrorCode` variant case encodes its own declared payload type.

## Wasm asset memory rewriting

`convert_memory_to_import` accepts the three shapes `loader.rs` admits: a module defining one memory, a module already importing `env.memory`, and a module with no memory at all. Every section other than the memory definition, the memory export and the import section is copied through byte-for-byte in order, so table, element, start and custom sections survive and every index space is unchanged. The memory's `maximum` carries onto the import.

## One spelling per key

Keys and dispatches used across many sites have a single definition: `cm_instance_key` for the package-qualified component-instance key, `error_code_key` and `alias_package_error_code` for a package's `error-code`, `resource_type_key`, `CmFunctionInfo::used_key`, `emits_function`, `CmInterfaceRegistry::declares_own_error_code`, `emit_array_get` for the packed-array read, and `array_copy_slot` / `array_clone_slot` for the emitter's scratch locals, which the declaring walker and the emitter must spell identically.

`WirInstr::ArrayClone` carries a non-optional `element_copy_mangle`, since a primitive element lowers to a bulk clone rather than to this instruction.

`docs/compiler.md` attributes the branch-hint section to `emit.rs` and describes `postprocess.rs` as the memory-import rewrite and export pruning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vo6wP5KvJPaqYsmSeKoyNj