### PR TITLE
docs(wep): a third handle kind — non-owning tokens

### DIFF
--- a/docs/wep-2026-05-21-resource-ownership.md
+++ b/docs/wep-2026-05-21-resource-ownership.md
@@ -51,36 +51,30 @@ traps.
 | Host-object resource | a Wasm GC reference to a host object (no `dtor`)       | Value semantics     | Wasm GC                  |
 | Non-owning token     | an index naming something owned elsewhere (no `dtor`)  | Value semantics     | none — the owner's       |
 
-The `dtor` decides the kind, not the representation. A handle to a one-shot,
-destructor-bearing thing must be move-only, because copying it aliases it — a
-double-drop, a use-after-transfer, or a double free. Without a `dtor` there is
-nothing to run twice and nothing to free, so aliasing is safe and the handle is
-an ordinary value. The `i32`-vs-`externref` question is orthogonal to all three
-rows.
+The `dtor` decides the kind, not the representation. A handle that owns one must
+be move-only, because copying it aliases a destructor; without one there is
+nothing to free, so the handle is an ordinary value. `i32`-vs-`externref` is
+orthogonal to all three rows.
 
 ### Non-owning tokens
 
 A non-owning token names something whose lifetime another party already
-guarantees, so it carries no lifecycle of its own. It is a copyable newtype, not
-affine. Two backings qualify:
+guarantees. Two backings qualify:
 
 - **An affine resource owns the referent.** `Waitable` is this: `Subtask::join`
-  returns the subtask's own handle number as the identity to match a
-  `WaitEvent` against, and the `Subtask` owns the drop.
+  returns the subtask's own handle number as the identity to match a `WaitEvent`
+  against, and the `Subtask` owns the drop.
 - **An immortal table in a statically composed component.** `core:icu`'s
-  interned handles are this: the implementation component interns each object
-  whose configuration the program bounds at compile time, so the table is finite
-  by construction and never freed. Composition is static, so the table's
-  lifetime is the program's.
+  interned handles are this: the component interns each object whose
+  configuration the program bounds at compile time, so the table is finite by
+  construction and never freed.
 
-A CM `borrow<R>` cannot stand in for either. A borrow must be dropped before the
-call returns, where a token is compared long after it is obtained, is copied
-across those comparisons, and travels inside an ordinary struct by value —
-`WaitEvent.handle` is a plain field.
+A CM `borrow<R>` cannot stand in for either: it must be dropped before the call
+returns, where a token is compared long after, is copied across comparisons, and
+travels inside a struct by value (`WaitEvent.handle`).
 
-What disqualifies a token is a referent with neither backing: an object the
-far side allocates per call from unbounded runtime input has no owner and no
-bound, so a copyable index leaks it. That case is affine.
+A referent with neither backing — allocated per call from unbounded runtime
+input — is affine instead: a copyable index would leak it.
 
 The rest of this WEP concerns affine resources.
 
@@ -493,5 +487,5 @@ client.
 - [Migration to GC in Components](./wep-2026-03-28-gc-in-components.md)
 - [Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md)
 - [`core:icu`](./wep-2026-08-09-core-icu.md) — the non-owning token's second
-  backing, and its first consumer outside `Waitable`.
+  backing.
 - [NIR Optimizer Architecture](./wep-2026-06-05-nir-optimizer-architecture.md)

--- a/docs/wep-2026-05-21-resource-ownership.md
+++ b/docs/wep-2026-05-21-resource-ownership.md
@@ -49,7 +49,7 @@ traps.
 | -------------------- | ------------------------------------------------------ | ------------------- | ------------------------ |
 | Affine resource      | a CM `own`/`borrow` or waitable handle, or a guest one | Move-only + a check | `resource.drop` / `dtor` |
 | Host-object resource | a Wasm GC reference to a host object (no `dtor`)       | Value semantics     | Wasm GC                  |
-| Non-owning token     | an index naming something owned elsewhere (no `dtor`)  | Value semantics     | none — the owner's       |
+| Non-owning token     | an index naming something owned elsewhere (no `dtor`)  | Value semantics     | none of its own          |
 
 The `dtor` decides the kind, not the representation. A handle that owns one must
 be move-only, because copying it aliases a destructor; without one there is

--- a/docs/wep-2026-05-21-resource-ownership.md
+++ b/docs/wep-2026-05-21-resource-ownership.md
@@ -43,18 +43,45 @@ traps.
 
 ## Decision
 
-### Two resource kinds
+### Three resource kinds
 
 | Kind                 | Backed by                                              | Ownership           | Cleanup                  |
 | -------------------- | ------------------------------------------------------ | ------------------- | ------------------------ |
 | Affine resource      | a CM `own`/`borrow` or waitable handle, or a guest one | Move-only + a check | `resource.drop` / `dtor` |
 | Host-object resource | a Wasm GC reference to a host object (no `dtor`)       | Value semantics     | Wasm GC                  |
+| Non-owning token     | an index naming something owned elsewhere (no `dtor`)  | Value semantics     | none — the owner's       |
 
-An affine resource holds a one-shot, destructor-bearing thing, so copying it
-would alias it — a double-drop, a use-after-transfer, or a double free. A
-host-object resource is a GC reference with no `dtor`, so aliasing is safe. The
-`i32`-vs-`externref` representation is orthogonal; the kind decides the model.
-`Waitable` (from `join`) has no `drop` and is a copyable newtype, not affine.
+The `dtor` decides the kind, not the representation. A handle to a one-shot,
+destructor-bearing thing must be move-only, because copying it aliases it — a
+double-drop, a use-after-transfer, or a double free. Without a `dtor` there is
+nothing to run twice and nothing to free, so aliasing is safe and the handle is
+an ordinary value. The `i32`-vs-`externref` question is orthogonal to all three
+rows.
+
+### Non-owning tokens
+
+A non-owning token names something whose lifetime another party already
+guarantees, so it carries no lifecycle of its own. It is a copyable newtype, not
+affine. Two backings qualify:
+
+- **An affine resource owns the referent.** `Waitable` is this: `Subtask::join`
+  returns the subtask's own handle number as the identity to match a
+  `WaitEvent` against, and the `Subtask` owns the drop.
+- **An immortal table in a statically composed component.** `core:icu`'s
+  interned handles are this: the implementation component interns each object
+  whose configuration the program bounds at compile time, so the table is finite
+  by construction and never freed. Composition is static, so the table's
+  lifetime is the program's.
+
+A CM `borrow<R>` cannot stand in for either. A borrow must be dropped before the
+call returns, where a token is compared long after it is obtained, is copied
+across those comparisons, and travels inside an ordinary struct by value —
+`WaitEvent.handle` is a plain field.
+
+What disqualifies a token is a referent with neither backing: an object the
+far side allocates per call from unbounded runtime input has no owner and no
+bound, so a copyable index leaks it. That case is affine.
+
 The rest of this WEP concerns affine resources.
 
 ### Move-only resources
