### PR TITLE
bench(http-routing): check which side ran out of CPU

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -308,8 +308,15 @@ Four workers — a small VM running one instance:
 | `GET /static/index.html`        |     373,769 |                  228,782 |                86,381 |                    72,744 |
 
 `wado serve` places third: level with Hono on Node at one worker, clear of it at
-four. It stops gaining past roughly eight workers, and the allocation behind its
-`content-length` header value costs it a few percent of every request.
+four. The allocation behind its `content-length` header value costs it a few
+percent of every request.
+
+`SHAPES` names worker counts, not cores. Scaling past them is a question this
+harness cannot answer: the generator-to-server thread ratio moves the result
+more than the cores do, and it shifts with every point.
+
+The Axum row at four workers is a floor — `oha` runs out of CPU there before the
+server does, so the figure is the generator's limit rather than Axum's.
 
 HTTP routing needs `oha` and Bun, and is measured separately
 (`SLICE=10 ROUNDS=3 SHAPES="1 4" mise run benchmark-http-routing`).

--- a/benchmark/http_routing/README.md
+++ b/benchmark/http_routing/README.md
@@ -42,8 +42,11 @@ A saturated `oha` caps the fastest servers and compresses every ratio. It takes
 a fixed `OHA_CORE_COUNT`, not the cores left over: more generator threads thin
 each one's batch and the server pays for the extra wakeups.
 
-`HEADROOM_CHECK=1` re-runs each server at twice the connections; a gain there
-means `oha` set that number. It passes at the settings above, so it is off.
+Every row is checked for which side ran out of CPU. Against a fast enough
+server the generator runs out first, and that row is a floor.
+
+`HEADROOM_CHECK=1` also re-runs each server at twice the connections, for a
+generator short of those rather than of CPU. Off, since it passes here.
 
 Only the measured server runs, and its port is asserted free first — a survivor
 keeps serving under `SO_REUSEPORT` and inflates the row. Each server is warmed

--- a/benchmark/http_routing/bench.sh
+++ b/benchmark/http_routing/bench.sh
@@ -76,6 +76,16 @@ assert_port_free() {
   exit 1
 }
 
