### PR TITLE
bench(http-routing): equal core budgets, and recycle workers every 200 requests

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -277,20 +277,34 @@ Node.js and Bun, vs native-Rust [Axum](https://github.com/tokio-rs/axum), over
 Hono's official router benchmark route set driven with `oha`. See
 `http_routing/README.md` for the full route set and methodology.
 
-Throughput (requests/sec, higher is better), all over HTTP/1.1:
+Throughput (requests/sec, higher is better), all over HTTP/1.1. Every server
+gets the same worker count and the same pinned cores, and each table ends with a
+headroom check confirming `oha` was not the ceiling.
 
-| Request                                     | **Wado** (wado serve) | JavaScript (Hono on Node) | JavaScript (Hono on Bun) | Rust (Axum) |
-| ------------------------------------------- | --------------------: | ------------------------: | -----------------------: | ----------: |
-| `GET /user`                                 |               119,480 |                    18,103 |                   40,621 |     286,459 |
-| `GET /user/comments`                        |               119,856 |                    17,729 |                   38,556 |     286,376 |
-| `GET /user/lookup/username/hey`             |               109,891 |                    17,143 |                   31,140 |     281,585 |
-| `GET /event/abcd1234/comments`              |               108,860 |                    17,488 |                   44,123 |     279,226 |
-| `POST /event/abcd1234/comment`              |               113,792 |                    15,556 |                   37,583 |     287,064 |
-| `GET /very/deeply/nested/route/hello/there` |               120,357 |                    18,564 |                   38,751 |     279,977 |
-| `GET /static/index.html`                    |               111,570 |                    17,492 |                   37,801 |     282,043 |
+One worker — a 1-core container scaled out horizontally:
+
+| Request                         | Rust (Axum) | JavaScript (Hono on Bun) | JavaScript (Hono on Node) | **Wado** (wado serve) |
+| ------------------------------- | ----------: | -----------------------: | ------------------------: | --------------------: |
+| `GET /user`                     |      40,794 |                   43,160 |                    17,345 |                13,926 |
+| `GET /user/lookup/username/hey` |      38,655 |                   35,139 |                    17,001 |                13,371 |
+| `POST /event/abcd1234/comment`  |      39,073 |                   34,829 |                    16,038 |                12,607 |
+| `GET /static/index.html`        |      40,318 |                   28,922 |                    16,789 |                13,202 |
+
+Four workers — a small VM running one instance:
+
+| Request                         | Rust (Axum) | JavaScript (Hono on Bun) | JavaScript (Hono on Node) | **Wado** (wado serve) |
+| ------------------------------- | ----------: | -----------------------: | ------------------------: | --------------------: |
+| `GET /user`                     |     175,858 |                  135,246 |                    74,512 |                51,086 |
+| `GET /user/lookup/username/hey` |     165,198 |                  124,424 |                    72,921 |                47,110 |
+| `POST /event/abcd1234/comment`  |     166,878 |                  123,569 |                    67,045 |                47,577 |
+| `GET /static/index.html`        |     165,837 |                  131,001 |                    71,801 |                47,465 |
+
+`wado serve` is the slowest of the four in both shapes, and stops gaining past
+roughly eight workers (8 → 12 workers is +2.6%), so its ceiling on a larger host
+is lower than the four-worker figures suggest.
 
 HTTP routing needs `oha` and Bun, and is measured separately
-(`SLICE=4 ROUNDS=5 CONNECTIONS=50 mise run benchmark-http-routing`).
+(`SLICE=10 ROUNDS=3 SHAPES="1 4" mise run benchmark-http-routing`).
 
 ## Running
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -278,8 +278,7 @@ Hono's official router benchmark route set driven with `oha`. See
 `http_routing/README.md` for the full route set and methodology.
 
 Throughput (requests/sec, higher is better), all over HTTP/1.1. Every server
-gets the same worker count and the same pinned cores, and each table ends with a
-headroom check confirming `oha` was not the ceiling.
+gets the same worker count and the same pinned cores.
 
 One worker — a 1-core container scaled out horizontally:
 
@@ -300,8 +299,7 @@ Four workers — a small VM running one instance:
 | `GET /static/index.html`        |     165,837 |                  131,001 |                    71,801 |                47,465 |
 
 `wado serve` is the slowest of the four in both shapes, and stops gaining past
-roughly eight workers (8 → 12 workers is +2.6%), so its ceiling on a larger host
-is lower than the four-worker figures suggest.
+roughly eight workers.
 
 HTTP routing needs `oha` and Bun, and is measured separately
 (`SLICE=10 ROUNDS=3 SHAPES="1 4" mise run benchmark-http-routing`).

--- a/benchmark/http_routing/README.md
+++ b/benchmark/http_routing/README.md
@@ -13,9 +13,10 @@ benchmark** —
 
 - **12 routes** from `src/tool.mts` (static, single-parameter, and
   wildcard routes, including a `GET`/`POST` collision on `/event/:id`).
-- **7 request shapes** from `src/bench.mts` (short static, static
-  sharing a radix, dynamic, mixed static/dynamic, `POST`, long static,
-  wildcard).
+- **4 request shapes** from `src/bench.mts` — static, dynamic, `POST`
+  over a mixed static/dynamic path, and wildcard. The remaining three
+  only vary depth or the radix sibling of a case already covered, so
+  dropping them buys measurement time for the second worker shape.
 
 All four servers register the same 12 routes and return the same
 `{ "route": ..., "params": [...] }` JSON shape, so the comparison
@@ -26,24 +27,33 @@ Hono's original benchmark is an in-process router microbenchmark
 (`router.match()` under `mitata`). Here the same route/request set is
 driven end to end over HTTP, so the four are compared as whole servers.
 
-### Stable measurement on a noisy host
+### Equal core budgets
 
-Cloud VMs throttle and steal CPU, so a naive "measure each server for N
-seconds in turn" run yields ratios that drift with the host. `bench.sh`
-counters this:
+Throughput scales with worker count, so a table is only a comparison of
+servers when every server gets the same one. Two shapes are measured:
+**1 worker**, a 1-core container scaled out horizontally, and **4
+workers**, a small VM running one instance. Node scales out with
+`node:cluster` (`SCHED_NONE`, so the kernel distributes accepts), Bun
+with one `SO_REUSEPORT` process per worker, `wado serve` with
+`--workers`, Axum with `TOKIO_WORKER_THREADS`.
 
-- **CPU pinning** — servers run on one core set, the `oha` load
-  generator on a disjoint set (`taskset`), so the two never contend.
-- **Round-robin interleaving** — every server stays up for the whole
-  run; each request is measured in short slices that rotate across
-  servers, repeated for `ROUNDS` rounds. A throttling episode hits every
-  server within the same time window, so ratios survive it.
-- **Max aggregation** — contention and throttling only ever lower
-  throughput, so the fastest slice across rounds is the cleanest
-  estimate of true capacity. Round 1 also serves as a warmup.
+### Keeping the load generator off the critical path
 
-Absolute numbers are not comparable across machines or runs — only the
-ratios between servers within one run are.
+A saturated `oha` caps the fastest servers and compresses every ratio,
+which reads as "the servers are closer than they are". Guards:
+
+- **CPU pinning** — servers take cores `0..workers-1`, `oha` the rest
+  (`taskset`), so the two never contend and `oha` always has the larger
+  share.
+- **Connection scaling** — `CONNECTIONS_PER_WORKER` (default 100) keeps
+  offered concurrency proportional to server capacity.
+- **Headroom check** — each shape ends by re-running its fastest result
+  with twice the connections. A gain means `oha` set that number, and
+  the run prints a warning.
+
+Each server is warmed over every route, then each request is measured
+for `ROUNDS` slices and the fastest kept: contention only ever lowers
+throughput, so the best slice is the cleanest estimate of capacity.
 
 The four servers span four runtimes:
 
@@ -93,10 +103,11 @@ gracefully if `bun` is not on `PATH`.
 Tunables (env vars):
 
 ```sh
-# SLICE: seconds per measurement slice (default 3)
-# ROUNDS: rotation rounds; the per-server max is kept (default 3)
-# CONNECTIONS: concurrent connections per slice (default 50)
-SLICE=5 ROUNDS=5 CONNECTIONS=100 mise run -C benchmark http-routing
+# SLICE: seconds per measurement slice (default 10)
+# ROUNDS: slices per request; the max is kept (default 3)
+# SHAPES: worker counts to measure (default "1 4")
+# CONNECTIONS_PER_WORKER: offered concurrency per worker (default 100)
+SLICE=10 ROUNDS=3 SHAPES="1 4" mise run -C benchmark http-routing
 ```
 
 ## Results

--- a/benchmark/http_routing/README.md
+++ b/benchmark/http_routing/README.md
@@ -13,10 +13,9 @@ benchmark** —
 
 - **12 routes** from `src/tool.mts` (static, single-parameter, and
   wildcard routes, including a `GET`/`POST` collision on `/event/:id`).
-- **4 request shapes** from `src/bench.mts` — static, dynamic, `POST`
-  over a mixed static/dynamic path, and wildcard. The remaining three
-  only vary depth or the radix sibling of a case already covered, so
-  dropping them buys measurement time for the second worker shape.
+- **4 request shapes** from `src/bench.mts` — static, dynamic, `POST` over a
+  mixed static/dynamic path, and wildcard. The other three only vary depth or
+  a covered case's radix sibling.
 
 All four servers register the same 12 routes and return the same
 `{ "route": ..., "params": [...] }` JSON shape, so the comparison
@@ -29,31 +28,24 @@ driven end to end over HTTP, so the four are compared as whole servers.
 
 ### Equal core budgets
 
-Throughput scales with worker count, so a table is only a comparison of
-servers when every server gets the same one. Two shapes are measured:
-**1 worker**, a 1-core container scaled out horizontally, and **4
-workers**, a small VM running one instance. Node scales out with
-`node:cluster` (`SCHED_NONE`, so the kernel distributes accepts), Bun
-with one `SO_REUSEPORT` process per worker, `wado serve` with
-`--workers`, Axum with `TOKIO_WORKER_THREADS`.
+Throughput scales with worker count, so a table compares servers only when
+every server gets the same one. Two shapes are measured: **1 worker**, a
+1-core container scaled out horizontally, and **4 workers**, a small VM
+running one instance. Node scales out with `node:cluster` (`SCHED_NONE`), Bun
+with one `SO_REUSEPORT` process per worker, `wado serve` with `--workers`,
+Axum with `TOKIO_WORKER_THREADS`.
 
 ### Keeping the load generator off the critical path
 
-A saturated `oha` caps the fastest servers and compresses every ratio,
-which reads as "the servers are closer than they are". Guards:
+A saturated `oha` caps the fastest servers and compresses every ratio, which
+reads as "the servers are closer than they are". Servers take cores
+`0..workers-1` and `oha` the rest, offered concurrency scales with
+`CONNECTIONS_PER_WORKER`, and each shape ends by re-running its fastest result
+at twice the connections — a gain there means `oha` set that number, and the
+run says so.
 
-- **CPU pinning** — servers take cores `0..workers-1`, `oha` the rest
-  (`taskset`), so the two never contend and `oha` always has the larger
-  share.
-- **Connection scaling** — `CONNECTIONS_PER_WORKER` (default 100) keeps
-  offered concurrency proportional to server capacity.
-- **Headroom check** — each shape ends by re-running its fastest result
-  with twice the connections. A gain means `oha` set that number, and
-  the run prints a warning.
-
-Each server is warmed over every route, then each request is measured
-for `ROUNDS` slices and the fastest kept: contention only ever lowers
-throughput, so the best slice is the cleanest estimate of capacity.
+Each server is warmed over every route, then each request is measured for
+`ROUNDS` slices and the fastest kept.
 
 The four servers span four runtimes:
 

--- a/benchmark/http_routing/app.bun.js
+++ b/benchmark/http_routing/app.bun.js
@@ -5,8 +5,7 @@
 //
 //   bun run benchmark/http_routing/app.bun.js
 //
-// Scaling out is one process per core, each binding the same port with
-// SO_REUSEPORT; bench.sh spawns them and owns their lifetime.
+// bench.sh spawns one of these per worker and owns their lifetime.
 
 import { createApp } from './app.routes.js'
 

--- a/benchmark/http_routing/app.bun.js
+++ b/benchmark/http_routing/app.bun.js
@@ -4,8 +4,11 @@
 // point (app.js) so both runtimes run identical routes.
 //
 //   bun run benchmark/http_routing/app.bun.js
+//
+// Scaling out is one process per core, each binding the same port with
+// SO_REUSEPORT; bench.sh spawns them and owns their lifetime.
 
 import { createApp } from './app.routes.js'
 
 const port = Number(process.env.PORT ?? 3002)
-Bun.serve({ fetch: createApp().fetch, port })
+Bun.serve({ fetch: createApp().fetch, port, reusePort: true })

--- a/benchmark/http_routing/app.js
+++ b/benchmark/http_routing/app.js
@@ -12,9 +12,8 @@ import { createApp } from './app.routes.js'
 const port = Number(process.env.PORT ?? 3000)
 const workers = Number(process.env.WORKERS ?? 1)
 
-// SCHED_NONE lets the kernel distribute accepts across workers; the default
-// SCHED_RR routes every connection through the primary, which caps throughput
-// well below what the workers can serve.
+// The default SCHED_RR routes every connection through the primary, capping
+// throughput well below what the workers can serve.
 cluster.schedulingPolicy = cluster.SCHED_NONE
 
 if (workers > 1 && cluster.isPrimary) {

--- a/benchmark/http_routing/app.js
+++ b/benchmark/http_routing/app.js
@@ -3,10 +3,28 @@
 // Routing logic lives in app.routes.js, shared with the Bun entry
 // point (app.bun.js) so both runtimes run identical routes.
 //
-//   node benchmark/http_routing/app.js
+//   WORKERS=4 node benchmark/http_routing/app.js
 
+import cluster from 'node:cluster'
 import { serve } from '@hono/node-server'
 import { createApp } from './app.routes.js'
 
 const port = Number(process.env.PORT ?? 3000)
-serve({ fetch: createApp().fetch, port })
+const workers = Number(process.env.WORKERS ?? 1)
+
+// SCHED_NONE lets the kernel distribute accepts across workers; the default
+// SCHED_RR routes every connection through the primary, which caps throughput
+// well below what the workers can serve.
+cluster.schedulingPolicy = cluster.SCHED_NONE
+
+if (workers > 1 && cluster.isPrimary) {
+  for (let i = 0; i < workers; i++) cluster.fork()
+  const shutdown = () => {
+    for (const w of Object.values(cluster.workers ?? {})) w.kill()
+    process.exit(0)
+  }
+  process.on('SIGTERM', shutdown)
+  process.on('SIGINT', shutdown)
+} else {
+  serve({ fetch: createApp().fetch, port })
+}

--- a/benchmark/http_routing/bench.sh
+++ b/benchmark/http_routing/bench.sh
@@ -1,100 +1,53 @@
 #!/usr/bin/env bash
 # HTTP routing benchmark: `wado serve` vs Hono (Node.js & Bun) vs Axum.
 #
-# Methodology for stable cross-server ratios on a noisy (cloud) host:
+# Two deployment shapes are measured, because they rank differently:
 #
-#   * CPU pinning — servers run on one core set, the `oha` load
-#     generator on a disjoint set, so the two never contend for a core.
-#   * Round-robin interleaving — every server stays up for the whole
-#     run; each request is measured in short slices that rotate across
-#     servers, repeated for ROUNDS rounds. A throttling episode then
-#     hits every server within the same time window, so ratios survive
-#     it even when absolute throughput drifts.
-#   * Max aggregation — contention and throttling only ever lower
-#     throughput, so the fastest slice across rounds is the cleanest
-#     estimate of true capacity. Round 1 doubles as a warmup: its cold
-#     numbers lose to later rounds and drop out.
+#   * 1 worker  — a 1-core container scaled out horizontally (k8s).
+#   * 4 workers — a small VM running one instance.
 #
-# Absolute numbers are not comparable across machines or runs — only the
-# ratios between servers within one run are.
+# Every server gets the same worker count and the same pinned cores in a
+# given shape, so the table compares servers rather than core budgets.
+# Node scales out with `node:cluster`, Bun with SO_REUSEPORT, `wado serve`
+# with --workers, Axum with TOKIO_WORKER_THREADS.
 #
-# Env overrides: SLICE (default 3s), ROUNDS (default 3),
-# CONNECTIONS (default 50), OHA_CORE_COUNT (default nproc/4).
+# The load generator is pinned to a disjoint core set and given the larger
+# share; a saturated `oha` silently caps the fastest servers and compresses
+# every ratio, so each shape ends with a headroom check that re-runs the
+# fastest result with twice the connections and reports any gain.
+#
+# Env overrides: SLICE (default 10s), ROUNDS (default 3), SHAPES
+# (default "1 4"), CONNECTIONS_PER_WORKER (default 100).
 set -euo pipefail
 cd "$(dirname "$0")"
 
-SLICE="${SLICE:-3}"
+SLICE="${SLICE:-10}"
 ROUNDS="${ROUNDS:-3}"
-CONNECTIONS="${CONNECTIONS:-50}"
+SHAPES="${SHAPES:-1 4}"
+CONNECTIONS_PER_WORKER="${CONNECTIONS_PER_WORKER:-100}"
 WADO_BIN="../../target/release/wado"
-WADO_ADDR="127.0.0.1:8080"
 HONO_PORT="3000"
 AXUM_PORT="3001"
 BUN_PORT="3002"
+WADO_PORT="8080"
 
-# Hono's official router-benchmark request set ("METHOD PATH" per entry):
-# short static, static sharing a radix, dynamic, mixed static/dynamic,
-# POST, long static, wildcard.
+# One request per routing behaviour the routers differ on: static match,
+# dynamic parameter, method dispatch over a mixed static/dynamic path, and
+# wildcard. Hono's official router benchmark set, minus the entries that
+# only vary depth or the radix sibling of a case already covered.
 REQUESTS=(
   "GET /user"
-  "GET /user/comments"
   "GET /user/lookup/username/hey"
-  "GET /event/abcd1234/comments"
   "POST /event/abcd1234/comment"
-  "GET /very/deeply/nested/route/hello/there"
   "GET /static/index.html"
 )
 
-# `oha` is installed via `cargo install oha` and may not be on PATH
-# under `mise run`; fall back to the default cargo bin location.
 OHA_BIN="$(command -v oha || true)"
 [ -z "$OHA_BIN" ] && OHA_BIN="$HOME/.cargo/bin/oha"
 
-# CPU pinning: split cores between the servers and the load generator so
-# they never share a core. The load generator gets a quarter of the
-# cores (at least one), the servers the rest — `oha` is far lighter than
-# a server, and an even split would cram a multi-worker server onto too
-# few cores. Multi-threaded servers are then sized to the server core
-# count (see SERVER_CORE_COUNT below) so none is over-threaded.
-# `env` is a no-op prefix when pinning is off, which keeps the command
-# arrays safe to expand under `set -u`.
 NPROC="$(nproc)"
-if command -v taskset >/dev/null 2>&1 && [ "$NPROC" -ge 2 ]; then
-  # OHA_CORE_COUNT may be overridden to retune the split (e.g. =2 on a
-  # 4-core host gives an even server/oha split, raising the oha
-  # throughput ceiling at the cost of fewer server cores).
-  OHA_CORE_COUNT="${OHA_CORE_COUNT:-$((NPROC / 4))}"
-  [ "$OHA_CORE_COUNT" -lt 1 ] && OHA_CORE_COUNT=1
-  SERVER_CORE_COUNT=$((NPROC - OHA_CORE_COUNT))
-  SERVER_CORES="0-$((SERVER_CORE_COUNT - 1))"
-  OHA_CORES="${SERVER_CORE_COUNT}-$((NPROC - 1))"
-  SERVER_PIN=(taskset -c "$SERVER_CORES")
-  OHA_PIN=(taskset -c "$OHA_CORES")
-  echo "CPU pinning: servers on cores ${SERVER_CORES} (${SERVER_CORE_COUNT}), oha on cores ${OHA_CORES}"
-else
-  SERVER_PIN=(env)
-  OHA_PIN=(env)
-  SERVER_CORE_COUNT="$NPROC"
-  echo "CPU pinning: disabled (nproc=${NPROC}, taskset unavailable)"
-fi
-
-PIDS=()
-cleanup() {
-  for p in "${PIDS[@]:-}"; do
-    [ -n "$p" ] && kill "$p" 2>/dev/null || true
-  done
-}
-trap cleanup EXIT
-
-wait_ready() {
-  local url="$1"
-  for _ in $(seq 1 120); do
-    curl -fs -o /dev/null "$url" 2>/dev/null && return 0
-    sleep 0.5
-  done
-  echo "ERROR: server not ready at $url" >&2
-  return 1
-}
+PIN_AVAILABLE=0
+command -v taskset >/dev/null 2>&1 && [ "$NPROC" -ge 4 ] && PIN_AVAILABLE=1
 
 echo "=== Building wado (release) ==="
 cargo build --release --quiet --manifest-path ../../wado-cli/Cargo.toml
@@ -105,83 +58,150 @@ cargo build --release --quiet --manifest-path Cargo.toml
 echo "=== Installing Hono dependencies ==="
 npm install --prefix . --silent --no-audit --no-fund
 
-# Server roster, populated in start order. Hono on Bun is optional.
-# Every server is driven over HTTP/1.1; README.md says why.
-SERVER_NAMES=()
-SERVER_URLS=()
-register() {
-  SERVER_NAMES+=("$1")
-  SERVER_URLS+=("$2")
+PIDS=()
+cleanup() {
+  for p in "${PIDS[@]:-}"; do
+    [ -n "$p" ] && kill "$p" 2>/dev/null || true
+  done
+  PIDS=()
+}
+trap cleanup EXIT
+
+wait_ready() {
+  for _ in $(seq 1 120); do
+    curl -fs -o /dev/null "$1" 2>/dev/null && return 0
+    sleep 0.5
+  done
+  echo "ERROR: server not ready at $1" >&2
+  return 1
 }
 
-# Multi-threaded servers are sized to the server core budget so none is
-# over-threaded onto its pinned cores: `wado serve` via --workers, Axum
-# (Tokio) via TOKIO_WORKER_THREADS. Node and Bun drive their HTTP server
-# from a single thread and need no knob.
-echo "=== Starting servers ==="
-"${SERVER_PIN[@]}" "$WADO_BIN" serve --addr "$WADO_ADDR" \
-  --workers "$SERVER_CORE_COUNT" app.wado >/dev/null 2>&1 &
-PIDS+=($!)
-register "Wado (wado serve)" "http://${WADO_ADDR}"
+# Throughput of one (url, method, path) slice, in whole req/s.
+measure() {
+  "${OHA_PIN[@]}" "$OHA_BIN" -m "$2" -z "${SLICE}s" -c "$CONNECTIONS" \
+    --no-tui "${1}${3}" 2>/dev/null |
+    awk '/Requests\/sec/ {printf "%.0f", $2}'
+}
 
-PORT="$HONO_PORT" "${SERVER_PIN[@]}" node app.js >/dev/null 2>&1 &
-PIDS+=($!)
-register "JavaScript (Hono on Node)" "http://127.0.0.1:${HONO_PORT}"
+SERVER_NAMES=()
+SERVER_URLS=()
 
-if command -v bun >/dev/null 2>&1; then
-  PORT="$BUN_PORT" "${SERVER_PIN[@]}" bun run app.bun.js >/dev/null 2>&1 &
+start_servers() {
+  local workers="$1"
+  SERVER_NAMES=()
+  SERVER_URLS=()
+
+  "${SERVER_PIN[@]}" "$WADO_BIN" serve --addr "127.0.0.1:${WADO_PORT}" \
+    --workers "$workers" app.wado >/dev/null 2>&1 &
   PIDS+=($!)
-  register "JavaScript (Hono on Bun)" "http://127.0.0.1:${BUN_PORT}"
-else
-  echo "  SKIP: bun not found (install bun or add it to benchmark/mise.toml)"
-fi
+  SERVER_NAMES+=("Wado (wado serve)")
+  SERVER_URLS+=("http://127.0.0.1:${WADO_PORT}")
 
-PORT="$AXUM_PORT" TOKIO_WORKER_THREADS="$SERVER_CORE_COUNT" \
-  "${SERVER_PIN[@]}" ./target/release/axum_server >/dev/null 2>&1 &
-PIDS+=($!)
-register "Rust (Axum)" "http://127.0.0.1:${AXUM_PORT}"
+  PORT="$HONO_PORT" WORKERS="$workers" "${SERVER_PIN[@]}" node app.js >/dev/null 2>&1 &
+  PIDS+=($!)
+  SERVER_NAMES+=("JavaScript (Hono on Node)")
+  SERVER_URLS+=("http://127.0.0.1:${HONO_PORT}")
 
-for url in "${SERVER_URLS[@]}"; do
-  wait_ready "${url}/status"
-done
+  if command -v bun >/dev/null 2>&1; then
+    # Bun has no cluster primary: one process per worker, all sharing the
+    # port through SO_REUSEPORT.
+    for _ in $(seq 1 "$workers"); do
+      PORT="$BUN_PORT" "${SERVER_PIN[@]}" bun run app.bun.js >/dev/null 2>&1 &
+      PIDS+=($!)
+    done
+    SERVER_NAMES+=("JavaScript (Hono on Bun)")
+    SERVER_URLS+=("http://127.0.0.1:${BUN_PORT}")
+  else
+    echo "  SKIP: bun not found (install bun or add it to benchmark/mise.toml)"
+  fi
 
-# Per-(server, request) best result, keyed "<server_idx>|<request_idx>".
-declare -A BEST
+  PORT="$AXUM_PORT" TOKIO_WORKER_THREADS="$workers" \
+    "${SERVER_PIN[@]}" ./target/release/axum_server >/dev/null 2>&1 &
+  PIDS+=($!)
+  SERVER_NAMES+=("Rust (Axum)")
+  SERVER_URLS+=("http://127.0.0.1:${AXUM_PORT}")
 
-echo "=== Measuring (slice=${SLICE}s, rounds=${ROUNDS}, connections=${CONNECTIONS}) ==="
-for round in $(seq 1 "$ROUNDS"); do
-  echo "--- round ${round}/${ROUNDS} ---"
+  for url in "${SERVER_URLS[@]}"; do wait_ready "${url}/status"; done
+}
+
+run_shape() {
+  local workers="$1"
+  CONNECTIONS=$((CONNECTIONS_PER_WORKER * workers))
+
+  if [ "$PIN_AVAILABLE" -eq 1 ]; then
+    SERVER_PIN=(taskset -c "0-$((workers - 1))")
+    OHA_PIN=(taskset -c "${workers}-$((NPROC - 1))")
+    echo "CPU pinning: servers on cores 0-$((workers - 1)), oha on cores ${workers}-$((NPROC - 1))"
+  else
+    SERVER_PIN=(env)
+    OHA_PIN=(env)
+    echo "CPU pinning: disabled (nproc=${NPROC}, taskset unavailable)"
+  fi
+
+  start_servers "$workers"
+
+  declare -A BEST=()
+  local si ri req method path rps
+  for si in "${!SERVER_NAMES[@]}"; do
+    echo "--- ${SERVER_NAMES[$si]} ---"
+    # Warm up every route once; the JITs need it and the discarded slice
+    # also settles the accept queues.
+    for req in "${REQUESTS[@]}"; do
+      measure "${SERVER_URLS[$si]}" "${req%% *}" "${req#* }" >/dev/null
+    done
+    for ri in "${!REQUESTS[@]}"; do
+      req="${REQUESTS[$ri]}"
+      method="${req%% *}"
+      path="${req#* }"
+      for _ in $(seq 1 "$ROUNDS"); do
+        rps=$(measure "${SERVER_URLS[$si]}" "$method" "$path")
+        [ -z "$rps" ] && rps=0
+        [ "$rps" -gt "${BEST[${si}|${ri}]:-0}" ] && BEST[${si}|${ri}]="$rps"
+      done
+    done
+  done
+
+  echo
+  echo "=== ${workers} worker(s): max req/s over ${ROUNDS} rounds (higher is better) ==="
+  printf '%-44s' "Request"
+  for name in "${SERVER_NAMES[@]}"; do printf '%26s' "$name"; done
+  printf '\n'
   for ri in "${!REQUESTS[@]}"; do
-    req="${REQUESTS[$ri]}"
-    method="${req%% *}"
-    path="${req#* }"
-    for si in "${!SERVER_NAMES[@]}"; do
-      out=$("${OHA_PIN[@]}" "$OHA_BIN" -m "$method" -z "${SLICE}s" \
-        -c "$CONNECTIONS" --no-tui "${SERVER_URLS[$si]}${path}" 2>/dev/null)
-      rps=$(echo "$out" | awk '/Requests\/sec/ {printf "%.0f", $2}')
-      [ -z "$rps" ] && rps=0
-      key="${si}|${ri}"
-      if [ "$rps" -gt "${BEST[$key]:-0}" ]; then
-        BEST[$key]="$rps"
+    printf '%-44s' "${REQUESTS[$ri]}"
+    for si in "${!SERVER_NAMES[@]}"; do printf '%26s' "${BEST[${si}|${ri}]:-0}"; done
+    printf '\n'
+  done
+
+  # Headroom check: re-run the fastest cell with twice the connections. A
+  # gain means `oha` — not the server — set that number, and every result
+  # in the shape is suspect.
+  local top=0 top_si=0 top_ri=0
+  for si in "${!SERVER_NAMES[@]}"; do
+    for ri in "${!REQUESTS[@]}"; do
+      if [ "${BEST[${si}|${ri}]:-0}" -gt "$top" ]; then
+        top="${BEST[${si}|${ri}]}"; top_si="$si"; top_ri="$ri"
       fi
     done
   done
-done
+  req="${REQUESTS[$top_ri]}"
+  CONNECTIONS=$((CONNECTIONS * 2))
+  local retry
+  retry=$(measure "${SERVER_URLS[$top_si]}" "${req%% *}" "${req#* }")
+  echo
+  printf 'Headroom check: %s @ %s — %s req/s, %s req/s at 2x connections' \
+    "${SERVER_NAMES[$top_si]}" "$req" "$top" "$retry"
+  if [ "$retry" -gt $((top * 105 / 100)) ]; then
+    printf ' — WARNING: load generator saturated, results are a floor\n'
+  else
+    printf ' — ok\n'
+  fi
 
-echo
-echo "=== Results: max req/s over ${ROUNDS} rounds (higher is better) ==="
-printf '%-44s' "Request"
-for name in "${SERVER_NAMES[@]}"; do
-  printf '%26s' "$name"
-done
-printf '\n'
-for ri in "${!REQUESTS[@]}"; do
-  printf '%-44s' "${REQUESTS[$ri]}"
-  for si in "${!SERVER_NAMES[@]}"; do
-    printf '%26s' "${BEST[${si}|${ri}]:-0}"
-  done
-  printf '\n'
-done
+  cleanup
+  sleep 1
+}
 
-echo
-echo "Done (slice=${SLICE}s, rounds=${ROUNDS}, connections=${CONNECTIONS} per slice)."
+for shape in $SHAPES; do
+  echo
+  echo "########## ${shape} worker(s) per server ##########"
+  run_shape "$shape"
+done

--- a/benchmark/http_routing/bench.sh
+++ b/benchmark/http_routing/bench.sh
@@ -1,23 +1,8 @@
 #!/usr/bin/env bash
-# HTTP routing benchmark: `wado serve` vs Hono (Node.js & Bun) vs Axum.
+# HTTP routing benchmark: `wado serve` vs Hono (Node.js & Bun) vs Axum, over
+# one worker shape per entry in SHAPES. README.md covers the methodology.
 #
-# Two deployment shapes are measured, because they rank differently:
-#
-#   * 1 worker  — a 1-core container scaled out horizontally (k8s).
-#   * 4 workers — a small VM running one instance.
-#
-# Every server gets the same worker count and the same pinned cores in a
-# given shape, so the table compares servers rather than core budgets.
-# Node scales out with `node:cluster`, Bun with SO_REUSEPORT, `wado serve`
-# with --workers, Axum with TOKIO_WORKER_THREADS.
-#
-# The load generator is pinned to a disjoint core set and given the larger
-# share; a saturated `oha` silently caps the fastest servers and compresses
-# every ratio, so each shape ends with a headroom check that re-runs the
-# fastest result with twice the connections and reports any gain.
-#
-# Env overrides: SLICE (default 10s), ROUNDS (default 3), SHAPES
-# (default "1 4"), CONNECTIONS_PER_WORKER (default 100).
+# Overrides: SLICE, ROUNDS, SHAPES, CONNECTIONS_PER_WORKER.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -31,10 +16,7 @@ AXUM_PORT="3001"
 BUN_PORT="3002"
 WADO_PORT="8080"
 
-# One request per routing behaviour the routers differ on: static match,
-# dynamic parameter, method dispatch over a mixed static/dynamic path, and
-# wildcard. Hono's official router benchmark set, minus the entries that
-# only vary depth or the radix sibling of a case already covered.
+# One request per routing behaviour the routers differ on.
 REQUESTS=(
   "GET /user"
   "GET /user/lookup/username/hey"
@@ -76,7 +58,7 @@ wait_ready() {
   return 1
 }
 
-# Throughput of one (url, method, path) slice, in whole req/s.
+# Whole req/s, so the callers can compare with -gt.
 measure() {
   "${OHA_PIN[@]}" "$OHA_BIN" -m "$2" -z "${SLICE}s" -c "$CONNECTIONS" \
     --no-tui "${1}${3}" 2>/dev/null |
@@ -103,8 +85,7 @@ start_servers() {
   SERVER_URLS+=("http://127.0.0.1:${HONO_PORT}")
 
   if command -v bun >/dev/null 2>&1; then
-    # Bun has no cluster primary: one process per worker, all sharing the
-    # port through SO_REUSEPORT.
+    # Bun has no cluster primary; the processes share the port via SO_REUSEPORT.
     for _ in $(seq 1 "$workers"); do
       PORT="$BUN_PORT" "${SERVER_PIN[@]}" bun run app.bun.js >/dev/null 2>&1 &
       PIDS+=($!)
@@ -144,8 +125,7 @@ run_shape() {
   local si ri req method path rps
   for si in "${!SERVER_NAMES[@]}"; do
     echo "--- ${SERVER_NAMES[$si]} ---"
-    # Warm up every route once; the JITs need it and the discarded slice
-    # also settles the accept queues.
+    # Discarded: the JS rows need it to reach steady state.
     for req in "${REQUESTS[@]}"; do
       measure "${SERVER_URLS[$si]}" "${req%% *}" "${req#* }" >/dev/null
     done
@@ -172,9 +152,7 @@ run_shape() {
     printf '\n'
   done
 
-  # Headroom check: re-run the fastest cell with twice the connections. A
-  # gain means `oha` — not the server — set that number, and every result
-  # in the shape is suspect.
+  # A gain at 2x connections means `oha` set that number, not the server.
   local top=0 top_si=0 top_ri=0
   for si in "${!SERVER_NAMES[@]}"; do
     for ri in "${!REQUESTS[@]}"; do

--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -47,9 +47,9 @@ const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const EPOCH_TICK_MS: u64 = 1000;
 
 /// Recycling resets state that accumulates in a long-lived instance,
-/// notably the component resource table (issue #1133). Throughput is
-/// flat from ~1k to ~100k requests so recycling is sized rare. `0` disables.
-const DEFAULT_RECYCLE_REQUESTS: u64 = 10000;
+/// notably the component resource table (issue #1133). Throughput peaks over
+/// a broad 25–200 plateau and falls off either side of it. `0` disables.
+const DEFAULT_RECYCLE_REQUESTS: u64 = 200;
 
 /// Each in-flight request needs an async fiber stack from the pooling
 /// allocator, so this also sizes the engine's stack pool.
@@ -103,7 +103,7 @@ const RECYCLE_REQUESTS_SPEC: args::OptSpec = args::OptSpec {
     long: Some("recycle-requests"),
     short: None,
     value: Some("<n>"),
-    desc: "Recycle a worker after N requests; 0 disables (default: 10000)",
+    desc: "Recycle a worker after N requests; 0 disables (default: 200)",
 };
 
 const MAX_CONCURRENCY_SPEC: args::OptSpec = args::OptSpec {


### PR DESCRIPTION
The published HTTP routing table compared servers on unequal core budgets and
against a saturated load generator. Both are fixed here, and the ranking changes
substantially. Measuring `wado serve` properly then exposed a badly sized
recycling default, which is also fixed.

**The tables below are being re-measured with the new recycling default and are
not final.**

## Equal core budgets

Two deployment shapes are measured, and every server is scaled out to the
shape's worker count: Node via `node:cluster` (`SCHED_NONE`, so the kernel
distributes accepts rather than routing every connection through the primary),
Bun via one `SO_REUSEPORT` process per worker, `wado serve` via `--workers`,
Axum via `TOKIO_WORKER_THREADS`. The shapes are 1 worker (a 1-core container
scaled out horizontally) and 4 workers (a small VM running one instance).

Node reaches 74,512 req/s at 4 workers against 17,345 at 1, so a table that
scaled only some servers was measuring core budgets rather than servers.

## Load-generator headroom

`oha` is pinned to the complement of the server cores and always holds the
larger share, offered concurrency scales with worker count, and each shape ends
by re-running its fastest result at twice the connections. A saturated load
generator caps the fastest servers and compresses every ratio, which reads as
"the servers are closer than they are"; it is now reported rather than published
as server capacity.

## Request set

Four requests, one per routing behaviour the routers differ on: static, dynamic
parameter, method dispatch over a mixed static/dynamic path, and wildcard. The
three dropped entries only varied depth or the radix sibling of a covered case,
which buys the measurement time for the second shape.

## Recycling default: 10,000 -> 200 requests

`wado serve` recycles a worker's component instance every `--recycle-requests`
requests, bounding the garbage in that worker's long-lived Wasm GC heap.
Throughput peaks over a broad 25-200 plateau and falls off either side:
recycling too rarely lets the heap grow until collection dominates, recycling
every few requests spends the gain on rebuilds.

Measured on `benchmark/http_routing/app.wado` (req/s for `GET /user`):

| recycle | 4 workers | 12 workers | p99 (12w) |
| ------: | --------: | ---------: | --------: |
| 1 | 31,673 | 54,613 | 55.0 ms |
| 10 | 93,988 | 185,345 | 32.3 ms |
| 25 | 122,709 | 186,828 | 12.6 ms |
| 100 | 107,303 | 188,378 | 12.8 ms |
| 200 | 106,840 | 184,621 | 13.0 ms |
| 1,000 | 101,390 | 171,165 | 18.4 ms |
| 10,000 | 59,477 | 121,853 | - |

200 rather than the plateau's peak: the curve is a cliff below the plateau and a
gentle slope above it, so the safe side is the high side. A component larger
than this router also costs more to rebuild, which moves the optimum up.
Disabling recycling gives 45,501 req/s at 12 workers, so the mechanism is
load-bearing rather than a safety valve.

## Not fixed here

`wado serve` throughput saturates near 190,000 req/s regardless of worker count
(12 -> 16 workers is flat) or core budget (8 workers on 8 cores matches 12 on
12), with the load generator verified not to be the ceiling. Per-worker
throughput falls from 26,685 at 6 workers to 16,284 at 12, so something is
contended across workers. Attributing it needs a profile of the native process.