### PR TITLE
docs(compiler): the rules, and a help list that follows them

### DIFF
--- a/wado-cli/src/dump.rs
+++ b/wado-cli/src/dump.rs
@@ -70,6 +70,24 @@ impl Opt {
         KnobOpt::Feature,
     ];
 
+    /// Whether this names a pipeline stage, which help lists under `Phases:`.
+    const fn is_phase(self) -> bool {
+        match self {
+            Self::Tokens
+            | Self::Ast
+            | Self::Modules
+            | Self::Symbols
+            | Self::Types
+            | Self::TirResolved
+            | Self::TirMonomorphized
+            | Self::AssertPlan
+            | Self::NirLowered
+            | Self::Nir
+            | Self::Wir => true,
+            Self::World | Self::Help => false,
+        }
+    }
+
     const fn spec(self) -> args::OptSpec {
         match self {
             Self::Tokens => args::OptSpec {
@@ -160,26 +178,8 @@ fn format_usage() -> String {
     .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Phases:").unwrap();
-    write!(
-        buf,
-        "{}",
-        args::format_opts_help(
-            &[
-                Opt::Tokens,
-                Opt::Ast,
-                Opt::Modules,
-                Opt::Symbols,
-                Opt::Types,
-                Opt::TirResolved,
-                Opt::TirMonomorphized,
-                Opt::NirLowered,
-                Opt::Nir,
-                Opt::Wir,
-            ],
-            |o| o.spec(),
-        )
-    )
-    .unwrap();
+    let phases: Vec<Opt> = Opt::ALL.iter().copied().filter(|o| o.is_phase()).collect();
+    write!(buf, "{}", args::format_opts_help(&phases, |o| o.spec())).unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Other:").unwrap();
     write!(

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -9,10 +9,18 @@ optimizer has its own guide: [`docs/optimizer.md`](../docs/optimizer.md).
 - Name mangling and monomorphization go through `name.rs`. No other component knows a name format.
 - A declaration is identified by its `DefId`, never by its name — see
   [WEP: Declaration Identity](../docs/wep-2026-08-12-declaration-identity.md).
-- Walk IR through the visitor utilities, not by hand.
+- Walk IR through the visitor utilities, not by hand, and answer a question
+  once: one resolver total over the IR, rather than partial walkers, which
+  multiply until each misses a different shape.
+- Take a finding one altitude up before fixing it. It names a line; ask whether
+  that shape occurs at all, and what else answers the same question. A fix aimed
+  at the line leaves the invariant free to break again elsewhere.
+- Optimize as far as correctness allows. A conservatism is a claim about
+  precision: measure what it buys before keeping it, and drop the ones that buy
+  nothing.
 - Escalate the test scope as the work matures: `cargo check` while iterating,
   `mise run test` during development, `mise run test-wado` when wrapping up.
-- This crate must compile for `wasm32-unknown-unknown` (a CI build check). Keep
+- This crate must compile for `wasm32-unknown-unknown` (checked in CI). Keep
   OS-dependent `std` modules out of production code.
 
 ## Standard Libraries
@@ -29,7 +37,7 @@ section whose fields are the `serde` structs in `tests/e2e.rs`.
 - Run `touch tests/e2e.rs` after adding or removing a fixture, or after changing
   `WADO_FULL_TEST`. `datatest_mini` resolves fixtures at macro-expansion time and
   an incremental `cargo test` will not re-expand on its own.
-- `wado dump [-O0|-O2] file.wado` is how you find `wir_expect:Ox` patterns.
+- `wado dump -Ox file.wado` is how you find `wir_expect:Ox` patterns.
 - `wado dump --assert-plan file.wado` shows which operands an `assert` captures
   and which of them a short-circuit can skip.
 - `builtin::black_box(value)` returns `value` opaquely, keeping a fixture's input


### PR DESCRIPTION
Three rules the compiler crate works by, and one place the code did not follow
them.

## Rules

`wado-compiler/AGENTS.md` states how to answer a question in an analysis, what to
do with a finding, and how far to push an optimization.

The walk rule gains the second half of its point: walking the IR through the
visitor utilities is how, and answering the question once — one resolver total
over the IR rather than partial walkers — is what. Partial walkers multiply until
each misses a different shape.

A finding is taken one altitude up before it is fixed: it names a line, and the
question is whether that shape occurs at all and what else answers the same
question. A conservatism is a claim about precision, so what it buys is measured
before it is kept.

## `wado dump --help`

Help lists the phases by filtering `Opt::ALL`, so every phase it accepts is a
phase it prints — `--assert-plan` among them. The classification is exhaustive,
so a new phase does not compile until it is placed.

`wado-compiler/AGENTS.md` is checked against the tree it describes: the dump
example spells `-Ox`, the levels `wir_expect` accepts, and the
`wasm32-unknown-unknown` note names the `cargo check` CI runs.