@@ -342,8 +369,9 @@ untouched even with the cloned array provably unread.
 
 ## Consequences
 
-- One story: move-only affine resources, GC value semantics for host-object
-  ones. Double-drop / use-after-transfer / leaked borrow become compile errors.
+- One story: move-only affine resources, value semantics for the two kinds that
+  own nothing. Double-drop / use-after-transfer / leaked borrow become compile
+  errors.
 - No lifetimes, no annotations, no keyword. The cleanup heuristic and
   `optimize::escape` + `optimize::value_copy_elide` shrink or disappear.
 - Move-only is a new concept for one type category; an element cannot be moved
@@ -464,4 +492,6 @@ client.
 - [Resource Inheritance and Downcast](./wep-2026-04-28-resource-inheritance.md)
 - [Migration to GC in Components](./wep-2026-03-28-gc-in-components.md)
 - [Value Semantics and Reference Stores](./wep-2026-01-12-value-semantics-and-stores.md)
+- [`core:icu`](./wep-2026-08-09-core-icu.md) — the non-owning token's second
+  backing, and its first consumer outside `Waitable`.
 - [NIR Optimizer Architecture](./wep-2026-06-05-nir-optimizer-architecture.md)

--- a/docs/wep-2026-06-26-wasm-cm-component-import.md
+++ b/docs/wep-2026-06-26-wasm-cm-component-import.md
@@ -96,7 +96,10 @@ the two components' host imports without hand-written forwarding.
       consuming direction of the mapping. It splits: a `dtor`-less exported
       handle decodes to a copyable
       [token](./wep-2026-05-21-resource-ownership.md) with no ownership analysis
-      to consume, where a `dtor`-bearing one needs the full affine mapping. The
+      to consume, where a `dtor`-bearing one needs the full affine mapping.
+      Nothing in a component's type distinguishes an interned referent from one
+      minted per call, so omitting the `dtor` is the exporter's assertion that
+      its referents have a backing, and the importer takes it at its word. The
       compile-time-bounded half of a bundled ICU surface
       ([`core:icu`](./wep-2026-08-09-core-icu.md)) rests on the token alone.
 - [ ] Async value types (`stream<T>` / `future<T>`) in an imported signature.

--- a/docs/wep-2026-06-26-wasm-cm-component-import.md
+++ b/docs/wep-2026-06-26-wasm-cm-component-import.md
@@ -93,9 +93,12 @@ the two components' host imports without hand-written forwarding.
 - [ ] Resources and handles. A component exporting a `resource` — with its
       methods, static constructors, and `borrow<T>` parameters — is rejected
       when its type is decoded. Wado has resources; what is missing is the
-      consuming direction of the mapping. A bundled ICU surface
-      ([`core:icu`](./wep-2026-08-09-core-icu.md))
-      rests on this.
+      consuming direction of the mapping. It splits in two, and the first half
+      is much the smaller: a `dtor`-less exported handle decodes to a copyable
+      newtype (a [non-owning token](./wep-2026-05-21-resource-ownership.md)) with no ownership analysis
+      to consume, where a `dtor`-bearing one needs the full affine mapping. The
+      compile-time-bounded half of a bundled ICU surface
+      ([`core:icu`](./wep-2026-08-09-core-icu.md)) rests on the first alone.
 - [ ] Async value types (`stream<T>` / `future<T>`) in an imported signature.
       This is the async import surface of
       [Generic `AsyncCall<T>`](./wep-2026-04-22-subtask-generic.md).

--- a/docs/wep-2026-06-26-wasm-cm-component-import.md
+++ b/docs/wep-2026-06-26-wasm-cm-component-import.md
@@ -93,12 +93,12 @@ the two components' host imports without hand-written forwarding.
 - [ ] Resources and handles. A component exporting a `resource` — with its
       methods, static constructors, and `borrow<T>` parameters — is rejected
       when its type is decoded. Wado has resources; what is missing is the
-      consuming direction of the mapping. It splits in two, and the first half
-      is much the smaller: a `dtor`-less exported handle decodes to a copyable
-      newtype (a [non-owning token](./wep-2026-05-21-resource-ownership.md)) with no ownership analysis
+      consuming direction of the mapping. It splits: a `dtor`-less exported
+      handle decodes to a copyable
+      [token](./wep-2026-05-21-resource-ownership.md) with no ownership analysis
       to consume, where a `dtor`-bearing one needs the full affine mapping. The
       compile-time-bounded half of a bundled ICU surface
-      ([`core:icu`](./wep-2026-08-09-core-icu.md)) rests on the first alone.
+      ([`core:icu`](./wep-2026-08-09-core-icu.md)) rests on the token alone.
 - [ ] Async value types (`stream<T>` / `future<T>`) in an imported signature.
       This is the async import surface of
       [Generic `AsyncCall<T>`](./wep-2026-04-22-subtask-generic.md).

--- a/docs/wep-2026-08-09-core-icu.md
+++ b/docs/wep-2026-08-09-core-icu.md
@@ -53,24 +53,9 @@ The user-visible module is deliberately not the unit of code splitting.
 A free function covers normalization, case folding, `is_nfc`, character
 properties, and one-shot locale-sensitive casing.
 
-What separates the two handle shapes is who ends the object's life.
-
-**Non-owning token.** A collator over a declared locale, plural rules, a
-formatter over a fixed skeleton, a segmenter: immutable, and configured only
-from what `with { locales: [...] }` and the program's types already bound. The
-implementation component interns these, so the set is finite by construction and
-never needs freeing, and the handle keeps the value semantics the rest of
-`core:*` has — it sits in a global, and a closure captures it by copy, so
-`list.sort_by(|a, b| c.compare(a, b))` is written the obvious way.
-
-**Affine resource.** A collator tailored from user-supplied rules, a formatter
-compiled from a runtime skeleton or message pattern, anything keyed by an
-`Accept-Language` string, a lazy segmentation iterator. The far side allocates
-these per call from input the program does not bound, so the object has an end
-and something must reach it: the handle carries a `dtor` and is move-only.
-
-The split is the slicer's own line, so a program whose data can be sliced meets
-no move-only handle at all.
+What separates the two handle shapes is who ends the object's life. That split is
+the slicer's own line, so a program whose data can be sliced meets no move-only
+handle at all.
 
 Statefulness forces the affine shape for a second, independent reason: copying a
 token aliases its referent, which two copies of a lazy iterator would show by