+# Busy jiffies over a CPU list, from /proc/stat: per-CPU rather than per-PID, so
+# it covers Node's cluster children and Bun's SO_REUSEPORT processes.
+cpu_busy() {
+  awk -v want="$1" '
+    BEGIN { n = split(want, a, ","); for (i = 1; i <= n; i++) sel["cpu" a[i]] = 1 }
+    /^cpu[0-9]/ && ($1 in sel) { for (f = 2; f <= NF; f++) tot += $f; idle += $5 + $6 }
+    END { print tot, idle }
+  ' /proc/stat
+}
+
 # Whole req/s, so the callers can compare with -gt.
 measure() {
   "${OHA_PIN[@]}" "$OHA_BIN" -m "$2" -z "${SLICE}s" -c "$CONNECTIONS" \
@@ -141,7 +151,10 @@ start_server() {
 run_shape() {
   local workers="$1"
   local key si ri req method path rps url best_rps best_method best_path
-  local pinned="" saturated="" got differs=""
+  local pinned="" saturated="" got differs="" unsaturated=""
+  local cpu_tot0 cpu_idle0 cpu_tot1 cpu_idle1 cpu_tot_acc cpu_idle_acc busy
+  local oha_tot0 oha_idle0 oha_tot1 oha_idle1 oha_tot_acc oha_idle_acc oha_busy
+  local SERVER_CPUS="" OHA_CPUS=""
   CONNECTIONS=$((CONNECTIONS_PER_WORKER * workers))
 
   # `oha` gets a fixed core count, not "the rest": spreading the same
@@ -157,6 +170,8 @@ run_shape() {
   if [ -n "$pinned" ]; then
     SERVER_PIN=(taskset -c "0-$((workers - 1))")
     OHA_PIN=(taskset -c "$((NPROC - OHA_CORE_COUNT))-$((NPROC - 1))")
+    SERVER_CPUS=$(seq -s, 0 $((workers - 1)))
+    OHA_CPUS=$(seq -s, $((NPROC - OHA_CORE_COUNT)) $((NPROC - 1)))
     echo "CPU pinning: servers on cores 0-$((workers - 1)), oha on cores $((NPROC - OHA_CORE_COUNT))-$((NPROC - 1))"
   else
     SERVER_PIN=(env)
@@ -190,13 +205,31 @@ run_shape() {
     best_rps=0
     best_method=""
     best_path=""
+    cpu_tot_acc=0
+    cpu_idle_acc=0
+    oha_tot_acc=0
+    oha_idle_acc=0
     for ri in "${!REQUESTS[@]}"; do
       req="${REQUESTS[$ri]}"
       method="${req%% *}"
       path="${req#* }"
       BEST[${si}|${ri}]=0
       for _ in $(seq 1 "$ROUNDS"); do
+        # Sampled around each slice, not across the whole block: the gaps
+        # between oha invocations are idle and would read as unsaturated.
+        if [ -n "$pinned" ]; then
+          read -r cpu_tot0 cpu_idle0 <<<"$(cpu_busy "$SERVER_CPUS")"
+          read -r oha_tot0 oha_idle0 <<<"$(cpu_busy "$OHA_CPUS")"
+        fi
         rps=$(measure "$url" "$method" "$path")
+        if [ -n "$pinned" ]; then
+          read -r cpu_tot1 cpu_idle1 <<<"$(cpu_busy "$SERVER_CPUS")"
+          read -r oha_tot1 oha_idle1 <<<"$(cpu_busy "$OHA_CPUS")"
+          cpu_tot_acc=$((cpu_tot_acc + cpu_tot1 - cpu_tot0))
+          cpu_idle_acc=$((cpu_idle_acc + cpu_idle1 - cpu_idle0))
+          oha_tot_acc=$((oha_tot_acc + oha_tot1 - oha_tot0))
+          oha_idle_acc=$((oha_idle_acc + oha_idle1 - oha_idle0))
+        fi
         [ -z "$rps" ] && rps=0
         [ "$rps" -gt "${BEST[${si}|${ri}]}" ] && BEST[${si}|${ri}]="$rps"
       done
@@ -206,6 +239,23 @@ run_shape() {
         best_path="$path"
       fi
     done
+
+    # Against a fast enough server the generator runs out first, and more
+    # connections will not show it: `oha` is short of CPU, not of work.
+    if [ -n "$pinned" ]; then
+      busy=$(awk -v d="$cpu_tot_acc" -v i="$cpu_idle_acc" \
+        'BEGIN { printf "%.0f", (d > 0 ? (1 - i / d) * 100 : 0) }')
+      oha_busy=$(awk -v d="$oha_tot_acc" -v i="$oha_idle_acc" \
+        'BEGIN { printf "%.0f", (d > 0 ? (1 - i / d) * 100 : 0) }')
+      if [ "$busy" -lt 90 ]; then
+        if [ "$oha_busy" -ge 90 ]; then
+          echo "    WARNING: $(server_name "$key") ran at ${busy}% while oha ran at ${oha_busy}%; this row is a floor set by the generator"
+        else
+          echo "    WARNING: $(server_name "$key") ran at ${busy}% and oha at ${oha_busy}%; neither side ran out of CPU"
+        fi
+        unsaturated="yes"
+      fi
+    fi
 
     # A gain at 2x connections means `oha` set that number, not the server.
     # It passes at the tuned settings, so it costs a slice only when asked.
@@ -236,6 +286,11 @@ run_shape() {
   echo
   if [ -z "$pinned" ]; then
     echo "These rows are unpinned: the servers and the load generator shared cores."
+  fi
+  if [ -n "$unsaturated" ]; then
+    echo "Saturation check: FAILED — see the warnings above."
+  else
+    echo "Saturation check: ok — every server ran its pinned cores out of CPU."
   fi
   if [ -n "$differs" ]; then
     echo "Response check: FAILED — the servers do not answer alike; see above."


### PR DESCRIPTION
A row measures the server only when the server is what ran out of CPU. Against a
fast enough server the load generator runs out first, and the row is then a
floor — one that offering more connections will not lift, because `oha` is short
of CPU rather than of work. Each row now reports which side it was.

At the settings in the tree the Axum row at four workers runs its pinned cores
at 86% while `oha` runs at 92%, so that figure is the generator's limit and not
Axum's. `benchmark/README.md` says so beside the table. The other three rows are
server-bound; the one-worker shape is server-bound throughout.

Splitting `oha` into two processes over the same cores reproduces the number,
and connections past 800 make it worse, which is what being short of CPU rather
than of connections looks like. `HEADROOM_CHECK` covers the other case — a
generator starved of connections — and is unchanged.

CPU is sampled around each slice rather than across the whole block, since the
gaps between `oha` invocations are idle and would read as unsaturated, and it is
read per-CPU from `/proc/stat` rather than per-PID, which covers Node's cluster
children and Bun's `SO_REUSEPORT` processes without special cases.

## Scaling

`SHAPES` names worker counts, not cores, and this harness cannot answer what
happens past them: the generator-to-server thread ratio moves the result more
than the cores do, and it shifts with every point measured. The README no longer
claims `wado serve` stops gaining past eight workers.