### PR TITLE
refactor(reflect): one mechanism per concern across the four reflect kinds

### DIFF
--- a/docs/wep-2026-08-12-declaration-identity.md
+++ b/docs/wep-2026-08-12-declaration-identity.md
@@ -503,6 +503,18 @@ caller of the same first-wins index. A removed mechanism takes one fix.
       a declaration outside the pass that declares, and with the unit tests
       resting on them. A feature whose only unit test needs a hole cut in it is
       covered by `tests/fixtures/` instead, which exercises the real path.
+- [ ] The bound-driven synthesis request key stops carrying a receiver
+      spelling. `synthesis::traits::SynthRequests` holds
+      `(receiver, module, trait)`, and the trait is already a `DefId` while
+      `SynthesisCtx::key` renders the receiver's head to a `String` — a
+      spelling as an equality operand, which §4 and §9 forbid. It does not
+      become a `DefId`: `SynthesisCtx::instance_has_impl` keys a monomorphized
+      instantiation, which no declaration names. It becomes the
+      declaration-or-shape sum this design already has — `TypeHead`, whose
+      `Declared` compares by its `DefId` and whose `Shape` compares by its
+      rendering. `FqTypeName::head` hands one over and `key` discards it. The
+      producers are `TypeTable::record_bound_driven_synth_request` and its
+      elaborator callers.
 - [ ] `SymbolPath`. `LocalMethodName` and `FqTypeName` already serve as the
       structured identity a name renders from, and nothing parses a rendering
       back. What is left is that `FqTraitName::args` and

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -1322,11 +1322,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         ctx: &mut FunctionContext,
     ) -> TypeId {
         // `Reflect{Struct,Variant,Enum,Flags}::<T>::method()` — a reflect trait
-        // is a (sealed) trait, not a type, so `target_type` would not resolve.
-        // Intercept and route to the concrete `T`'s synthesized
-        // `T^Trait::method` (WEP 2026-06-13 §1 / §3b–d). This is the only
-        // spelling for reflection metadata; a bare `T::members()` never
-        // resolves, so type namespaces stay clean.
+        // is a trait, not a type, so `target_type` would not resolve. Intercept
+        // and route to the concrete `T`'s synthesized `T^Trait::method` (WEP
+        // 2026-06-13 §1 / §3b–d). It is the only spelling: a bare
+        // `T::members()` never resolves, so type namespaces stay clean.
         if let ast::Type::Generic(g) = &static_call.target_type
             && let Some(self_ty_ast) = g.args.first()
         {

--- a/wado-compiler/src/elaborator/method_call.rs
+++ b/wado-compiler/src/elaborator/method_call.rs
@@ -1321,37 +1321,25 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         static_call: &ast::StaticMethodCallExpr,
         ctx: &mut FunctionContext,
     ) -> TypeId {
-        // ReflectStruct trait-qualified static call: `ReflectStruct::<T>::members()` /
-        // `type_name()`. `ReflectStruct` is a (sealed) trait, not a type, so
-        // `target_type` would not resolve — intercept and route to the
-        // concrete `T`'s synthesized `T^ReflectStruct::method`. This is the only
-        // spelling for ReflectStruct metadata; a bare `T::members()` never
-        // resolves, so struct namespaces stay clean.
+        // `Reflect{Struct,Variant,Enum,Flags}::<T>::method()` — a reflect trait
+        // is a (sealed) trait, not a type, so `target_type` would not resolve.
+        // Intercept and route to the concrete `T`'s synthesized
+        // `T^Trait::method` (WEP 2026-06-13 §1 / §3b–d). This is the only
+        // spelling for reflection metadata; a bare `T::members()` never
+        // resolves, so type namespaces stay clean.
         if let ast::Type::Generic(g) = &static_call.target_type
-            && self.is_reflect_trait_call(&g.name, &static_call.method)
             && let Some(self_ty_ast) = g.args.first()
         {
-            let self_ty = self.resolve_type(self_ty_ast);
-            return self.resolve_reflect_static_call(self_ty, static_call, ctx);
-        }
-
-        // `ReflectVariant::<T>::…` — the variant analog of the interception
-        // above (WEP 2026-06-13 §3d).
-        if let ast::Type::Generic(g) = &static_call.target_type
-            && self.is_reflect_variant_trait_call(&g.name, &static_call.method)
-            && let Some(self_ty_ast) = g.args.first()
-        {
-            let self_ty = self.resolve_type(self_ty_ast);
-            return self.resolve_reflect_variant_static_call(self_ty, static_call, ctx);
-        }
-
-        // `ReflectEnum::<T>::…` / `ReflectFlags::<T>::…` — the scalar-kind
-        // analogs (WEP 2026-06-13 §3b / §3c), sharing one resolver.
-        if let ast::Type::Generic(g) = &static_call.target_type {
+            if self.is_reflect_trait_call(&g.name, &static_call.method) {
+                let self_ty = self.resolve_type(self_ty_ast);
+                return self.resolve_reflect_static_call(self_ty, static_call, ctx);
+            }
+            if self.is_reflect_variant_trait_call(&g.name, &static_call.method) {
+                let self_ty = self.resolve_type(self_ty_ast);
+                return self.resolve_reflect_variant_static_call(self_ty, static_call, ctx);
+            }
             for spec in [ScalarReflectSpec::ENUM, ScalarReflectSpec::FLAGS] {
-                if self.is_reflect_scalar_trait_call(spec, &g.name, &static_call.method)
-                    && let Some(self_ty_ast) = g.args.first()
-                {
+                if self.is_reflect_scalar_trait_call(spec, &g.name, &static_call.method) {
                     let self_ty = self.resolve_type(self_ty_ast);
                     return self.resolve_reflect_scalar_static_call(
                         spec,

--- a/wado-compiler/src/elaborator/reflect.rs
+++ b/wado-compiler/src/elaborator/reflect.rs
@@ -222,10 +222,9 @@ struct PackHead {
     index: u32,
 }
 
-/// The dispatch record's per-parameter mutability. A reflect member's single
-/// argument — the subject for `discriminant(&self)` / `bits(&self)`, the raw
-/// scalar for `from_<value>(raw)` — is never `mut`; a metadata member takes no
-/// argument at all.
+/// The dispatch record's per-parameter mutability. A reflect member takes
+/// either one never-`mut` argument — the subject of `discriminant(&self)` /
+/// `bits(&self)`, the raw scalar of `from_<value>(raw)` — or none.
 fn arg_param_is_mut(takes_argument: bool) -> Vec<bool> {
     if takes_argument {
         vec![false]
@@ -1042,9 +1041,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// Map the `[..P]` pack `T`'s bound projects through `elem`, rewrapped in
-    /// the `[..X]` tuple shape a member type carries. The single place the
-    /// projected pack is scanned out of the bound; `None` when `T` carries no
-    /// such pack bound.
+    /// the `[..X]` tuple shape a member type carries. `None` when `T` carries
+    /// no such pack bound.
     fn map_bound_pack(
         &mut self,
         type_param_name: &str,

--- a/wado-compiler/src/elaborator/reflect.rs
+++ b/wado-compiler/src/elaborator/reflect.rs
@@ -222,10 +222,11 @@ struct PackHead {
     index: u32,
 }
 
-/// The dispatch record's per-parameter mutability. A value-reading member
-/// (`discriminant(&self)` / `bits(&self)` / `from_<value>(raw)`) takes exactly
-/// one non-mut argument; a metadata member takes none.
-fn receiver_param_is_mut(takes_argument: bool) -> Vec<bool> {
+/// The dispatch record's per-parameter mutability. A reflect member's single
+/// argument — the subject for `discriminant(&self)` / `bits(&self)`, the raw
+/// scalar for `from_<value>(raw)` — is never `mut`; a metadata member takes no
+/// argument at all.
+fn arg_param_is_mut(takes_argument: bool) -> Vec<bool> {
     if takes_argument {
         vec![false]
     } else {
@@ -334,7 +335,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
     /// Record a reflect call's dispatch fact for reify. A reflection member
     /// carries no method-level type args, no parameter defaults and no
-    /// self-in-args, so only the callee and the receiver's mutability vary.
+    /// self-in-args, so only the callee and the argument list vary.
     fn record_reflect_dispatch(
         &mut self,
         call_id: ast::AstId,
@@ -957,11 +958,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             &method,
             module_source,
         );
-        self.record_reflect_dispatch(
-            static_call.id,
-            func_ref,
-            receiver_param_is_mut(is_discriminant),
-        );
+        self.record_reflect_dispatch(static_call.id, func_ref, arg_param_is_mut(is_discriminant));
 
         return_type
     }
@@ -1038,7 +1035,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             trait_name,
             method,
             static_call,
-            receiver_param_is_mut(is_discriminant),
+            arg_param_is_mut(is_discriminant),
         );
 
         return_type
@@ -1535,7 +1532,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     fn reflect_scalar_param_is_mut(&self, spec: ScalarReflectSpec, method: &str) -> Vec<bool> {
         let tt = self.tysys.type_table.borrow();
         let items = tt.compiler_items();
-        receiver_param_is_mut(
+        arg_param_is_mut(
             method == items.method_name(spec.value_method_item)
                 || method == items.method_name(spec.from_method_item),
         )

--- a/wado-compiler/src/elaborator/reflect.rs
+++ b/wado-compiler/src/elaborator/reflect.rs
@@ -88,6 +88,149 @@ impl ScalarReflectSpec {
             ScalarReflectKind::Flags => matches!(subject, ResolvedType::Flags { .. }),
         }
     }
+
+    fn methods(self, tt: &TypeTable) -> ScalarMethods {
+        let items = tt.compiler_items();
+        ScalarMethods {
+            type_name: items.method_name(self.type_name_item).to_string(),
+            value: items.method_name(self.value_method_item).to_string(),
+            from: items.method_name(self.from_method_item).to_string(),
+            members: items.method_name(self.members_method_item).to_string(),
+            wire_name_policy: items.method_name(self.wire_name_policy_item).to_string(),
+        }
+    }
+}
+
+/// `ReflectStruct`'s member names, resolved once through the compiler-item
+/// registry so a stdlib rename flows through both the `is_*_trait_call`
+/// predicate and the resolver that dispatches on them.
+struct StructMethods {
+    type_name: String,
+    members: String,
+    from_fields: String,
+    defaults: String,
+    wire_name_policy: String,
+}
+
+impl StructMethods {
+    fn resolve(tt: &TypeTable) -> Self {
+        let items = tt.compiler_items();
+        Self {
+            type_name: items
+                .method_name(CompilerItem::ReflectStructTypeName)
+                .to_string(),
+            members: items
+                .method_name(CompilerItem::ReflectStructMembers)
+                .to_string(),
+            from_fields: items
+                .method_name(CompilerItem::ReflectStructFromFields)
+                .to_string(),
+            defaults: items
+                .method_name(CompilerItem::ReflectStructDefaults)
+                .to_string(),
+            wire_name_policy: items
+                .method_name(CompilerItem::ReflectStructWireNamePolicy)
+                .to_string(),
+        }
+    }
+
+    fn declares(&self, method: &str) -> bool {
+        [
+            &self.type_name,
+            &self.members,
+            &self.from_fields,
+            &self.defaults,
+            &self.wire_name_policy,
+        ]
+        .into_iter()
+        .any(|name| name == method)
+    }
+}
+
+/// `ReflectVariant`'s member names — the variant analog of [`StructMethods`].
+struct VariantMethods {
+    type_name: String,
+    discriminant: String,
+    cases: String,
+    wire_name_policy: String,
+}
+
+impl VariantMethods {
+    fn resolve(tt: &TypeTable) -> Self {
+        let items = tt.compiler_items();
+        Self {
+            type_name: items
+                .method_name(CompilerItem::ReflectVariantTypeName)
+                .to_string(),
+            discriminant: items
+                .method_name(CompilerItem::ReflectVariantDiscriminant)
+                .to_string(),
+            cases: items
+                .method_name(CompilerItem::ReflectVariantMembers)
+                .to_string(),
+            wire_name_policy: items
+                .method_name(CompilerItem::ReflectVariantWireNamePolicy)
+                .to_string(),
+        }
+    }
+
+    fn declares(&self, method: &str) -> bool {
+        [
+            &self.type_name,
+            &self.discriminant,
+            &self.cases,
+            &self.wire_name_policy,
+        ]
+        .into_iter()
+        .any(|name| name == method)
+    }
+}
+
+/// A scalar kind's member names, sourced from its [`ScalarReflectSpec`].
+struct ScalarMethods {
+    type_name: String,
+    value: String,
+    from: String,
+    members: String,
+    wire_name_policy: String,
+}
+
+impl ScalarMethods {
+    fn declares(&self, method: &str) -> bool {
+        [
+            &self.type_name,
+            &self.value,
+            &self.from,
+            &self.members,
+            &self.wire_name_policy,
+        ]
+        .into_iter()
+        .any(|name| name == method)
+    }
+}
+
+/// How the missing-pack-bound diagnostic spells the binding each payload kind
+/// needs on a generic subject.
+const STRUCT_PACK_BOUND: &str = "FieldTypes = [..F]";
+const VARIANT_PACK_BOUND: &str = "CasePayloads = [..P]";
+
+/// The `[..P]` pack a reflect bound projects: the pack element type itself and
+/// the `(name, index)` handle a mapped pack is rebuilt from.
+struct PackHead {
+    ty: TypeId,
+    name: String,
+    index: u32,
+}
+
+/// The dispatch record's per-parameter mutability. A value-reading member
+/// (`discriminant(&self)` / `bits(&self)` / `from_<value>(raw)`) takes exactly
+/// one non-mut argument; a metadata member takes none.
+fn receiver_param_is_mut(takes_argument: bool) -> Vec<bool> {
+    if takes_argument {
+        vec![false]
+    } else {
+        Vec::new()
+    }
 }
 
 impl<H: CompilerHost> Elaborator<'_, H> {
@@ -108,7 +251,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         // type-param-receiver dispatch that monomorphization redirects to the
         // concrete `Struct^ReflectStruct::method`.
         let subject = self.tysys.type_table.borrow().get(self_ty).clone();
-        if let crate::tir::ResolvedType::TypeParam { name, .. } = subject {
+        if let ResolvedType::TypeParam { name, .. } = subject {
             return self.resolve_generic_reflect_static_call(self_ty, &name, static_call, ctx);
         }
 
@@ -128,33 +271,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             member_types: field_types,
         } = subject;
 
-        let (
-            reflect_trait_name,
-            members_method,
-            from_fields_method,
-            defaults_method,
-            wire_name_policy_method,
-        ) = {
+        let (reflect_trait_name, methods) = {
             let tt = self.tysys.type_table.borrow();
-            let items = tt.compiler_items();
             (
-                items.trait_fq(crate::compiler_item::CompilerItem::ReflectStruct),
-                items
-                    .method_name(crate::compiler_item::CompilerItem::ReflectStructMembers)
-                    .to_string(),
-                items
-                    .method_name(crate::compiler_item::CompilerItem::ReflectStructFromFields)
-                    .to_string(),
-                items
-                    .method_name(crate::compiler_item::CompilerItem::ReflectStructDefaults)
-                    .to_string(),
-                items
-                    .method_name(crate::compiler_item::CompilerItem::ReflectStructWireNamePolicy)
-                    .to_string(),
+                tt.compiler_items().trait_fq(CompilerItem::ReflectStruct),
+                StructMethods::resolve(&tt),
             )
         };
 
-        let well_formed = if method == from_fields_method {
+        let well_formed = if method == methods.from_fields {
             self.check_reflect_from_fields_arg(&field_types, static_call, ctx)
         } else {
             self.reject_reflect_metadata_args(static_call, ctx)
@@ -174,31 +299,24 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                     .expect("a compiler trait item names a declaration"),
             );
 
-        let return_type = if method == from_fields_method {
+        let return_type = if method == methods.from_fields {
             self_ty
-        } else if method == defaults_method {
+        } else if method == methods.defaults {
             let mut tt = self.tysys.type_table.borrow_mut();
             let slots: Vec<TypeId> = field_types.iter().map(|&f| tt.make_option(f)).collect();
             tt.make_tuple(slots)
-        } else if method == members_method {
-            let mut tt = self.tysys.type_table.borrow_mut();
-            let def = tt
-                .require_compiler_item_def(crate::compiler_item::CompilerItem::ReflectStructField);
-            let members: Vec<TypeId> = field_types
-                .into_iter()
-                .map(|field_ty| tt.make_generic_instance(def, vec![self_ty, field_ty]))
-                .collect();
-            tt.make_tuple(members)
-        } else if method == wire_name_policy_method {
+        } else if method == methods.members {
+            self.payload_members_ty(CompilerItem::ReflectStructField, self_ty, &field_types)
+        } else if method == methods.wire_name_policy {
             self.tysys
                 .type_table
                 .borrow_mut()
-                .make_compiler_enum(crate::compiler_item::CompilerItem::CaseStyle)
+                .make_compiler_enum(CompilerItem::CaseStyle)
         } else {
             self.tysys
                 .type_table
                 .borrow_mut()
-                .make_compiler_struct(crate::compiler_item::CompilerItem::String)
+                .make_compiler_struct(CompilerItem::String)
         };
 
         let func_ref = self.reflect_func_ref(
@@ -209,19 +327,31 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             &method,
             module_source,
         );
+        self.record_reflect_dispatch(static_call.id, func_ref, Vec::new());
+
+        return_type
+    }
+
+    /// Record a reflect call's dispatch fact for reify. A reflection member
+    /// carries no method-level type args, no parameter defaults and no
+    /// self-in-args, so only the callee and the receiver's mutability vary.
+    fn record_reflect_dispatch(
+        &mut self,
+        call_id: ast::AstId,
+        function_ref: FunctionRef,
+        param_is_mut: Vec<bool>,
+    ) {
         self.sem.types.static_method_dispatch.insert(
-            static_call.id,
+            call_id,
             super::sem::types::StaticMethodDispatch {
-                function_ref: func_ref,
-                param_is_mut: Vec::new(),
+                function_ref,
+                param_is_mut,
                 param_types: Vec::new(),
                 type_args: Vec::new(),
                 param_defaults: Vec::new(),
                 self_in_args: false,
             },
         );
-
-        return_type
     }
 
     /// Build the `FunctionRef` targeting a reflect subject's synthesized
@@ -280,39 +410,16 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         static_call: &ast::StaticMethodCallExpr,
         ctx: &mut FunctionContext,
     ) -> TypeId {
-        use crate::compiler_item::CompilerItem;
         let method = static_call.method.clone();
-        let (
-            reflect_trait_name,
-            type_name_method,
-            members_method,
-            from_fields_method,
-            defaults_method,
-            wire_name_policy_method,
-        ) = {
+        let (reflect_trait_name, methods) = {
             let tt = self.tysys.type_table.borrow();
-            let items = tt.compiler_items();
             (
-                items.trait_fq(CompilerItem::ReflectStruct),
-                items
-                    .method_name(CompilerItem::ReflectStructTypeName)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectStructMembers)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectStructFromFields)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectStructDefaults)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectStructWireNamePolicy)
-                    .to_string(),
+                tt.compiler_items().trait_fq(CompilerItem::ReflectStruct),
+                StructMethods::resolve(&tt),
             )
         };
 
-        if method == from_fields_method {
+        if method == methods.from_fields {
             return self.resolve_generic_reflect_from_fields(
                 self_ty,
                 type_param_name,
@@ -322,41 +429,45 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             );
         }
 
-        let return_type = if method == type_name_method {
+        let return_type = if method == methods.type_name {
             self.tysys
                 .type_table
                 .borrow_mut()
                 .make_compiler_struct(CompilerItem::String)
-        } else if method == wire_name_policy_method {
+        } else if method == methods.wire_name_policy {
             self.tysys
                 .type_table
                 .borrow_mut()
                 .make_compiler_enum(CompilerItem::CaseStyle)
-        } else if method == defaults_method {
+        } else if method == methods.defaults {
             let Some(slots_ty) =
                 self.struct_defaults_bound_ty(type_param_name, reflect_trait_name.base_name())
             else {
-                let _ = self.emit(TypeError::UnknownFunction {
-                    name: format!(
-                        "ReflectStruct::<{type_param_name}>::{method} (no `FieldTypes = [..F]` bound on {type_param_name})"
-                    ),
-                    span: static_call.span,
-                });
+                self.emit_missing_pack_bound(
+                    reflect_trait_name.base_name(),
+                    type_param_name,
+                    &method,
+                    STRUCT_PACK_BOUND,
+                    static_call,
+                );
                 return TypeTable::ERROR;
             };
             slots_ty
-        } else if method == members_method {
-            let Some(members_ty) = self.struct_members_bound_ty(
+        } else if method == methods.members {
+            let Some(members_ty) = self.payload_member_pack_bound_ty(
                 self_ty,
                 type_param_name,
                 reflect_trait_name.base_name(),
+                crate::synthesis::traits::REFLECT_FIELD_TYPES_ASSOC,
+                CompilerItem::ReflectStructField,
             ) else {
-                let _ = self.emit(TypeError::UnknownFunction {
-                    name: format!(
-                        "ReflectStruct::<{type_param_name}>::{method} (no `FieldTypes = [..F]` bound on {type_param_name})"
-                    ),
-                    span: static_call.span,
-                });
+                self.emit_missing_pack_bound(
+                    reflect_trait_name.base_name(),
+                    type_param_name,
+                    &method,
+                    STRUCT_PACK_BOUND,
+                    static_call,
+                );
                 return TypeTable::ERROR;
             };
             members_ty
@@ -377,9 +488,29 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             reflect_trait_name,
             method,
             static_call,
+            Vec::new(),
         );
 
         return_type
+    }
+
+    /// The diagnostic for a reflect member on a generic subject `T` that
+    /// carries no pack bound to source the member's shape from. `pack_bound`
+    /// spells the missing binding, e.g. `FieldTypes = [..F]`.
+    fn emit_missing_pack_bound(
+        &mut self,
+        trait_name: &str,
+        type_param_name: &str,
+        method: &str,
+        pack_bound: &str,
+        static_call: &ast::StaticMethodCallExpr,
+    ) {
+        let _ = self.emit(TypeError::UnknownFunction {
+            name: format!(
+                "{trait_name}::<{type_param_name}>::{method} (no `{pack_bound}` bound on {type_param_name})"
+            ),
+            span: static_call.span,
+        });
     }
 
     /// Resolve `ReflectStruct::<T>::from_fields(fields)` on a generic subject: the
@@ -399,12 +530,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             reflect_trait_name.base_name(),
             crate::synthesis::traits::REFLECT_FIELD_TYPES_ASSOC,
         ) else {
-            let _ = self.emit(TypeError::UnknownFunction {
-                name: format!(
-                    "ReflectStruct::<{type_param_name}>::{method} (no `FieldTypes = [..F]` bound on {type_param_name})"
-                ),
-                span: static_call.span,
-            });
+            self.emit_missing_pack_bound(
+                reflect_trait_name.base_name(),
+                type_param_name,
+                &method,
+                STRUCT_PACK_BOUND,
+                static_call,
+            );
             return TypeTable::ERROR;
         };
 
@@ -427,6 +559,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             reflect_trait_name,
             method,
             static_call,
+            Vec::new(),
         );
 
         self_ty
@@ -440,6 +573,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         reflect_trait_name: crate::name::FqTraitName,
         method: String,
         static_call: &ast::StaticMethodCallExpr,
+        param_is_mut: Vec<bool>,
     ) {
         let mut method_info = LocalMethodName::new(
             FqTypeName::binder(type_param_name),
@@ -447,25 +581,14 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             method,
         );
         method_info.is_type_param_receiver = true;
-        let mangled_name = method_info.to_mangled_name();
 
         let func_ref = FunctionRef {
             module_source: self.current_module_source.clone(),
-            name: mangled_name,
+            name: method_info.to_mangled_name(),
             monomorph_info: None,
             method_info: Some(method_info),
         };
-        self.sem.types.static_method_dispatch.insert(
-            static_call.id,
-            super::sem::types::StaticMethodDispatch {
-                function_ref: func_ref,
-                param_is_mut: Vec::new(),
-                param_types: Vec::new(),
-                type_args: Vec::new(),
-                param_defaults: Vec::new(),
-                self_in_args: false,
-            },
-        );
+        self.record_reflect_dispatch(static_call.id, func_ref, param_is_mut);
     }
 
     /// The `Assoc = [..F]` pack binding on `T`'s bound of the given trait
@@ -727,17 +850,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         {
             return false;
         }
-        let tt = self.tysys.type_table.borrow();
-        let items = tt.compiler_items();
-        method == items.method_name(crate::compiler_item::CompilerItem::ReflectStructTypeName)
-            || method == items.method_name(crate::compiler_item::CompilerItem::ReflectStructMembers)
-            || method
-                == items.method_name(crate::compiler_item::CompilerItem::ReflectStructFromFields)
-            || method
-                == items.method_name(crate::compiler_item::CompilerItem::ReflectStructDefaults)
-            || method
-                == items
-                    .method_name(crate::compiler_item::CompilerItem::ReflectStructWireNamePolicy)
+        StructMethods::resolve(&self.tysys.type_table.borrow()).declares(method)
     }
 
     /// Whether `prefix::method` names a `ReflectVariant` trait-qualified static
@@ -750,16 +863,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         {
             return false;
         }
-        let tt = self.tysys.type_table.borrow();
-        let items = tt.compiler_items();
-        method == items.method_name(crate::compiler_item::CompilerItem::ReflectVariantTypeName)
-            || method
-                == items.method_name(crate::compiler_item::CompilerItem::ReflectVariantDiscriminant)
-            || method
-                == items.method_name(crate::compiler_item::CompilerItem::ReflectVariantMembers)
-            || method
-                == items
-                    .method_name(crate::compiler_item::CompilerItem::ReflectVariantWireNamePolicy)
+        VariantMethods::resolve(&self.tysys.type_table.borrow()).declares(method)
     }
 
     /// Resolve a `ReflectVariant::<T>::method()` trait-qualified static call to
@@ -771,13 +875,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         static_call: &ast::StaticMethodCallExpr,
         ctx: &mut FunctionContext,
     ) -> TypeId {
-        use crate::compiler_item::CompilerItem;
         let method = static_call.method.clone();
 
         // Generic subject `T: ReflectVariant`: the concrete variant is unknown
         // until monomorphization; mirror `resolve_reflect_static_call`.
         let subject = self.tysys.type_table.borrow().get(self_ty).clone();
-        if let crate::tir::ResolvedType::TypeParam { name, .. } = subject {
+        if let ResolvedType::TypeParam { name, .. } = subject {
             return self.resolve_generic_reflect_variant_static_call(
                 self_ty,
                 &name,
@@ -801,24 +904,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             member_types: payloads,
         } = subject;
 
-        let (trait_name, discriminant_method, cases_method, wire_name_policy_method) = {
+        let (trait_name, methods) = {
             let tt = self.tysys.type_table.borrow();
-            let items = tt.compiler_items();
             (
-                items.trait_fq(CompilerItem::ReflectVariant),
-                items
-                    .method_name(CompilerItem::ReflectVariantDiscriminant)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectVariantMembers)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectVariantWireNamePolicy)
-                    .to_string(),
+                tt.compiler_items().trait_fq(CompilerItem::ReflectVariant),
+                VariantMethods::resolve(&tt),
             )
         };
 
-        let is_discriminant = method == discriminant_method;
+        let is_discriminant = method == methods.discriminant;
         let args_valid = if is_discriminant {
             self.check_reflect_fields_receiver(self_ty, &self_name, static_call, ctx)
         } else {
@@ -841,19 +935,13 @@ impl<H: CompilerHost> Elaborator<'_, H> {
 
         let return_type = if is_discriminant {
             TypeTable::I32
-        } else if method == wire_name_policy_method {
+        } else if method == methods.wire_name_policy {
             self.tysys
                 .type_table
                 .borrow_mut()
                 .make_compiler_enum(CompilerItem::CaseStyle)
-        } else if method == cases_method {
-            let mut tt = self.tysys.type_table.borrow_mut();
-            let def = tt.require_compiler_item_def(CompilerItem::ReflectVariantCase);
-            let members: Vec<TypeId> = payloads
-                .into_iter()
-                .map(|payload| tt.make_generic_instance(def, vec![self_ty, payload]))
-                .collect();
-            tt.make_tuple(members)
+        } else if method == methods.cases {
+            self.payload_members_ty(CompilerItem::ReflectVariantCase, self_ty, &payloads)
         } else {
             self.tysys
                 .type_table
@@ -869,20 +957,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             &method,
             module_source,
         );
-        self.sem.types.static_method_dispatch.insert(
+        self.record_reflect_dispatch(
             static_call.id,
-            super::sem::types::StaticMethodDispatch {
-                function_ref: func_ref,
-                param_is_mut: if is_discriminant {
-                    vec![false]
-                } else {
-                    Vec::new()
-                },
-                type_args: Vec::new(),
-                param_defaults: Vec::new(),
-                param_types: Vec::new(),
-                self_in_args: false,
-            },
+            func_ref,
+            receiver_param_is_mut(is_discriminant),
         );
 
         return_type
@@ -902,57 +980,43 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         static_call: &ast::StaticMethodCallExpr,
         ctx: &mut FunctionContext,
     ) -> TypeId {
-        use crate::compiler_item::CompilerItem;
         let method = static_call.method.clone();
-        let (
-            trait_name,
-            type_name_method,
-            discriminant_method,
-            cases_method,
-            wire_name_policy_method,
-        ) = {
+        let (trait_name, methods) = {
             let tt = self.tysys.type_table.borrow();
-            let items = tt.compiler_items();
             (
-                items.trait_fq(CompilerItem::ReflectVariant),
-                items
-                    .method_name(CompilerItem::ReflectVariantTypeName)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectVariantDiscriminant)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectVariantMembers)
-                    .to_string(),
-                items
-                    .method_name(CompilerItem::ReflectVariantWireNamePolicy)
-                    .to_string(),
+                tt.compiler_items().trait_fq(CompilerItem::ReflectVariant),
+                VariantMethods::resolve(&tt),
             )
         };
 
-        let is_discriminant = method == discriminant_method;
-        let return_type = if method == wire_name_policy_method {
+        let is_discriminant = method == methods.discriminant;
+        let return_type = if method == methods.wire_name_policy {
             self.tysys
                 .type_table
                 .borrow_mut()
                 .make_compiler_enum(CompilerItem::CaseStyle)
-        } else if method == type_name_method {
+        } else if method == methods.type_name {
             self.tysys
                 .type_table
                 .borrow_mut()
                 .make_compiler_struct(CompilerItem::String)
         } else if is_discriminant {
             TypeTable::I32
-        } else if method == cases_method {
-            let Some(members_ty) =
-                self.variant_members_bound_ty(self_ty, type_param_name, trait_name.base_name())
-            else {
-                let _ = self.emit(TypeError::UnknownFunction {
-                    name: format!(
-                        "ReflectVariant::<{type_param_name}>::{method} (no `CasePayloads = [..P]` bound on {type_param_name})"
-                    ),
-                    span: static_call.span,
-                });
+        } else if method == methods.cases {
+            let Some(members_ty) = self.payload_member_pack_bound_ty(
+                self_ty,
+                type_param_name,
+                trait_name.base_name(),
+                crate::synthesis::traits::REFLECT_CASE_PAYLOADS_ASSOC,
+                CompilerItem::ReflectVariantCase,
+            ) else {
+                self.emit_missing_pack_bound(
+                    trait_name.base_name(),
+                    type_param_name,
+                    &method,
+                    VARIANT_PACK_BOUND,
+                    static_call,
+                );
                 return TypeTable::ERROR;
             };
             members_ty
@@ -969,137 +1033,92 @@ impl<H: CompilerHost> Elaborator<'_, H> {
             return TypeTable::ERROR;
         }
 
-        let mut method_info = LocalMethodName::new(
-            FqTypeName::binder(type_param_name),
-            Some(trait_name),
+        self.record_type_param_reflect_dispatch(
+            type_param_name,
+            trait_name,
             method,
-        );
-        method_info.is_type_param_receiver = true;
-        let mangled_name = method_info.to_mangled_name();
-
-        let func_ref = FunctionRef {
-            module_source: self.current_module_source.clone(),
-            name: mangled_name,
-            monomorph_info: None,
-            method_info: Some(method_info),
-        };
-        self.sem.types.static_method_dispatch.insert(
-            static_call.id,
-            super::sem::types::StaticMethodDispatch {
-                function_ref: func_ref,
-                param_is_mut: if is_discriminant {
-                    vec![false]
-                } else {
-                    Vec::new()
-                },
-                type_args: Vec::new(),
-                param_defaults: Vec::new(),
-                param_types: Vec::new(),
-                self_in_args: false,
-            },
+            static_call,
+            receiver_param_is_mut(is_discriminant),
         );
 
         return_type
     }
 
-    /// The constructor-mapped member pack `[..Case<T, P>]` — the type of
-    /// `members()` under a `T: ReflectVariant<CasePayloads = [..P]>` bound. The pack
-    /// param recurs inside the mapped element as a scalar placeholder, so
-    /// per-element substitution binds it to `P_k`. `None` when `T` carries no
-    /// `Cases` pack bound.
-    fn variant_members_bound_ty(
+    /// Map the `[..P]` pack `T`'s bound projects through `elem`, rewrapped in
+    /// the `[..X]` tuple shape a member type carries. The single place the
+    /// projected pack is scanned out of the bound; `None` when `T` carries no
+    /// such pack bound.
+    fn map_bound_pack(
         &mut self,
-        self_ty: TypeId,
         type_param_name: &str,
-        trait_name: &str,
+        reflect_trait_name: &str,
+        assoc_name: &str,
+        elem: impl FnOnce(&mut TypeTable, &PackHead) -> TypeId,
     ) -> Option<TypeId> {
-        use crate::compiler_item::CompilerItem;
-        let cases_ty = self.reflect_pack_bound_ty(
-            type_param_name,
-            trait_name,
-            crate::synthesis::traits::REFLECT_CASE_PAYLOADS_ASSOC,
-        )?;
+        let pack_tuple =
+            self.reflect_pack_bound_ty(type_param_name, reflect_trait_name, assoc_name)?;
         let mut tt = self.tysys.type_table.borrow_mut();
-        let elems = tt.as_tuple(cases_ty)?;
-        let (pack_name, pack_index) = elems.iter().find_map(|&e| match tt.get(e) {
-            crate::tir::ResolvedType::TypePack {
+        let elems = tt.as_tuple(pack_tuple)?;
+        let head = elems.iter().find_map(|&e| match tt.get(e) {
+            ResolvedType::TypePack {
                 name,
                 index,
                 mapped_elem: None,
-            } => Some((name.clone(), *index)),
+            } => Some(PackHead {
+                ty: e,
+                name: name.clone(),
+                index: *index,
+            }),
             _ => None,
         })?;
-        let def = tt.require_compiler_item_def(CompilerItem::ReflectVariantCase);
-        let elem_param = tt.make_type_param(pack_name.clone(), pack_index);
-        let member = tt.make_generic_instance(def, vec![self_ty, elem_param]);
-        let member_pack = tt.make_mapped_type_pack(pack_name, pack_index, member);
+        let mapped = elem(&mut tt, &head);
+        let member_pack = tt.make_mapped_type_pack(head.name, head.index, mapped);
         Some(tt.make_tuple(vec![member_pack]))
     }
 
-    /// The constructor-mapped member pack `[..StructField<T, F>]` — the type of
-    /// `members()` under a `T: ReflectStruct<FieldTypes = [..F]>` bound. The variant
-    /// analog is [`Self::variant_members_bound_ty`]; both map the projected element
-    /// pack through a member constructor. `None` when `T` carries no `FieldTypes`
-    /// pack bound.
-    fn struct_members_bound_ty(
+    /// The constructor-mapped member pack `[..M<T, P>]` — the type of
+    /// `members()` under a `T: Trait<Assoc = [..P]>` bound whose member handle
+    /// carries the element as its payload parameter (`StructField<T, F>` /
+    /// `VariantCase<T, P>`). The pack param recurs inside the mapped element as
+    /// a scalar placeholder, so per-element substitution binds it to `P_k`.
+    fn payload_member_pack_bound_ty(
         &mut self,
         self_ty: TypeId,
         type_param_name: &str,
         reflect_trait_name: &str,
+        assoc_name: &str,
+        member_struct_item: CompilerItem,
     ) -> Option<TypeId> {
-        use crate::compiler_item::CompilerItem;
-        let fields_ty = self.reflect_pack_bound_ty(
+        self.map_bound_pack(
             type_param_name,
             reflect_trait_name,
-            crate::synthesis::traits::REFLECT_FIELD_TYPES_ASSOC,
-        )?;
-        let mut tt = self.tysys.type_table.borrow_mut();
-        let elems = tt.as_tuple(fields_ty)?;
-        let (pack_name, pack_index) = elems.iter().find_map(|&e| match tt.get(e) {
-            crate::tir::ResolvedType::TypePack {
-                name,
-                index,
-                mapped_elem: None,
-            } => Some((name.clone(), *index)),
-            _ => None,
-        })?;
-        let def = tt.require_compiler_item_def(CompilerItem::ReflectStructField);
-        let elem_param = tt.make_type_param(pack_name.clone(), pack_index);
-        let member = tt.make_generic_instance(def, vec![self_ty, elem_param]);
-        let member_pack = tt.make_mapped_type_pack(pack_name, pack_index, member);
-        Some(tt.make_tuple(vec![member_pack]))
+            assoc_name,
+            |tt, head| {
+                let def = tt.require_compiler_item_def(member_struct_item);
+                let elem_param = tt.make_type_param(head.name.clone(), head.index);
+                tt.make_generic_instance(def, vec![self_ty, elem_param])
+            },
+        )
     }
 
     /// The slot pack `[..Option<F>]` — the type of `defaults()` under a
     /// `T: ReflectStruct<FieldTypes = [..F]>` bound. Maps the field-type pack
-    /// through `Option`, as [`Self::struct_members_bound_ty`] maps it through
-    /// the member constructor.
+    /// through `Option`, as [`Self::payload_member_pack_bound_ty`] maps it
+    /// through the member constructor.
     fn struct_defaults_bound_ty(
         &mut self,
         type_param_name: &str,
         reflect_trait_name: &str,
     ) -> Option<TypeId> {
-        let fields_ty = self.reflect_pack_bound_ty(
+        self.map_bound_pack(
             type_param_name,
             reflect_trait_name,
             crate::synthesis::traits::REFLECT_FIELD_TYPES_ASSOC,
-        )?;
-        let mut tt = self.tysys.type_table.borrow_mut();
-        let elems = tt.as_tuple(fields_ty)?;
-        let (pack_ty, pack_name, pack_index) = elems.iter().find_map(|&e| match tt.get(e) {
-            crate::tir::ResolvedType::TypePack {
-                name,
-                index,
-                mapped_elem: None,
-            } => Some((e, name.clone(), *index)),
-            _ => None,
-        })?;
-        // The slot names the pack itself, not a `TypeParam` placeholder: a
-        // derivation infers `Option<F>`'s payload from it, and inference binds
-        // through the pack.
-        let slot = tt.make_option(pack_ty);
-        let slot_pack = tt.make_mapped_type_pack(pack_name, pack_index, slot);
-        Some(tt.make_tuple(vec![slot_pack]))
+            // The slot names the pack itself, not a `TypeParam` placeholder: a
+            // derivation infers `Option<F>`'s payload from it, and inference
+            // binds through the pack.
+            |tt, head| tt.make_option(head.ty),
+        )
     }
 
     /// Whether `prefix::method` names a member of the scalar-kind reflection
@@ -1118,17 +1137,8 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         {
             return false;
         }
-        let tt = self.tysys.type_table.borrow();
-        let items = tt.compiler_items();
-        [
-            spec.type_name_item,
-            spec.value_method_item,
-            spec.from_method_item,
-            spec.members_method_item,
-            spec.wire_name_policy_item,
-        ]
-        .into_iter()
-        .any(|item| method == items.method_name(item))
+        spec.methods(&self.tysys.type_table.borrow())
+            .declares(method)
     }
 
     /// Resolve a `ReflectEnum` / `ReflectFlags` `::<T>::method()` static call to
@@ -1212,17 +1222,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                 method.clone(),
             )),
         };
-        self.sem.types.static_method_dispatch.insert(
-            static_call.id,
-            super::sem::types::StaticMethodDispatch {
-                function_ref: func_ref,
-                param_is_mut,
-                type_args: Vec::new(),
-                param_defaults: Vec::new(),
-                param_types: Vec::new(),
-                self_in_args: false,
-            },
-        );
+        self.record_reflect_dispatch(static_call.id, func_ref, param_is_mut);
 
         return_type
     }
@@ -1259,30 +1259,12 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         };
 
         let param_is_mut = self.reflect_scalar_param_is_mut(spec, &method);
-        let mut method_info = LocalMethodName::new(
-            FqTypeName::binder(type_param_name),
-            Some(trait_name),
+        self.record_type_param_reflect_dispatch(
+            type_param_name,
+            trait_name,
             method,
-        );
-        method_info.is_type_param_receiver = true;
-        let mangled_name = method_info.to_mangled_name();
-
-        let func_ref = FunctionRef {
-            module_source: self.current_module_source.clone(),
-            name: mangled_name,
-            monomorph_info: None,
-            method_info: Some(method_info),
-        };
-        self.sem.types.static_method_dispatch.insert(
-            static_call.id,
-            super::sem::types::StaticMethodDispatch {
-                function_ref: func_ref,
-                param_is_mut,
-                type_args: Vec::new(),
-                param_defaults: Vec::new(),
-                param_types: Vec::new(),
-                self_in_args: false,
-            },
+            static_call,
+            param_is_mut,
         );
 
         return_type
@@ -1302,19 +1284,9 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         static_call: &ast::StaticMethodCallExpr,
         ctx: &mut FunctionContext,
     ) -> Option<TypeId> {
-        let (type_name_method, value_method, from_method, members_method, wire_name_policy_method) = {
-            let tt = self.tysys.type_table.borrow();
-            let items = tt.compiler_items();
-            (
-                items.method_name(spec.type_name_item).to_string(),
-                items.method_name(spec.value_method_item).to_string(),
-                items.method_name(spec.from_method_item).to_string(),
-                items.method_name(spec.members_method_item).to_string(),
-                items.method_name(spec.wire_name_policy_item).to_string(),
-            )
-        };
+        let methods = spec.methods(&self.tysys.type_table.borrow());
 
-        if *method == wire_name_policy_method {
+        if *method == methods.wire_name_policy {
             self.reject_reflect_metadata_args(static_call, ctx)
                 .then(|| {
                     self.tysys
@@ -1322,7 +1294,7 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_compiler_enum(CompilerItem::CaseStyle)
                 })
-        } else if *method == type_name_method {
+        } else if *method == methods.type_name {
             self.reject_reflect_metadata_args(static_call, ctx)
                 .then(|| {
                     self.tysys
@@ -1330,15 +1302,15 @@ impl<H: CompilerHost> Elaborator<'_, H> {
                         .borrow_mut()
                         .make_compiler_struct(CompilerItem::String)
                 })
-        } else if *method == members_method {
+        } else if *method == methods.members {
             if !self.reject_reflect_metadata_args(static_call, ctx) {
                 return None;
             }
             self.scalar_members_return_ty(spec, self_ty, self_name, static_call)
-        } else if *method == value_method {
+        } else if *method == methods.value {
             self.check_reflect_fields_receiver(self_ty, self_name, static_call, ctx)
                 .then_some(spec.value_type)
-        } else if *method == from_method {
+        } else if *method == methods.from {
             let arg_types: Vec<TypeId> = static_call
                 .args
                 .iter()
@@ -1540,10 +1512,10 @@ impl<H: CompilerHost> Elaborator<'_, H> {
     }
 
     /// The mapped member pack `[..M<T>]` — the type of `members()` under a
-    /// `T: Trait<Members = [..C]>` bound. Analogous to
-    /// [`Self::variant_members_bound_ty`], but the member carries no payload param,
-    /// so the mapped element is a constant `M<T>` and the bound pack serves only
-    /// to source the arity. `None` when `T` carries no `Members` pack bound.
+    /// `T: Trait<Members = [..C]>` bound. Unlike
+    /// [`Self::payload_member_pack_bound_ty`] the member carries no payload
+    /// param, so the mapped element is a constant `M<T>` and the bound pack
+    /// serves only to source the arity.
     fn scalar_members_bound_ty(
         &mut self,
         spec: ScalarReflectSpec,
@@ -1551,36 +1523,21 @@ impl<H: CompilerHost> Elaborator<'_, H> {
         type_param_name: &str,
         trait_name: &str,
     ) -> Option<TypeId> {
-        let members_ty =
-            self.reflect_pack_bound_ty(type_param_name, trait_name, spec.members_assoc)?;
-        let mut tt = self.tysys.type_table.borrow_mut();
-        let elems = tt.as_tuple(members_ty)?;
-        let (pack_name, pack_index) = elems.iter().find_map(|&e| match tt.get(e) {
-            crate::tir::ResolvedType::TypePack {
-                name,
-                index,
-                mapped_elem: None,
-            } => Some((name.clone(), *index)),
-            _ => None,
-        })?;
-        let def = tt.require_compiler_item_def(spec.member_struct_item);
-        let member = tt.make_generic_instance(def, vec![self_ty]);
-        let member_pack = tt.make_mapped_type_pack(pack_name, pack_index, member);
-        Some(tt.make_tuple(vec![member_pack]))
+        self.map_bound_pack(type_param_name, trait_name, spec.members_assoc, |tt, _| {
+            let def = tt.require_compiler_item_def(spec.member_struct_item);
+            tt.make_generic_instance(def, vec![self_ty])
+        })
     }
 
     /// Per-parameter mutability of a scalar-kind member's dispatch record:
-    /// `<value>(&self)` and `from_<value>(raw)` take one non-mut argument; the
-    /// metadata members take none.
+    /// `<value>(&self)` and `from_<value>(raw)` take one argument; the metadata
+    /// members take none.
     fn reflect_scalar_param_is_mut(&self, spec: ScalarReflectSpec, method: &str) -> Vec<bool> {
         let tt = self.tysys.type_table.borrow();
         let items = tt.compiler_items();
-        if method == items.method_name(spec.value_method_item)
-            || method == items.method_name(spec.from_method_item)
-        {
-            vec![false]
-        } else {
-            Vec::new()
-        }
+        receiver_param_is_mut(
+            method == items.method_name(spec.value_method_item)
+                || method == items.method_name(spec.from_method_item),
+        )
     }
 }

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -68,8 +68,21 @@ pub(crate) struct TraitsStdlibNames {
 /// always available; a `None` here means the registry was not populated.
 const KEYED: &str = "a compiler trait item names a declaration";
 
-/// The `(name, module, def)` triples a demand-driven synthesis was asked for,
-/// and the shape the still-pending ones are accumulated in.
+/// The `(receiver, module, trait)` triples a demand-driven synthesis was asked
+/// for, and the shape the still-pending ones are accumulated in. The receiver
+/// is [`SynthesisCtx::key`]'s rendered head; the trait is its declaration.
+///
+// TODO(declaration-identity): the receiver half is a spelling used as a set
+// key, which WEP 2026-08-12 §4 / §9 forbid — a declaration is compared to a
+// declaration, never to the spelling that reached it. It cannot become a bare
+// `DefId` either: `SynthesisCtx::instance_has_impl` keys a monomorphized
+// instantiation (`Fn<1,i32>`), which no declaration names. The WEP's own answer
+// is the declaration-or-shape sum, so this becomes
+// `(TypeHead, ModuleSource, DefId)` — `Declared` compared by its `DefId`,
+// `Shape` by its rendering. `FqTypeName::head()` already hands one over;
+// `SynthesisCtx::key` discards it by calling `.rendered()`. Changing it here
+// enumerates every producer and consumer, including
+// `TypeTable::record_bound_driven_synth_request` and its elaborator callers.
 pub(crate) type SynthRequests = IndexSet<(String, ModuleSource, crate::defs::DefId)>;
 
 impl TraitsStdlibNames {

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -2151,11 +2151,21 @@ struct ReflectEnumTarget {
     wire_name_policy: Option<String>,
 }
 
+/// Which payload-free kind an env was resolved for. One env type now serves
+/// both, so this is what keeps a flags env out of the enum generator: the
+/// separate env types used to make that a compile error.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ScalarKind {
+    Enum,
+    Flags,
+}
+
 /// The compiler items one payload-free reflect kind names. `ReflectEnum` and
 /// `ReflectFlags` declare the same five members — differing only in the scalar
 /// they bridge through (`i32` discriminant / `u64` bits) — so one env serves
 /// both, as `ScalarReflectSpec` does on the elaborator side.
 struct ScalarReflectItems {
+    kind: ScalarKind,
     member_struct: CompilerItem,
     type_name: CompilerItem,
     value: CompilerItem,
@@ -2165,6 +2175,7 @@ struct ScalarReflectItems {
 }
 
 const REFLECT_ENUM_ITEMS: ScalarReflectItems = ScalarReflectItems {
+    kind: ScalarKind::Enum,
     member_struct: CompilerItem::ReflectEnumCase,
     type_name: CompilerItem::ReflectEnumTypeName,
     value: CompilerItem::ReflectEnumDiscriminant,
@@ -2174,6 +2185,7 @@ const REFLECT_ENUM_ITEMS: ScalarReflectItems = ScalarReflectItems {
 };
 
 const REFLECT_FLAGS_ITEMS: ScalarReflectItems = ScalarReflectItems {
+    kind: ScalarKind::Flags,
     member_struct: CompilerItem::ReflectFlagsBit,
     type_name: CompilerItem::ReflectFlagsTypeName,
     value: CompilerItem::ReflectFlagsBits,
@@ -2185,6 +2197,7 @@ const REFLECT_FLAGS_ITEMS: ScalarReflectItems = ScalarReflectItems {
 /// Module-level types and method names resolved once from the compiler-item
 /// registry and reused across every payload-free type's reflect synthesis.
 struct ScalarReflectSynthEnv {
+    kind: ScalarKind,
     string_type: TypeId,
     case_style_type: TypeId,
     member_struct_name: String,
@@ -2207,6 +2220,7 @@ impl ScalarReflectSynthEnv {
         let (member_struct_name, member_struct_def) = resolve_member_struct(tt, kind.member_struct);
         let items = tt.compiler_items();
         Self {
+            kind: kind.kind,
             string_type,
             case_style_type,
             member_struct_name,
@@ -2228,6 +2242,7 @@ fn generate_enum_reflect_methods(
     enum_trait_name: &crate::name::FqTraitName,
     target: &ReflectEnumTarget,
 ) -> Vec<TirFunction> {
+    assert_eq!(env.kind, ScalarKind::Enum);
     let span = target.span;
 
     let type_name_fn = generate_type_name_fn(
@@ -2593,6 +2608,7 @@ fn generate_flags_reflect_methods(
     flags_trait_name: &crate::name::FqTraitName,
     target: &ReflectFlagsTarget,
 ) -> Vec<TirFunction> {
+    assert_eq!(env.kind, ScalarKind::Flags);
     let span = target.span;
 
     let type_name_fn = generate_type_name_fn(

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -68,6 +68,10 @@ pub(crate) struct TraitsStdlibNames {
 /// always available; a `None` here means the registry was not populated.
 const KEYED: &str = "a compiler trait item names a declaration";
 
+/// The `(name, module, def)` triples a demand-driven synthesis was asked for,
+/// and the shape the still-pending ones are accumulated in.
+pub(crate) type SynthRequests = IndexSet<(String, ModuleSource, crate::defs::DefId)>;
+
 impl TraitsStdlibNames {
     pub(crate) fn from_type_table(type_table: &crate::tir::TypeTable) -> Self {
         let items = type_table.compiler_items();
@@ -330,7 +334,7 @@ pub fn synthesize_traits(project: Package) -> Package {
         )
     };
     // `Default` is drained later by `synthesize_defaults` (after `serde_synth`).
-    let requested: IndexSet<(String, ModuleSource, crate::defs::DefId)> = first_module
+    let requested: SynthRequests = first_module
         .type_table
         .borrow()
         .bound_driven_synth_requests(|key| *key == eq_trait_key || *key == ord_trait_key)
@@ -346,7 +350,7 @@ pub fn synthesize_traits(project: Package) -> Package {
     // canonical project-wide synthesis layer is rebuilt afterwards by
     // `collect_synthesised_impls` (see `synthesis.rs`), which scans TIR
     // and captures concrete-ness from the synthesized function itself.
-    let mut pending: IndexSet<(String, ModuleSource, crate::defs::DefId)> = IndexSet::default();
+    let mut pending: SynthRequests = IndexSet::default();
     for module in project.tir_modules.values_mut() {
         let module_source = module.module_source.clone();
         let names = {
@@ -392,14 +396,14 @@ pub fn synthesize_defaults(project: &mut Package) {
         .compiler_items()
         .trait_fq(CompilerItem::Default);
     let default_trait_key = default_trait_name.canonical();
-    let requested: IndexSet<(String, ModuleSource, crate::defs::DefId)> = first_module
+    let requested: SynthRequests = first_module
         .type_table
         .borrow()
         .bound_driven_synth_requests(|key| Some(key) == default_trait_key.as_ref())
         .into_iter()
         .collect();
 
-    let mut pending: IndexSet<(String, ModuleSource, crate::defs::DefId)> = IndexSet::default();
+    let mut pending: SynthRequests = IndexSet::default();
     for module in project.tir_modules.values_mut() {
         let module_source = module.module_source.clone();
         let names = {
@@ -417,25 +421,47 @@ pub fn synthesize_defaults(project: &mut Package) {
     }
 }
 
-/// Generate `Struct^ReflectStruct::type_name()` for each eligible struct
+/// Generate the `ReflectStruct` impl of each eligible struct
 /// (WEP 2026-06-13 §1).
 pub fn synthesize_reflect(project: &mut Package) {
-    let trait_env = project.trait_env.clone();
-    let first_module = project
+    let trait_name = reflect_trait_fq(project, CompilerItem::ReflectStruct);
+    // Not demand-driven: `TypeTable::is_reflect_eligible` decides coverage, and
+    // the bound check reads the same predicate.
+    let requested = SynthRequests::default();
+    run_reflect_synthesis(
+        project,
+        &trait_name,
+        &requested,
+        generate_struct_reflect_impls,
+    );
+}
+
+/// A reflect trait's fully-qualified name, read off the compiler-item registry
+/// any module shares.
+fn reflect_trait_fq(project: &Package, trait_item: CompilerItem) -> crate::name::FqTraitName {
+    project
         .tir_modules
         .values()
         .next()
-        .expect("tir_modules must contain at least the entry module during synthesis");
-    let reflect_trait_name = first_module
+        .expect("tir_modules must contain at least the entry module during synthesis")
         .type_table
         .borrow()
         .compiler_items()
-        .trait_fq(CompilerItem::ReflectStruct);
-    // Not demand-driven: `TypeTable::is_reflect_eligible` decides coverage, and
-    // the bound check reads the same predicate.
-    let requested: IndexSet<(String, ModuleSource, crate::defs::DefId)> = IndexSet::default();
+        .trait_fq(trait_item)
+}
 
-    let mut pending: IndexSet<(String, ModuleSource, crate::defs::DefId)> = IndexSet::default();
+/// Run one reflect kind's per-module impl generator across the project,
+/// threading a fresh [`SynthesisCtx`] into each module. `requested` is the
+/// demand set the generator filters on — empty for a kind whose coverage a
+/// predicate decides instead.
+fn run_reflect_synthesis(
+    project: &mut Package,
+    trait_name: &crate::name::FqTraitName,
+    requested: &SynthRequests,
+    generate_impls: fn(&mut TirModule, &mut SynthesisCtx<'_, '_, '_>, &crate::name::FqTraitName),
+) {
+    let trait_env = project.trait_env.clone();
+    let mut pending = SynthRequests::default();
     for module in project.tir_modules.values_mut() {
         let module_source = module.module_source.clone();
         let names = {
@@ -445,11 +471,11 @@ pub fn synthesize_reflect(project: &mut Package) {
         let mut ctx = SynthesisCtx {
             trait_env: &trait_env,
             pending: &mut pending,
-            requested: &requested,
+            requested,
             module: module_source,
             names: &names,
         };
-        generate_struct_reflect_impls(module, &mut ctx, &reflect_trait_name);
+        generate_impls(module, &mut ctx, trait_name);
     }
 }
 
@@ -767,18 +793,25 @@ struct ReflectSynthEnv {
     wire_name_policy_method: String,
 }
 
+/// The member-handle struct a reflect kind's synthesised bodies construct
+/// (`StructField` / `VariantCase` / `EnumCase` / `FlagsBit`): its declaration
+/// and the name those bodies spell it by.
+fn resolve_member_struct(tt: &TypeTable, item: CompilerItem) -> (String, crate::defs::DefId) {
+    let (_, name) = tt.compiler_items().require_struct(item);
+    let name = name.to_string();
+    let def = tt
+        .compiler_item_def(item)
+        .expect("a reflect kind's member-handle struct is declared");
+    (name, def)
+}
+
 impl ReflectSynthEnv {
     fn resolve(tt: &mut TypeTable) -> Self {
         let string_type = tt.make_compiler_struct(CompilerItem::String);
         let case_style_type = tt.make_compiler_enum(CompilerItem::CaseStyle);
+        let (member_struct_name, member_struct_def) =
+            resolve_member_struct(tt, CompilerItem::ReflectStructField);
         let items = tt.compiler_items();
-        let member_struct_name = {
-            let (_, n) = items.require_struct(CompilerItem::ReflectStructField);
-            n.to_string()
-        };
-        let member_struct_def = tt
-            .compiler_item_def(CompilerItem::ReflectStructField)
-            .expect("the Member compiler item is declared");
         Self {
             string_type,
             case_style_type,
@@ -812,41 +845,19 @@ fn synthesize_reflect_kind(
     trait_item: CompilerItem,
     generate_impls: fn(&mut TirModule, &mut SynthesisCtx<'_, '_, '_>, &crate::name::FqTraitName),
 ) {
-    let trait_env = project.trait_env.clone();
-    let first_module = project
+    let trait_name = reflect_trait_fq(project, trait_item);
+    let trait_key = trait_name.canonical();
+    let requested: SynthRequests = project
         .tir_modules
         .values()
         .next()
-        .expect("tir_modules must contain at least the entry module during synthesis");
-    let trait_name = first_module
-        .type_table
-        .borrow()
-        .compiler_items()
-        .trait_fq(trait_item);
-    let trait_key = trait_name.canonical();
-    let requested: IndexSet<(String, ModuleSource, crate::defs::DefId)> = first_module
+        .expect("tir_modules must contain at least the entry module during synthesis")
         .type_table
         .borrow()
         .bound_driven_synth_requests(|key| Some(key) == trait_key.as_ref())
         .into_iter()
         .collect();
-
-    let mut pending: IndexSet<(String, ModuleSource, crate::defs::DefId)> = IndexSet::default();
-    for module in project.tir_modules.values_mut() {
-        let module_source = module.module_source.clone();
-        let names = {
-            let tt = module.type_table.borrow();
-            TraitsStdlibNames::from_type_table(&tt)
-        };
-        let mut ctx = SynthesisCtx {
-            trait_env: &trait_env,
-            pending: &mut pending,
-            requested: &requested,
-            module: module_source.clone(),
-            names: &names,
-        };
-        generate_impls(module, &mut ctx, &trait_name);
-    }
+    run_reflect_synthesis(project, &trait_name, &requested, generate_impls);
 }
 
 /// `members()` for a payload-free kind: one member struct literal per case /
@@ -1388,7 +1399,6 @@ fn generate_variant_reflect_impls(
         return;
     }
 
-    let _module_source = module.module_source.clone();
     let env = ReflectVariantSynthEnv::resolve(&mut module.type_table.borrow_mut());
 
     let mut generated = Vec::new();
@@ -1472,14 +1482,9 @@ impl ReflectVariantSynthEnv {
     fn resolve(tt: &mut TypeTable) -> Self {
         let string_type = tt.make_compiler_struct(CompilerItem::String);
         let case_style_type = tt.make_compiler_enum(CompilerItem::CaseStyle);
+        let (member_struct_name, member_struct_def) =
+            resolve_member_struct(tt, CompilerItem::ReflectVariantCase);
         let items = tt.compiler_items();
-        let member_struct_name = {
-            let (_, n) = items.require_struct(CompilerItem::ReflectVariantCase);
-            n.to_string()
-        };
-        let member_struct_def = tt
-            .compiler_item_def(CompilerItem::ReflectVariantCase)
-            .expect("the Member compiler item is declared");
         Self {
             string_type,
             member_struct_name,
@@ -2106,8 +2111,8 @@ fn generate_enum_reflect_impls(
         return;
     }
 
-    let _module_source = module.module_source.clone();
-    let env = ReflectEnumSynthEnv::resolve(&mut module.type_table.borrow_mut());
+    let env =
+        ScalarReflectSynthEnv::resolve(&mut module.type_table.borrow_mut(), &REFLECT_ENUM_ITEMS);
 
     let mut generated = Vec::new();
     for target in &targets {
@@ -2133,54 +2138,71 @@ struct ReflectEnumTarget {
     wire_name_policy: Option<String>,
 }
 
+/// The compiler items one payload-free reflect kind names. `ReflectEnum` and
+/// `ReflectFlags` declare the same five members — differing only in the scalar
+/// they bridge through (`i32` discriminant / `u64` bits) — so one env serves
+/// both, as `ScalarReflectSpec` does on the elaborator side.
+struct ScalarReflectItems {
+    member_struct: CompilerItem,
+    type_name: CompilerItem,
+    value: CompilerItem,
+    from_value: CompilerItem,
+    members: CompilerItem,
+    wire_name_policy: CompilerItem,
+}
+
+const REFLECT_ENUM_ITEMS: ScalarReflectItems = ScalarReflectItems {
+    member_struct: CompilerItem::ReflectEnumCase,
+    type_name: CompilerItem::ReflectEnumTypeName,
+    value: CompilerItem::ReflectEnumDiscriminant,
+    from_value: CompilerItem::ReflectEnumFromDiscriminant,
+    members: CompilerItem::ReflectEnumMembers,
+    wire_name_policy: CompilerItem::ReflectEnumWireNamePolicy,
+};
+
+const REFLECT_FLAGS_ITEMS: ScalarReflectItems = ScalarReflectItems {
+    member_struct: CompilerItem::ReflectFlagsBit,
+    type_name: CompilerItem::ReflectFlagsTypeName,
+    value: CompilerItem::ReflectFlagsBits,
+    from_value: CompilerItem::ReflectFlagsFromBits,
+    members: CompilerItem::ReflectFlagsMembers,
+    wire_name_policy: CompilerItem::ReflectFlagsWireNamePolicy,
+};
+
 /// Module-level types and method names resolved once from the compiler-item
-/// registry and reused across every enum's `ReflectEnum` synthesis.
-struct ReflectEnumSynthEnv {
+/// registry and reused across every payload-free type's reflect synthesis.
+struct ScalarReflectSynthEnv {
     string_type: TypeId,
+    case_style_type: TypeId,
     member_struct_name: String,
     /// The declaration `member_struct_name` spells; the name is only rendered
     /// into the synthesised bodies.
     member_struct_def: crate::defs::DefId,
     type_name_method: String,
-    discriminant_method: String,
-    from_discriminant_method: String,
+    /// `discriminant(&self)` on an enum, `bits(&self)` on a flags type.
+    value_method: String,
+    /// `from_discriminant(raw)` / `from_bits(raw)`.
+    from_value_method: String,
     members_method: String,
-    case_style_type: TypeId,
     wire_name_policy_method: String,
 }
 
-impl ReflectEnumSynthEnv {
-    fn resolve(tt: &mut TypeTable) -> Self {
+impl ScalarReflectSynthEnv {
+    fn resolve(tt: &mut TypeTable, kind: &ScalarReflectItems) -> Self {
         let string_type = tt.make_compiler_struct(CompilerItem::String);
         let case_style_type = tt.make_compiler_enum(CompilerItem::CaseStyle);
+        let (member_struct_name, member_struct_def) = resolve_member_struct(tt, kind.member_struct);
         let items = tt.compiler_items();
-        let member_struct_name = {
-            let (_, n) = items.require_struct(CompilerItem::ReflectEnumCase);
-            n.to_string()
-        };
-        let member_struct_def = tt
-            .compiler_item_def(CompilerItem::ReflectEnumCase)
-            .expect("the Member compiler item is declared");
         Self {
             string_type,
+            case_style_type,
             member_struct_name,
             member_struct_def,
-            type_name_method: items
-                .method_name(CompilerItem::ReflectEnumTypeName)
-                .to_string(),
-            discriminant_method: items
-                .method_name(CompilerItem::ReflectEnumDiscriminant)
-                .to_string(),
-            from_discriminant_method: items
-                .method_name(CompilerItem::ReflectEnumFromDiscriminant)
-                .to_string(),
-            members_method: items
-                .method_name(CompilerItem::ReflectEnumMembers)
-                .to_string(),
-            case_style_type,
-            wire_name_policy_method: items
-                .method_name(CompilerItem::ReflectEnumWireNamePolicy)
-                .to_string(),
+            type_name_method: items.method_name(kind.type_name).to_string(),
+            value_method: items.method_name(kind.value).to_string(),
+            from_value_method: items.method_name(kind.from_value).to_string(),
+            members_method: items.method_name(kind.members).to_string(),
+            wire_name_policy_method: items.method_name(kind.wire_name_policy).to_string(),
         }
     }
 }
@@ -2189,7 +2211,7 @@ impl ReflectEnumSynthEnv {
 /// `from_discriminant(disc)`, and `members()` methods.
 fn generate_enum_reflect_methods(
     type_table: &RefCell<TypeTable>,
-    env: &ReflectEnumSynthEnv,
+    env: &ScalarReflectSynthEnv,
     enum_trait_name: &crate::name::FqTraitName,
     target: &ReflectEnumTarget,
 ) -> Vec<TirFunction> {
@@ -2277,7 +2299,7 @@ fn generate_enum_reflect_methods(
 /// homogeneous `Members` tuple.
 fn generate_enum_members_fn(
     type_table: &RefCell<TypeTable>,
-    env: &ReflectEnumSynthEnv,
+    env: &ScalarReflectSynthEnv,
     enum_trait_name: &crate::name::FqTraitName,
     target: &ReflectEnumTarget,
     enum_type: TypeId,
@@ -2357,15 +2379,14 @@ fn generate_enum_members_fn(
 /// — an enum value is its i32 discriminant, so a direct cast reads the tag (the
 /// enum analog of `ReflectFlags::bits`'s `*self as u32`).
 fn generate_enum_discriminant_fn(
-    env: &ReflectEnumSynthEnv,
+    env: &ScalarReflectSynthEnv,
     enum_trait_name: &crate::name::FqTraitName,
     target: &ReflectEnumTarget,
     enum_type: TypeId,
     ref_enum_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info =
-        trait_method_info(&target.receiver, enum_trait_name, &env.discriminant_method);
+    let method_info = trait_method_info(&target.receiver, enum_trait_name, &env.value_method);
     let qualified_name = method_info.to_mangled_name();
 
     let as_i32 = crate::synthesis::common::cast(
@@ -2396,18 +2417,14 @@ fn generate_enum_discriminant_fn(
 /// an `if disc == k { return Some(Case_k); }` chain ending in `None`.
 fn generate_enum_from_discriminant_fn(
     type_table: &RefCell<TypeTable>,
-    env: &ReflectEnumSynthEnv,
+    env: &ScalarReflectSynthEnv,
     enum_trait_name: &crate::name::FqTraitName,
     target: &ReflectEnumTarget,
     enum_type: TypeId,
     option_enum_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(
-        &target.receiver,
-        enum_trait_name,
-        &env.from_discriminant_method,
-    );
+    let method_info = trait_method_info(&target.receiver, enum_trait_name, &env.from_value_method);
     let qualified_name = method_info.to_mangled_name();
 
     let mut stmts = Vec::new();
@@ -2505,7 +2522,6 @@ fn generate_flags_reflect_impls(
         return;
     }
 
-    let _module_source = module.module_source.clone();
     let targets: Vec<ReflectFlagsTarget> = module
         .flags
         .iter()
@@ -2528,7 +2544,8 @@ fn generate_flags_reflect_impls(
         return;
     }
 
-    let env = ReflectFlagsSynthEnv::resolve(&mut module.type_table.borrow_mut());
+    let env =
+        ScalarReflectSynthEnv::resolve(&mut module.type_table.borrow_mut(), &REFLECT_FLAGS_ITEMS);
 
     let mut generated = Vec::new();
     for target in &targets {
@@ -2555,63 +2572,11 @@ struct ReflectFlagsTarget {
     wire_name_policy: Option<String>,
 }
 
-/// Module-level types and method names resolved once from the compiler-item
-/// registry and reused across every flags type's `ReflectFlags` synthesis.
-struct ReflectFlagsSynthEnv {
-    string_type: TypeId,
-    member_struct_name: String,
-    /// The declaration `member_struct_name` spells; the name is only rendered
-    /// into the synthesised bodies.
-    member_struct_def: crate::defs::DefId,
-    type_name_method: String,
-    bits_method: String,
-    from_bits_method: String,
-    members_method: String,
-    case_style_type: TypeId,
-    wire_name_policy_method: String,
-}
-
-impl ReflectFlagsSynthEnv {
-    fn resolve(tt: &mut TypeTable) -> Self {
-        let string_type = tt.make_compiler_struct(CompilerItem::String);
-        let case_style_type = tt.make_compiler_enum(CompilerItem::CaseStyle);
-        let items = tt.compiler_items();
-        let member_struct_name = {
-            let (_, n) = items.require_struct(CompilerItem::ReflectFlagsBit);
-            n.to_string()
-        };
-        let member_struct_def = tt
-            .compiler_item_def(CompilerItem::ReflectFlagsBit)
-            .expect("the Member compiler item is declared");
-        Self {
-            string_type,
-            member_struct_name,
-            member_struct_def,
-            type_name_method: items
-                .method_name(CompilerItem::ReflectFlagsTypeName)
-                .to_string(),
-            bits_method: items
-                .method_name(CompilerItem::ReflectFlagsBits)
-                .to_string(),
-            from_bits_method: items
-                .method_name(CompilerItem::ReflectFlagsFromBits)
-                .to_string(),
-            members_method: items
-                .method_name(CompilerItem::ReflectFlagsMembers)
-                .to_string(),
-            case_style_type,
-            wire_name_policy_method: items
-                .method_name(CompilerItem::ReflectFlagsWireNamePolicy)
-                .to_string(),
-        }
-    }
-}
-
 /// Synthesize one flags type's `type_name()`, `bits(&self)`, `from_bits(raw)`,
 /// and `members()` methods.
 fn generate_flags_reflect_methods(
     type_table: &RefCell<TypeTable>,
-    env: &ReflectFlagsSynthEnv,
+    env: &ScalarReflectSynthEnv,
     flags_trait_name: &crate::name::FqTraitName,
     target: &ReflectFlagsTarget,
 ) -> Vec<TirFunction> {
@@ -2693,7 +2658,7 @@ fn generate_flags_reflect_methods(
 /// one `FlagsBit<Flags>` per member, packed into the homogeneous `Members`
 /// tuple.
 fn generate_flags_members_fn(
-    env: &ReflectFlagsSynthEnv,
+    env: &ScalarReflectSynthEnv,
     flags_trait_name: &crate::name::FqTraitName,
     target: &ReflectFlagsTarget,
     member_type: TypeId,
@@ -2748,13 +2713,13 @@ fn generate_flags_members_fn(
 /// Build `Flags^ReflectFlags::bits(&self) -> u64` as
 /// `return (*self as u32) as u64;` — the widening is lossless.
 fn generate_flags_bits_fn(
-    env: &ReflectFlagsSynthEnv,
+    env: &ScalarReflectSynthEnv,
     flags_trait_name: &crate::name::FqTraitName,
     target: &ReflectFlagsTarget,
     ref_flags_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(&target.receiver, flags_trait_name, &env.bits_method);
+    let method_info = trait_method_info(&target.receiver, flags_trait_name, &env.value_method);
     let qualified_name = method_info.to_mangled_name();
 
     let as_u32 = crate::synthesis::common::cast(
@@ -2787,13 +2752,13 @@ fn generate_flags_bits_fn(
 /// — unknown bits are rejected (CM semantics).
 fn generate_flags_from_bits_fn(
     type_table: &RefCell<TypeTable>,
-    env: &ReflectFlagsSynthEnv,
+    env: &ScalarReflectSynthEnv,
     flags_trait_name: &crate::name::FqTraitName,
     target: &ReflectFlagsTarget,
     option_flags_type: TypeId,
     span: Span,
 ) -> TirFunction {
-    let method_info = trait_method_info(&target.receiver, flags_trait_name, &env.from_bits_method);
+    let method_info = trait_method_info(&target.receiver, flags_trait_name, &env.from_value_method);
     let qualified_name = method_info.to_mangled_name();
 
     let valid_mask: u64 = target
@@ -2891,7 +2856,7 @@ pub(crate) struct SynthesisCtx<'env, 'pend, 'req> {
     /// component, the second derivation would be silently skipped and the
     /// receiver type from the second module would dispatch to the first
     /// module's impl.
-    pub(crate) pending: &'pend mut IndexSet<(String, ModuleSource, crate::defs::DefId)>,
+    pub(crate) pending: &'pend mut SynthRequests,
     /// `(type_name, module, trait_name)` triples that a real `T: Eq` /
     /// `T: Ord` bound or explicit marker actually demanded (WEP
     /// 2026-06-25-trait-derivation), snapshotted from
@@ -2900,7 +2865,7 @@ pub(crate) struct SynthesisCtx<'env, 'pend, 'req> {
     /// `generate_variant_eq_impls` — an impl is emitted only for a pair
     /// recorded here, not for every declared type. Default / Inspect /
     /// Display and their `Alt` siblings stay unconditional.
-    pub(crate) requested: &'req IndexSet<(String, ModuleSource, crate::defs::DefId)>,
+    pub(crate) requested: &'req SynthRequests,
     /// Module currently being synthesised. Auto-derived impls live in this
     /// module by convention.
     pub(crate) module: ModuleSource,
@@ -3235,7 +3200,6 @@ fn generate_enum_trait_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_, 
         return;
     }
 
-    let _module_source = module.module_source.clone();
     let (eq_trait_name, ord_trait_name) = {
         let tt = module.type_table.borrow();
         let items = tt.compiler_items();
@@ -3294,7 +3258,6 @@ fn generate_flags_trait_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_,
         return;
     }
 
-    let _module_source = module.module_source.clone();
     let (eq_trait_name, ord_trait_name) = {
         let tt = module.type_table.borrow();
         let items = tt.compiler_items();
@@ -3469,7 +3432,6 @@ fn generate_struct_default_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<
         return;
     }
 
-    let _module_source = module.module_source.clone();
     let mut generated = Vec::new();
 
     let default_trait_name = module
@@ -3836,7 +3798,6 @@ fn generate_enum_display_impls(module: &mut TirModule, ctx: &mut SynthesisCtx<'_
         return;
     }
 
-    let _module_source = module.module_source.clone();
     let display_fq = ctx.names.display_fq.clone();
     let display_method = ctx.names.display_method.clone();
     let formatter_fq = ctx.names.formatter_fq.clone();

--- a/wado-compiler/src/synthesis/traits.rs
+++ b/wado-compiler/src/synthesis/traits.rs
@@ -71,18 +71,9 @@ const KEYED: &str = "a compiler trait item names a declaration";
 /// The `(receiver, module, trait)` triples a demand-driven synthesis was asked
 /// for, and the shape the still-pending ones are accumulated in. The receiver
 /// is [`SynthesisCtx::key`]'s rendered head; the trait is its declaration.
-///
 // TODO(declaration-identity): the receiver half is a spelling used as a set
-// key, which WEP 2026-08-12 §4 / §9 forbid — a declaration is compared to a
-// declaration, never to the spelling that reached it. It cannot become a bare
-// `DefId` either: `SynthesisCtx::instance_has_impl` keys a monomorphized
-// instantiation (`Fn<1,i32>`), which no declaration names. The WEP's own answer
-// is the declaration-or-shape sum, so this becomes
-// `(TypeHead, ModuleSource, DefId)` — `Declared` compared by its `DefId`,
-// `Shape` by its rendering. `FqTypeName::head()` already hands one over;
-// `SynthesisCtx::key` discards it by calling `.rendered()`. Changing it here
-// enumerates every producer and consumer, including
-// `TypeTable::record_bound_driven_synth_request` and its elaborator callers.
+// key, which WEP 2026-08-12 forbids. Its Remaining work says what replaces it
+// and why a bare `DefId` is not it.
 pub(crate) type SynthRequests = IndexSet<(String, ModuleSource, crate::defs::DefId)>;
 
 impl TraitsStdlibNames {
@@ -2151,9 +2142,8 @@ struct ReflectEnumTarget {
     wire_name_policy: Option<String>,
 }
 
-/// Which payload-free kind an env was resolved for. One env type now serves
-/// both, so this is what keeps a flags env out of the enum generator: the
-/// separate env types used to make that a compile error.
+/// Which payload-free kind an env was resolved for: one env type serves both,
+/// so only this keeps a flags env out of the enum generator.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum ScalarKind {
     Enum,


### PR DESCRIPTION
Reflect static-call resolution and reflect metadata synthesis each express their four kinds — `ReflectStruct` / `ReflectVariant` / `ReflectEnum` / `ReflectFlags` — through one mechanism per concern.

## Resolution (`elaborator/`)

- A reflect trait's member names live in one struct resolved from the compiler-item registry: `StructMethods`, `VariantMethods`, and `ScalarMethods` (sourced from a kind's `ScalarReflectSpec`). The `is_reflect_*_trait_call` predicates and the resolvers that dispatch on a spelled method read the same struct, so a stdlib rename reaches both.
- `map_bound_pack` is where a `T: Trait<Assoc = [..P]>` bound's projected pack is scanned out. `payload_member_pack_bound_ty`, `scalar_members_bound_ty` and `struct_defaults_bound_ty` supply only the element constructor each maps the pack through.
- `record_reflect_dispatch` builds every reflect `StaticMethodDispatch`, and `record_type_param_reflect_dispatch` builds the type-param-receiver form on top of it. `arg_param_is_mut` carries the one axis that varies: whether the member takes an argument.
- `emit_missing_pack_bound` renders the "no `… = [..X]` bound" diagnostic, naming the trait from the registry.
- `resolve_static_method_call` intercepts all four reflect traits in a single `ast::Type::Generic` match.

## Synthesis (`synthesis/traits.rs`)

- `run_reflect_synthesis` drives every reflect kind's per-module impl generator. `synthesize_reflect` and `synthesize_reflect_kind` differ only in how each computes its demand set.
- `ScalarReflectSynthEnv` serves both payload-free kinds, resolved from a per-kind `ScalarReflectItems` table. It carries a `ScalarKind` that `generate_enum_reflect_methods` and `generate_flags_reflect_methods` assert on, so one env type cannot synthesize the other kind's methods.
- `resolve_member_struct` resolves the member-handle struct a kind's synthesized bodies construct (`StructField` / `VariantCase` / `EnumCase` / `FlagsBit`).
- `SynthRequests` names the demand-set type the reflect and trait syntheses share.

## Declaration identity

`SynthRequests` keys its receiver half on a rendered head, which [WEP 2026-08-12](https://github.com/wado-lang/wado/blob/main/docs/wep-2026-08-12-declaration-identity.md) forbids. Its Remaining work carries the entry: the replacement is `TypeHead`, not a bare `DefId`, because `SynthesisCtx::instance_has_impl` keys a monomorphized instantiation that no declaration names. A `TODO(declaration-identity)` at the type points there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151M7BM9xmSeBa7muTVw5Di