@@ -82,6 +67,24 @@ Where a capability serves both a one-shot and a loop, the facade offers both: a
 convenience function that constructs and discards, and the handle for when the
 construction should be hoisted. The facade makes the cost visible where it is
 paid.
+
+#### Non-owning token
+
+A collator over a declared locale, plural rules, a formatter over a fixed
+skeleton, a segmenter: immutable, and configured only from what
+`with { locales: [...] }` and the program's types already bound. The
+implementation component interns these, so the set is finite by construction and
+never needs freeing, and the handle keeps the value semantics the rest of
+`core:*` has — it sits in a global, and a closure captures it by copy, so
+`list.sort_by(|a, b| c.compare(a, b))` is written the obvious way.
+
+#### Affine resource
+
+A collator tailored from user-supplied rules, a formatter compiled from a runtime
+skeleton or message pattern, anything keyed by an `Accept-Language` string, a
+lazy segmentation iterator. The far side allocates these per call from input the
+program does not bound, so the object has an end and something must reach it: the
+handle carries a `dtor` and is move-only.
 
 ### The code partition is invisible
 
@@ -275,9 +278,9 @@ runtime data dependencies, not taxonomy.
   deserialization cost. For a single capability this is roughly size-neutral
   against baking; the win is across capabilities and from per-program slicing.
 - The CM import blocker splits. The compile-time-bounded surface needs only a
-  `dtor`-less imported handle; the tailored and runtime-configured surface waits
-  on full resource import, a gap shared with every resource-bearing third-party
-  component.
+  `dtor`-less imported handle; the tailored, runtime-configured, and stateful
+  surface waits on full resource import, a gap shared with every
+  resource-bearing third-party component.
 
 ## Open questions
 
@@ -288,8 +291,9 @@ runtime data dependencies, not taxonomy.
       diagnosing toward the affine form is undecided.
 - [ ] Holding an affine handle in a global, and capturing one in a closure
       ([resource ownership](./wep-2026-05-21-resource-ownership.md)). The token
-      form needs neither, so this bounds only the runtime-configured surface —
-      where a service caching a collator per `Accept-Language` lives.
+      form needs neither, so this bounds only the tailored, runtime-configured,
+      and stateful surface — where a service caching a collator per
+      `Accept-Language` lives.
 - [ ] Does ICU4X expose collation sort keys? A bulk key-extraction call would let
       a sort cross the boundary once instead of per comparison, which dominates
       any handle-versus-lookup difference.
@@ -307,10 +311,11 @@ runtime data dependencies, not taxonomy.
       ([Wasm CM Component Import](./wep-2026-06-26-wasm-cm-component-import.md)):
       a `dtor`-less imported handle decoded as a copyable newtype. It is all the
       first slice needs — normalization, case mapping, character properties,
-      collation over the declared locales, grapheme segmentation.
+      collation over the declared locales, and grapheme boundaries by eager
+      pass.
 - [ ] Affine resource support in the same path — methods, static constructors,
-      `borrow<T>` parameters, `resource.drop` — gating the runtime-configured
-      surface, not the package.
+      `borrow<T>` parameters, `resource.drop` — gating the tailored,
+      runtime-configured, and stateful surface, not the package.
 - [ ] The [data-provider mechanism](./wep-2026-06-13-compile-time-data-providers.md)
       itself.
 - [ ] Promote the spike's data-free components into first-party prebuilt
@@ -332,5 +337,5 @@ runtime data dependencies, not taxonomy.
   the implementation components are consumed and composed.
 - [Provider Metadata](./wep-2026-07-26-provider-metadata.md) — why a `core:*` API
   need no longer be CM-representable.
-- [Resource Ownership](./wep-2026-05-21-resource-ownership.md) — the three
-  handle kinds the facade draws on.
+- [Resource Ownership](./wep-2026-05-21-resource-ownership.md) — the token and
+  affine handle kinds the facade draws on.

--- a/docs/wep-2026-08-09-core-icu.md
+++ b/docs/wep-2026-08-09-core-icu.md
@@ -42,33 +42,53 @@ identifiers.
 
 The user-visible module is deliberately not the unit of code splitting.
 
-### Two API shapes, chosen by what the thing is
+### Three API shapes, chosen by what the thing is
 
-A free function, when the operation is a pure function of its arguments with no
-construction worth keeping: normalization, case folding, `is_nfc`, character
+| Shape                                | When                                                               |
+| ------------------------------------ | ------------------------------------------------------------------ |
+| Free function                        | pure in its arguments, no construction worth keeping               |
+| Constructed handle, non-owning token | construction worth hoisting, configuration bounded at compile time |
+| Constructed handle, affine resource  | built from unbounded runtime input, or stateful                    |
+
+A free function covers normalization, case folding, `is_nfc`, character
 properties, and one-shot locale-sensitive casing.
 
-A resource, when the object is expensive to construct, is compiled from runtime
-input, or is itself stateful: collators, the formatters (date/time, number, list,
-relative time, message), plural rules, transliterators, and segmentation
-iterators.
+Everything else is constructed, and construction is what makes the cost visible:
+a constructor says where the expensive thing happens, where a call that is
+expensive only the first time reads as free at every call site. What separates
+the two handle shapes is not that — it is who ends the object's life.
 
-The test is whether the object is a pure function of a key the program bounds at
-compile time. If it is, a free function costs nothing and keeps the value
-semantics the rest of `core:*` has. If it is not, a handle is the honest model —
-and across full ICU it frequently is not:
+**Non-owning token.** A collator over a declared locale, plural rules, a
+formatter over a fixed skeleton, a segmenter: immutable, and configured only
+from what `with { locales: [...] }` and the program's own types already bound at
+compile time. The implementation component interns these, so the set is finite
+by construction and never needs freeing, and the handle is a copyable newtype
+under the [non-owning token](./wep-2026-05-21-resource-ownership.md) rule. It
+keeps the value semantics the rest of `core:*` has: it sits in a global, and a
+closure captures it by copy, so `list.sort_by(|a, b| c.compare(a, b))` is
+written the obvious way.
 
