### PR TITLE
feat(stdlib)!: order core:uuid v7 sub-millisecond, and give it serde, byte access and a faster codec

### DIFF
--- a/.claude/skills/jco/SKILL.md
+++ b/.claude/skills/jco/SKILL.md
@@ -110,7 +110,8 @@ jco's built-in shim (`transpile-released.mjs` wires these automatically):
 - `cli.js` — stdout/stderr via `globalThis._jcoStreamWriteHook` (bypasses the
   rendezvous). `writeViaStream` returns a `Promise` because `write-via-stream`
   is async — jco lowers its result as a future and expects a Promise/Thenable.
-- `clocks.js` — `wasi:clocks` via `process.hrtime` / `Date.now`.
+- `clocks.js` — `wasi:clocks` via `process.hrtime` / `performance.timeOrigin`
+  (the wall clock keeps sub-millisecond precision).
 - `random.js` — `wasi:random` via Node crypto.
 
 ### `@bytecodealliance/preview3-shim`

--- a/docs/stdlib-core-args.md
+++ b/docs/stdlib-core-args.md
@@ -133,6 +133,9 @@ _Fields are private._
 
 ##### `fn deserialize_any<V: Visitor>(&mut self, visitor: &mut V) -> Result<V::Value, DeserializeError>`
 
+An argv token is always text, so a type that deserializes dynamically
+(`Uuid`, `Instant`, …) gets the raw token.
+
 ## Enums
 
 ### `pub enum ArgsErrorKind`

--- a/docs/stdlib-core-args.md
+++ b/docs/stdlib-core-args.md
@@ -133,8 +133,7 @@ _Fields are private._
 
 ##### `fn deserialize_any<V: Visitor>(&mut self, visitor: &mut V) -> Result<V::Value, DeserializeError>`
 
-An argv token is always text, so a type that deserializes dynamically
-(`Uuid`, `Instant`, …) gets the raw token.
+An argv token is always text, so a dynamic `Deserialize` gets it raw.
 
 ## Enums
 

--- a/docs/stdlib-core-cbor.md
+++ b/docs/stdlib-core-cbor.md
@@ -100,6 +100,8 @@ _Fields are private._
 
 ##### `fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError>`
 
+##### `fn is_human_readable(&self) -> bool`
+
 ##### `fn serialize_tag(&mut self, tag: u64) -> Result<(), SerializeError>`
 
 ##### `fn serialize_bytes(&mut self, v: ByteSlice) -> Result<(), SerializeError>`
@@ -143,6 +145,8 @@ _Fields are private._
 ##### `fn serialize_char(&mut self, v: char) -> Result<(), SerializeError>`
 
 ##### `fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError>`
+
+##### `fn is_human_readable(&self) -> bool`
 
 ##### `fn serialize_tag(&mut self, tag: u64) -> Result<(), SerializeError>`
 

--- a/docs/stdlib-core-serde.md
+++ b/docs/stdlib-core-serde.md
@@ -154,6 +154,12 @@ else the type's `name_policy` applies, else identity.
 
 #### `fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError>`
 
