### PR TITLE
perf(serve): recycle workers every 200 requests

### DIFF
--- a/wado-cli/src/serve.rs
+++ b/wado-cli/src/serve.rs
@@ -47,9 +47,9 @@ const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const EPOCH_TICK_MS: u64 = 1000;
 
 /// Recycling resets state that accumulates in a long-lived instance,
-/// notably the component resource table (issue #1133). Throughput is
-/// flat from ~1k to ~100k requests so recycling is sized rare. `0` disables.
-const DEFAULT_RECYCLE_REQUESTS: u64 = 10000;
+/// notably the component resource table (issue #1133). Throughput peaks over
+/// a broad 25–200 plateau and falls off either side of it. `0` disables.
+const DEFAULT_RECYCLE_REQUESTS: u64 = 200;
 
 /// Each in-flight request needs an async fiber stack from the pooling
 /// allocator, so this also sizes the engine's stack pool.
@@ -103,7 +103,7 @@ const RECYCLE_REQUESTS_SPEC: args::OptSpec = args::OptSpec {
     long: Some("recycle-requests"),
     short: None,
     value: Some("<n>"),
-    desc: "Recycle a worker after N requests; 0 disables (default: 10000)",
+    desc: "Recycle a worker after N requests; 0 disables (default: 200)",
 };
 
 const MAX_CONCURRENCY_SPEC: args::OptSpec = args::OptSpec {


### PR DESCRIPTION
`wado serve` recycles a worker's component instance every
`--recycle-requests` requests, which bounds the garbage accumulating in that
worker's long-lived Wasm GC heap. Throughput peaks over a broad 25-200 request
plateau and falls off either side: recycling too rarely lets the heap grow until
collection dominates, recycling every few requests spends the gain on rebuilds.

Measured on `benchmark/http_routing/app.wado` (5700X, `oha` pinned to cores
disjoint from the server, req/s for `GET /user`):

| recycle | 4 workers | 12 workers | p99 (12w) |
| ------: | --------: | ---------: | --------: |
| 1 | 31,673 | 54,613 | 55.0 ms |
| 5 | 80,708 | 142,232 | 38.4 ms |
| 10 | 93,988 | 185,345 | 32.3 ms |
| 25 | 122,709 | 186,828 | 12.6 ms |
| 50 | 111,217 | 186,566 | 12.0 ms |
| 100 | 107,303 | 188,378 | 12.8 ms |
| 200 | 106,840 | 184,621 | 13.0 ms |
| 1,000 | 101,390 | 171,165 | 18.4 ms |
| 10,000 | 59,477 | 121,853 | - |

200 rather than the plateau's peak: the curve is a cliff below the plateau and a
gentle slope above it, so the safe side is the high side. A component larger
than this router also costs more to rebuild, which moves the optimum up.

Disabling recycling entirely gives 45,501 req/s at 12 workers, so the mechanism
is load-bearing rather than a safety valve.

## Not fixed here

Throughput saturates near 190,000 req/s regardless of worker count (12 -> 16
workers is flat) or core budget (8 workers on 8 cores matches 12 on 12), and the
load generator is verified not to be the ceiling. Per-worker throughput falls
from 26,685 at 6 workers to 16,284 at 12, so something is contended across
workers. Attributing it needs a profile of the native process.