-- Collator options are a combinatorial space (strength, alternate handling, case
-  level, case first, numeric ordering, backward second level), and a tailored
-  collator is compiled from user-supplied rules.
-- A formatter is compiled from a skeleton or a message pattern, which is runtime
-  data.
-- A segmentation iterator over a large document is state by definition; forcing
-  it into a `list<u32>` of every boundary is pathological when the caller wants
-  the first few.
+**Affine resource.** A collator tailored from user-supplied rules, a formatter
+compiled from a runtime skeleton or message pattern, anything keyed by an
+`Accept-Language` string, a lazy segmentation iterator. Here the far side
+allocates per call from input the program does not bound, so the object has an
+end and something must reach it: the handle carries a `dtor` and is move-only.
+
+The line between them is the one the slicer already draws — whether the object
+is a pure function of a key the program bounds at compile time. It is the same
+test that decides whether a capability's data can be sliced, so a program that
+stays inside the compile-time-bounded surface meets no move-only handle at all.
+
+Statefulness forces the affine shape for a second, independent reason. Copying a
+token aliases its referent, which is unobservable for an immutable object and
+observable for a stateful one: two copies of a lazy iterator would advance each
+other. So the segmenter is a token and the iteration is not — a full pass
+returns a `List<u32>` of boundaries and needs no handle of its own, while lazy
+iteration over a large document is affine. Forcing the lazy case into an eager
+list is pathological when the caller wants the first few.
 
 Where a capability serves both a one-shot and a loop, the facade offers both: a
-convenience function that constructs and discards, and the resource for when the
+convenience function that constructs and discards, and the handle for when the
 construction should be hoisted. The facade makes the cost visible where it is
 paid.
 
@@ -204,9 +224,28 @@ compile-time-bounded key. A design that holds for case mapping and breaks at dat
 formatting is not a design for `core:icu`.
 
 The counterargument — that move-only resources clash with Wado's value semantics
-— is real but narrow. It bites only when a resource is treated as a copyable
-value, which none of these need to be, and Wado users already meet resources
-throughout the WASI standard library.
+— is real, and the three-shape split above is the answer to it rather than a
+concession: the objects that want to be copyable values are copyable values.
+What stays move-only is what genuinely has an end.
+
+### One handle shape for everything
+
+Two collapses were considered, and each loses what the split keeps.
+
+Making every handle affine is uniform and adds no kind, but move-only on an
+immutable interned object is a discipline with no safety payoff — nothing can be
+double-freed because nothing is freed — and it costs exactly what the hot paths
+need: a collator in a global for a long-running service, and a collator captured
+by a comparison closure. It would also put the entire surface behind CM resource
+import rather than only the part that owns a `dtor`.
+
+Making every handle a bare index is the mirror error. It reintroduces what sank
+the memoizing surface above: an object built per request from `Accept-Language`
+accumulates in the far side's table with no eviction and no visibility — a leak
+rather than a cache, since nothing is even reused. And it breaks value semantics
+wherever the object is stateful, because copying the handle silently shares the
+state. The representation was never the question. A CM handle is already an
+index into a per-instance table; ownership is what differs.
 
 ### Three user-visible modules
 
@@ -248,18 +287,24 @@ runtime data dependencies, not taxonomy.
 - Runtime-loaded data loses zero-copy-from-static and adds a fixed per-capability
   deserialization cost. For a single capability this is roughly size-neutral
   against baking; the win is across capabilities and from per-program slicing.
-- Resources in the surface make this depend on CM resource import, which is not
-  implemented. The cost is shared: the same gap blocks every resource-bearing
-  third-party component, and WASI's own surface is resource-heavy.
+- The CM import blocker is split rather than shared. The compile-time-bounded
+  surface needs only a `dtor`-less imported handle, which is strictly less than
+  resource import; only the tailored and runtime-configured surface waits on the
+  full thing. That gap is still shared with every resource-bearing third-party
+  component, and WASI's own surface is resource-heavy.
 
 ## Open questions
 
-- [ ] Can a resource be held in a global? An HTTP service wants one collator
-      across requests, so the answer shapes how usable the resource form is.
-- [ ] Can a borrow be captured by a closure — `list.sort_by(|a, b| c.compare(a, b))`
-      — under the ownership analysis
-      ([resource ownership](./wep-2026-05-21-resource-ownership.md))? If not, the
-      sorting path needs a different shape.
+- [ ] What proves a construction site's configuration compile-time bounded, so
+      the facade may offer the token form there. A combinatorial option space is
+      not the obstacle — a constant at the site is what bounds the interned set —
+      but whether that is expressed as a distinct type, or as a const-argument
+      requirement whose failure diagnoses toward the affine form, is undecided.
+- [ ] Holding an affine handle in a global, and capturing one in a closure
+      ([resource ownership](./wep-2026-05-21-resource-ownership.md)). The token
+      form needs neither, so this bounds only the tailored and
+      runtime-configured surface — but a service caching a collator built from
+      `Accept-Language` wants precisely that.
 - [ ] Does ICU4X expose collation sort keys? A bulk key-extraction call would let
       a sort cross the boundary once instead of per comparison, which dominates
       any handle-versus-lookup difference.
@@ -273,10 +318,14 @@ runtime data dependencies, not taxonomy.
 
 ## Implementation
 
-- [ ] Resource and handle support in CM component import
-      ([Wasm CM Component Import](./wep-2026-06-26-wasm-cm-component-import.md)).
-      A prerequisite: the facade's resource-bearing components cannot be consumed
-      without it.
+- [ ] Non-owning token support in CM component import
+      ([Wasm CM Component Import](./wep-2026-06-26-wasm-cm-component-import.md)):
+      a `dtor`-less imported handle decoded as a copyable newtype. This is all
+      the first slice needs — normalization, case mapping, character properties,
+      collation over the declared locales, grapheme segmentation.
+- [ ] Affine resource support in the same path — methods, static constructors,
+      `borrow<T>` parameters, `resource.drop`. It gates the tailored and
+      runtime-configured surface, not the package.
 - [ ] The [data-provider mechanism](./wep-2026-06-13-compile-time-data-providers.md)
       itself.
 - [ ] Promote the spike's data-free components into first-party prebuilt
