### PR TITLE
chore: add a skill cleanup-comments-and-docs

### DIFF
--- a/.claude/skills/cleanup-comments-and-docs/SKILL.md
+++ b/.claude/skills/cleanup-comments-and-docs/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: cleanup-comments-and-docs
+description: Cut the branch's comments, doc comments, and Markdown down to the minimum — delete anything the code already says, cap doc/module comments at 3 lines and each Markdown topic at 2. Mandatory: run it after finishing a requested task, before reporting back to the user.
+---
+
+## Scope
+
+```sh
+git diff origin/main...HEAD --stat
+```
+
+Every file in that diff — Rust, Wado, Markdown — plus any doc it made stale.
+
+## Rules
+
+- Comments: delete what is readable from the code. Express intent through naming,
+  structure, and assertions instead; an assert is checked, a comment goes stale.
+- Doc and module comments: 3 lines max. Say what it is, not how it works.
+- Markdown: correct, fresh, concise. 2 lines max per topic.
+
+## Cycle
+
+Three passes over the diff, each re-reading what the last one left; surviving one
+pass is no exemption. Stop when a pass finds nothing to remove.
+
+## Finish
+
+```sh
+mise run format
+```
+
+Re-run the tests only when a refactor touched the code itself; comment and doc
+edits alone need none.

--- a/wado-compiler/tests/generated/fixtures/anon_struct_destructure.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/anon_struct_destructure.wir.wado
@@ -361,11 +361,7 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
                 result = "core:rt/cm_await_blocked"(handle);
             }
             offset = offset + (result >> 4);
-            break_if b15 (if (result >> 4) == 0 -> i32 {
-                1;
-            } else {
-                (result & 15) != 0;
-            });
+            break_if b15 select i32((result >> 4) == 0, 1, (result & 15) != 0);
             continue l16;
         };
     };
@@ -390,12 +386,12 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal"(self, f) {
         }
         n = 0;
         t = abs_val;
