### PR TITLE
fix(skills): repair the skill frontmatter YAML and scope on-task-done to explicit requests

### DIFF
--- a/.claude/skills/cleanup-comments-and-docs/SKILL.md
+++ b/.claude/skills/cleanup-comments-and-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleanup-comments-and-docs
-description: Cut the branch's comments, doc comments, and Markdown down to the minimum — delete anything the code already says, cap doc/module comments at 3 lines and each Markdown topic at 2. Mandatory: run it after finishing a requested task, before reporting back to the user.
+description: "Cut the branch's comments, doc comments, and Markdown down to the minimum — delete anything the code already says, cap doc/module comments at 3 lines and each Markdown topic at 2. Mandatory: run it after finishing a requested task, before reporting back to the user."
 ---
 
 ## Scope

--- a/.claude/skills/on-task-done/SKILL.md
+++ b/.claude/skills/on-task-done/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: on-task-done
-description: "Task-completion flow: self-review the branch, update docs (spec/cheatsheet/compiler/optimizer), then run `mise run on-task-done` (build, clippy-fix, golden + format fixtures, doc-stdlib, format, tests; 40+ min) and commit its generated changes. Run when asked to."
+description: "Task-completion flow: self-review the branch, update docs (spec/cheatsheet/compiler/optimizer), then run `mise run on-task-done` (build, clippy-fix, golden + format fixtures, doc-stdlib, format, tests; 70+ min) and commit its generated changes. Run when asked to."
 ---
 
 # Overview
@@ -27,7 +27,7 @@ mise run test
 mise run test-wado
 ```
 
-`on-task-done` will take 40+ minutes.
+`on-task-done` will take 70+ minutes.
 
 ## Notes
 

--- a/.claude/skills/on-task-done/SKILL.md
+++ b/.claude/skills/on-task-done/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: on-task-done
-description: "Mandatory task-completion flow: self-review the branch, update docs (spec/cheatsheet/compiler/optimizer), then run `mise run on-task-done` (build, clippy-fix, golden + format fixtures, doc-stdlib, format, tests; 40+ min) and commit its generated changes. Run before committing a finished task or opening a PR."
+description: "Task-completion flow: self-review the branch, update docs (spec/cheatsheet/compiler/optimizer), then run `mise run on-task-done` (build, clippy-fix, golden + format fixtures, doc-stdlib, format, tests; 40+ min) and commit its generated changes. Run when asked to."
 ---
 
 # Overview

--- a/.claude/skills/on-task-done/SKILL.md
+++ b/.claude/skills/on-task-done/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: on-task-done
-description: Mandatory task-completion flow: self-review the branch, update docs (spec/cheatsheet/compiler/optimizer), then run `mise run on-task-done` (build, clippy-fix, golden + format fixtures, doc-stdlib, format, tests; 40+ min) and commit its generated changes. Run before committing a finished task or opening a PR.
+description: "Mandatory task-completion flow: self-review the branch, update docs (spec/cheatsheet/compiler/optimizer), then run `mise run on-task-done` (build, clippy-fix, golden + format fixtures, doc-stdlib, format, tests; 40+ min) and commit its generated changes. Run before committing a finished task or opening a PR."
 ---
 
 # Overview

--- a/.claude/skills/optimizer-debug/SKILL.md
+++ b/.claude/skills/optimizer-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: optimizer-debug
-description: Debug Wado optimizer (NIR/WIR pass) bugs using WADO_TRACE, WADO_DUMP_PASS_BEFORE/AFTER, WADO_LIST_PASSES, and WADO_SKIP_PASS env vars. Use when an optimization pass produces wrong code, ICEs the WIR pipeline ("invalid core Wasm module: type mismatch ..."), or when you need to see how a specific pass transforms the IR.
+description: "Debug Wado optimizer (NIR/WIR pass) bugs using WADO_TRACE, WADO_DUMP_PASS_BEFORE/AFTER, WADO_LIST_PASSES, and WADO_SKIP_PASS env vars. Use when an optimization pass produces wrong code, ICEs the WIR pipeline (\"invalid core Wasm module: type mismatch ...\"), or when you need to see how a specific pass transforms the IR."
 ---
 
 # Optimizer pass debugging

--- a/.claude/skills/rust/SKILL.md
+++ b/.claude/skills/rust/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust
-description: Workspace-specific Rust rules that override common habits: panic instead of dummy or no-op fallbacks, no wildcard match arms, dependencies managed in the workspace Cargo.toml, 2024 edition, zero warnings and clippy lints. Read before writing or editing Rust (.rs) code.
+description: "Workspace-specific Rust rules that override common habits: panic instead of dummy or no-op fallbacks, no wildcard match arms, dependencies managed in the workspace Cargo.toml, 2024 edition, zero warnings and clippy lints. Read before writing or editing Rust (.rs) code."
 ---
 
 - Manage dependencies in the workspace `Cargo.toml`.

--- a/.claude/skills/wado/SKILL.md
+++ b/.claude/skills/wado/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wado
-description: Wado is not Rust: value semantics (deep copy on assign/pass), variant/enum/flags instead of one enum, an effect system, and no lifetimes/borrow-checker/unsafe/macros. Read this cheatsheet before writing, editing, or reviewing Wado (.wado) source — guessing the syntax from general knowledge will be wrong.
+description: "Wado is not Rust: value semantics (deep copy on assign/pass), variant/enum/flags instead of one enum, an effect system, and no lifetimes/borrow-checker/unsafe/macros. Read this cheatsheet before writing, editing, or reviewing Wado (.wado) source — guessing the syntax from general knowledge will be wrong."
 ---
 
 @../../../docs/cheatsheet.md


### PR DESCRIPTION
Every `SKILL.md` under `.claude/skills/` carries frontmatter that a spec-conformant YAML parser accepts.

A `description` whose text contains a colon followed by a space needs quoting: unquoted, the colon reads as a mapping separator and the parser rejects the whole block. Five descriptions carry such a colon — `cleanup-comments-and-docs`, `on-task-done`, `optimizer-debug`, `rust`, and `wado` — and each is a quoted scalar.

`on-task-done` describes itself as a flow to run when asked for it, and states its runtime as 70+ minutes, so an agent reaches for it on request rather than reading it as a step every task owes.

`gh skill publish --dry-run .claude` (GitHub CLI 2.90+) validates the set against the Agent Skills specification and reports no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)