@@ -298,5 +347,6 @@ runtime data dependencies, not taxonomy.
   the implementation components are consumed and composed.
 - [Provider Metadata](./wep-2026-07-26-provider-metadata.md) — why a `core:*` API
   need no longer be CM-representable.
-- [Resource Ownership](./wep-2026-05-21-resource-ownership.md) — the discipline
-  the facade's resources carry.
+- [Resource Ownership](./wep-2026-05-21-resource-ownership.md) — the three
+  handle kinds the facade draws on, and the non-owning token rule the
+  compile-time-bounded surface rests on.

--- a/docs/wep-2026-08-09-core-icu.md
+++ b/docs/wep-2026-08-09-core-icu.md
@@ -53,39 +53,30 @@ The user-visible module is deliberately not the unit of code splitting.
 A free function covers normalization, case folding, `is_nfc`, character
 properties, and one-shot locale-sensitive casing.
 
-Everything else is constructed, and construction is what makes the cost visible:
-a constructor says where the expensive thing happens, where a call that is
-expensive only the first time reads as free at every call site. What separates
-the two handle shapes is not that — it is who ends the object's life.
+What separates the two handle shapes is who ends the object's life.
 
 **Non-owning token.** A collator over a declared locale, plural rules, a
 formatter over a fixed skeleton, a segmenter: immutable, and configured only
-from what `with { locales: [...] }` and the program's own types already bound at
-compile time. The implementation component interns these, so the set is finite
-by construction and never needs freeing, and the handle is a copyable newtype
-under the [non-owning token](./wep-2026-05-21-resource-ownership.md) rule. It
-keeps the value semantics the rest of `core:*` has: it sits in a global, and a
-closure captures it by copy, so `list.sort_by(|a, b| c.compare(a, b))` is
-written the obvious way.
+from what `with { locales: [...] }` and the program's types already bound. The
+implementation component interns these, so the set is finite by construction and
+never needs freeing, and the handle keeps the value semantics the rest of
+`core:*` has — it sits in a global, and a closure captures it by copy, so
+`list.sort_by(|a, b| c.compare(a, b))` is written the obvious way.
 
 **Affine resource.** A collator tailored from user-supplied rules, a formatter
 compiled from a runtime skeleton or message pattern, anything keyed by an
-`Accept-Language` string, a lazy segmentation iterator. Here the far side
-allocates per call from input the program does not bound, so the object has an
-end and something must reach it: the handle carries a `dtor` and is move-only.
+`Accept-Language` string, a lazy segmentation iterator. The far side allocates
+these per call from input the program does not bound, so the object has an end
+and something must reach it: the handle carries a `dtor` and is move-only.
 
-The line between them is the one the slicer already draws — whether the object
-is a pure function of a key the program bounds at compile time. It is the same
-test that decides whether a capability's data can be sliced, so a program that
-stays inside the compile-time-bounded surface meets no move-only handle at all.
+The split is the slicer's own line, so a program whose data can be sliced meets
+no move-only handle at all.
 
-Statefulness forces the affine shape for a second, independent reason. Copying a
-token aliases its referent, which is unobservable for an immutable object and
-observable for a stateful one: two copies of a lazy iterator would advance each
-other. So the segmenter is a token and the iteration is not — a full pass
-returns a `List<u32>` of boundaries and needs no handle of its own, while lazy
-iteration over a large document is affine. Forcing the lazy case into an eager
-list is pathological when the caller wants the first few.
+Statefulness forces the affine shape for a second, independent reason: copying a
+token aliases its referent, which two copies of a lazy iterator would show by
+advancing each other. So the segmenter is a token and the iteration is not — a
+full pass returns a `List<u32>` of boundaries, while lazy iteration is affine, an
+eager list being pathological when the caller wants the first few.
 
 Where a capability serves both a one-shot and a loop, the facade offers both: a
 convenience function that constructs and discards, and the handle for when the
@@ -230,22 +221,18 @@ What stays move-only is what genuinely has an end.
 
 ### One handle shape for everything
 
-Two collapses were considered, and each loses what the split keeps.
-
-Making every handle affine is uniform and adds no kind, but move-only on an
-immutable interned object is a discipline with no safety payoff — nothing can be
-double-freed because nothing is freed — and it costs exactly what the hot paths
-need: a collator in a global for a long-running service, and a collator captured
-by a comparison closure. It would also put the entire surface behind CM resource
-import rather than only the part that owns a `dtor`.
+Making every handle affine adds no kind, but move-only on an immutable interned
+object is a discipline with no safety payoff — nothing can be double-freed
+because nothing is freed — and it costs what the hot paths need: a collator in a
+global, and a collator captured by a comparison closure. It would also put the
+entire surface behind CM resource import rather than the part owning a `dtor`.
 
 Making every handle a bare index is the mirror error. It reintroduces what sank
-the memoizing surface above: an object built per request from `Accept-Language`
-accumulates in the far side's table with no eviction and no visibility — a leak
-rather than a cache, since nothing is even reused. And it breaks value semantics
-wherever the object is stateful, because copying the handle silently shares the
-state. The representation was never the question. A CM handle is already an
-index into a per-instance table; ownership is what differs.
+the memoizing surface above — an object built per request from `Accept-Language`
+accumulates far-side with no eviction and no visibility, a leak rather than a
+cache — and it silently shares the state of every object that has some.
+Representation was never the question: a CM handle is already an index into a
+per-instance table.
 
 ### Three user-visible modules
 
@@ -287,24 +274,22 @@ runtime data dependencies, not taxonomy.
 - Runtime-loaded data loses zero-copy-from-static and adds a fixed per-capability
   deserialization cost. For a single capability this is roughly size-neutral
   against baking; the win is across capabilities and from per-program slicing.
-- The CM import blocker is split rather than shared. The compile-time-bounded
-  surface needs only a `dtor`-less imported handle, which is strictly less than
-  resource import; only the tailored and runtime-configured surface waits on the
-  full thing. That gap is still shared with every resource-bearing third-party
-  component, and WASI's own surface is resource-heavy.
+- The CM import blocker splits. The compile-time-bounded surface needs only a
+  `dtor`-less imported handle; the tailored and runtime-configured surface waits
+  on full resource import, a gap shared with every resource-bearing third-party
+  component.
 
 ## Open questions
 
 - [ ] What proves a construction site's configuration compile-time bounded, so
       the facade may offer the token form there. A combinatorial option space is
       not the obstacle — a constant at the site is what bounds the interned set —