-        b20: block {
-            l21: loop {
-                break_if b20 t <= 0_i64;
+        b19: block {
+            l20: loop {
+                break_if b19 t <= 0_i64;
                 n = n + 1;
                 t = t / 10_i64;
-                continue l21;
+                continue l20;
             };
         };
         break __inline_count_digits_i64_0: n;
@@ -524,11 +520,7 @@ fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_wri
     prefix_len = prefix.used;
     content_len = (sign_len + prefix_len) + digit_count;
     _av_66 = self.width;
-    if (if _av_66 <= 0 -> i32 {
-        1;
-    } else {
-        content_len >= _av_66;
-    }) {
+    if select i32(_av_66 <= 0, 1, content_len >= _av_66) {
         if sign_len > 0 {
             "core:prelude/string.wado/core:prelude/string.wado/String::push_str"(self.buf, sign);
         }
@@ -550,12 +542,12 @@ fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_wri
         }
         i_24 = 0;
         _licm_buf_61 = self.buf;
-        b39: block {
-            l40: loop {
-                break_if b39 i_24 >= padding;
+        b37: block {
+            l38: loop {
+                break_if b37 i_24 >= padding;
                 "core:prelude/string.wado/core:prelude/string.wado/String::push_ascii_unchecked"(_licm_buf_61, 48);
                 i_24 = i_24 + 1;
-                continue l40;
+                continue l38;
             };
         };
         return self_25 = self.buf, new_used_27 = self_25.used + digit_count, if @unlikely(new_used_27 > builtin::array_len(self_25.repr)) {
@@ -582,12 +574,12 @@ fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_wri
         c_36 = self.fill;
         i_38 = 0;
         _licm_buf_62 = self.buf;
-        b46: block {
-            l47: loop {
-                break_if b46 i_38 >= padding;
+        b44: block {
+            l45: loop {
+                break_if b44 i_38 >= padding;
                 "core:prelude/string.wado/core:prelude/string.wado/String::push"(_licm_buf_62, c_36);
                 i_38 = i_38 + 1;
-                continue l47;
+                continue l45;
             };
         };
         return start_33;
@@ -597,12 +589,12 @@ fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_wri
         c_40 = self.fill;
         i_42 = 0;
         _licm_buf_63 = self.buf;
-        b49: block {
-            l50: loop {
-                break_if b49 i_42 >= left_pad;
+        b47: block {
+            l48: loop {
+                break_if b47 i_42 >= left_pad;
                 "core:prelude/string.wado/core:prelude/string.wado/String::push"(_licm_buf_63, c_40);
                 i_42 = i_42 + 1;
-                continue l50;
+                continue l48;
             };
         };
         if sign_len > 0 {
@@ -622,12 +614,12 @@ fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_wri
         c_49 = self.fill;
         i_51 = 0;
         _licm_buf_64 = self.buf;
-        b54: block {
-            l55: loop {
-                break_if b54 i_51 >= right_pad;
+        b52: block {
+            l53: loop {
+                break_if b52 i_51 >= right_pad;
                 "core:prelude/string.wado/core:prelude/string.wado/String::push"(_licm_buf_64, c_49);
                 i_51 = i_51 + 1;
-                continue l55;
+                continue l53;
             };
         };
         return start_46;
@@ -635,12 +627,12 @@ fn "core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_wri
         c_53 = self.fill;
         i_55 = 0;
         _licm_buf_65 = self.buf;
-        b56: block {
-            l57: loop {
-                break_if b56 i_55 >= padding;
+        b54: block {
+            l55: loop {
+                break_if b54 i_55 >= padding;
                 "core:prelude/string.wado/core:prelude/string.wado/String::push"(_licm_buf_65, c_53);
                 i_55 = i_55 + 1;
-                continue l57;
+                continue l55;
             };
         };
         if sign_len > 0 {
@@ -672,12 +664,12 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$spec0"(self, f) {
         }
         n = 0;
         t = abs_val;
-        b62: block {
-            l63: loop {
-                break_if b62 t <= 0_i64;
+        b60: block {
+            l61: loop {
+                break_if b60 t <= 0_i64;
                 n = n + 1;
                 t = t / 10_i64;
-                continue l63;
+                continue l61;
             };
         };
         break __inline_count_digits_i64_0: n;

--- a/wado-compiler/tests/generated/fixtures/effect_interface_default_body.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/effect_interface_default_body.wir.wado
@@ -600,11 +600,7 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
                 result = "core:rt/cm_await_blocked"(handle);
             }
             offset = offset + (result >> 4);
-            break_if b24 (if (result >> 4) == 0 -> i32 {
-                1;
-            } else {
-                (result & 15) != 0;
-            });
+            break_if b24 select i32((result >> 4) == 0, 1, (result & 15) != 0);
             continue l25;
         };
     };

--- a/wado-compiler/tests/generated/fixtures/effect_interface_default_body_calls.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/effect_interface_default_body_calls.wir.wado
@@ -574,11 +574,7 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
                 result = "core:rt/cm_await_blocked"(handle);
             }
             offset = offset + (result >> 4);
-            break_if b29 (if (result >> 4) == 0 -> i32 {
-                1;
-            } else {
-                (result & 15) != 0;
-            });
+            break_if b29 select i32((result >> 4) == 0, 1, (result & 15) != 0);
             continue l30;
         };
     };
@@ -827,12 +823,12 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$spec0"(self, f) {
         }
         n = 0;
         t = abs_val;
-        b53: block {
-            l54: loop {
-                break_if b53 t <= 0_i64;
+        b52: block {
+            l53: loop {
+                break_if b52 t <= 0_i64;
                 n = n + 1;
                 t = t / 10_i64;
-                continue l54;
+                continue l53;
             };
         };
         break __inline_count_digits_i64_0: n;

--- a/wado-compiler/tests/generated/fixtures/effect_interface_default_partial_handler.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/effect_interface_default_partial_handler.wir.wado
@@ -431,11 +431,7 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
                 result = "core:rt/cm_await_blocked"(handle);
             }
             offset = offset + (result >> 4);
-            break_if b16 (if (result >> 4) == 0 -> i32 {
-                1;
-            } else {
-                (result & 15) != 0;
-            });
+            break_if b16 select i32((result >> 4) == 0, 1, (result & 15) != 0);
             continue l17;
         };
     };
@@ -538,12 +534,12 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$spec0"(self, f) {
         }
         n = 0;
         t = abs_val;
-        b26: block {
-            l27: loop {
-                break_if b26 t <= 0_i64;
+        b25: block {
+            l26: loop {
+                break_if b25 t <= 0_i64;
                 n = n + 1;
                 t = t / 10_i64;
-                continue l27;
+                continue l26;
             };
         };
         break __inline_count_digits_i64_0: n;

--- a/wado-compiler/tests/generated/fixtures/stmt_semicolon_rules.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/stmt_semicolon_rules.wir.wado
@@ -294,11 +294,7 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
                 result = "core:rt/cm_await_blocked"(handle);
             }
             offset = offset + (result >> 4);
-            break_if b6 (if (result >> 4) == 0 -> i32 {
-                1;
-            } else {
-                (result & 15) != 0;
-            });
+            break_if b6 select i32((result >> 4) == 0, 1, (result & 15) != 0);
             continue l7;
         };
     };
@@ -358,12 +354,12 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$spec0"(self, f) {
         }
         n = 0;
         t = abs_val;
-        b14: block {
-            l15: loop {
-                break_if b14 t <= 0_i64;
+        b13: block {
+            l14: loop {
+                break_if b13 t <= 0_i64;
                 n = n + 1;
                 t = t / 10_i64;
-                continue l15;
+                continue l14;
             };
         };
         break __inline_count_digits_i64_0: n;

--- a/wado-compiler/tests/generated/fixtures/wasm_import_big_memory.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasm_import_big_memory.wir.wado
@@ -234,11 +234,7 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
                 result = "core:rt/cm_await_blocked"(handle);
             }
             offset = offset + (result >> 4);
-            break_if b6 (if (result >> 4) == 0 -> i32 {
-                1;
-            } else {
-                (result & 15) != 0;
-            });
+            break_if b6 select i32((result >> 4) == 0, 1, (result & 15) != 0);
             continue l7;
         };
     };
@@ -298,12 +294,12 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$spec0"(self, f) {
         }
         n = 0;
         t = abs_val;
-        b14: block {
-            l15: loop {
-                break_if b14 t <= 0_i64;
+        b13: block {
+            l14: loop {
+                break_if b13 t <= 0_i64;
                 n = n + 1;
                 t = t / 10_i64;
-                continue l15;
+                continue l14;
             };
         };
         break __inline_count_digits_i64_0: n;

--- a/wado-compiler/tests/generated/fixtures/wasm_import_memory_limits.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/wasm_import_memory_limits.wir.wado
@@ -234,11 +234,7 @@ fn "core:rt/cm_stream_write_drain"(handle, ptr, count, elem_size) {
                 result = "core:rt/cm_await_blocked"(handle);
             }
             offset = offset + (result >> 4);
-            break_if b6 (if (result >> 4) == 0 -> i32 {
-                1;
-            } else {
-                (result & 15) != 0;
-            });
+            break_if b6 select i32((result >> 4) == 0, 1, (result & 15) != 0);
             continue l7;
         };
     };
@@ -298,12 +294,12 @@ fn "core:prelude/primitive.wado/i32::fmt_decimal$spec0"(self, f) {
         }
         n = 0;
         t = abs_val;
-        b14: block {
-            l15: loop {
-                break_if b14 t <= 0_i64;
+        b13: block {
+            l14: loop {
+                break_if b13 t <= 0_i64;
                 n = n + 1;
                 t = t / 10_i64;
-                continue l15;
+                continue l14;
             };
         };
         break __inline_count_digits_i64_0: n;


### PR DESCRIPTION
Adds the `cleanup-comments-and-docs` skill: a mandatory pass over the branch, run
after finishing a requested task and before reporting back to the user.

It scopes to `git diff origin/main...HEAD`, deletes comments the code already
says, caps doc and module comments at 3 lines and each Markdown topic at 2, and
repeats until a pass finds nothing to remove. It finishes with `mise run format`;
tests re-run only when a refactor touched the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)