### PR TITLE
perf(optimizer): keep alias-class work linear in the class size

### DIFF
--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -26,6 +26,12 @@ struct HeapState {
     field_global: IndexMap<u32, HeapVersion>,
     /// Version covering slots in none of the maps above.
     default_version: HeapVersion,
+    /// One version standing in for a `per_local` entry on every `mut_escaped`
+    /// local. An impure call invalidates that whole set at once, and versions
+    /// are only ever compared per key, so a shared version reads identically to
+    /// a distinct one per local — at `O(1)` per call instead of the
+    /// `O(escaped)` a bump each cost.
+    escaped_version: HeapVersion,
 }
 
 impl HeapState {
@@ -36,6 +42,7 @@ impl HeapState {
             per_local: IndexMap::default(),
             field_global: IndexMap::default(),
             default_version: HeapVersion::INITIAL,
+            escaped_version: HeapVersion::INITIAL,
         }
     }
 
@@ -49,10 +56,13 @@ impl HeapState {
     /// generation that could have invalidated it. `root` is `None` when the
     /// receiver is not a determinable bare `Local`, so per-slot / per-local
     /// precision does not apply — only `field_global` and `default`.
-    fn version_of(&self, root: Option<u32>, field: u32) -> HeapVersion {
+    fn version_of(&self, root: Option<u32>, field: u32, root_escaped: bool) -> HeapVersion {
         let mut v = self.default_version;
         if let Some(&fg) = self.field_global.get(&field) {
             v = v.max(fg);
+        }
+        if root_escaped {
+            v = v.max(self.escaped_version);
         }
         if let Some(r) = root {
             if let Some(&pl) = self.per_local.get(&r) {
@@ -63,6 +73,12 @@ impl HeapState {
             }
         }
         v
+    }
+
+    /// Invalidate every `mut_escaped` local's fields in one step.
+    fn bump_escaped(&mut self) {
+        let v = self.fresh();
+        self.escaped_version = v;
     }
 
     fn bump_slot(&mut self, root: u32, field: u32) {
@@ -85,6 +101,7 @@ impl HeapState {
         self.per_slot.clear();
         self.per_local.clear();
         self.field_global.clear();
+        self.escaped_version = HeapVersion::INITIAL;
         self.default_version = v;
     }
 
@@ -97,6 +114,7 @@ impl HeapState {
             per_local: self.per_local.clone(),
             field_global: self.field_global.clone(),
             default_version: self.default_version,
+            escaped_version: self.escaped_version,
         }
     }
 
@@ -105,6 +123,7 @@ impl HeapState {
         self.per_local = snap.per_local;
         self.field_global = snap.field_global;
         self.default_version = snap.default_version;
+        self.escaped_version = snap.escaped_version;
     }
 
     /// Seed a fresh `HeapState` (as in [`build_scoped`]) with a snapshot taken at
@@ -118,12 +137,14 @@ impl HeapState {
         self.per_local.clone_from(&snap.per_local);
         self.field_global.clone_from(&snap.field_global);
         self.default_version = snap.default_version;
+        self.escaped_version = snap.escaped_version;
         let max = snap
             .per_slot
             .values()
             .chain(snap.per_local.values())
             .chain(snap.field_global.values())
             .chain(std::iter::once(&snap.default_version))
+            .chain(std::iter::once(&snap.escaped_version))
             .copied()
             .max()
             .unwrap_or(HeapVersion::INITIAL);
@@ -137,6 +158,7 @@ pub(crate) struct HeapSnapshot {
     per_local: IndexMap<u32, HeapVersion>,
     field_global: IndexMap<u32, HeapVersion>,
     default_version: HeapVersion,
+    escaped_version: HeapVersion,
 }
 
 /// A snapshot of *all* flow-sensitive builder state at a program point:
@@ -669,18 +691,34 @@ impl<'a> Builder<'a> {
     /// can reach; otherwise every `mut_escaped` local is bumped — not just this
     /// call's arguments, since a mutable reference that escaped earlier may have
     /// been retained.
+    /// [`HeapState::version_of`] with the `mut_escaped` membership it needs to
+    /// apply the shared escape version.
+    fn heap_version_of(&self, root: Option<u32>, field: u32) -> HeapVersion {
+        let escaped = root.is_some_and(|r| self.mut_escaped.contains(&r));
+        self.heap_state.version_of(root, field, escaped)
+    }
+
     fn bump_call_effects(&mut self, call: ExprId) {
         let pure = self.pure_calls.contains(&call);
         // Iterate ascending local index, not `mut_escaped`'s insertion order:
         // opaque `ValueId`s and heap versions are handed out in visit order, so
         // this keeps the value graph a deterministic function of the program
         // regardless of how the alias sets were built (#1440).
+        // An impure call invalidates the whole `mut_escaped` set, which the
+        // shared escape version covers in one step. A pure one reaches only the
+        // `untrackable` locals, too few to be worth a set-wide version, so those
+        // keep their individual `per_local` bump.
+        if !pure {
+            self.heap_state.bump_escaped();
+        }
         for i in 0..self.mut_escaped_sorted.len() {
             let l = self.mut_escaped_sorted[i];
-            if pure && !self.untrackable.contains(&l) {
-                continue;
+            if pure {
+                if !self.untrackable.contains(&l) {
+                    continue;
+                }
+                self.heap_state.bump_local(l);
             }
-            self.heap_state.bump_local(l);
             self.invalidate_local_with_source(l, Some(OpaqueSource::Local(l)));
         }
     }
@@ -960,7 +998,7 @@ impl<'a> Builder<'a> {
                             && bare_local
                             && !self.untrackable.contains(&r)
                         {
-                            let ver = self.heap_state.version_of(Some(r), field_index);
+                            let ver = self.heap_version_of(Some(r), field_index);
                             self.field_store.insert((rv, field_index, ver), v);
                         }
                     }
@@ -1081,7 +1119,7 @@ impl<'a> Builder<'a> {
                     Some((pointee_vn, pointee)) => (pointee_vn, Some(pointee)),
                     None => (walked, inner_e.and_then(|ie| self.receiver_root(ie))),
                 };
-                let heap_ver = self.heap_state.version_of(root, field_index);
+                let heap_ver = self.heap_version_of(root, field_index);
                 // Store→load forwarding: a value stored to this exact
                 // `(receiver, field, version)` is the value this read sees.
                 if let Some(&stored) = self.field_store.get(&(recv, field_index, heap_ver)) {
@@ -1285,7 +1323,7 @@ impl<'a> Builder<'a> {
                 Operand::Expr(e) => self.value_of.get(&e).copied(),
             };
             if let Some(fv) = fv {
-                let ver = self.heap_state.version_of(Some(root), field_index);
+                let ver = self.heap_version_of(Some(root), field_index);
                 self.field_store.insert((recv, field_index, ver), fv);
             }
         }
@@ -1320,12 +1358,12 @@ impl<'a> Builder<'a> {
             .field_store
             .iter()
             .filter_map(|(&(recv, field, ver), &stored)| {
-                (recv == src_recv && ver == self.heap_state.version_of(Some(src), field))
+                (recv == src_recv && ver == self.heap_version_of(Some(src), field))
                     .then_some((field, stored))
             })
             .collect();
         for (field, stored) in live {
-            let dst_ver = self.heap_state.version_of(Some(dst_root), field);
+            let dst_ver = self.heap_version_of(Some(dst_root), field);
             self.field_store.insert((dst_recv, field, dst_ver), stored);
         }
     }
@@ -1583,6 +1621,17 @@ impl<'a> Builder<'a> {
         } else {
             pre.default_version
         };
+        // The escape version joins like `default_version`: an arm that bumped it
+        // means the set may have been written on some path in, so the merge
+        // takes a fresh one that no pre-branch read can match.
+        let escaped_changed = live
+            .iter()
+            .any(|a| a.escaped_version != pre.escaped_version);
+        let new_escaped = if escaped_changed {
+            self.heap_state.fresh()
+        } else {
+            pre.escaped_version
+        };
         let new_per_slot = self.join_overlay(
             new_default,
             &pre.per_slot,
@@ -1605,6 +1654,7 @@ impl<'a> Builder<'a> {
         self.heap_state.per_local = new_per_local;
         self.heap_state.field_global = new_field_global;
         self.heap_state.default_version = new_default;
+        self.heap_state.escaped_version = new_escaped;
     }
 
     /// Join one overlay map across the live arms. A key keeps its pre version
@@ -2268,3 +2318,4 @@ mod tests {
         assert_eq!(build_with(&escaped([0, 1])), build_with(&escaped([1, 0])));
     }
 }
+

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -26,16 +26,9 @@ struct HeapState {
     field_global: IndexMap<u32, HeapVersion>,
     /// Version covering slots in none of the maps above.
     default_version: HeapVersion,
-    /// The generation of the whole `mut_escaped` set, bumped as a unit by
-    /// everything that invalidates all of it at once ([`HeapState::bump_escaped`]'s
-    /// callers). Versions are only ever compared per key, so one shared version
-    /// reads identically to a distinct `per_local` entry per local, at `O(1)`
-    /// instead of the `O(escaped)` a bump each cost.
-    ///
-    /// An *additional* channel, never a replacement: [`HeapState::version_of`]
-    /// maxes it alongside `per_local`, which still carries the bumps aimed at a
-    /// single local (a `&mut` borrow of one, say). Consulting it *instead of*
-    /// `per_local` for an escaped root would drop those.
+    /// The generation of the whole `mut_escaped` set, bumped as a unit. Maxed
+    /// *alongside* `per_local`, never in place of it — `per_local` still carries
+    /// the bumps aimed at one local.
     escaped_version: HeapVersion,
 }
 
@@ -691,8 +684,6 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// [`HeapState::version_of`], reading the `mut_escaped` membership it needs
-    /// to apply the shared escape version.
     fn heap_version_of(&self, root: Option<u32>, field: u32) -> HeapVersion {
         let escaped = root.is_some_and(|r| self.mut_escaped.contains(&r));
         self.heap_state.version_of(root, field, escaped)
@@ -708,11 +699,9 @@ impl<'a> Builder<'a> {
         // Iterate ascending local index, not `mut_escaped`'s insertion order:
         // opaque `ValueId`s and heap versions are handed out in visit order, so
         // this keeps the value graph a deterministic function of the program
-        // regardless of how the alias sets were built (#1440).
-        // An impure call invalidates the whole `mut_escaped` set, which the
-        // shared escape version covers in one step. A pure one reaches only the
-        // `untrackable` locals, too few to be worth a set-wide version, so those
-        // keep their individual `per_local` bump.
+        // regardless of how the alias sets were built (#1440). A pure call
+        // reaches only the `untrackable` locals, too few for the set-wide
+        // version, so those keep their `per_local` bump.
         if !pure {
             self.heap_state.bump_escaped();
         }
@@ -1626,9 +1615,8 @@ impl<'a> Builder<'a> {
         } else {
             pre.default_version
         };
-        // The escape version joins like `default_version`: an arm that bumped it
-        // means the set may have been written on some path in, so the merge
-        // takes a fresh one that no pre-branch read can match.
+        // An arm that bumped it may have written the set, so the merge takes a
+        // fresh version no pre-branch read can match.
         let escaped_changed = live
             .iter()
             .any(|a| a.escaped_version != pre.escaped_version);

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -686,18 +686,18 @@ impl<'a> Builder<'a> {
         }
     }
 
-    /// Invalidate the locals a call may mutate. One proven to mutate nothing
-    /// ([`BuildConfig::pure_calls`]) bumps only the `untrackable` locals any call
-    /// can reach; otherwise every `mut_escaped` local is bumped — not just this
-    /// call's arguments, since a mutable reference that escaped earlier may have
-    /// been retained.
-    /// [`HeapState::version_of`] with the `mut_escaped` membership it needs to
-    /// apply the shared escape version.
+    /// [`HeapState::version_of`], reading the `mut_escaped` membership it needs
+    /// to apply the shared escape version.
     fn heap_version_of(&self, root: Option<u32>, field: u32) -> HeapVersion {
         let escaped = root.is_some_and(|r| self.mut_escaped.contains(&r));
         self.heap_state.version_of(root, field, escaped)
     }
 
+    /// Invalidate the locals a call may mutate. One proven to mutate nothing
+    /// ([`BuildConfig::pure_calls`]) bumps only the `untrackable` locals any call
+    /// can reach; otherwise every `mut_escaped` local is bumped — not just this
+    /// call's arguments, since a mutable reference that escaped earlier may have
+    /// been retained.
     fn bump_call_effects(&mut self, call: ExprId) {
         let pure = self.pure_calls.contains(&call);
         // Iterate ascending local index, not `mut_escaped`'s insertion order:
@@ -2318,4 +2318,3 @@ mod tests {
         assert_eq!(build_with(&escaped([0, 1])), build_with(&escaped([1, 0])));
     }
 }
-

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -26,11 +26,16 @@ struct HeapState {
     field_global: IndexMap<u32, HeapVersion>,
     /// Version covering slots in none of the maps above.
     default_version: HeapVersion,
-    /// One version standing in for a `per_local` entry on every `mut_escaped`
-    /// local. An impure call invalidates that whole set at once, and versions
-    /// are only ever compared per key, so a shared version reads identically to
-    /// a distinct one per local — at `O(1)` per call instead of the
-    /// `O(escaped)` a bump each cost.
+    /// The generation of the whole `mut_escaped` set, bumped as a unit by
+    /// everything that invalidates all of it at once ([`HeapState::bump_escaped`]'s
+    /// callers). Versions are only ever compared per key, so one shared version
+    /// reads identically to a distinct `per_local` entry per local, at `O(1)`
+    /// instead of the `O(escaped)` a bump each cost.
+    ///
+    /// An *additional* channel, never a replacement: [`HeapState::version_of`]
+    /// maxes it alongside `per_local`, which still carries the bumps aimed at a
+    /// single local (a `&mut` borrow of one, say). Consulting it *instead of*
+    /// `per_local` for an escaped root would drop those.
     escaped_version: HeapVersion,
 }
 
@@ -1854,9 +1859,9 @@ impl<'a> Builder<'a> {
 
     /// Invalidate the heap generations a loop body may write: a written
     /// `local.field` bumps `per_slot`, or `field_global` when aliased; a borrow
-    /// bumps `per_local`; an external write invalidates every `mut_escaped`
-    /// local. Keyed on `mut_escaped` to agree with the per-call
-    /// [`Builder::bump_call_effects`]; untouched fields survive.
+    /// bumps that one local's `per_local`; an external write invalidates the
+    /// whole `mut_escaped` set through its shared version, exactly as the
+    /// per-call [`Builder::bump_call_effects`] does. Untouched fields survive.
     fn apply_loop_heap_effects(&mut self, eff: &LoopHeapEffects) {
         for &(local, field) in &eff.written_fields {
             if self.aliased.contains(&local) {
@@ -1869,9 +1874,7 @@ impl<'a> Builder<'a> {
             self.heap_state.bump_local(local);
         }
         if eff.has_external_writes {
-            for &local in &self.mut_escaped {
-                self.heap_state.bump_local(local);
-            }
+            self.heap_state.bump_escaped();
         }
     }
 

--- a/wado-compiler/src/optimize/alias.rs
+++ b/wado-compiler/src/optimize/alias.rs
@@ -31,13 +31,8 @@ pub struct AliasInfo {
     pub alias_groups: AliasGroups,
 }
 
-/// The alias equivalence classes, stored once per class and indexed by member.
-///
-/// Members are unique by construction (each comes from one union-find key), so
-/// a slice carries them; the per-member indirection keeps a class of `m` locals
-/// at `O(m)`. Giving every member its own copy of the class instead is
-/// `O(m^2)`, which a generated parser reaches easily — its reference locals
-/// share one pointee struct, so they land in a single class.
+/// The alias equivalence classes, held once per class and indexed by member, so
+/// a class of `m` locals costs `O(m)`, not the `O(m^2)` a copy per member costs.
 #[derive(Default, Clone, Debug)]
 pub struct AliasGroups {
     root_of: IndexMap<u32, u32>,
@@ -49,9 +44,8 @@ impl AliasGroups {
         self.root_of.is_empty()
     }
 
-    /// The alias class containing `local`, itself included, or `None` when
-    /// `local` is in no class. Paired with the class's canonical root, so a
-    /// caller sweeping many locals can visit each class once.
+    /// The alias class containing `local`, itself included, with the canonical
+    /// root a caller sweeping many locals dedupes on.
     pub fn class_of(&self, local: u32) -> Option<(u32, &[u32])> {
         let &root = self.root_of.get(&local)?;
         let members = self.members_of.get(&root)?;
@@ -265,9 +259,8 @@ fn build_mut_escaped(
         })
         .collect();
     // Close over the reference alias groups: if any group member is mutably
-    // escaped, every member's pointee may be mutated through it. Sweeping the
-    // seed by class root visits each class once — the members of one class are
-    // all seeds of it, so walking the member list per seed would be `O(m^2)`.
+    // escaped, every member's pointee may be mutated through it. Nearly every
+    // member seeds its own class, so closing per seed would be `O(m^2)`.
     if !alias_groups.is_empty() {
         let seed: Vec<u32> = esc.iter().copied().collect();
         let mut closed: IndexSet<u32> = IndexSet::default();
@@ -999,9 +992,7 @@ fn alias_groups_from_edges(edges: Vec<(u32, u32)>) -> AliasGroups {
     if edges.is_empty() {
         return AliasGroups::default();
     }
-    // Union-find via simple parent pointers; locals are sparse u32s. `find` is
-    // iterative: a chain of `let dst = src` copies makes the parent chain as
-    // long as the class, which recursion walks one stack frame at a time.
+    // Union-find via simple parent pointers; locals are sparse u32s.
     let mut parent: IndexMap<u32, u32> = IndexMap::default();
     fn find(parent: &mut IndexMap<u32, u32>, x: u32) -> u32 {
         let mut root = x;
@@ -1285,10 +1276,6 @@ mod tests {
         assert_eq!(members(&groups, 0), None);
     }
 
-    /// Every member used to hold its own copy of the member set, so a function
-    /// whose reference locals share a pointee struct cost `O(m^2)`. These sizes
-    /// are ordinary for a generated parser and intractable under that shape, so
-    /// the case doubles as the complexity guard.
     #[test]
     fn one_large_group_is_linear() {
         const N: u32 = 20_000;
@@ -1304,9 +1291,7 @@ mod tests {
         );
     }
 
-    /// A chain unions each local onto the next, so resolving the first root
-    /// walks the whole chain — depth the union-find must survive, which a
-    /// recursive `find` does not.
+    /// A parent chain as long as the class, a depth recursion does not survive.
     #[test]
     fn long_chain_collapses_to_one_group() {
         const N: u32 = 20_000;

--- a/wado-compiler/src/optimize/alias.rs
+++ b/wado-compiler/src/optimize/alias.rs
@@ -28,7 +28,33 @@ use crate::tir::{ResolvedType, TypeId, TypeTable};
 pub struct AliasInfo {
     pub aliased: LocalSet,
     pub untrackable: LocalSet,
-    pub alias_groups: IndexMap<u32, IndexSet<u32>>,
+    pub alias_groups: AliasGroups,
+}
+
+/// The alias equivalence classes, stored once per class and indexed by member.
+///
+/// Members are unique by construction (each comes from one union-find key), so
+/// a slice carries them; the per-member indirection keeps a class of `m` locals
+/// at `O(m)`. Giving every member its own copy of the class instead is
+/// `O(m^2)`, which a generated parser reaches easily — its reference locals
+/// share one pointee struct, so they land in a single class.
+#[derive(Default, Clone, Debug)]
+pub struct AliasGroups {
+    root_of: IndexMap<u32, u32>,
+    members_of: IndexMap<u32, Vec<u32>>,
+}
+
+impl AliasGroups {
+    pub fn is_empty(&self) -> bool {
+        self.root_of.is_empty()
+    }
+
+    /// The alias class containing `local`, itself included, or `None` when
+    /// `local` is in no class.
+    pub fn members(&self, local: u32) -> Option<&[u32]> {
+        let root = self.root_of.get(&local)?;
+        self.members_of.get(root).map(Vec::as_slice)
+    }
 }
 
 /// Apply `f` to every node reachable from the body root, parents before
@@ -223,7 +249,7 @@ fn build_mut_escaped(
     aliased: &IndexSet<u32>,
     syntactic_mut: IndexSet<u32>,
     call_immutability: &CallImmutability,
-    alias_groups: &IndexMap<u32, IndexSet<u32>>,
+    alias_groups: &AliasGroups,
 ) -> IndexSet<u32> {
     let local_type = |idx: u32| locals.get(idx as usize).map(|l| l.type_id);
     // Keep a local in `mut_escaped` unless it is provably immutable across
@@ -241,7 +267,7 @@ fn build_mut_escaped(
     if !alias_groups.is_empty() {
         let seed: Vec<u32> = esc.iter().copied().collect();
         for v in seed {
-            if let Some(group) = alias_groups.get(&v) {
+            if let Some(group) = alias_groups.members(v) {
                 for &member in group {
                     esc.insert(member);
                 }
@@ -960,21 +986,29 @@ fn same_pointee_reference_edges(
 /// body walk — read off `locals` alone) before its shared walk extends it via
 /// [`collect_alias_edges_node`] for every `let dst = src` / `dst = src` copy
 /// found in the body.
-fn alias_groups_from_edges(edges: Vec<(u32, u32)>) -> IndexMap<u32, IndexSet<u32>> {
+fn alias_groups_from_edges(edges: Vec<(u32, u32)>) -> AliasGroups {
     if edges.is_empty() {
-        return IndexMap::default();
+        return AliasGroups::default();
     }
-    // Union-find via simple parent pointers; locals are sparse u32s.
+    // Union-find via simple parent pointers; locals are sparse u32s. `find` is
+    // iterative: a chain of `let dst = src` copies makes the parent chain as
+    // long as the class, which recursion walks one stack frame at a time.
     let mut parent: IndexMap<u32, u32> = IndexMap::default();
     fn find(parent: &mut IndexMap<u32, u32>, x: u32) -> u32 {
-        let p = *parent.get(&x).unwrap_or(&x);
-        if p == x {
-            x
-        } else {
-            let r = find(parent, p);
-            parent.insert(x, r);
-            r
+        let mut root = x;
+        while let Some(&p) = parent.get(&root)
+            && p != root
+        {
+            root = p;
         }
+        let mut cur = x;
+        while let Some(&p) = parent.get(&cur)
+            && p != cur
+        {
+            parent.insert(cur, root);
+            cur = p;
+        }
+        root
     }
     for (a, b) in edges {
         parent.entry(a).or_insert(a);
@@ -986,18 +1020,17 @@ fn alias_groups_from_edges(edges: Vec<(u32, u32)>) -> IndexMap<u32, IndexSet<u32
         }
     }
     let keys: Vec<u32> = parent.keys().copied().collect();
-    let mut groups: IndexMap<u32, IndexSet<u32>> = IndexMap::default();
-    for k in &keys {
-        let r = find(&mut parent, *k);
-        groups.entry(r).or_default().insert(*k);
+    let mut root_of: IndexMap<u32, u32> = IndexMap::default();
+    let mut members_of: IndexMap<u32, Vec<u32>> = IndexMap::default();
+    for k in keys {
+        let r = find(&mut parent, k);
+        root_of.insert(k, r);
+        members_of.entry(r).or_default().push(k);
     }
-    let mut out: IndexMap<u32, IndexSet<u32>> = IndexMap::default();
-    for set in groups.into_values() {
-        for &k in &set {
-            out.insert(k, set.clone());
-        }
+    AliasGroups {
+        root_of,
+        members_of,
     }
-    out
 }
 
 /// True when copying a `type_id` value between locals aliases them onto one heap
@@ -1204,5 +1237,67 @@ fn collect_aliased_node(body: &Body, node: NodeRef, out: &mut LocalSet) {
             | ExprKind::EnumConstruct { .. } => {}
         },
         NodeRef::Block(_) | NodeRef::Pat(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn members(groups: &AliasGroups, local: u32) -> Option<Vec<u32>> {
+        groups.members(local).map(|m| {
+            let mut v: Vec<u32> = m.to_vec();
+            v.sort_unstable();
+            v
+        })
+    }
+
+    #[test]
+    fn disjoint_edges_form_separate_groups() {
+        let groups = alias_groups_from_edges(vec![(1, 2), (3, 4)]);
+        assert_eq!(members(&groups, 1), Some(vec![1, 2]));
+        assert_eq!(members(&groups, 2), Some(vec![1, 2]));
+        assert_eq!(members(&groups, 3), Some(vec![3, 4]));
+        assert_eq!(members(&groups, 5), None);
+    }
+
+    #[test]
+    fn shared_endpoints_merge_transitively() {
+        let groups = alias_groups_from_edges(vec![(1, 2), (2, 3), (10, 11)]);
+        assert_eq!(members(&groups, 1), Some(vec![1, 2, 3]));
+        assert_eq!(members(&groups, 3), Some(vec![1, 2, 3]));
+        assert_eq!(members(&groups, 10), Some(vec![10, 11]));
+    }
+
+    #[test]
+    fn no_edges_yields_no_groups() {
+        let groups = alias_groups_from_edges(Vec::new());
+        assert!(groups.is_empty());
+        assert_eq!(members(&groups, 0), None);
+    }
+
+    /// Every member used to hold its own copy of the member set, so a function
+    /// whose reference locals share a pointee struct cost `O(m^2)`. These sizes
+    /// are ordinary for a generated parser and intractable under that shape, so
+    /// the case doubles as the complexity guard.
+    #[test]
+    fn one_large_group_is_linear() {
+        const N: u32 = 20_000;
+        let star: Vec<(u32, u32)> = (1..=N).map(|i| (0, i)).collect();
+        let groups = alias_groups_from_edges(star);
+        assert_eq!(groups.members(0).map(<[u32]>::len), Some(N as usize + 1));
+        assert_eq!(groups.members(N).map(<[u32]>::len), Some(N as usize + 1));
+    }
+
+    /// A chain unions each local onto the next, so resolving the first root
+    /// walks the whole chain — depth the union-find must survive, which a
+    /// recursive `find` does not.
+    #[test]
+    fn long_chain_collapses_to_one_group() {
+        const N: u32 = 20_000;
+        let chain: Vec<(u32, u32)> = (0..N).map(|i| (i, i + 1)).collect();
+        let groups = alias_groups_from_edges(chain);
+        assert_eq!(groups.members(0).map(<[u32]>::len), Some(N as usize + 1));
+        assert_eq!(groups.members(N).map(<[u32]>::len), Some(N as usize + 1));
     }
 }

--- a/wado-compiler/src/optimize/alias.rs
+++ b/wado-compiler/src/optimize/alias.rs
@@ -50,10 +50,12 @@ impl AliasGroups {
     }
 
     /// The alias class containing `local`, itself included, or `None` when
-    /// `local` is in no class.
-    pub fn members(&self, local: u32) -> Option<&[u32]> {
-        let root = self.root_of.get(&local)?;
-        self.members_of.get(root).map(Vec::as_slice)
+    /// `local` is in no class. Paired with the class's canonical root, so a
+    /// caller sweeping many locals can visit each class once.
+    pub fn class_of(&self, local: u32) -> Option<(u32, &[u32])> {
+        let &root = self.root_of.get(&local)?;
+        let members = self.members_of.get(&root)?;
+        Some((root, members.as_slice()))
     }
 }
 
@@ -263,14 +265,21 @@ fn build_mut_escaped(
         })
         .collect();
     // Close over the reference alias groups: if any group member is mutably
-    // escaped, every member's pointee may be mutated through it.
+    // escaped, every member's pointee may be mutated through it. Sweeping the
+    // seed by class root visits each class once — the members of one class are
+    // all seeds of it, so walking the member list per seed would be `O(m^2)`.
     if !alias_groups.is_empty() {
         let seed: Vec<u32> = esc.iter().copied().collect();
+        let mut closed: IndexSet<u32> = IndexSet::default();
         for v in seed {
-            if let Some(group) = alias_groups.members(v) {
-                for &member in group {
-                    esc.insert(member);
-                }
+            let Some((root, members)) = alias_groups.class_of(v) else {
+                continue;
+            };
+            if !closed.insert(root) {
+                continue;
+            }
+            for &member in members {
+                esc.insert(member);
             }
         }
     }
@@ -1245,7 +1254,7 @@ mod tests {
     use super::*;
 
     fn members(groups: &AliasGroups, local: u32) -> Option<Vec<u32>> {
-        groups.members(local).map(|m| {
+        groups.class_of(local).map(|(_, m)| {
             let mut v: Vec<u32> = m.to_vec();
             v.sort_unstable();
             v
@@ -1285,8 +1294,14 @@ mod tests {
         const N: u32 = 20_000;
         let star: Vec<(u32, u32)> = (1..=N).map(|i| (0, i)).collect();
         let groups = alias_groups_from_edges(star);
-        assert_eq!(groups.members(0).map(<[u32]>::len), Some(N as usize + 1));
-        assert_eq!(groups.members(N).map(<[u32]>::len), Some(N as usize + 1));
+        assert_eq!(
+            groups.class_of(0).map(|(_, m)| m.len()),
+            Some(N as usize + 1)
+        );
+        assert_eq!(
+            groups.class_of(N).map(|(_, m)| m.len()),
+            Some(N as usize + 1)
+        );
     }
 
     /// A chain unions each local onto the next, so resolving the first root
@@ -1297,7 +1312,13 @@ mod tests {
         const N: u32 = 20_000;
         let chain: Vec<(u32, u32)> = (0..N).map(|i| (i, i + 1)).collect();
         let groups = alias_groups_from_edges(chain);
-        assert_eq!(groups.members(0).map(<[u32]>::len), Some(N as usize + 1));
-        assert_eq!(groups.members(N).map(<[u32]>::len), Some(N as usize + 1));
+        assert_eq!(
+            groups.class_of(0).map(|(_, m)| m.len()),
+            Some(N as usize + 1)
+        );
+        assert_eq!(
+            groups.class_of(N).map(|(_, m)| m.len()),
+            Some(N as usize + 1)
+        );
     }
 }


### PR DESCRIPTION
A function whose reference locals share one pointee struct lands them all in a single alias class — the shape every Gale-generated parser and the Gale codegen itself have. Work proportional to the square of that class size showed up in three places; each is now linear.

## Alias classes

`AliasGroups` holds each equivalence class once and indexes it by member, so a class of `m` locals costs `O(m)`. `class_of` hands back the canonical root with the members, and `build_mut_escaped`'s escape closure sweeps by that root — every member seeds its own class, so closing per seed would walk the member list `m` times.

The union-find `find` is iterative. A chain of `let dst = src` copies leaves a parent chain as long as the class, which recursion does not survive; two unit tests pin a 20 000-member star and a 20 000-link chain.

## Heap versions

`HeapState` carries one `escaped_version` for the whole `mut_escaped` set. Everything that invalidates the set as a unit — an impure call, a loop body's external writes — bumps that single version, and `version_of` maxes it in for escaped roots. Versions are only ever compared per key, so one shared version reads identically to a distinct `per_local` entry per local, and `per_local` stays sparse for `join_heap` to walk. It is an additional channel rather than a replacement: `per_local` still carries the bumps aimed at one local, such as a `&mut` borrow.

`escaped_version` snapshots, restores, seeds, and joins alongside `default_version`, taking a fresh version when any arm bumped it.

## Effect

Compiler output is unchanged where it was compared: the WAT for the five benchmarks that build is byte-identical at -O2, as is `json_twitter` at -O3.

`wado test -O3 package-gale`, measured against `origin/main` back to back on one machine:

| | main | this branch |
| --- | ---: | ---: |
| wall | 1782.16s | 1601.95s (-10.1%) |
| peak RSS | 6710 MiB | 5691 MiB (-15.2%) |

2630 tests pass either way. The CI "Test (Gale O3)" job is the run's critical path, so the wall-clock saving lands there.