-      but whether that is expressed as a distinct type, or as a const-argument
-      requirement whose failure diagnoses toward the affine form, is undecided.
+      but whether that is a distinct type or a const-argument requirement
+      diagnosing toward the affine form is undecided.
 - [ ] Holding an affine handle in a global, and capturing one in a closure
       ([resource ownership](./wep-2026-05-21-resource-ownership.md)). The token
-      form needs neither, so this bounds only the tailored and
-      runtime-configured surface — but a service caching a collator built from
-      `Accept-Language` wants precisely that.
+      form needs neither, so this bounds only the runtime-configured surface —
+      where a service caching a collator per `Accept-Language` lives.
 - [ ] Does ICU4X expose collation sort keys? A bulk key-extraction call would let
       a sort cross the boundary once instead of per comparison, which dominates
       any handle-versus-lookup difference.
@@ -320,12 +305,12 @@ runtime data dependencies, not taxonomy.
 
 - [ ] Non-owning token support in CM component import
       ([Wasm CM Component Import](./wep-2026-06-26-wasm-cm-component-import.md)):
-      a `dtor`-less imported handle decoded as a copyable newtype. This is all
-      the first slice needs — normalization, case mapping, character properties,
+      a `dtor`-less imported handle decoded as a copyable newtype. It is all the
+      first slice needs — normalization, case mapping, character properties,
       collation over the declared locales, grapheme segmentation.
 - [ ] Affine resource support in the same path — methods, static constructors,
-      `borrow<T>` parameters, `resource.drop`. It gates the tailored and
-      runtime-configured surface, not the package.
+      `borrow<T>` parameters, `resource.drop` — gating the runtime-configured
+      surface, not the package.
 - [ ] The [data-provider mechanism](./wep-2026-06-13-compile-time-data-providers.md)
       itself.
 - [ ] Promote the spike's data-free components into first-party prebuilt
@@ -348,5 +333,4 @@ runtime data dependencies, not taxonomy.
 - [Provider Metadata](./wep-2026-07-26-provider-metadata.md) — why a `core:*` API
   need no longer be CM-representable.
 - [Resource Ownership](./wep-2026-05-21-resource-ownership.md) — the three
-  handle kinds the facade draws on, and the non-owning token rule the
-  compile-time-bounded surface rests on.
+  handle kinds the facade draws on.

--- a/wado-compiler/tests/generated/fixtures/inspect_option_ref_primitive.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/inspect_option_ref_primitive.wir.wado
@@ -56,91 +56,103 @@ struct core:prelude/slice.wado//SliceRefIter<i32> {  // TypeId(11)
     mut end: i32,
 }
 
-struct core:prelude//List<i32> {  // TypeId(12)
+struct core:prelude/slice.wado//Slice<core:prelude/string.wado/String> {  // TypeId(12)
+    mut repr: ref "Array<core:prelude/string.wado/String>",
+    mut start: i32,
+    mut end: i32,
+}
+
+struct core:prelude/slice.wado//Slice<i32> {  // TypeId(13)
+    mut repr: ref Array<i32>,
+    mut start: i32,
+    mut end: i32,
+}
+
+struct core:prelude//List<i32> {  // TypeId(14)
     mut repr: ref Array<i32>,
     mut used: i32,
 }
 
-struct core:prelude//List<core:prelude/string.wado/String> {  // TypeId(13)
+struct core:prelude//List<core:prelude/string.wado/String> {  // TypeId(15)
     mut repr: ref "Array<core:prelude/string.wado/String>",
     mut used: i32,
 }
 
-struct inspect_option_ref_primitive.wado//Holder<core:prelude/types.wado/Option<&i32>> {  // TypeId(14)
+struct inspect_option_ref_primitive.wado//Holder<core:prelude/types.wado/Option<&i32>> {  // TypeId(16)
     mut v: ref null "core:prelude/types.wado//Box<i32>",
 }
 
-type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(15)
+type "functype//mem/realloc" = fn(i32, i32, i32, i32) -> i32;  // TypeId(17)
 
-type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(16)
+type "functype//wasi/stream-write" = fn(i32, i32, i32) -> i32;  // TypeId(18)
 
-type "functype//wasi/task-return" = fn(i32);  // TypeId(17)
+type "functype//wasi/task-return" = fn(i32);  // TypeId(19)
 
-type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(18)
+type "functype//wasi/waitable-join" = fn(i32, i32);  // TypeId(20)
 
-type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(19)
+type "functype//wasi/waitable-set-drop" = fn(i32);  // TypeId(21)
 
-type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(20)
+type "functype//wasi/waitable-set-new" = fn() -> i32;  // TypeId(22)
 
-type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(21)
+type "functype//wasi/waitable-set-wait" = fn(i32, i32) -> i32;  // TypeId(23)
 
-type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(22)
+type "functype//wasi/wasi:cli/Stdout::write_via_stream" = fn(i32) -> i32;  // TypeId(24)
 
-type "functype//inspect_option_ref_primitive.wado/run" = fn();  // TypeId(23)
+type "functype//inspect_option_ref_primitive.wado/run" = fn();  // TypeId(25)
 
-type "functype//inspect_option_ref_primitive.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(24)
+type "functype//inspect_option_ref_primitive.wado/__cm_binding__Stdout_write_via_stream" = fn(i32) -> i32;  // TypeId(26)
 
-type "functype//inspect_option_ref_primitive.wado/__cm_export__run" = fn();  // TypeId(25)
+type "functype//inspect_option_ref_primitive.wado/__cm_export__run" = fn();  // TypeId(27)
 
-type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(26)
+type "functype//core:cli/write_to_stream" = fn(i32, ref "core:prelude/string.wado//String", bool);  // TypeId(28)
 
-type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref Array<u8>, i32, i64, i32);  // TypeId(27)
+type "functype//core:prelude/primitive.wado/write_decimal_digits" = fn(ref Array<u8>, i32, i64, i32);  // TypeId(29)
 
-type "functype//core:prelude/primitive.wado/count_digits_u64_base" = fn(i64, i32) -> i32;  // TypeId(28)
+type "functype//core:prelude/primitive.wado/count_digits_u64_base" = fn(i64, i32) -> i32;  // TypeId(30)
 