+#### `fn is_human_readable(&self) -> bool`
+
+Whether the output is meant to be read by people. Text formats leave
+this true; binary ones override it to false so a value can pick a
+compact representation.
+
 #### `fn serialize_tag(&mut self, _tag: u64) -> Result<(), SerializeError>`
 
 Tag the next value with a CBOR semantic tag (major type 6, RFC 8949

--- a/docs/stdlib-core-serde.md
+++ b/docs/stdlib-core-serde.md
@@ -156,9 +156,8 @@ else the type's `name_policy` applies, else identity.
 
 #### `fn is_human_readable(&self) -> bool`
 
-Whether the output is meant to be read by people. Text formats leave
-this true; binary ones override it to false so a value can pick a
-compact representation.
+Whether the output is meant to be read by people. Binary formats
+override it to false so a value can pick a compact representation.
 
 #### `fn serialize_tag(&mut self, _tag: u64) -> Result<(), SerializeError>`
 

--- a/docs/stdlib-core-uuid.md
+++ b/docs/stdlib-core-uuid.md
@@ -15,8 +15,9 @@ A `Uuid` is a single 128-bit value, held as 16 big-endian bytes; equality
 and ordering compare them in that order.
 
 `Uuid::v4()` needs `Random`; `Uuid::v7()` needs `Random` and `SystemClock`.
-`parse` accepts the four forms Rust's `uuid` and Go's `uuid` do; `Display`,
-`Inspect` and `Serialize` all render the canonical hyphenated form.
+`parse` accepts the four forms Rust's `uuid` and Go's `uuid` do. `Display`
+and `Inspect` render the canonical hyphenated form, as does `Serialize` for
+text formats; binary ones get CBOR tag 37 and the 16 bytes.
 
 `v7` sorts by creation time under RFC 9562 method 3: the timestamp and, in
 `rand_a`, its sub-millisecond fraction lead the bytes, one tick per 244 ns,
@@ -87,6 +88,10 @@ The canonical hyphenated lowercase string form.
 #### `impl Inspect for Uuid`
 
 ##### `pub fn inspect(&self, f: &mut Formatter)`
+
+#### `impl InspectAlt for Uuid`
+
+##### `pub fn inspect_alt(&self, f: &mut Formatter)`
 
 #### `impl Serialize for Uuid`
 

--- a/docs/stdlib-core-uuid.md
+++ b/docs/stdlib-core-uuid.md
@@ -8,18 +8,22 @@ UUID generation and parsing (RFC 9562).
 Only the two versions in common use today are provided:
 
 - `Uuid::v4()` — random UUID. The default for "just give me a unique id".
-- `Uuid::v7()` — time-ordered UUID. A 48-bit Unix-millisecond timestamp in
-  the high bytes makes values sortable by creation time, which is ideal for
-  database keys and log correlation.
+- `Uuid::v7()` — time-ordered UUID, ideal for database keys and log
+  correlation.
 
 A `Uuid` is a single 128-bit value (stored as a `u8x16` SIMD register, one
 lane per byte). Construction, formatting, and parsing are all byte-oriented,
 which maps directly onto the lane layout. Equality and ordering compare the
-16 bytes in big-endian order, so `v7` values sort by timestamp.
+16 bytes in big-endian order.
 
 `Uuid::v4()` needs `Random`; `Uuid::v7()` needs `Random` and `SystemClock`.
 `parse` accepts both the hyphenated form and the 32-digit hyphenless
 "simple" form, matching Rust's `uuid` and Go's `google/uuid`.
+
+`v7` sorts by creation time under RFC 9562 method 3: the timestamp and, in
+`rand_a`, its sub-millisecond fraction lead the bytes, one tick per 244 ns,
+needing no generator state. Values within a tick, across a backwards clock
+step, or from a coarser clock are unordered.
 
 ## Synopsis
 
@@ -54,12 +58,9 @@ into place per RFC 9562.
 
 #### `pub fn v7() -> Uuid with (Random, SystemClock)`
 
-Generate a version-7 (time-ordered) UUID.
-
-The high 48 bits are the Unix timestamp in milliseconds, read from the
-`SystemClock` effect; the remaining bits are random. Because the
-timestamp occupies the most significant bytes, lexicographic / numeric
-ordering of `v7` values matches creation-time ordering.
+Generate a version-7 (time-ordered) UUID: a 48-bit millisecond timestamp
+and a 12-bit sub-millisecond fraction from `SystemClock`, then 62
+random bits.
 
 #### `pub fn parse(s: &String) -> Option<Uuid>`
 

--- a/docs/stdlib-core-uuid.md
+++ b/docs/stdlib-core-uuid.md
@@ -31,8 +31,8 @@ assert Uuid::parse(&"550e8400-e29b-41d4-a716-446655440000") matches { Ok(id) && 
 
 ### `pub struct Uuid`
 
-A 128-bit universally unique identifier, held big-endian: byte 0 is the most
-significant, the order RFC 9562 lays the fields out in.
+A 128-bit universally unique identifier, held big-endian as RFC 9562 lays
+the fields out.
 
 _Fields are private._
 

--- a/docs/stdlib-core-uuid.md
+++ b/docs/stdlib-core-uuid.md
@@ -11,14 +11,12 @@ Only the two versions in common use today are provided:
 - `Uuid::v7()` — time-ordered UUID, ideal for database keys and log
   correlation.
 
-A `Uuid` is a single 128-bit value (stored as a `u8x16` SIMD register, one
-lane per byte). Construction, formatting, and parsing are all byte-oriented,
-which maps directly onto the lane layout. Equality and ordering compare the
-16 bytes in big-endian order.
+A `Uuid` is a single 128-bit value, held as 16 big-endian bytes; equality
+and ordering compare them in that order.
 
 `Uuid::v4()` needs `Random`; `Uuid::v7()` needs `Random` and `SystemClock`.
-`parse` accepts both the hyphenated form and the 32-digit hyphenless
-"simple" form, matching Rust's `uuid` and Go's `google/uuid`.
+`parse` accepts the four forms Rust's `uuid` and Go's `uuid` do; `Display`,
+`Inspect` and `Serialize` all render the canonical hyphenated form.
 
 `v7` sorts by creation time under RFC 9562 method 3: the timestamp and, in
 `rand_a`, its sub-millisecond fraction lead the bytes, one tick per 244 ns,
@@ -28,7 +26,7 @@ step, or from a coarser clock are unordered.
 ## Synopsis
 
 ```wado
-assert Uuid::parse(&"550e8400-e29b-41d4-a716-446655440000") matches { Some(id) && id.version() == 4
+assert Uuid::parse(&"550e8400-e29b-41d4-a716-446655440000") matches { Ok(id) && id.version() == 4
     && id.to_string() == "550e8400-e29b-41d4-a716-446655440000" };
 ```
 
@@ -36,11 +34,8 @@ assert Uuid::parse(&"550e8400-e29b-41d4-a716-446655440000") matches { Some(id) &
 
 ### `pub struct Uuid`
 
-A 128-bit universally unique identifier.
-
-The bytes are held big-endian: byte 0 is the most significant. This is the
-order RFC 9562 lays out the fields in, so the natural byte order is also the
-canonical string order and (for `v7`) the timestamp order.
+A 128-bit universally unique identifier, held big-endian: byte 0 is the most
+significant, the order RFC 9562 lays the fields out in.
 
 _Fields are private._
 
@@ -48,13 +43,14 @@ _Fields are private._
 
 The nil UUID — all 128 bits zero (`00000000-0000-0000-0000-000000000000`).
 
+#### `pub fn max() -> Uuid`
+
+The max UUID — all 128 bits one (`ffffffff-ffff-ffff-ffff-ffffffffffff`).
+
 #### `pub fn v4() -> Uuid with Random`
 
-Generate a version-4 (random) UUID.
-
-All 122 free bits come from the cryptographically-secure `Random`
-effect; the version (`0100`) and variant (`10`) bits are then forced
-into place per RFC 9562.
+Generate a version-4 (random) UUID: 122 bits from `Random`, with the
+RFC 9562 version and variant bits forced into place.
 
 #### `pub fn v7() -> Uuid with (Random, SystemClock)`
 
@@ -62,16 +58,19 @@ Generate a version-7 (time-ordered) UUID: a 48-bit millisecond timestamp
 and a 12-bit sub-millisecond fraction from `SystemClock`, then 62
 random bits.
 
-#### `pub fn parse(s: &String) -> Option<Uuid>`
+#### `pub fn parse(s: &String) -> Result<Uuid, ParseError>`
 
-Parse a UUID string (case-insensitive), like Rust's `uuid` and Go's
-`google/uuid`:
+Parse a UUID string (case-insensitive), accepting every form Go's
+`uuid` and Rust's `uuid` do: `8-4-4-4-12`, 32 bare hex digits,
+`{8-4-4-4-12}`, and `urn:uuid:8-4-4-4-12`.
 
-- the canonical hyphenated form `8-4-4-4-12` (36 chars), with hyphens
-  required at exactly the field boundaries, or
-- the simple form: 32 hex digits with no hyphens.
+#### `pub fn from_bytes(bytes: &ByteList) -> Option<Uuid>`
 
-Returns `null` for anything else.
+Build a UUID from its 16 big-endian bytes. `null` for any other length.
+
+#### `pub fn as_bytes(&self) -> ByteList`
+
+The 16 bytes, most significant first.
 
 #### `pub fn version(&self) -> i32`
 
@@ -85,6 +84,18 @@ The canonical hyphenated lowercase string form.
 
 ##### `fn fmt(&self, f: &mut Formatter)`
 
+#### `impl Inspect for Uuid`
+
+##### `pub fn inspect(&self, f: &mut Formatter)`
+
+#### `impl Serialize for Uuid`
+
+##### `fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerializeError>`
+
+#### `impl Deserialize for Uuid`
+
+##### `fn deserialize<D: Deserializer>(d: &mut D) -> Result<Uuid, DeserializeError>`
+
 #### `impl Eq for Uuid`
 
 ##### `fn eq(&self, other: &Uuid) -> bool`
@@ -96,3 +107,19 @@ The canonical hyphenated lowercase string form.
 #### `impl Default for Uuid`
 
 ##### `fn default() -> Uuid`
+
+## Variants
+
+### `pub variant ParseError`
+
+Why a string was not a UUID.
+
+#### `InvalidLength`
+
+Not 32, 36, 38 (braced) or 45 (URN) characters long.
+
+#### `InvalidGroups`
+
+Hyphens, braces or the `urn:uuid:` prefix are not where they belong.
+
+#### `InvalidCharacter`

--- a/docs/stdlib-core-uuid.md
+++ b/docs/stdlib-core-uuid.md
@@ -11,18 +11,14 @@ Only the two versions in common use today are provided:
 - `Uuid::v7()` — time-ordered UUID, ideal for database keys and log
   correlation.
 
-A `Uuid` is a single 128-bit value, held as 16 big-endian bytes; equality
-and ordering compare them in that order.
-
 `Uuid::v4()` needs `Random`; `Uuid::v7()` needs `Random` and `SystemClock`.
 `parse` accepts the four forms Rust's `uuid` and Go's `uuid` do. `Display`
 and `Inspect` render the canonical hyphenated form, as does `Serialize` for
 text formats; binary ones get CBOR tag 37 and the 16 bytes.
 
-`v7` sorts by creation time under RFC 9562 method 3: the timestamp and, in
-`rand_a`, its sub-millisecond fraction lead the bytes, one tick per 244 ns,
-needing no generator state. Values within a tick, across a backwards clock
-step, or from a coarser clock are unordered.
+`v7` sorts by creation time under RFC 9562 method 3: the timestamp leads the
+bytes, `rand_a` holding its sub-millisecond fraction, one tick per 244 ns.
+Values within a tick, or across a backwards clock step, are unordered.
 
 ## Synopsis
 

--- a/example/jco-shim/clocks.js
+++ b/example/jco-shim/clocks.js
@@ -2,7 +2,6 @@
 
 export const monotonicClock = {
   now() {
-    // Return nanoseconds as BigInt
     const [sec, nsec] = process.hrtime();
     return BigInt(sec) * 1000000000n + BigInt(nsec);
   },
@@ -17,8 +16,8 @@ export const monotonicClock = {
   },
 };
 
-// The high-resolution clock has sub-millisecond precision but runs from process
-// start, so anchor it to `Date.now()` and re-anchor once the two diverge.
+// The high-resolution clock is sub-millisecond but process-relative, so anchor
+// it to `Date.now()`.
 let anchor = null;
 
 export const wallClock = {

--- a/example/jco-shim/clocks.js
+++ b/example/jco-shim/clocks.js
@@ -17,9 +17,8 @@ export const monotonicClock = {
   },
 };
 
-// The high-resolution clock has the sub-millisecond precision UUID v7 orders
-// by but runs from process start, so anchor it to `Date.now()` and re-anchor
-// once the two disagree by more than the millisecond `Date.now()` truncates.
+// The high-resolution clock has sub-millisecond precision but runs from process
+// start, so anchor it to `Date.now()` and re-anchor once the two diverge.
 let anchor = null;
 
 export const wallClock = {

--- a/example/jco-shim/clocks.js
+++ b/example/jco-shim/clocks.js
@@ -19,16 +19,16 @@ export const monotonicClock = {
 
 export const wallClock = {
   now() {
-    const ms = Date.now();
-    return {
-      seconds: BigInt(Math.floor(ms / 1000)),
-      nanoseconds: (ms % 1000) * 1000000,
-    };
+    // Keeps the sub-millisecond fraction `Date.now()` truncates; UUID v7 needs it.
+    const ms = performance.timeOrigin + performance.now();
+    const seconds = Math.floor(ms / 1000);
+    const nanoseconds = Math.min(999999999, Math.floor((ms - seconds * 1000) * 1000000));
+    return { seconds: BigInt(seconds), nanoseconds };
   },
   resolution() {
     return {
       seconds: 0n,
-      nanoseconds: 1000000, // 1ms
+      nanoseconds: 1000, // ~1us; browsers clamp this far coarser
     };
   },
 };

--- a/example/jco-shim/clocks.js
+++ b/example/jco-shim/clocks.js
@@ -19,10 +19,12 @@ export const monotonicClock = {
 
 export const wallClock = {
   now() {
-    // Keeps the sub-millisecond fraction `Date.now()` truncates; UUID v7 needs it.
-    const ms = performance.timeOrigin + performance.now();
+    // `Date.now()` fixes the millisecond, so the clock still follows system
+    // time; the high-resolution clock only fills in the fraction it truncates.
+    const ms = Date.now();
+    const fraction = (performance.timeOrigin + performance.now()) % 1;
     const seconds = Math.floor(ms / 1000);
-    const nanoseconds = Math.min(999999999, Math.floor((ms - seconds * 1000) * 1000000));
+    const nanoseconds = (ms % 1000) * 1000000 + Math.floor(fraction * 1000000);
     return { seconds: BigInt(seconds), nanoseconds };
   },
   resolution() {

--- a/example/jco-shim/clocks.js
+++ b/example/jco-shim/clocks.js
@@ -17,15 +17,25 @@ export const monotonicClock = {
   },
 };
 
+// The high-resolution clock has the sub-millisecond precision UUID v7 orders
+// by but runs from process start, so anchor it to `Date.now()` and re-anchor
+// once the two disagree by more than the millisecond `Date.now()` truncates.
+let anchor = null;
+
 export const wallClock = {
   now() {
-    // `Date.now()` fixes the millisecond, so the clock still follows system
-    // time; the high-resolution clock only fills in the fraction it truncates.
-    const ms = Date.now();
-    const fraction = (performance.timeOrigin + performance.now()) % 1;
+    const elapsed = performance.timeOrigin + performance.now();
+    const system = Date.now();
+    let ms = anchor === null ? system : anchor.system + (elapsed - anchor.elapsed);
+    if (ms < system || ms >= system + 2) {
+      anchor = { elapsed, system };
+      ms = system;
+    }
     const seconds = Math.floor(ms / 1000);
-    const nanoseconds = (ms % 1000) * 1000000 + Math.floor(fraction * 1000000);
-    return { seconds: BigInt(seconds), nanoseconds };
+    return {
+      seconds: BigInt(seconds),
+      nanoseconds: Math.floor((ms - seconds * 1000) * 1000000),
+    };
   },
   resolution() {
     return {

--- a/example/uuid_v7.wado
+++ b/example/uuid_v7.wado
@@ -1,7 +1,8 @@
 //! Deterministic UUID v7 via effect handlers.
 //!
 //! `Uuid::v7()` draws from two effects: `Random` for the entropy bytes and
-//! `SystemClock` for the 48-bit millisecond timestamp. In production both come
+//! `SystemClock` for the timestamp, down to its sub-millisecond fraction. In
+//! production both come
 //! from the host, so every call yields a fresh value. By installing our own
 //! handlers with `with Effect => handler do { ... }`, we pin both sources and
 //! get fully reproducible output — useful for tests, golden files, and demos.

--- a/example/uuid_v7.wado
+++ b/example/uuid_v7.wado
@@ -1,8 +1,7 @@
 //! Deterministic UUID v7 via effect handlers.
 //!
-//! `Uuid::v7()` draws from two effects: `Random` and `SystemClock`. Installing
-//! our own handlers pins both, so the output is reproducible — for tests,
-//! golden files, demos.
+//! `Uuid::v7()` draws from `Random` and `SystemClock`; installing our own
+//! handlers pins both, so the output is reproducible.
 //!
 //!     wado run example/uuid_v7.wado
 
@@ -77,14 +76,12 @@ export fn run() with Stdout {
     println(`v7 @ 1000ms: ${a}`);
     println(`v7 @ 2000ms: ${b}`);
 
-    // The clock leads the bytes, down to a 244 ns fraction, so later sorts after.
     assert a < b, "v7 values must sort by timestamp";
     assert a.version() == 7;
 
     let fine = gen_v7(1, 250_000, repeat(0xAB, 16));
     assert a < fine, "v7 values must sort within a millisecond too";
 
-    // Determinism: the same handlers reproduce the same UUID byte for byte.
     assert gen_v7(1, 0, repeat(0xAB, 16)) == a;
     println("deterministic: re-running yields the same UUID");
 }

--- a/example/uuid_v7.wado
+++ b/example/uuid_v7.wado
@@ -79,10 +79,13 @@ export fn run() with Stdout {
     println(`v7 @ 1000ms: ${a}`);
     println(`v7 @ 2000ms: ${b}`);
 
-    // The timestamp lives in the most significant bytes, so a later instant
-    // always sorts after an earlier one — the defining property of v7.
+    // The timestamp and its sub-millisecond fraction lead the bytes, so a later
+    // instant sorts after an earlier one — down to 244 ns, not just the ms.
     assert a < b, "v7 values must sort by timestamp";
     assert a.version() == 7;
+
+    let fine = gen_v7(1, 250_000, repeat(0xAB, 16));
+    assert a < fine, "v7 values must sort within a millisecond too";
 
     // Determinism: the same handlers reproduce the same UUID byte for byte.
     assert gen_v7(1, 0, repeat(0xAB, 16)) == a;
@@ -90,10 +93,10 @@ export fn run() with Stdout {
 }
 
 test "v7 is fully determined by the installed handlers" {
-    // seconds = 1, nanoseconds = 0 -> 1000 ms = 0x0000_0000_03E8.
-    // Entropy is all 0xFF, so byte 6 -> 0x7F (version) and byte 8 -> 0xBF.
+    // 1000 ms = 0x0000_0000_03E8, fraction 0 -> bytes 6..=7 = 0x70, 0x00.
+    // Entropy is all 0xFF, so byte 8 -> 0xBF.
     let id = gen_v7(1, 0, repeat(0xFF, 16));
-    assert id.to_string() == "00000000-03e8-7fff-bfff-ffffffffffff";
+    assert id.to_string() == "00000000-03e8-7000-bfff-ffffffffffff";
     assert id.version() == 7;
 }
 

--- a/example/uuid_v7.wado
+++ b/example/uuid_v7.wado
@@ -2,10 +2,9 @@
 //!
 //! `Uuid::v7()` draws from two effects: `Random` for the entropy bytes and
 //! `SystemClock` for the timestamp, down to its sub-millisecond fraction. In
-//! production both come
-//! from the host, so every call yields a fresh value. By installing our own
-//! handlers with `with Effect => handler do { ... }`, we pin both sources and
-//! get fully reproducible output — useful for tests, golden files, and demos.
+//! production both come from the host, so every call yields a fresh value. By
+//! installing our own handlers with `with Effect => handler do { ... }`, we pin
+//! both sources and get reproducible output — for tests, golden files, demos.
 //!
 //!     wado run example/uuid_v7.wado
 

--- a/example/uuid_v7.wado
+++ b/example/uuid_v7.wado
@@ -1,10 +1,8 @@
 //! Deterministic UUID v7 via effect handlers.
 //!
-//! `Uuid::v7()` draws from two effects: `Random` for the entropy bytes and
-//! `SystemClock` for the timestamp, down to its sub-millisecond fraction. In
-//! production both come from the host, so every call yields a fresh value. By
-//! installing our own handlers with `with Effect => handler do { ... }`, we pin
-//! both sources and get reproducible output — for tests, golden files, demos.
+//! `Uuid::v7()` draws from two effects: `Random` and `SystemClock`. Installing
+//! our own handlers pins both, so the output is reproducible — for tests,
+//! golden files, demos.
 //!
 //!     wado run example/uuid_v7.wado
 
@@ -79,8 +77,7 @@ export fn run() with Stdout {
     println(`v7 @ 1000ms: ${a}`);
     println(`v7 @ 2000ms: ${b}`);
 
-    // The timestamp and its sub-millisecond fraction lead the bytes, so a later
-    // instant sorts after an earlier one — down to 244 ns, not just the ms.
+    // The clock leads the bytes, down to a 244 ns fraction, so later sorts after.
     assert a < b, "v7 values must sort by timestamp";
     assert a.version() == 7;
 
@@ -93,8 +90,7 @@ export fn run() with Stdout {
 }
 
 test "v7 is fully determined by the installed handlers" {
-    // 1000 ms = 0x0000_0000_03E8, fraction 0 -> bytes 6..=7 = 0x70, 0x00.
-    // Entropy is all 0xFF, so byte 8 -> 0xBF.
+    // 1000 ms = 0x3E8, fraction 0 -> bytes 6..=7 = 0x70, 0x00; 0xFF entropy -> byte 8 = 0xBF.
     let id = gen_v7(1, 0, repeat(0xFF, 16));
     assert id.to_string() == "00000000-03e8-7000-bfff-ffffffffffff";
     assert id.version() == 7;

--- a/wado-compiler/lib/core/args.wado
+++ b/wado-compiler/lib/core/args.wado
@@ -614,8 +614,7 @@ impl Deserializer for ArgvDeserializer {
         return Result::Ok(ArgvVariantAccess { de: self, tag });
     }
 
-    /// An argv token is always text, so a type that deserializes dynamically
-    /// (`Uuid`, `Instant`, …) gets the raw token.
+    /// An argv token is always text, so a dynamic `Deserialize` gets it raw.
     fn deserialize_any<V: Visitor>(&mut self, visitor: &mut V) -> Result<V::Value, DeserializeError> {
         let text = self.take_value()?;
         return visitor.visit_string(text);

--- a/wado-compiler/lib/core/args.wado
+++ b/wado-compiler/lib/core/args.wado
@@ -614,8 +614,11 @@ impl Deserializer for ArgvDeserializer {
         return Result::Ok(ArgvVariantAccess { de: self, tag });
     }
 
+    /// An argv token is always text, so a type that deserializes dynamically
+    /// (`Uuid`, `Instant`, …) gets the raw token.
     fn deserialize_any<V: Visitor>(&mut self, visitor: &mut V) -> Result<V::Value, DeserializeError> {
-        return Result::Err(unsupported("dynamic deserialization"));
+        let text = self.take_value()?;
+        return visitor.visit_string(text);
     }
 }
 

--- a/wado-compiler/lib/core/args_test.wado
+++ b/wado-compiler/lib/core/args_test.wado
@@ -6,6 +6,8 @@
 
 use { Deserialize } from "core:serde";
 use { parse, ArgsError, ArgsErrorKind } from "core:args";
+use { Uuid } from "core:uuid";
+use { Instant } from "core:temporal";
 
 struct Cli {
     #[wire(positional)]
@@ -28,6 +30,30 @@ fn cli(r: Result<Cli, ArgsError>) -> Cli {
         panic(`parse failed: ${e.message}`);
     }
     unreachable();
+}
+
+struct RunCli {
+    #[wire(positional)]
+    job: Uuid,
+    tenant: Uuid,
+    since: Instant,
+    trace: Option<Uuid> = null,
+}
+impl Deserialize for RunCli;
+
+test "a field type that asks for any" {
+    let r = parse::<RunCli>([
+        "00010203-0405-4607-8809-0a0b0c0d0e0f", "--tenant", "550e8400-e29b-41d4-a716-446655440000", "--since",
+        "2026-08-21T00:00:00Z", "--trace", "ffffffff-ffff-4fff-bfff-ffffffffffff",
+    ]);
+    assert r matches { Ok(_) };
+    if let Ok(c) = r {
+        assert c.job.to_string() == "00010203-0405-4607-8809-0a0b0c0d0e0f";
+        assert c.tenant.to_string() == "550e8400-e29b-41d4-a716-446655440000";
+        assert c.since.seconds == 1787270400;
+        assert c.trace matches { Some(t) && t.to_string() == "ffffffff-ffff-4fff-bfff-ffffffffffff" };
+    }
+    assert parse::<RunCli>(["nope", "--tenant", "also-nope", "--since", "now"]) matches { Err(_) };
 }
 
 test "positionals and options mixed" {

--- a/wado-compiler/lib/core/cbor.wado
+++ b/wado-compiler/lib/core/cbor.wado
@@ -92,6 +92,7 @@ global BREAK: u8 = 0xff;  // major 7, AI_INDEFINITE — stop code for indefinite
 // Tag numbers (RFC 8949 §3.4).
 global TAG_BIGNUM_POS: u64 = 2;  // §3.4.3 — unsigned bignum (byte-string magnitude)
 global TAG_BIGNUM_NEG: u64 = 3;  // §3.4.3 — negative bignum
+global TAG_UUID: u64 = 37;  // IANA CBOR tags — binary UUID
 global TAG_SELF_DESCRIBED: u64 = 55799;  // §3.4.6 — self-described CBOR marker
 
 // The quiet binary32 NaN — the single canonical NaN, since Wado has no f16.
@@ -390,6 +391,10 @@ impl Serializer for CborSerializer {
     fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError> {
         write_text(self.buf, v);
         return Result::Ok(());
+    }
+
+    fn is_human_readable(&self) -> bool {
+        return false;
     }
 
     fn serialize_tag(&mut self, tag: u64) -> Result<(), SerializeError> {
@@ -692,6 +697,10 @@ impl Serializer for CanonicalCborSerializer {
         return Result::Ok(());
     }
 
+    fn is_human_readable(&self) -> bool {
+        return false;
+    }
+
     fn serialize_tag(&mut self, tag: u64) -> Result<(), SerializeError> {
         write_head(self.buf, MAJOR_TAG, tag);
         return Result::Ok(());
@@ -821,8 +830,8 @@ fn simple_float_to_f64(ai: u8, bits: u64) -> f64 {
 fn is_passthrough_tag(tag: u64) -> bool {
     // Tags whose content is decoded directly, ignoring the tag number
     // (RFC 8949 §6.1): date/time text (0) / epoch (1), base64url/base64/base16
-    // hints (21/22/23), and the self-described CBOR marker (55799).
-    return tag == 0 || tag == 1 || tag == 21 || tag == 22 || tag == 23 || tag == TAG_SELF_DESCRIBED;
+    // hints (21/22/23), binary UUID (37), and the self-described marker (55799).
+    return tag == 0 || tag == 1 || tag == 21 || tag == 22 || tag == 23 || tag == TAG_UUID || tag == TAG_SELF_DESCRIBED;
 }
 
 pub struct CborDeserializer {

--- a/wado-compiler/lib/core/router.wado
+++ b/wado-compiler/lib/core/router.wado
@@ -952,8 +952,11 @@ impl Deserializer for PathParamsDeserializer {
         return Result::Err(DeserializeError::unexpected_type("path params cannot be deserialized as a variant", -1));
     }
 
-    fn deserialize_any<V: Visitor>(&mut self, _visitor: &mut V) -> Result<V::Value, DeserializeError> {
-        return Result::Err(DeserializeError::unexpected_type("path params do not support dynamic deserialize_any", -1));
+    /// A path parameter is always text, so a type that deserializes
+    /// dynamically (`Uuid`, `Instant`, …) gets the raw segment.
+    fn deserialize_any<V: Visitor>(&mut self, visitor: &mut V) -> Result<V::Value, DeserializeError> {
+        let text = self.deserialize_string()?;
+        return visitor.visit_string(text);
     }
 }
 

--- a/wado-compiler/lib/core/router.wado
+++ b/wado-compiler/lib/core/router.wado
@@ -952,8 +952,7 @@ impl Deserializer for PathParamsDeserializer {
         return Result::Err(DeserializeError::unexpected_type("path params cannot be deserialized as a variant", -1));
     }
 
-    /// A path parameter is always text, so a type that deserializes
-    /// dynamically (`Uuid`, `Instant`, …) gets the raw segment.
+    /// A path segment is always text, so a dynamic `Deserialize` gets it raw.
     fn deserialize_any<V: Visitor>(&mut self, visitor: &mut V) -> Result<V::Value, DeserializeError> {
         let text = self.deserialize_string()?;
         return visitor.visit_string(text);

--- a/wado-compiler/lib/core/router_test.wado
+++ b/wado-compiler/lib/core/router_test.wado
@@ -1,6 +1,8 @@
 use { Router } from "core:router";
 use { Method } from "wasi:http";
 use { Deserialize, DeserializeError, DeserializeErrorKind } from "core:serde";
+use { Uuid } from "core:uuid";
+use { Instant } from "core:temporal";
 
 test "router: static routes" {
     let mut r = Router::<i32>::new();
@@ -289,6 +291,38 @@ struct NestedParam {
     inner: InnerParam,
 }
 impl Deserialize for NestedParam;
+
+struct UuidParam {
+    id: Uuid,
+}
+impl Deserialize for UuidParam;
+
+struct InstantParam {
+    at: Instant,
+}
+impl Deserialize for InstantParam;
+
+test "router: deserialize a param type that asks for any" {
+    let mut r = Router::<i32>::new();
+    r.get("/users/:id", 1);
+    r.get("/events/:at", 2);
+
+    let m = r.match_path(Method::Get, &"/users/00010203-0405-4607-8809-0a0b0c0d0e0f").unwrap();
+    let p = m.params.deserialize::<UuidParam>().unwrap();
+    assert p.id.to_string() == "00010203-0405-4607-8809-0a0b0c0d0e0f";
+
+    let e = r.match_path(Method::Get, &"/events/2026-08-21T00:00:00Z").unwrap();
+    let q = e.params.deserialize::<InstantParam>().unwrap();
+    assert q.at.seconds == 1787270400;
+}
+
+test "router: deserialize rejects a malformed any-shaped param" {
+    let mut r = Router::<i32>::new();
+    r.get("/users/:id", 1);
+
+    let m = r.match_path(Method::Get, &"/users/nope").unwrap();
+    assert m.params.deserialize::<UuidParam>() matches { Err(_) };
+}
 
 test "router: deserialize params into struct" {
     let mut r = Router::<i32>::new();

--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -215,9 +215,8 @@ pub trait Serializer {
     fn serialize_bool(&mut self, v: bool) -> Result<(), SerializeError>;
     fn serialize_char(&mut self, v: char) -> Result<(), SerializeError>;
     fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError>;
-    /// Whether the output is meant to be read by people. Text formats leave
-    /// this true; binary ones override it to false so a value can pick a
-    /// compact representation.
+    /// Whether the output is meant to be read by people. Binary formats
+    /// override it to false so a value can pick a compact representation.
     fn is_human_readable(&self) -> bool {
         return true;
     }

--- a/wado-compiler/lib/core/serde.wado
+++ b/wado-compiler/lib/core/serde.wado
@@ -215,6 +215,12 @@ pub trait Serializer {
     fn serialize_bool(&mut self, v: bool) -> Result<(), SerializeError>;
     fn serialize_char(&mut self, v: char) -> Result<(), SerializeError>;
     fn serialize_string(&mut self, v: &String) -> Result<(), SerializeError>;
+    /// Whether the output is meant to be read by people. Text formats leave
+    /// this true; binary ones override it to false so a value can pick a
+    /// compact representation.
+    fn is_human_readable(&self) -> bool {
+        return true;
+    }
     /// Tag the next value with a CBOR semantic tag (major type 6, RFC 8949
     /// §3.4). Formats with no tag concept ignore it; the default no-op means
     /// only tag-aware serializers (CBOR) need to implement it.

--- a/wado-compiler/lib/core/uuid.wado
+++ b/wado-compiler/lib/core/uuid.wado
@@ -31,7 +31,6 @@ use {
 use { Random } from "wasi:random";
 use { SystemClock } from "wasi:clocks";
 
-/// `rand_a` resolution: one tick per 1 ms / 4096 = 244 ns.
 global SUB_MS_TICKS: i64 = 4096;
 
 /// IANA CBOR tag for a UUID's 16 raw bytes.
@@ -52,8 +51,8 @@ pub variant ParseError {
     InvalidCharacter,
 }
 
-/// A 128-bit universally unique identifier, held big-endian: byte 0 is the most
-/// significant, the order RFC 9562 lays the fields out in.
+/// A 128-bit universally unique identifier, held big-endian as RFC 9562 lays
+/// the fields out.
 pub struct Uuid {
     bytes: u8x16,
 }

--- a/wado-compiler/lib/core/uuid.wado
+++ b/wado-compiler/lib/core/uuid.wado
@@ -11,8 +11,9 @@
 //! and ordering compare them in that order.
 //!
 //! `Uuid::v4()` needs `Random`; `Uuid::v7()` needs `Random` and `SystemClock`.
-//! `parse` accepts the four forms Rust's `uuid` and Go's `uuid` do; `Display`,
-//! `Inspect` and `Serialize` all render the canonical hyphenated form.
+//! `parse` accepts the four forms Rust's `uuid` and Go's `uuid` do. `Display`
+//! and `Inspect` render the canonical hyphenated form, as does `Serialize` for
+//! text formats; binary ones get CBOR tag 37 and the 16 bytes.
 //!
 //! `v7` sorts by creation time under RFC 9562 method 3: the timestamp and, in
 //! `rand_a`, its sub-millisecond fraction lead the bytes, one tick per 244 ns,
@@ -27,13 +28,18 @@ use {
     Deserialize,
     Deserializer,
     DeserializeError,
-    DeserializeErrorKind,
+    DeserializeSeq,
+    DeserializeMap,
+    Visitor,
 } from "core:serde";
 use { Random } from "wasi:random";
 use { SystemClock } from "wasi:clocks";
 
 /// `rand_a` resolution: one tick per 1 ms / 4096 = 244 ns.
 global SUB_MS_TICKS: i64 = 4096;
+
+/// IANA CBOR tag for a UUID's 16 raw bytes.
+global CBOR_TAG_UUID: u64 = 37;
 
 #[synopsis]
 test {
@@ -72,7 +78,7 @@ impl Uuid {
     pub fn v4() -> Uuid with Random {
         let mut b = fill_random(16);
         b[6] = (b[6] as i32 & 0x0F | 0x40) as u8;
-        set_variant(&mut b);
+        b[8] = with_variant(b[8]);
         return from_byte_list(&b);
     }
 
@@ -83,16 +89,21 @@ impl Uuid {
         let now = SystemClock::now();
         let ms = now.seconds * 1000 + now.nanoseconds as i64 / 1_000_000;
         let sub_ms = now.nanoseconds as i64 % 1_000_000 * SUB_MS_TICKS / 1_000_000;
-        let mut b = fill_random(16);
-        b[0] = (ms >> 40 & 0xFF) as u8;
-        b[1] = (ms >> 32 & 0xFF) as u8;
-        b[2] = (ms >> 24 & 0xFF) as u8;
-        b[3] = (ms >> 16 & 0xFF) as u8;
-        b[4] = (ms >> 8 & 0xFF) as u8;
-        b[5] = (ms & 0xFF) as u8;
-        b[6] = (0x70 | sub_ms >> 8 & 0x0F) as u8;
-        b[7] = (sub_ms & 0xFF) as u8;
-        set_variant(&mut b);
+        // Bytes 0..=7 are all clock, so only the trailing 8 need entropy.
+        let r = fill_random(8);
+        let mut b = ByteList::with_capacity(16);
+        b.push((ms >> 40 & 0xFF) as u8);
+        b.push((ms >> 32 & 0xFF) as u8);
+        b.push((ms >> 24 & 0xFF) as u8);
+        b.push((ms >> 16 & 0xFF) as u8);
+        b.push((ms >> 8 & 0xFF) as u8);
+        b.push((ms & 0xFF) as u8);
+        b.push((0x70 | sub_ms >> 8 & 0x0F) as u8);
+        b.push((sub_ms & 0xFF) as u8);
+        b.push(with_variant(r[0]));
+        for let mut i = 1; i < 8; i += 1 {
+            b.push(r[i]);
+        }
         return from_byte_list(&b);
     }
 
@@ -192,29 +203,69 @@ impl Inspect for Uuid {
     }
 }
 
+impl InspectAlt for Uuid {
+    pub fn inspect_alt(&self, f: &mut Formatter) {
+        f.write_str(&self.to_string());
+    }
+}
+
 impl Serialize for Uuid {
     fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerializeError> {
-        let str = self.to_string();
-        return s.serialize_string(&str);
+        if s.is_human_readable() {
+            let str = self.to_string();
+            return s.serialize_string(&str);
+        }
+        s.serialize_tag(CBOR_TAG_UUID)?;
+        return s.serialize_bytes(self.as_bytes().as_byte_slice());
+    }
+}
+
+/// Accepts the canonical text form or the 16 raw bytes.
+struct UuidVisitor {
+}
+
+impl Visitor for UuidVisitor {
+    type Value = Uuid;
+
+    fn visit_string(&mut self, v: String) -> Result<Uuid, DeserializeError> {
+        return match Uuid::parse(&v) {
+            Ok(id) => Result::Ok(id),
+            Err(_) => Result::Err(DeserializeError::invalid_value("invalid UUID", -1)),
+        };
+    }
+
+    fn visit_bytes(&mut self, v: ByteList) -> Result<Uuid, DeserializeError> {
+        return match Uuid::from_bytes(&v) {
+            Some(id) => Result::Ok(id),
+            None => Result::Err(DeserializeError::invalid_value("a UUID is 16 bytes", -1)),
+        };
+    }
+
+    fn visit_null(&mut self) -> Result<Uuid, DeserializeError> {
+        return Result::Err(DeserializeError::unexpected_type("expected a UUID", -1));
+    }
+
+    fn visit_bool(&mut self, _v: bool) -> Result<Uuid, DeserializeError> {
+        return Result::Err(DeserializeError::unexpected_type("expected a UUID", -1));
+    }
+
+    fn visit_f64(&mut self, _v: f64) -> Result<Uuid, DeserializeError> {
+        return Result::Err(DeserializeError::unexpected_type("expected a UUID", -1));
+    }
+
+    fn visit_seq<A: DeserializeSeq>(&mut self, _seq: &mut A) -> Result<Uuid, DeserializeError> {
+        return Result::Err(DeserializeError::unexpected_type("expected a UUID, found sequence", -1));
+    }
+
+    fn visit_map<A: DeserializeMap>(&mut self, _map: &mut A) -> Result<Uuid, DeserializeError> {
+        return Result::Err(DeserializeError::unexpected_type("expected a UUID, found map", -1));
     }
 }
 
 impl Deserialize for Uuid {
     fn deserialize<D: Deserializer>(d: &mut D) -> Result<Uuid, DeserializeError> {
-        let str = match d.deserialize_string() {
-            Ok(s) => s,
-            Err(e) => {
-                return Result::Err(e);
-            },
-        };
-        return match Uuid::parse(&str) {
-            Ok(id) => Result::Ok(id),
-            Err(_) => Result::Err(DeserializeError {
-                kind: DeserializeErrorKind::InvalidValue,
-                message: "invalid UUID",
-                offset: 0,
-            }),
-        };
+        let mut v = UuidVisitor {};
+        return d.deserialize_any::<UuidVisitor>(&mut v);
     }
 }
 
@@ -246,9 +297,9 @@ impl Default for Uuid {
     }
 }
 
-/// Force the RFC 9562 variant (top two bits of byte 8) into a 16-byte buffer.
-fn set_variant(b: &mut ByteList) {
-    b[8] = (b[8] as i32 & 0x3F | 0x80) as u8;
+/// Byte 8 with the RFC 9562 variant forced into its top two bits.
+fn with_variant(byte: u8) -> u8 {
+    return (byte as i32 & 0x3F | 0x80) as u8;
 }
 
 /// Collect exactly `n` random bytes, looping to tolerate short reads (the
@@ -282,6 +333,7 @@ fn hex_digit(nibble: i32) -> char {
 }
 
 fn has_urn_prefix(s: &String) -> bool {
+    assert s.len() >= 9;
     let prefix = "urn:uuid:";
     for let mut i = 0; i < 9; i += 1 {
         let c = s.get_byte_unchecked(i) as char;

--- a/wado-compiler/lib/core/uuid.wado
+++ b/wado-compiler/lib/core/uuid.wado
@@ -4,22 +4,29 @@
 //! Only the two versions in common use today are provided:
 //!
 //! - `Uuid::v4()` — random UUID. The default for "just give me a unique id".
-//! - `Uuid::v7()` — time-ordered UUID. A 48-bit Unix-millisecond timestamp in
-//!   the high bytes makes values sortable by creation time, which is ideal for
-//!   database keys and log correlation.
+//! - `Uuid::v7()` — time-ordered UUID, ideal for database keys and log
+//!   correlation.
 //!
 //! A `Uuid` is a single 128-bit value (stored as a `u8x16` SIMD register, one
 //! lane per byte). Construction, formatting, and parsing are all byte-oriented,
 //! which maps directly onto the lane layout. Equality and ordering compare the
-//! 16 bytes in big-endian order, so `v7` values sort by timestamp.
+//! 16 bytes in big-endian order.
 //!
 //! `Uuid::v4()` needs `Random`; `Uuid::v7()` needs `Random` and `SystemClock`.
 //! `parse` accepts both the hyphenated form and the 32-digit hyphenless
 //! "simple" form, matching Rust's `uuid` and Go's `google/uuid`.
+//!
+//! `v7` sorts by creation time under RFC 9562 method 3: the timestamp and, in
+//! `rand_a`, its sub-millisecond fraction lead the bytes, one tick per 244 ns,
+//! needing no generator state. Values within a tick, across a backwards clock
+//! step, or from a coarser clock are unordered.
 
 use { u8x16 } from "core:simd";
 use { Random } from "wasi:random";
 use { SystemClock } from "wasi:clocks";
+
+/// `rand_a` resolution: one tick per 1 ms / 4096 = 244 ns.
+global SUB_MS_TICKS: i64 = 4096;
 
 #[synopsis]
 test {
@@ -49,19 +56,18 @@ impl Uuid {
     /// into place per RFC 9562.
     pub fn v4() -> Uuid with Random {
         let mut b = fill_random(16);
-        set_version_and_variant(&mut b, 0x40);
+        b[6] = (b[6] as i32 & 0x0F | 0x40) as u8;
+        set_variant(&mut b);
         return from_byte_list(&b);
     }
 
-    /// Generate a version-7 (time-ordered) UUID.
-    ///
-    /// The high 48 bits are the Unix timestamp in milliseconds, read from the
-    /// `SystemClock` effect; the remaining bits are random. Because the
-    /// timestamp occupies the most significant bytes, lexicographic / numeric
-    /// ordering of `v7` values matches creation-time ordering.
+    /// Generate a version-7 (time-ordered) UUID: a 48-bit millisecond timestamp
+    /// and a 12-bit sub-millisecond fraction from `SystemClock`, then 62
+    /// random bits.
     pub fn v7() -> Uuid with (Random, SystemClock) {
         let now = SystemClock::now();
-        let ms = now.seconds as i64 * 1000 + now.nanoseconds as i64 / 1_000_000;
+        let ms = now.seconds * 1000 + now.nanoseconds as i64 / 1_000_000;
+        let sub_ms = now.nanoseconds as i64 % 1_000_000 * SUB_MS_TICKS / 1_000_000;
         let mut b = fill_random(16);
         b[0] = (ms >> 40 & 0xFF) as u8;
         b[1] = (ms >> 32 & 0xFF) as u8;
@@ -69,7 +75,9 @@ impl Uuid {
         b[3] = (ms >> 16 & 0xFF) as u8;
         b[4] = (ms >> 8 & 0xFF) as u8;
         b[5] = (ms & 0xFF) as u8;
-        set_version_and_variant(&mut b, 0x70);
+        b[6] = (0x70 | sub_ms >> 8 & 0x0F) as u8;
+        b[7] = (sub_ms & 0xFF) as u8;
+        set_variant(&mut b);
         return from_byte_list(&b);
     }
 
@@ -167,11 +175,8 @@ impl Default for Uuid {
     }
 }
 
-/// Force the RFC 9562 version (high nibble of byte 6) and variant (top two bits
-/// of byte 8) into a 16-byte buffer. `version_byte` is the version nibble
-/// already shifted into the high position (`0x40` for v4, `0x70` for v7).
-fn set_version_and_variant(b: &mut ByteList, version_byte: u8) {
-    b[6] = (b[6] as i32 & 0x0F | version_byte as i32) as u8;
+/// Force the RFC 9562 variant (top two bits of byte 8) into a 16-byte buffer.
+fn set_variant(b: &mut ByteList) {
     b[8] = (b[8] as i32 & 0x3F | 0x80) as u8;
 }
 

--- a/wado-compiler/lib/core/uuid.wado
+++ b/wado-compiler/lib/core/uuid.wado
@@ -7,14 +7,12 @@
 //! - `Uuid::v7()` — time-ordered UUID, ideal for database keys and log
 //!   correlation.
 //!
-//! A `Uuid` is a single 128-bit value (stored as a `u8x16` SIMD register, one
-//! lane per byte). Construction, formatting, and parsing are all byte-oriented,
-//! which maps directly onto the lane layout. Equality and ordering compare the
-//! 16 bytes in big-endian order.
+//! A `Uuid` is a single 128-bit value, held as 16 big-endian bytes; equality
+//! and ordering compare them in that order.
 //!
 //! `Uuid::v4()` needs `Random`; `Uuid::v7()` needs `Random` and `SystemClock`.
-//! `parse` accepts both the hyphenated form and the 32-digit hyphenless
-//! "simple" form, matching Rust's `uuid` and Go's `google/uuid`.
+//! `parse` accepts the four forms Rust's `uuid` and Go's `uuid` do; `Display`,
+//! `Inspect` and `Serialize` all render the canonical hyphenated form.
 //!
 //! `v7` sorts by creation time under RFC 9562 method 3: the timestamp and, in
 //! `rand_a`, its sub-millisecond fraction lead the bytes, one tick per 244 ns,
@@ -22,6 +20,15 @@
 //! step, or from a coarser clock are unordered.
 
 use { u8x16 } from "core:simd";
+use {
+    Serialize,
+    Serializer,
+    SerializeError,
+    Deserialize,
+    Deserializer,
+    DeserializeError,
+    DeserializeErrorKind,
+} from "core:serde";
 use { Random } from "wasi:random";
 use { SystemClock } from "wasi:clocks";
 
@@ -30,15 +37,21 @@ global SUB_MS_TICKS: i64 = 4096;
 
 #[synopsis]
 test {
-    assert Uuid::parse(&"550e8400-e29b-41d4-a716-446655440000") matches { Some(id) && id.version() == 4
+    assert Uuid::parse(&"550e8400-e29b-41d4-a716-446655440000") matches { Ok(id) && id.version() == 4
         && id.to_string() == "550e8400-e29b-41d4-a716-446655440000" };
 }
 
-/// A 128-bit universally unique identifier.
-///
-/// The bytes are held big-endian: byte 0 is the most significant. This is the
-/// order RFC 9562 lays out the fields in, so the natural byte order is also the
-/// canonical string order and (for `v7`) the timestamp order.
+/// Why a string was not a UUID.
+pub variant ParseError {
+    /// Not 32, 36, 38 (braced) or 45 (URN) characters long.
+    InvalidLength,
+    /// Hyphens, braces or the `urn:uuid:` prefix are not where they belong.
+    InvalidGroups,
+    InvalidCharacter,
+}
+
+/// A 128-bit universally unique identifier, held big-endian: byte 0 is the most
+/// significant, the order RFC 9562 lays the fields out in.
 pub struct Uuid {
     bytes: u8x16,
 }
@@ -49,11 +62,13 @@ impl Uuid {
         return Uuid { bytes: u8x16::splat(0) };
     }
 
-    /// Generate a version-4 (random) UUID.
-    ///
-    /// All 122 free bits come from the cryptographically-secure `Random`
-    /// effect; the version (`0100`) and variant (`10`) bits are then forced
-    /// into place per RFC 9562.
+    /// The max UUID — all 128 bits one (`ffffffff-ffff-ffff-ffff-ffffffffffff`).
+    pub fn max() -> Uuid {
+        return Uuid { bytes: u8x16::splat(0xFF) };
+    }
+
+    /// Generate a version-4 (random) UUID: 122 bits from `Random`, with the
+    /// RFC 9562 version and variant bits forced into place.
     pub fn v4() -> Uuid with Random {
         let mut b = fill_random(16);
         b[6] = (b[6] as i32 & 0x0F | 0x40) as u8;
@@ -81,45 +96,68 @@ impl Uuid {
         return from_byte_list(&b);
     }
 
-    /// Parse a UUID string (case-insensitive), like Rust's `uuid` and Go's
-    /// `google/uuid`:
-    ///
-    /// - the canonical hyphenated form `8-4-4-4-12` (36 chars), with hyphens
-    ///   required at exactly the field boundaries, or
-    /// - the simple form: 32 hex digits with no hyphens.
-    ///
-    /// Returns `null` for anything else.
-    pub fn parse(s: &String) -> Option<Uuid> {
+    /// Parse a UUID string (case-insensitive), accepting every form Go's
+    /// `uuid` and Rust's `uuid` do: `8-4-4-4-12`, 32 bare hex digits,
+    /// `{8-4-4-4-12}`, and `urn:uuid:8-4-4-4-12`.
+    pub fn parse(s: &String) -> Result<Uuid, ParseError> {
         let len = s.len();
-        if len != 36 && len != 32 {
-            return null;
+        let mut start = 0;
+        let mut hyphenated = true;
+        if len == 32 {
+            hyphenated = false;
+        } else if len == 38 {
+            if s.get_byte_unchecked(0) != b'{' || s.get_byte_unchecked(37) != b'}' {
+                return Result::Err(ParseError::InvalidGroups);
+            }
+            start = 1;
+        } else if len == 45 {
+            if !has_urn_prefix(s) {
+                return Result::Err(ParseError::InvalidGroups);
+            }
+            start = 9;
+        } else if len != 36 {
+            return Result::Err(ParseError::InvalidLength);
         }
-        // Field widths in hex digits. The hyphenated form's separators fall
-        // between these groups (8-4-4-4-12); the simple form is one group of
-        // 32. Deriving the hyphen positions from the field structure keeps the
-        // canonical layout explicit instead of hardcoding offsets.
-        let groups: List<i32> = if len == 36 { [8, 4, 4, 4, 12] } else { [32] };
-        let bytes: ByteList = s.bytes().collect();
-        let mut out: ByteList = [];
-        let mut pos = 0;
+        // Field widths in hex digits: the hyphens fall between the groups, so
+        // the layout states itself instead of hardcoding separator offsets.
+        let groups: List<i32> = if hyphenated { [8, 4, 4, 4, 12] } else { [32] };
+        let mut out = ByteList::with_capacity(16);
+        let mut pos = start;
         for let mut g = 0; g < groups.len(); g += 1 {
             if g > 0 {
-                if bytes[pos] != b'-' {
-                    return null;
+                if s.get_byte_unchecked(pos) != b'-' {
+                    return Result::Err(ParseError::InvalidGroups);
                 }
                 pos += 1;
             }
             for let mut k = 0; k < groups[g]; k += 2 {
-                let hi = hex_value(bytes[pos]);
-                let lo = hex_value(bytes[pos + 1]);
-                if hi < 0 || lo < 0 {
-                    return null;
+                let hi = s.get_byte_unchecked(pos) as char;
+                let lo = s.get_byte_unchecked(pos + 1) as char;
+                if !hi.is_hexdigit() || !lo.is_hexdigit() {
+                    return Result::Err(ParseError::InvalidCharacter);
                 }
-                out.push((hi << 4 | lo) as u8);
+                out.push((hi.hex_digit_value() << 4 | lo.hex_digit_value()) as u8);
                 pos += 2;
             }
         }
-        return Option::Some(from_byte_list(&out));
+        return Result::Ok(from_byte_list(&out));
+    }
+
+    /// Build a UUID from its 16 big-endian bytes. `null` for any other length.
+    pub fn from_bytes(bytes: &ByteList) -> Option<Uuid> {
+        if bytes.len() != 16 {
+            return null;
+        }
+        return Option::Some(from_byte_list(bytes));
+    }
+
+    /// The 16 bytes, most significant first.
+    pub fn as_bytes(&self) -> ByteList {
+        let mut out = ByteList::with_capacity(16);
+        for let mut i = 0; i < 16; i += 1 {
+            out.push(self.bytes.extract_lane(i) as u8);
+        }
+        return out;
     }
 
     /// The version number (4 or 7 for UUIDs produced by this module).
@@ -135,7 +173,8 @@ impl Uuid {
                 s.push('-');
             }
             let byte = self.bytes.extract_lane(i);
-            s.push_str(&`${byte:02x}`);
+            s.push(hex_digit(byte >> 4 & 0xF));
+            s.push(hex_digit(byte & 0xF));
         }
         return s;
     }
@@ -144,6 +183,38 @@ impl Uuid {
 impl Display for Uuid {
     fn fmt(&self, f: &mut Formatter) {
         f.write_str(&self.to_string());
+    }
+}
+
+impl Inspect for Uuid {
+    pub fn inspect(&self, f: &mut Formatter) {
+        f.write_str(&self.to_string());
+    }
+}
+
+impl Serialize for Uuid {
+    fn serialize<S: Serializer>(&self, s: &mut S) -> Result<(), SerializeError> {
+        let str = self.to_string();
+        return s.serialize_string(&str);
+    }
+}
+
+impl Deserialize for Uuid {
+    fn deserialize<D: Deserializer>(d: &mut D) -> Result<Uuid, DeserializeError> {
+        let str = match d.deserialize_string() {
+            Ok(s) => s,
+            Err(e) => {
+                return Result::Err(e);
+            },
+        };
+        return match Uuid::parse(&str) {
+            Ok(id) => Result::Ok(id),
+            Err(_) => Result::Err(DeserializeError {
+                kind: DeserializeErrorKind::InvalidValue,
+                message: "invalid UUID",
+                offset: 0,
+            }),
+        };
     }
 }
 
@@ -204,17 +275,19 @@ fn from_byte_list(b: &ByteList) -> Uuid {
     return Uuid { bytes: v };
 }
 
-/// The value of a single ASCII hex digit byte (`0`–`9`, `a`–`f`, `A`–`F`), or
-/// `-1` when the byte is not a hex digit.
-fn hex_value(byte: u8) -> i32 {
-    if byte >= b'0' && byte <= b'9' {
-        return (byte - b'0') as i32;
+/// The lowercase hex digit for a nibble.
+fn hex_digit(nibble: i32) -> char {
+    assert nibble >= 0 && nibble < 16;
+    return if nibble < 10 { (b'0' + nibble as u8) as char } else { (b'a' + (nibble - 10) as u8) as char };
+}
+
+fn has_urn_prefix(s: &String) -> bool {
+    let prefix = "urn:uuid:";
+    for let mut i = 0; i < 9; i += 1 {
+        let c = s.get_byte_unchecked(i) as char;
+        if !c.eq_ignore_ascii_case(&(prefix.get_byte_unchecked(i) as char)) {
+            return false;
+        }
     }
-    if byte >= b'a' && byte <= b'f' {
-        return (byte - b'a') as i32 + 10;
-    }
-    if byte >= b'A' && byte <= b'F' {
-        return (byte - b'A') as i32 + 10;
-    }
-    return -1;
+    return true;
 }

--- a/wado-compiler/lib/core/uuid.wado
+++ b/wado-compiler/lib/core/uuid.wado
@@ -7,18 +7,14 @@
 //! - `Uuid::v7()` — time-ordered UUID, ideal for database keys and log
 //!   correlation.
 //!
-//! A `Uuid` is a single 128-bit value, held as 16 big-endian bytes; equality
-//! and ordering compare them in that order.
-//!
 //! `Uuid::v4()` needs `Random`; `Uuid::v7()` needs `Random` and `SystemClock`.
 //! `parse` accepts the four forms Rust's `uuid` and Go's `uuid` do. `Display`
 //! and `Inspect` render the canonical hyphenated form, as does `Serialize` for
 //! text formats; binary ones get CBOR tag 37 and the 16 bytes.
 //!
-//! `v7` sorts by creation time under RFC 9562 method 3: the timestamp and, in
-//! `rand_a`, its sub-millisecond fraction lead the bytes, one tick per 244 ns,
-//! needing no generator state. Values within a tick, across a backwards clock
-//! step, or from a coarser clock are unordered.
+//! `v7` sorts by creation time under RFC 9562 method 3: the timestamp leads the
+//! bytes, `rand_a` holding its sub-millisecond fraction, one tick per 244 ns.
+//! Values within a tick, or across a backwards clock step, are unordered.
 
 use { u8x16 } from "core:simd";
 use {
@@ -129,8 +125,6 @@ impl Uuid {
         } else if len != 36 {
             return Result::Err(ParseError::InvalidLength);
         }
-        // Field widths in hex digits: the hyphens fall between the groups, so
-        // the layout states itself instead of hardcoding separator offsets.
         let groups: List<i32> = if hyphenated { [8, 4, 4, 4, 12] } else { [32] };
         let mut out = ByteList::with_capacity(16);
         let mut pos = start;

--- a/wado-compiler/lib/core/uuid_test.wado
+++ b/wado-compiler/lib/core/uuid_test.wado
@@ -76,16 +76,46 @@ test "v4 always sets version 4 and the RFC variant" {
 }
 
 test "v7 embeds the millisecond timestamp big-endian" {
-    // seconds = 1, nanoseconds = 0  ->  1000 ms = 0x0000_0000_03E8
+    // seconds = 1, nanoseconds = 0  ->  1000 ms = 0x0000_0000_03E8, rand_a = 0
     let mut rng = MockRandom { data: repeated(0xFF, 16), pos: 0 };
     let clock = MockClock {
         instant: Instant { seconds: 1, nanoseconds: 0 },
     };
     with Random => &mut rng, SystemClock => &clock do {
         let id = Uuid::v7();
-        assert id.to_string() == "00000000-03e8-7fff-bfff-ffffffffffff";
+        assert id.to_string() == "00000000-03e8-7000-bfff-ffffffffffff";
         assert id.version() == 7;
     };
+}
+
+test "v7 encodes the sub-millisecond fraction in rand_a" {
+    // 500_000 ns into the millisecond -> 500_000 * 4096 / 1_000_000 = 2048 = 0x800.
+    let mut rng = MockRandom { data: repeated(0xFF, 16), pos: 0 };
+    let clock = MockClock {
+        instant: Instant { seconds: 1, nanoseconds: 500_000 },
+    };
+    with Random => &mut rng, SystemClock => &clock do {
+        let id = Uuid::v7();
+        assert id.to_string() == "00000000-03e8-7800-bfff-ffffffffffff";
+    };
+}
+
+test "v7 sorts by sub-millisecond time within one millisecond" {
+    // Same millisecond, same entropy: only rand_a can order these.
+    let mut rng = MockRandom { data: repeated(0x00, 32), pos: 0 };
+    let early = MockClock {
+        instant: Instant { seconds: 1, nanoseconds: 100_000 },
+    };
+    let late = MockClock {
+        instant: Instant { seconds: 1, nanoseconds: 900_000 },
+    };
+    let a = with Random => &mut rng, SystemClock => &early do {
+        Uuid::v7();
+    };
+    let b = with Random => &mut rng, SystemClock => &late do {
+        Uuid::v7();
+    };
+    assert a < b;
 }
 
 test "v7 values sort by timestamp" {

--- a/wado-compiler/lib/core/uuid_test.wado
+++ b/wado-compiler/lib/core/uuid_test.wado
@@ -1,5 +1,6 @@
 use { Uuid, ParseError } from "core:uuid";
 use { to_string, from_string } from "core:json";
+use { to_bytes, from_bytes } from "core:cbor";
 use { Random } from "wasi:random";
 use { SystemClock, Instant } from "wasi:clocks";
 
@@ -151,6 +152,8 @@ test "parse round-trips canonical form" {
 test "parse accepts uppercase hex" {
     let lower = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
     let upper = Uuid::parse(&"00010203-0405-4607-8809-0A0B0C0D0E0F");
+    assert lower matches { Ok(_) };
+    assert upper matches { Ok(_) };
     if let Ok(l) = lower {
         if let Ok(u) = upper {
             assert l == u;
@@ -185,6 +188,7 @@ test "parse reports why the input was rejected" {
 
 test "bytes round-trip" {
     let id = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
+    assert id matches { Ok(_) };
     if let Ok(id) = id {
         let bytes = id.as_bytes();
         assert bytes.len() == 16;
@@ -209,10 +213,29 @@ test "max is all ones" {
 test "Inspect shows the canonical form" {
     let id = Uuid::nil();
     assert `${id:?}` == "00000000-0000-0000-0000-000000000000";
+    assert `${id:#?}` == "00000000-0000-0000-0000-000000000000";
+}
+
+test "serializes as a CBOR binary UUID" {
+    let id = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
+    assert id matches { Ok(_) };
+    if let Ok(id) = id {
+        let encoded = to_bytes(&id);
+        assert encoded matches { Ok(_) };
+        if let Ok(bytes) = encoded {
+            // Tag 37 (binary UUID) + a 16-byte string: 2 + 1 + 16.
+            assert bytes.len() == 19;
+            assert bytes[0] == 0xD8;
+            assert bytes[1] == 37;
+            assert bytes[2] == 0x50;
+            assert from_bytes::<Uuid>(bytes) matches { Ok(back) && back == id };
+        }
+    }
 }
 
 test "serializes as a JSON string" {
     let id = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
+    assert id matches { Ok(_) };
     if let Ok(id) = id {
         assert to_string(&id) matches { Ok(json) && json == "\"00010203-0405-4607-8809-0a0b0c0d0e0f\"" };
         let back = from_string::<Uuid>("\"00010203-0405-4607-8809-0a0b0c0d0e0f\"");
@@ -240,6 +263,9 @@ test "equality compares all 128 bits" {
     let a = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
     let b = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
     let c = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e10");
+    assert a matches { Ok(_) };
+    assert b matches { Ok(_) };
+    assert c matches { Ok(_) };
     if let Ok(a) = a {
         if let Ok(b) = b {
             if let Ok(c) = c {

--- a/wado-compiler/lib/core/uuid_test.wado
+++ b/wado-compiler/lib/core/uuid_test.wado
@@ -4,8 +4,7 @@ use { to_bytes, from_bytes } from "core:cbor";
 use { Random } from "wasi:random";
 use { SystemClock, Instant } from "wasi:clocks";
 
-// A fixed byte stream: `Uuid::v4` / `Uuid::v7` draw all their non-determinism
-// from `Random`, so pinning it pins the output.
+// Pinning `Random` pins `Uuid::v4` / `v7`: it is their only non-determinism.
 struct MockRandom {
     data: List<u8>,
     pos: i32,
@@ -26,7 +25,6 @@ impl Random for MockRandom {
     ..trap
 }
 
-// A deterministic `SystemClock` handler returning a fixed instant.
 struct MockClock {
     instant: Instant,
 }

--- a/wado-compiler/lib/core/uuid_test.wado
+++ b/wado-compiler/lib/core/uuid_test.wado
@@ -1,4 +1,5 @@
-use { Uuid } from "core:uuid";
+use { Uuid, ParseError } from "core:uuid";
+use { to_string, from_string } from "core:json";
 use { Random } from "wasi:random";
 use { SystemClock, Instant } from "wasi:clocks";
 
@@ -140,8 +141,8 @@ test "v7 values sort by timestamp" {
 test "parse round-trips canonical form" {
     let s: String = "00010203-0405-4607-8809-0a0b0c0d0e0f";
     let parsed = Uuid::parse(&s);
-    assert parsed matches { Some(_) };
-    if let Some(id) = parsed {
+    assert parsed matches { Ok(_) };
+    if let Ok(id) = parsed {
         assert id.to_string() == s;
         assert id.version() == 4;
     }
@@ -150,41 +151,78 @@ test "parse round-trips canonical form" {
 test "parse accepts uppercase hex" {
     let lower = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
     let upper = Uuid::parse(&"00010203-0405-4607-8809-0A0B0C0D0E0F");
-    assert lower matches { Some(_) };
-    assert upper matches { Some(_) };
-    if let Some(l) = lower {
-        if let Some(u) = upper {
+    if let Ok(l) = lower {
+        if let Ok(u) = upper {
             assert l == u;
         }
     }
 }
 
-test "parse accepts the simple (hyphenless) form" {
-    // 32 hex digits, no hyphens — same value as the hyphenated form.
-    let simple = Uuid::parse(&"000102030405460788090a0b0c0d0e0f");
-    let hyphenated = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
-    assert simple matches { Some(_) };
-    if let Some(s) = simple {
-        assert s.to_string() == "00010203-0405-4607-8809-0a0b0c0d0e0f";
-        if let Some(h) = hyphenated {
-            assert s == h;
-        }
+test "parse accepts every form Go's uuid does" {
+    let canonical = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
+    assert canonical matches { Ok(_) };
+    if let Ok(want) = canonical {
+        assert Uuid::parse(&"000102030405460788090a0b0c0d0e0f") matches { Ok(id) && id == want };
+        assert Uuid::parse(&"{00010203-0405-4607-8809-0a0b0c0d0e0f}") matches { Ok(id) && id == want };
+        assert Uuid::parse(&"urn:uuid:00010203-0405-4607-8809-0a0b0c0d0e0f") matches { Ok(id) && id == want };
+        assert Uuid::parse(&"URN:UUID:00010203-0405-4607-8809-0a0b0c0d0e0f") matches { Ok(id) && id == want };
     }
 }
 
-test "parse rejects malformed input" {
-    assert Uuid::parse(&"") matches { None };
-    assert Uuid::parse(&"not-a-uuid") matches { None };
-    // wrong length (35 chars)
-    assert Uuid::parse(&"0001020-0405-4607-8809-0a0b0c0d0e0f") matches { None };
-    // hyphen in the wrong place (strict field boundaries)
-    assert Uuid::parse(&"000102030-405-4607-8809-0a0b0c0d0e0f") matches { None };
-    // a field boundary that is not a hyphen
-    assert Uuid::parse(&"00010203f0405-4607-8809-0a0b0c0d0e0f") matches { None };
-    // non-hex digit
-    assert Uuid::parse(&"0001020g-0405-4607-8809-0a0b0c0d0e0f") matches { None };
-    // 33 hex digits (neither 32 nor 36 chars)
-    assert Uuid::parse(&"000102030405460788090a0b0c0d0e0ff") matches { None };
+test "parse reports why the input was rejected" {
+    assert Uuid::parse(&"") matches { Err(ParseError::InvalidLength) };
+    assert Uuid::parse(&"not-a-uuid") matches { Err(ParseError::InvalidLength) };
+    // 35 chars, 33 hex digits: neither length is a UUID.
+    assert Uuid::parse(&"0001020-0405-4607-8809-0a0b0c0d0e0f") matches { Err(ParseError::InvalidLength) };
+    assert Uuid::parse(&"000102030405460788090a0b0c0d0e0ff") matches { Err(ParseError::InvalidLength) };
+    // Hyphens, braces and the URN prefix must sit exactly where they belong.
+    assert Uuid::parse(&"000102030-405-4607-8809-0a0b0c0d0e0f") matches { Err(ParseError::InvalidGroups) };
+    assert Uuid::parse(&"00010203f0405-4607-8809-0a0b0c0d0e0f") matches { Err(ParseError::InvalidGroups) };
+    assert Uuid::parse(&"{00010203-0405-4607-8809-0a0b0c0d0e0f]") matches { Err(ParseError::InvalidGroups) };
+    assert Uuid::parse(&"urn:uuiX:00010203-0405-4607-8809-0a0b0c0d0e0f") matches { Err(ParseError::InvalidGroups) };
+    assert Uuid::parse(&"0001020g-0405-4607-8809-0a0b0c0d0e0f") matches { Err(ParseError::InvalidCharacter) };
+}
+
+test "bytes round-trip" {
+    let id = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
+    if let Ok(id) = id {
+        let bytes = id.as_bytes();
+        assert bytes.len() == 16;
+        assert bytes[0] == 0x00;
+        assert bytes[6] == 0x46;
+        assert bytes[15] == 0x0F;
+        assert Uuid::from_bytes(&bytes) matches { Some(back) && back == id };
+    }
+}
+
+test "from_bytes rejects any length but 16" {
+    assert Uuid::from_bytes(&[]) matches { None };
+    assert Uuid::from_bytes(&[0, 1, 2]) matches { None };
+}
+
+test "max is all ones" {
+    let max = Uuid::max();
+    assert max.to_string() == "ffffffff-ffff-ffff-ffff-ffffffffffff";
+    assert Uuid::nil() < max;
+}
+
+test "Inspect shows the canonical form" {
+    let id = Uuid::nil();
+    assert `${id:?}` == "00000000-0000-0000-0000-000000000000";
+}
+
+test "serializes as a JSON string" {
+    let id = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
+    if let Ok(id) = id {
+        assert to_string(&id) matches { Ok(json) && json == "\"00010203-0405-4607-8809-0a0b0c0d0e0f\"" };
+        let back = from_string::<Uuid>("\"00010203-0405-4607-8809-0a0b0c0d0e0f\"");
+        assert back matches { Ok(parsed) && parsed == id };
+    }
+}
+
+test "deserializing a malformed UUID fails" {
+    let back = from_string::<Uuid>("\"nope\"");
+    assert back matches { Err(_) };
 }
 
 test "Default is the nil UUID" {
@@ -202,9 +240,9 @@ test "equality compares all 128 bits" {
     let a = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
     let b = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e0f");
     let c = Uuid::parse(&"00010203-0405-4607-8809-0a0b0c0d0e10");
-    if let Some(a) = a {
-        if let Some(b) = b {
-            if let Some(c) = c {
+    if let Ok(a) = a {
+        if let Ok(b) = b {
+            if let Ok(c) = c {
                 assert a == b;
                 assert a != c;
                 assert a < c;

--- a/wado-compiler/lib/core/uuid_test.wado
+++ b/wado-compiler/lib/core/uuid_test.wado
@@ -4,10 +4,8 @@ use { to_bytes, from_bytes } from "core:cbor";
 use { Random } from "wasi:random";
 use { SystemClock, Instant } from "wasi:clocks";
 
-// A deterministic `Random` handler that hands out a fixed byte stream. This is
-// what makes `Uuid::v4` / `Uuid::v7` testable: the only non-determinism in
-// those functions is the `Random` effect, so installing a fixed source pins
-// the output exactly.
+// A fixed byte stream: `Uuid::v4` / `Uuid::v7` draw all their non-determinism
+// from `Random`, so pinning it pins the output.
 struct MockRandom {
     data: List<u8>,
     pos: i32,
@@ -178,7 +176,6 @@ test "parse reports why the input was rejected" {
     // 35 chars, 33 hex digits: neither length is a UUID.
     assert Uuid::parse(&"0001020-0405-4607-8809-0a0b0c0d0e0f") matches { Err(ParseError::InvalidLength) };
     assert Uuid::parse(&"000102030405460788090a0b0c0d0e0ff") matches { Err(ParseError::InvalidLength) };
-    // Hyphens, braces and the URN prefix must sit exactly where they belong.
     assert Uuid::parse(&"000102030-405-4607-8809-0a0b0c0d0e0f") matches { Err(ParseError::InvalidGroups) };
     assert Uuid::parse(&"00010203f0405-4607-8809-0a0b0c0d0e0f") matches { Err(ParseError::InvalidGroups) };
     assert Uuid::parse(&"{00010203-0405-4607-8809-0a0b0c0d0e0f]") matches { Err(ParseError::InvalidGroups) };

--- a/wado-compiler/tests/generated/fixtures/cbor_struct_decode.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/cbor_struct_decode.wir.wado
@@ -1671,7 +1671,7 @@ fn "core:cbor/core:cbor/CborDeserializer::read_signed_i128"(self) {
             } else if major == 1 {
                 return 0, struct.new "core:prelude/int128.wado//i128" { low: arg ^ -1_i64, high: -1_i64 }, ref.null none;
             } else if major == 6 {
-                continue_if l176 @likely(select i32(select i32(select i32(select i32(select i32(arg == 0_i64, 1, arg == 1_i64), 1, arg == 21_i64), 1, arg == 22_i64), 1, arg == 23_i64), 1, arg == 55799_i64));
+                continue_if l176 @likely(select i32(select i32(select i32(select i32(select i32(select i32(arg == 0_i64, 1, arg == 1_i64), 1, arg == 21_i64), 1, arg == 22_i64), 1, arg == 23_i64), 1, arg == 37_i64), 1, arg == 55799_i64));
                 if @unlikely(arg == 2_i64) {
                     let __vr_16_mv_0: i32;
                     let __vr_16_mv_1: ref null "core:prelude/int128.wado//u128";
@@ -2216,7 +2216,7 @@ fn "core:cbor/core:cbor/CborDeserializer^core:serde/Deserializer::deserialize_st
             if major == 3 {
                 return "core:cbor/core:cbor/CborDeserializer::read_text_body"(self, arg, indef);
             } else if @likely((if major == 6 -> i32 {
-                select i32(select i32(select i32(select i32(select i32(arg == 0_i64, 1, arg == 1_i64), 1, arg == 21_i64), 1, arg == 22_i64), 1, arg == 23_i64), 1, arg == 55799_i64);
+                select i32(select i32(select i32(select i32(select i32(select i32(arg == 0_i64, 1, arg == 1_i64), 1, arg == 21_i64), 1, arg == 22_i64), 1, arg == 23_i64), 1, arg == 37_i64), 1, arg == 55799_i64);
             } else {
                 0;
             })) {

--- a/wado-compiler/tests/generated/fixtures/partial_turbofish_infer_test.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/partial_turbofish_infer_test.wir.wado
@@ -1884,7 +1884,7 @@ fn "core:cbor/core:cbor/CborDeserializer::read_signed_i128"(self) {
             } else if major == 1 {
                 return 0, struct.new "core:prelude/int128.wado//i128" { low: arg ^ -1_i64, high: -1_i64 }, ref.null none;
             } else if major == 6 {
-                continue_if l194 @likely(select i32(select i32(select i32(select i32(select i32(arg == 0_i64, 1, arg == 1_i64), 1, arg == 21_i64), 1, arg == 22_i64), 1, arg == 23_i64), 1, arg == 55799_i64));
+                continue_if l194 @likely(select i32(select i32(select i32(select i32(select i32(select i32(arg == 0_i64, 1, arg == 1_i64), 1, arg == 21_i64), 1, arg == 22_i64), 1, arg == 23_i64), 1, arg == 37_i64), 1, arg == 55799_i64));
                 if @unlikely(arg == 2_i64) {
                     let __vr_16_mv_0: i32;
                     let __vr_16_mv_1: ref null "core:prelude/int128.wado//u128";
@@ -2480,7 +2480,7 @@ fn "core:cbor/core:cbor/CborDeserializer^core:serde/Deserializer::deserialize_st
             if major == 3 {
                 return "core:cbor/core:cbor/CborDeserializer::read_text_body"(self, arg, indef);
             } else if @likely((if major == 6 -> i32 {
-                select i32(select i32(select i32(select i32(select i32(arg == 0_i64, 1, arg == 1_i64), 1, arg == 21_i64), 1, arg == 22_i64), 1, arg == 23_i64), 1, arg == 55799_i64);
+                select i32(select i32(select i32(select i32(select i32(select i32(arg == 0_i64, 1, arg == 1_i64), 1, arg == 21_i64), 1, arg == 22_i64), 1, arg == 23_i64), 1, arg == 37_i64), 1, arg == 55799_i64);
             } else {
                 0;
             })) {


### PR DESCRIPTION
Go 1.27 landed a `uuid` package in its standard library, which prompted a comparison with `core:uuid`. The gaps it exposed are closed here.

## v7 ordering

`v7` follows RFC 9562 method 3: the 48-bit millisecond timestamp leads the bytes and the 12 `rand_a` bits carry its sub-millisecond fraction, one tick per 244 ns, leaving 62 random bits. Two values sort by creation time whenever the clock advances by at least one tick between them; values within a tick, or across a backwards clock step, are unordered.

Method 3 needs no generator state, so `v7` stays a pure function of its `Random` and `SystemClock` effects and remains reproducible under test handlers — the property `example/uuid_v7.wado` demonstrates. Measured under wasmtime, 10,000 consecutive `v7` values contain no inversions, and `v7` costs ~4.1 µs/op, of which the two host calls are the bulk.

## Wire formats

`Serialize` renders the canonical hyphenated string for text formats and CBOR tag 37 plus the 16 raw bytes for binary ones, chosen through a new `Serializer::is_human_readable()` (default `true`, `false` for both CBOR serializers). `Deserialize` accepts either through a visitor, and tag 37 joins the CBOR passthrough set so a tagged UUID decodes in strict mode. `Inspect` and `InspectAlt` render the canonical form.

`PathParamsDeserializer` and `ArgvDeserializer` answer `deserialize_any` with the text they hold, so a type that deserializes dynamically — `Uuid`, `core:temporal`'s `Instant` — works as a route parameter and as a CLI option.

## API

- `parse` takes the four forms Rust's `uuid` and Go's `uuid` accept — `8-4-4-4-12`, 32 bare hex digits, `{8-4-4-4-12}`, `urn:uuid:8-4-4-4-12` — and yields a `Result` whose error, `ParseError`, names which of the three ways the input was malformed.
- `max` is the all-ones UUID. `from_bytes` builds one from its 16 big-endian bytes and `as_bytes` returns them, so a UUID can cross a binary boundary.
- `to_string` runs at ~456 ns/op and `parse` at ~699 ns/op, and a UUID-using component links no formatter.

## Breaking changes

- `Uuid::parse` yields a `Result` carrying a `ParseError`, not an `Option`.
- A `Uuid` in CBOR is tag 37 and 16 bytes. JSON is unaffected.
- `Serializer` gains `is_human_readable()`; it is defaulted, so existing implementations need no change.

## jco shim

`example/jco-shim/clocks.js` anchors the high-resolution clock to `Date.now()`, re-anchoring when the two diverge by more than the millisecond `Date.now()` truncates. The wall clock keeps sub-millisecond precision for v7 ordering while tracking system time to within 1 ms and following clock adjustments; 2M consecutive samples on Node contain no backward step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxVHgzKrAJ1ecDTSQPB943