-type "functype//core:prelude/primitive.wado/write_u64_base_digits" = fn(ref Array<u8>, i32, i64, i32, i32, i32, bool);  // TypeId(29)
+type "functype//core:prelude/primitive.wado/write_u64_base_digits" = fn(ref Array<u8>, i32, i64, i32, i32, i32, bool);  // TypeId(31)
 
-type "functype//core:prelude/string.wado/encode_char" = fn(ref Array<u8>, i32, u32) -> i32;  // TypeId(30)
+type "functype//core:prelude/string.wado/encode_char" = fn(ref Array<u8>, i32, u32) -> i32;  // TypeId(32)
 
-type "functype//core:rt/gc_array_to_memory" = fn(ref Array<u8>, i32, i32, i32);  // TypeId(31)
+type "functype//core:rt/gc_array_to_memory" = fn(ref Array<u8>, i32, i32, i32);  // TypeId(33)
 
-type "functype//core:rt/cm_await_blocked" = fn(i32) -> i32;  // TypeId(32)
+type "functype//core:rt/cm_await_blocked" = fn(i32) -> i32;  // TypeId(34)
 
-type "functype//core:rt/cm_stream_write_drain" = fn(i32, i32, i32, i32);  // TypeId(33)
+type "functype//core:rt/cm_stream_write_drain" = fn(i32, i32, i32, i32);  // TypeId(35)
 
-type "functype//core:prelude/types.wado/$case_extract$core:prelude/types.wado/Option<&i32>$&i32" = fn(ref "core:prelude/types.wado//Box<core:prelude/types.wado/Option<&i32>>", i32) -> ref "core:prelude/types.wado//Box<i32>";  // TypeId(34)
+type "functype//core:prelude/types.wado/$case_extract$core:prelude/types.wado/Option<&i32>$&i32" = fn(ref "core:prelude/types.wado//Box<core:prelude/types.wado/Option<&i32>>", i32) -> ref "core:prelude/types.wado//Box<i32>";  // TypeId(36)
 
-type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(35)
+type "functype//core:prelude/fpfmt.wado/__initialize_module" = fn();  // TypeId(37)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/StrCharIter^core:prelude/traits.wado/Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(36)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/StrCharIter^core:prelude/traits.wado/Iterator::next" = fn(ref "core:prelude/string.wado//StrCharIter") -> [i32, char];  // TypeId(38)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(37)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::grow" = fn(ref "core:prelude/string.wado//String", i32);  // TypeId(39)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(38)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::push_str" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/string.wado//String");  // TypeId(40)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(39)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::push" = fn(ref "core:prelude/string.wado//String", char);  // TypeId(41)
 
-type "functype//core:prelude/string.wado/core:prelude/string.wado/String::push_ascii_unchecked" = fn(ref "core:prelude/string.wado//String", u8);  // TypeId(40)
+type "functype//core:prelude/string.wado/core:prelude/string.wado/String::push_ascii_unchecked" = fn(ref "core:prelude/string.wado//String", u8);  // TypeId(42)
 
-type "functype//core:prelude/traits.wado/inspect_option_ref_primitive.wado/Holder<core:prelude/types.wado/Option<&i32>>^core:prelude/traits.wado/Inspect::inspect$spec0" = fn(ref "inspect_option_ref_primitive.wado//Holder<core:prelude/types.wado/Option<&i32>>", ref "core:prelude/format.wado//Formatter");  // TypeId(41)
+type "functype//core:prelude/traits.wado/inspect_option_ref_primitive.wado/Holder<core:prelude/types.wado/Option<&i32>>^core:prelude/traits.wado/Inspect::inspect$spec0" = fn(ref "inspect_option_ref_primitive.wado//Holder<core:prelude/types.wado/Option<&i32>>", ref "core:prelude/format.wado//Formatter");  // TypeId(43)
 
-type "functype//core:prelude/traits.wado/core:prelude/types.wado/Option<&core:prelude/string.wado/String>^core:prelude/traits.wado/Inspect::inspect$spec0" = fn(ref "core:prelude/types.wado//Box<core:prelude/types.wado/Option<&core:prelude/string.wado/String>>", ref "core:prelude/format.wado//Formatter");  // TypeId(42)
+type "functype//core:prelude/traits.wado/core:prelude/types.wado/Option<&core:prelude/string.wado/String>^core:prelude/traits.wado/Inspect::inspect$spec0" = fn(ref "core:prelude/types.wado//Box<core:prelude/types.wado/Option<&core:prelude/string.wado/String>>", ref "core:prelude/format.wado//Formatter");  // TypeId(44)
 
-type "functype//core:prelude/traits.wado/core:prelude/types.wado/Option<&i32>^core:prelude/traits.wado/Inspect::inspect$spec0" = fn(ref "core:prelude/types.wado//Box<core:prelude/types.wado/Option<&i32>>", ref "core:prelude/format.wado//Formatter");  // TypeId(43)
+type "functype//core:prelude/traits.wado/core:prelude/types.wado/Option<&i32>^core:prelude/traits.wado/Inspect::inspect$spec0" = fn(ref "core:prelude/types.wado//Box<core:prelude/types.wado/Option<&i32>>", ref "core:prelude/format.wado//Formatter");  // TypeId(45)
 
-type "functype//core:prelude/primitive.wado/u64::fmt_base$spec0" = fn(u64, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(44)
+type "functype//core:prelude/primitive.wado/u64::fmt_base$spec0" = fn(u64, ref "core:prelude/format.wado//Formatter", i32, bool, ref "core:prelude/string.wado//String");  // TypeId(46)
 
-type "functype//core:prelude/format.wado/core:prelude/string.wado/String^core:prelude/traits.wado/Inspect::inspect$spec0" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(45)
+type "functype//core:prelude/format.wado/core:prelude/string.wado/String^core:prelude/traits.wado/Inspect::inspect$spec0" = fn(ref "core:prelude/string.wado//String", ref "core:prelude/format.wado//Formatter");  // TypeId(47)
 
-type "functype//core:prelude/primitive.wado/i32::fmt_decimal$spec0" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(46)
+type "functype//core:prelude/primitive.wado/i32::fmt_decimal$spec0" = fn(i32, ref "core:prelude/format.wado//Formatter");  // TypeId(48)
 
-type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(47)
+type "functype//core:prelude/format.wado/core:prelude/format.wado/Formatter::prepare_int_write$spec0" = fn(ref "core:prelude/format.wado//Formatter", bool, ref "core:prelude/string.wado//String", i32) -> i32;  // TypeId(49)
 
-type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(48)
+type "functype//wasi/stream-new" = fn() -> i64;  // TypeId(50)
 
-type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(49)
+type "functype//wasi/future-drop-readable:transmission-cli" = fn(i32);  // TypeId(51)
 
-type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(50)
+type "functype//wasi/stream-drop-writable" = fn(i32);  // TypeId(52)
 
 import fn mem/realloc from "mem/realloc";
 import fn wasi/stream-write from "wasi/stream-write";
@@ -189,6 +201,10 @@ fn "inspect_option_ref_primitive.wado/run"() with Stdout {
     let packed: i64;
     let rx_68: i32;
     let tx_69: i32;
+    let self_85: ref "core:prelude/slice.wado//Slice<i32>";
+    let repr_86: ref Array<i32>;
+    let self_93: ref "core:prelude/slice.wado//Slice<core:prelude/string.wado/String>";
+    let repr_94: ref "Array<core:prelude/string.wado/String>";
     __inline___initialize_modules_0: block {
         break_if __inline___initialize_modules_0 @likely(global:inspect_option_ref_primitive.wado::__modules_initialized);
         cold_path;
@@ -208,7 +224,9 @@ fn "inspect_option_ref_primitive.wado/run"() with Stdout {
     __local_5 = struct.new "core:prelude/string.wado//String" { repr: builtin::array_new<u8>(50), used: 0 };
     __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_5 };
     "core:prelude/traits.wado/core:prelude/types.wado/Option<&i32>^core:prelude/traits.wado/Inspect::inspect$spec0"(struct.new "core:prelude/types.wado//Box<core:prelude/types.wado/Option<&i32>>" { value: __inline_core_prelude_slice_wado_SliceRefIter_i32__core_prelude_traits_wado_Iterator__next_17: block -> ref null "core:prelude/types.wado//Box<i32>" {
-        self_32 = struct.new "core:prelude/slice.wado//SliceRefIter<i32>" { repr: xs.repr, index: 0, end: 3 };
+        self_85 = struct.new "core:prelude/slice.wado//Slice<i32>" { repr: xs.repr, start: 0, end: 3 };
+        repr_86 = self_85.repr;
+        self_32 = struct.new "core:prelude/slice.wado//SliceRefIter<i32>" { repr: repr_86, index: 0, end: 3 };
         block {
         };
         ref_val_33 = struct.new "core:prelude/types.wado//Box<i32>" { value: builtin::array_get_value<i32>(self_32.repr, 0) };
@@ -225,7 +243,9 @@ fn "inspect_option_ref_primitive.wado/run"() with Stdout {
     builtin::array_set_u8(__local_5.repr, start_40, 32);
     __local_6 = struct.new "core:prelude/format.wado//Formatter" { fill: 32, align: 2, sign_plus: 0, zero_pad: 0, width: -1, precision: -2, indent: 0, buf: __local_5 };
     "core:prelude/traits.wado/core:prelude/types.wado/Option<&core:prelude/string.wado/String>^core:prelude/traits.wado/Inspect::inspect$spec0"(struct.new "core:prelude/types.wado//Box<core:prelude/types.wado/Option<&core:prelude/string.wado/String>>" { value: __inline_core_prelude_slice_wado_SliceRefIter_core_prelude_string_wado_String__core_prelude_traits_wado_Iterator__next_25: block -> ref null "core:prelude/string.wado//String" {
-        self_50 = struct.new "core:prelude/slice.wado//SliceRefIter<core:prelude/string.wado/String>" { repr: ys.repr, index: 0, end: 1 };
+        self_93 = struct.new "core:prelude/slice.wado//Slice<core:prelude/string.wado/String>" { repr: ys.repr, start: 0, end: 1 };
+        repr_94 = self_93.repr;
+        self_50 = struct.new "core:prelude/slice.wado//SliceRefIter<core:prelude/string.wado/String>" { repr: repr_94, index: 0, end: 1 };
         block {
         };
         ref_val_51 = builtin::array_get_value<ref "core:prelude/string.wado//String">(self_50.repr, 0);


### PR DESCRIPTION
Resource Ownership names three handle kinds, and `core:icu` builds its API surface on them.

## The taxonomy

A **non-owning token** is a handle whose referent's lifetime another party already guarantees, so it has no `dtor` and is an ordinary copyable value. Two backings qualify: an affine resource that owns the referent (`Waitable` over its `Subtask`), and an immortal table in a statically composed component (`core:icu`'s interned handles). A referent with neither — allocated per call from unbounded runtime input — is affine instead, since a copyable index would leak it.

The `dtor` decides the kind, not the representation; `i32`-vs-`externref` is orthogonal to all three rows. A CM `borrow<R>` cannot stand in for a token, which is compared long after it is obtained, is copied across those comparisons, and travels inside a struct by value.

## `core:icu`

Three API shapes: a free function, a constructed handle that is a token, and a constructed handle that is an affine resource. A collator over a declared locale is interned, so it sits in a global and a closure captures it by copy — `list.sort_by(|a, b| c.compare(a, b))` is written the obvious way. A collator tailored from user rules, a formatter compiled from a runtime skeleton, anything keyed by `Accept-Language`, and a lazy segmentation iterator carry a `dtor` and stay move-only. That line is the data slicer's own, so a program whose data can be sliced meets no move-only handle at all.

Statefulness forces the affine shape independently: copying a token aliases its referent, which two copies of a lazy iterator would show by advancing each other.

The WEP's open questions on holding a handle in a global and capturing one in a closure are scoped to the runtime-configured surface, where a service caching a collator per `Accept-Language` lives. Undecided alongside them: what proves a construction site's configuration compile-time bounded, so the facade may offer the token form there.

## Consequence for CM component import

Consuming an exported handle splits in two. A `dtor`-less one decodes to a copyable token with no ownership analysis to consume; a `dtor`-bearing one needs the full affine mapping. The compile-time-bounded half of `core:icu` — normalization, case mapping, character properties, collation over the declared locales, grapheme segmentation — rests on the token alone.

Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified resource categories, including copyable non-owning tokens and affine resources.
  - Documented ownership, backing, and cleanup behavior for different resource types.
  - Expanded guidance for WebAssembly component imports and handle mapping.
  - Updated ICU API design notes to distinguish functions, tokens, and stateful resources.
  - Added rationale, consequences, implementation tasks, and references for the refined resource model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->