### PR TITLE
fix(compiler): compile a bundled stdlib module as its own entry point

### DIFF
--- a/docs/wep-2026-08-12-declaration-identity.md
+++ b/docs/wep-2026-08-12-declaration-identity.md
@@ -98,7 +98,10 @@ table is seeded rather than rebuilt — `DefTable::build_seeded` continues the
 snapshot's table, keeping every declaration it already identified at its `DefId`
 and minting only what it never saw, and `TypeTable` is seeded the same way. What
 makes that sound is that the stdlib AST is parsed once per process and shared, so
-an `AstId` means the same node in both tables.
+an `AstId` means the same node in both tables. An entry module claiming a stdlib
+identity (`#![stdlib("core:…")]`) is parsed from its own file instead, so the
+snapshot is dropped for that compile (`stdlib_snapshot::covers`) and the closure
+is elaborated from source.
 
 The rule binds every cached declaration fact, not just this one: a `DefId` in a
 `ResolvedType` or a registry key crosses the same boundary.

--- a/docs/wep-2026-08-12-declaration-identity.md
+++ b/docs/wep-2026-08-12-declaration-identity.md
@@ -98,10 +98,11 @@ table is seeded rather than rebuilt — `DefTable::build_seeded` continues the
 snapshot's table, keeping every declaration it already identified at its `DefId`
 and minting only what it never saw, and `TypeTable` is seeded the same way. What
 makes that sound is that the stdlib AST is parsed once per process and shared, so
-an `AstId` means the same node in both tables. An entry module claiming a stdlib
-identity (`#![stdlib("core:…")]`) is parsed from its own file instead, so the
-snapshot is dropped for that compile (`stdlib_snapshot::covers`) and the closure
-is elaborated from source.
+an `AstId` means the same node in both tables — bundled wasm assets included,
+whose synthesized bindings are cached the same way. That is a precondition, not
+an assumption: a compile carrying its own parse of a cached module (an entry
+naming itself `#![stdlib("core:…")]`) drops the snapshot and elaborates from
+source.
 
 The rule binds every cached declaration fact, not just this one: a `DefId` in a
 `ResolvedType` or a registry key crosses the same boundary.

--- a/docs/wep-2026-08-12-declaration-identity.md
+++ b/docs/wep-2026-08-12-declaration-identity.md
@@ -98,11 +98,9 @@ table is seeded rather than rebuilt — `DefTable::build_seeded` continues the
 snapshot's table, keeping every declaration it already identified at its `DefId`
 and minting only what it never saw, and `TypeTable` is seeded the same way. What
 makes that sound is that the stdlib AST is parsed once per process and shared, so
-an `AstId` means the same node in both tables — bundled wasm assets included,
-whose synthesized bindings are cached the same way. That is a precondition, not
-an assumption: a compile carrying its own parse of a cached module (an entry
-naming itself `#![stdlib("core:…")]`) drops the snapshot and elaborates from
-source.
+an `AstId` means the same node in both tables, bundled wasm assets included. It
+is checked, not assumed: an entry naming itself `#![stdlib("core:…")]` re-parses
+a cached module, and drops the snapshot.
 
 The rule binds every cached declaration fact, not just this one: a `DefId` in a
 `ResolvedType` or a registry key crosses the same boundary.

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -947,11 +947,18 @@ impl Module {
 
     /// Returns the `wasm_module` name if `#![wasm_module("name")]` is present.
     pub fn wasm_module(&self) -> Option<&str> {
+        self.wasm_module_attribute()
+            .and_then(|a| a.args.first())
+            .map(AttrArg::as_str)
+    }
+
+    /// The `#![wasm_module("…")]` attribute itself — the span a diagnostic
+    /// about the separate core module points at.
+    #[must_use]
+    pub fn wasm_module_attribute(&self) -> Option<&InnerAttribute> {
         self.inner_attributes
             .iter()
             .find(|a| a.name == "wasm_module")
-            .and_then(|a| a.args.first())
-            .map(AttrArg::as_str)
     }
 
     /// Returns the canonical bundled-stdlib import path declared by

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -964,11 +964,16 @@ impl Module {
     /// `ModuleSource` and dedup against the bundled cache when an editor
     /// opens the file directly.
     pub fn stdlib_identity(&self) -> Option<&str> {
-        self.inner_attributes
-            .iter()
-            .find(|a| a.name == "stdlib")
+        self.stdlib_identity_attribute()
             .and_then(|a| a.args.first())
             .map(AttrArg::as_str)
+    }
+
+    /// The `#![stdlib("…")]` attribute itself — the form a diagnostic needs,
+    /// since a malformed one has no identity to report but does have a span.
+    #[must_use]
+    pub fn stdlib_identity_attribute(&self) -> Option<&InnerAttribute> {
+        self.inner_attributes.iter().find(|a| a.name == "stdlib")
     }
 
     /// Returns the value of a scalar `key = "value"` argument on any

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -952,8 +952,7 @@ impl Module {
             .map(AttrArg::as_str)
     }
 
-    /// The `#![wasm_module("…")]` attribute itself — the span a diagnostic
-    /// about the separate core module points at.
+    /// The attribute itself, for a diagnostic's span.
     #[must_use]
     pub fn wasm_module_attribute(&self) -> Option<&InnerAttribute> {
         self.inner_attributes
@@ -976,8 +975,7 @@ impl Module {
             .map(AttrArg::as_str)
     }
 
-    /// The `#![stdlib("…")]` attribute itself — the form a diagnostic needs,
-    /// since a malformed one has no identity to report but does have a span.
+    /// The attribute itself: a malformed one has no identity, but has a span.
     #[must_use]
     pub fn stdlib_identity_attribute(&self) -> Option<&InnerAttribute> {
         self.inner_attributes.iter().find(|a| a.name == "stdlib")

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -1460,6 +1460,31 @@ fn compile_after_load<H: CompilerHost>(
         link::link(package)
     };
 
+    // A `#![wasm_module("…")]` module's code is emitted into that separate core
+    // module, which the component links beside the program rather than as it.
+    // Nothing would be left in the main module for the world to export, and the
+    // separated code cannot call back into it — so an entry that declares one
+    // has no component to compile to. Rejected here rather than at emit, where
+    // the split leaves a call to a function the separated module never holds.
+    if let Some(name) = flat.wasm_module_sources.get(&flat.entry_module_source) {
+        let _ = logger.error_in(
+            &flat.entry_module_source,
+            compiler_host::Diagnostic {
+                severity: compiler_host::Severity::Error,
+                code: compiler_host::Code::UnsupportedFeature,
+                message: format!(
+                    "the entry module declares `#![wasm_module({name:?})]`, so its code is \
+                     emitted into the separate core module `{name}` — it cannot itself be \
+                     the entry point of a component"
+                ),
+                span: entry_ast.wasm_module_attribute().map(|attribute| {
+                    compiler_host::DiagnosticSpan::from_span(&attribute.span, None)
+                }),
+            },
+        );
+        return Err(Bail);
+    }
+
     // === Phase 8e: Resolve compile-time parameters (`#[param]`) ===
     // After symbol resolution (so types are known and all globals are
     // flattened for flat-namespace unknown-`-D` detection) and before

--- a/wado-compiler/src/lib.rs
+++ b/wado-compiler/src/lib.rs
@@ -1460,12 +1460,8 @@ fn compile_after_load<H: CompilerHost>(
         link::link(package)
     };
 
-    // A `#![wasm_module("…")]` module's code is emitted into that separate core
-    // module, which the component links beside the program rather than as it.
-    // Nothing would be left in the main module for the world to export, and the
-    // separated code cannot call back into it — so an entry that declares one
-    // has no component to compile to. Rejected here rather than at emit, where
-    // the split leaves a call to a function the separated module never holds.
+    // Rejected here rather than at emit, where the split leaves a call to a
+    // function the separated module never holds.
     if let Some(name) = flat.wasm_module_sources.get(&flat.entry_module_source) {
         let _ = logger.error_in(
             &flat.entry_module_source,

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -62,12 +62,12 @@ pub enum LoadError {
         module_source: ModuleSource,
         message: String,
     },
-    /// `#![stdlib("…")]` names no bundled stdlib module. The attribute takes
-    /// over the entry's module identity, so accepting a name nothing answers to
-    /// would invent a stdlib module for the rest of the compile to resolve
-    /// against.
+    /// `#![stdlib("…")]` names no bundled stdlib module, or names nothing at
+    /// all. The attribute takes over the entry's module identity, so accepting
+    /// a name nothing answers to would invent a stdlib module for the rest of
+    /// the compile to resolve against.
     StdlibIdentity {
-        path: String,
+        path: Option<String>,
         file: String,
         line: usize,
         column: usize,
@@ -154,20 +154,33 @@ impl std::fmt::Display for LoadError {
             } => {
                 write!(f, "wasm import error in {module_source}: {message}")
             }
-            LoadError::StdlibIdentity { path, .. } => {
-                write!(f, "{}", stdlib_identity_message(path))
+            LoadError::StdlibIdentity {
+                path,
+                file,
+                line,
+                column,
+            } => {
+                write!(
+                    f,
+                    "{file}: line {line}, column {column}: {}",
+                    stdlib_identity_message(path.as_deref())
+                )
             }
         }
     }
 }
 
 /// The one wording both the [`LoadError::StdlibIdentity`] display and its
-/// diagnostic use.
-fn stdlib_identity_message(path: &str) -> String {
+/// diagnostic use. `None` is the argument-less form, which names nothing to
+/// quote back.
+fn stdlib_identity_message(path: Option<&str>) -> String {
+    let lead = match path {
+        Some(path) => format!("#![stdlib({path:?})] does not name a bundled stdlib module"),
+        None => "#![stdlib] names no bundled stdlib module".to_string(),
+    };
     format!(
-        "#![stdlib({path:?})] does not name a bundled stdlib module; \
-         the attribute declares the identity of a module bundled in the compiler \
-         and is not for use outside it"
+        "{lead}; the attribute declares the identity of a module bundled in the \
+         compiler and is not for use outside it"
     )
 }
 
@@ -237,7 +250,7 @@ impl From<LoadError> for crate::compiler_host::Diagnostic {
             } => Self {
                 severity: Severity::Error,
                 code: Code::ModuleNotFound,
-                message: stdlib_identity_message(path),
+                message: stdlib_identity_message(path.as_deref()),
                 span: Some(DiagnosticSpan {
                     file: file.clone(),
                     line,
@@ -983,17 +996,17 @@ fn parse_stdlib_identity_attribute(
     let Some(attribute) = module.stdlib_identity_attribute() else {
         return Ok(None);
     };
-    let path = module.stdlib_identity().unwrap_or_default();
+    let path = module.stdlib_identity();
     let reject = || LoadError::StdlibIdentity {
-        path: path.to_string(),
+        path: path.map(str::to_string),
         file: file.to_string(),
         line: attribute.span.line,
         column: attribute.span.column,
     };
 
-    if stdlib::get_stdlib_module(path).is_none() {
+    let Some(path) = path.filter(|p| stdlib::get_stdlib_module(p).is_some()) else {
         return Err(reject());
-    }
+    };
     if let Some(name) = path.strip_prefix("core:") {
         Ok(Some(interner.core(name)))
     } else if let Some(interface) = path.strip_prefix("wasi:") {

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -62,6 +62,16 @@ pub enum LoadError {
         module_source: ModuleSource,
         message: String,
     },
+    /// `#![stdlib("…")]` names no bundled stdlib module. The attribute takes
+    /// over the entry's module identity, so accepting a name nothing answers to
+    /// would invent a stdlib module for the rest of the compile to resolve
+    /// against.
+    StdlibIdentity {
+        path: String,
+        file: String,
+        line: usize,
+        column: usize,
+    },
 }
 
 impl LoadError {
@@ -144,8 +154,21 @@ impl std::fmt::Display for LoadError {
             } => {
                 write!(f, "wasm import error in {module_source}: {message}")
             }
+            LoadError::StdlibIdentity { path, .. } => {
+                write!(f, "{}", stdlib_identity_message(path))
+            }
         }
     }
+}
+
+/// The one wording both the [`LoadError::StdlibIdentity`] display and its
+/// diagnostic use.
+fn stdlib_identity_message(path: &str) -> String {
+    format!(
+        "#![stdlib({path:?})] does not name a bundled stdlib module; \
+         the attribute declares the identity of a module bundled in the compiler \
+         and is not for use outside it"
+    )
 }
 
 impl std::error::Error for LoadError {}
@@ -205,6 +228,23 @@ impl From<LoadError> for crate::compiler_host::Diagnostic {
                 code: Code::InvalidSyntax,
                 message: format!("wasm import error in {module_source}: {message}"),
                 span: None,
+            },
+            LoadError::StdlibIdentity {
+                ref path,
+                ref file,
+                line,
+                column,
+            } => Self {
+                severity: Severity::Error,
+                code: Code::ModuleNotFound,
+                message: stdlib_identity_message(path),
+                span: Some(DiagnosticSpan {
+                    file: file.clone(),
+                    line,
+                    column,
+                    end_line: None,
+                    end_column: None,
+                }),
             },
             ref other => Self {
                 severity: Severity::Error,
@@ -928,35 +968,39 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
 }
 
 /// Resolve a `#![stdlib("…")]` declaration on `module` to a canonical
-/// `ModuleSource`.
+/// `ModuleSource`, `Ok(None)` when the attribute is absent.
 ///
-/// Returns `None` only when the attribute is absent. The attribute is
-/// authored exclusively by files inside `wado-compiler/lib/`, so a
-/// malformed argument (anything not registered in
-/// [`stdlib::get_stdlib_module`]) is a stdlib bug — it panics rather than
-/// silently degrading to `EntryPoint`, since the LSP would then see the
-/// duplicate-definition cascade we introduced this attribute to suppress.
+/// A name no bundled module answers to is rejected rather than degraded to
+/// `EntryPoint`: the attribute pins the entry's identity, and the rest of the
+/// compile resolves against whatever it says. Any file can write it, so the
+/// rejection is a diagnostic, not a panic — `file` is the entry's path, which
+/// carries the attribute.
 fn parse_stdlib_identity_attribute(
     interner: &mut ModuleSourceInterner,
     module: &Module,
-) -> Option<ModuleSource> {
-    let path = module.stdlib_identity()?;
-    let resolved = if let Some(name) = path.strip_prefix("core:") {
-        interner.core(name)
-    } else if let Some(interface) = path.strip_prefix("wasi:") {
-        interner.wasi(interface)
-    } else {
-        panic!(
-            "#![stdlib({path:?})] must use a `core:` or `wasi:` prefix; \
-             this attribute is internal to bundled stdlib files"
-        );
+    file: &str,
+) -> Result<Option<ModuleSource>, LoadError> {
+    let Some(attribute) = module.stdlib_identity_attribute() else {
+        return Ok(None);
     };
-    assert!(
-        stdlib::get_stdlib_module(path).is_some(),
-        "#![stdlib({path:?})] does not match any bundled stdlib module; \
-         add the registration to `stdlib::get_stdlib_module` or correct the path",
-    );
-    Some(resolved)
+    let path = module.stdlib_identity().unwrap_or_default();
+    let reject = || LoadError::StdlibIdentity {
+        path: path.to_string(),
+        file: file.to_string(),
+        line: attribute.span.line,
+        column: attribute.span.column,
+    };
+
+    if stdlib::get_stdlib_module(path).is_none() {
+        return Err(reject());
+    }
+    if let Some(name) = path.strip_prefix("core:") {
+        Ok(Some(interner.core(name)))
+    } else if let Some(interface) = path.strip_prefix("wasi:") {
+        Ok(Some(interner.wasi(interface)))
+    } else {
+        Err(reject())
+    }
 }
 
 #[cfg(test)]
@@ -1003,8 +1047,21 @@ mod tests {
         let mut interner = ModuleSourceInterner::new();
         let want = interner.core("prelude/types.wado");
         assert_eq!(
-            parse_stdlib_identity_attribute(&mut interner, &module),
-            Some(want)
+            parse_stdlib_identity_attribute(&mut interner, &module, "types.wado").ok(),
+            Some(Some(want))
+        );
+    }
+
+    #[test]
+    fn unregistered_stdlib_identity_attribute_is_an_error() {
+        let module = parse_test_module("#![no_prelude]\n#![stdlib(\"core:bogus.wado\")]\n");
+        let mut interner = ModuleSourceInterner::new();
+        let err = parse_stdlib_identity_attribute(&mut interner, &module, "bogus.wado")
+            .expect_err("an unregistered path must be rejected");
+        assert!(
+            err.to_string()
+                .contains("does not name a bundled stdlib module"),
+            "unexpected message: {err}"
         );
     }
 }
@@ -1241,8 +1298,12 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
     ) -> Result<LoadResult, LoadError> {
         let resolved_filename = entry_filename.unwrap_or("<stdin>");
 
-        let entry_module_source = parse_stdlib_identity_attribute(&mut self.interner, &entry_ast)
-            .unwrap_or(tentative_entry_source);
+        let entry_module_source = parse_stdlib_identity_attribute(
+            &mut self.interner,
+            &entry_ast,
+            &tentative_entry_source.source_path(),
+        )?
+        .unwrap_or(tentative_entry_source);
         self.entry_module_source = Some(entry_module_source.clone());
         self.entry_canonical_name = Some(crate::name::canonicalize_entry_point(resolved_filename));
         self.entry_dir = crate::name::entry_dir_of(Some(&entry_module_source));

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -174,14 +174,16 @@ impl std::fmt::Display for LoadError {
 /// diagnostic use. `None` is the argument-less form, which names nothing to
 /// quote back.
 fn stdlib_identity_message(path: Option<&str>) -> String {
-    let lead = match path {
-        Some(path) => format!("#![stdlib({path:?})] does not name a bundled stdlib module"),
-        None => "#![stdlib] names no bundled stdlib module".to_string(),
-    };
-    format!(
-        "{lead}; the attribute declares the identity of a module bundled in the \
-         compiler and is not for use outside it"
-    )
+    match path {
+        Some(path) => format!(
+            "#![stdlib({path:?})] does not name a bundled stdlib module; the attribute \
+             declares the identity of a module bundled in the compiler and is not for \
+             use outside it"
+        ),
+        None => "#![stdlib] takes the name of a bundled stdlib module, as \
+                 `#![stdlib(\"core:cli\")]`"
+            .to_string(),
+    }
 }
 
 impl std::error::Error for LoadError {}
@@ -980,39 +982,51 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
     ast
 }
 
-/// Resolve a `#![stdlib("…")]` declaration on `module` to a canonical
-/// `ModuleSource`, `Ok(None)` when the attribute is absent.
+/// The bundled-stdlib identity `module` declares, `Ok(None)` when it declares
+/// none. `file` is the module's path, for the diagnostic.
 ///
-/// A name no bundled module answers to is rejected rather than degraded to
-/// `EntryPoint`: the attribute pins the entry's identity, and the rest of the
-/// compile resolves against whatever it says. Any file can write it, so the
-/// rejection is a diagnostic, not a panic — `file` is the entry's path, which
-/// carries the attribute.
+/// The attribute names one of the modules bundled in the compiler, and every
+/// spelling that names nothing — an omitted name, a name no bundled module
+/// answers to — is an error wherever it is written. Only the entry's identity
+/// is consulted, but a file does not become well-formed by being imported
+/// rather than compiled, so [`ModuleLoader::check_stdlib_identities`] holds
+/// every loaded module to the same rule.
+fn stdlib_identity_of<'a>(module: &'a Module, file: &str) -> Result<Option<&'a str>, LoadError> {
+    let Some(attribute) = module.stdlib_identity_attribute() else {
+        return Ok(None);
+    };
+    let path = module.stdlib_identity();
+    match path.filter(|p| stdlib::get_stdlib_module(p).is_some()) {
+        Some(path) => Ok(Some(path)),
+        None => Err(LoadError::StdlibIdentity {
+            path: path.map(str::to_string),
+            file: file.to_string(),
+            line: attribute.span.line,
+            column: attribute.span.column,
+        }),
+    }
+}
+
+/// Resolve `module`'s `#![stdlib("…")]` declaration to a canonical
+/// `ModuleSource`, `Ok(None)` when it declares none.
+///
+/// The identity pins the entry's `ModuleSource`, which the rest of the compile
+/// resolves against — hence [`stdlib_identity_of`]'s rejection rather than a
+/// silent degrade to `EntryPoint`.
 fn parse_stdlib_identity_attribute(
     interner: &mut ModuleSourceInterner,
     module: &Module,
     file: &str,
 ) -> Result<Option<ModuleSource>, LoadError> {
-    let Some(attribute) = module.stdlib_identity_attribute() else {
+    let Some(path) = stdlib_identity_of(module, file)? else {
         return Ok(None);
-    };
-    let path = module.stdlib_identity();
-    let reject = || LoadError::StdlibIdentity {
-        path: path.map(str::to_string),
-        file: file.to_string(),
-        line: attribute.span.line,
-        column: attribute.span.column,
-    };
-
-    let Some(path) = path.filter(|p| stdlib::get_stdlib_module(p).is_some()) else {
-        return Err(reject());
     };
     if let Some(name) = path.strip_prefix("core:") {
         Ok(Some(interner.core(name)))
     } else if let Some(interface) = path.strip_prefix("wasi:") {
         Ok(Some(interner.wasi(interface)))
     } else {
-        Err(reject())
+        unreachable!("a registered stdlib path is `core:`- or `wasi:`-prefixed")
     }
 }
 
@@ -1074,6 +1088,17 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("does not name a bundled stdlib module"),
+            "unexpected message: {err}"
+        );
+    }
+
+    #[test]
+    fn stdlib_identity_attribute_without_a_name_is_an_error() {
+        let module = parse_test_module("#![no_prelude]\n#![stdlib]\n");
+        let err = stdlib_identity_of(&module, "nameless.wado")
+            .expect_err("an omitted name must be rejected");
+        assert!(
+            err.to_string().contains("#![stdlib] takes the name of"),
             "unexpected message: {err}"
         );
     }
@@ -1432,6 +1457,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             self.handle_wasm_import(&from_ms, kind, &use_decl).await?;
         }
 
+        self.check_stdlib_identities()?;
+
         // Collect and load files referenced by #include_str / #include_bytes
         let included_files = {
             let _span = self.logger.span("load/included_files");
@@ -1449,6 +1476,16 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
             invocations: self.invocations,
             interner: self.interner,
         })
+    }
+
+    /// Hold every loaded module's `#![stdlib("…")]` declaration to the rule
+    /// [`stdlib_identity_of`] states. The entry's is resolved before its
+    /// imports load; this reaches the rest.
+    fn check_stdlib_identities(&self) -> Result<(), LoadError> {
+        for (module_source, module) in &self.loaded {
+            stdlib_identity_of(module, &module_source.source_path())?;
+        }
+        Ok(())
     }
 
     /// Collect import paths from a module's use declarations.

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -1054,6 +1054,33 @@ fn cached_stdlib_module(import_path: &str) -> Option<&'static Module> {
     )
 }
 
+/// The same slot table for the bindings synthesized from a *bundled* wasm asset
+/// (`core:libm.wat`). Its bytes are fixed at build time, so its synthesized
+/// module is as stable as a bundled source and must be parsed once per process
+/// too: an `AstId` has to mean the same node in every compile for the stdlib
+/// snapshot to seed one (WEP 2026-08-12 §1). A host-loaded asset can change
+/// between compiles and is parsed each time.
+fn wasm_binding_slots()
+-> &'static crate::hashmap::IndexMap<&'static str, std::sync::OnceLock<Module>> {
+    use std::sync::OnceLock;
+
+    static SLOTS: OnceLock<crate::hashmap::IndexMap<&'static str, OnceLock<Module>>> =
+        OnceLock::new();
+    SLOTS.get_or_init(|| {
+        stdlib::ALL_CORE_WASM_ASSETS
+            .iter()
+            .map(|&(path, _)| (path, OnceLock::new()))
+            .collect()
+    })
+}
+
+/// Return the cached bindings AST for a bundled wasm asset, parsing `source` on
+/// first access. `None` for a host-loaded asset.
+fn cached_wasm_binding_module(import_path: &str, source: &str) -> Option<&'static Module> {
+    let (key, slot) = wasm_binding_slots().get_key_value(import_path)?;
+    Some(slot.get_or_init(|| parse_bind_stdlib(key, source)))
+}
+
 /// Compute the cache key string used by [`cached_stdlib_module`] for a
 /// `ModuleSource`. Returns `None` for variants that the stdlib cache
 /// never holds (Local / Remote / `EntryPoint` / Redirected / Wasm).
@@ -1469,14 +1496,19 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         let synthesized_source = synthesize_wasm_bindings_source(&namespace, &function_exports);
         let span = format!("synthesize {namespace}");
         self.logger.span_start(&span);
-        let ast = self
-            .parse_source(&synthesized_source, &source)
-            .inspect_err(|_e| {
+        let ast = if let Some(cached) = cached_wasm_binding_module(&path, &synthesized_source) {
+            cached.clone()
+        } else {
+            let ast = self
+                .parse_source(&synthesized_source, &source)
+                .inspect_err(|_e| {
+                    self.logger.span_end(&span);
+                })?;
+            self.bind_module(&ast, &source).inspect_err(|_e| {
                 self.logger.span_end(&span);
             })?;
-        self.bind_module(&ast, &source).inspect_err(|_e| {
-            self.logger.span_end(&span);
-        })?;
+            ast
+        };
         self.logger.span_end(&span);
         self.loaded.insert(source.clone(), ast);
 

--- a/wado-compiler/src/loader.rs
+++ b/wado-compiler/src/loader.rs
@@ -62,10 +62,7 @@ pub enum LoadError {
         module_source: ModuleSource,
         message: String,
     },
-    /// `#![stdlib("…")]` names no bundled stdlib module, or names nothing at
-    /// all. The attribute takes over the entry's module identity, so accepting
-    /// a name nothing answers to would invent a stdlib module for the rest of
-    /// the compile to resolve against.
+    /// `#![stdlib("…")]` names no bundled stdlib module, or names nothing.
     StdlibIdentity {
         path: Option<String>,
         file: String,
@@ -170,9 +167,7 @@ impl std::fmt::Display for LoadError {
     }
 }
 
-/// The one wording both the [`LoadError::StdlibIdentity`] display and its
-/// diagnostic use. `None` is the argument-less form, which names nothing to
-/// quote back.
+/// The one wording the display and the diagnostic share.
 fn stdlib_identity_message(path: Option<&str>) -> String {
     match path {
         Some(path) => format!(
@@ -983,14 +978,8 @@ fn parse_bind_stdlib(label: &str, source: &str) -> Module {
 }
 
 /// The bundled-stdlib identity `module` declares, `Ok(None)` when it declares
-/// none. `file` is the module's path, for the diagnostic.
-///
-/// The attribute names one of the modules bundled in the compiler, and every
-/// spelling that names nothing — an omitted name, a name no bundled module
-/// answers to — is an error wherever it is written. Only the entry's identity
-/// is consulted, but a file does not become well-formed by being imported
-/// rather than compiled, so [`ModuleLoader::check_stdlib_identities`] holds
-/// every loaded module to the same rule.
+/// none. Naming nothing is an error wherever it is written — a file does not
+/// become well-formed by being imported rather than compiled.
 fn stdlib_identity_of<'a>(module: &'a Module, file: &str) -> Result<Option<&'a str>, LoadError> {
     let Some(attribute) = module.stdlib_identity_attribute() else {
         return Ok(None);
@@ -1008,11 +997,8 @@ fn stdlib_identity_of<'a>(module: &'a Module, file: &str) -> Result<Option<&'a s
 }
 
 /// Resolve `module`'s `#![stdlib("…")]` declaration to a canonical
-/// `ModuleSource`, `Ok(None)` when it declares none.
-///
-/// The identity pins the entry's `ModuleSource`, which the rest of the compile
-/// resolves against — hence [`stdlib_identity_of`]'s rejection rather than a
-/// silent degrade to `EntryPoint`.
+/// `ModuleSource`: it pins the entry's, which the rest of the compile resolves
+/// against.
 fn parse_stdlib_identity_attribute(
     interner: &mut ModuleSourceInterner,
     module: &Module,
@@ -1149,12 +1135,9 @@ fn cached_stdlib_module(import_path: &str) -> Option<&'static Module> {
     )
 }
 
-/// The same slot table for the bindings synthesized from a *bundled* wasm asset
-/// (`core:libm.wat`). Its bytes are fixed at build time, so its synthesized
-/// module is as stable as a bundled source and must be parsed once per process
-/// too: an `AstId` has to mean the same node in every compile for the stdlib
-/// snapshot to seed one (WEP 2026-08-12 §1). A host-loaded asset can change
-/// between compiles and is parsed each time.
+/// [`stdlib_slots`] for a *bundled* wasm asset's synthesized bindings: its bytes
+/// are fixed at build time, so it is parsed once per process too — an `AstId`
+/// must mean the same node in every compile (WEP 2026-08-12 §1).
 fn wasm_binding_slots()
 -> &'static crate::hashmap::IndexMap<&'static str, std::sync::OnceLock<Module>> {
     use std::sync::OnceLock;
@@ -1169,8 +1152,8 @@ fn wasm_binding_slots()
     })
 }
 
-/// Return the cached bindings AST for a bundled wasm asset, parsing `source` on
-/// first access. `None` for a host-loaded asset.
+/// The cached bindings AST for a bundled wasm asset; `None` for a host-loaded
+/// one, whose bytes can change between compiles.
 fn cached_wasm_binding_module(import_path: &str, source: &str) -> Option<&'static Module> {
     let (key, slot) = wasm_binding_slots().get_key_value(import_path)?;
     Some(slot.get_or_init(|| parse_bind_stdlib(key, source)))
@@ -1478,9 +1461,8 @@ impl<'a, H: CompilerHost> ModuleLoader<'a, H> {
         })
     }
 
-    /// Hold every loaded module's `#![stdlib("…")]` declaration to the rule
-    /// [`stdlib_identity_of`] states. The entry's is resolved before its
-    /// imports load; this reaches the rest.
+    /// Hold every loaded module to [`stdlib_identity_of`]'s rule. The entry's
+    /// is resolved before its imports load; this reaches the rest.
     fn check_stdlib_identities(&self) -> Result<(), LoadError> {
         for (module_source, module) in &self.loaded {
             stdlib_identity_of(module, &module_source.source_path())?;

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -1128,13 +1128,11 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // the ~28 s of CPU otherwise duplicated across a typical `wado test`
     // run.  Returns `None` when called from inside the snapshot builder
     // itself (re-entry guard); a fresh full pipeline runs in that case.
-    // A `#![stdlib("core:…")]` entry re-parses a module the snapshot holds its
-    // own parse of, and `AstId`s never survive a re-parse: seeding would give
-    // that one module two identities (#1875), so it compiles wholly from source.
     let snapshot = {
         let _span = logger.span("stdlib_snapshot");
-        crate::stdlib_snapshot::get_or_init_snapshot()
-            .filter(|snap| !crate::stdlib_snapshot::covers(snap, &load_result.entry_module_source))
+        crate::stdlib_snapshot::get_or_init_snapshot().filter(|snap| {
+            crate::stdlib_snapshot::reparsed_snapshot_module(snap, &load_result.modules).is_none()
+        })
     };
 
     let (symbols, analyze_ok) = {

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -1128,9 +1128,13 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // the ~28 s of CPU otherwise duplicated across a typical `wado test`
     // run.  Returns `None` when called from inside the snapshot builder
     // itself (re-entry guard); a fresh full pipeline runs in that case.
+    // A `#![stdlib("core:…")]` entry re-parses a module the snapshot holds its
+    // own parse of, and `AstId`s never survive a re-parse: seeding would give
+    // that one module two identities (#1875), so it compiles wholly from source.
     let snapshot = {
         let _span = logger.span("stdlib_snapshot");
         crate::stdlib_snapshot::get_or_init_snapshot()
+            .filter(|snap| !crate::stdlib_snapshot::covers(snap, &load_result.entry_module_source))
     };
 
     let (symbols, analyze_ok) = {

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -151,15 +151,9 @@ pub(crate) fn stdlib_sources(snap: &Semantics) -> IndexSet<ModuleSource> {
         .collect()
 }
 
-/// The first module `snap` cached that `modules` carries as a different parse,
-/// if any — the condition that decides whether the snapshot may seed a compile.
-///
-/// Restoring a cached module skips its decl pass, so its facts are read back
-/// against `DefId`s minted from the snapshot's own parse; that is sound only
-/// while an `AstId` means the same node in both tables (WEP 2026-08-12 §1).
-/// Every stdlib module is parsed once per process and shared, so the sets agree
-/// — until an entry names itself `#![stdlib("core:…")]` and its own file becomes
-/// a second parse of a cached identity. Such a compile elaborates from source.
+/// The first module `snap` cached that `modules` carries as a different parse —
+/// the condition the snapshot may seed a compile under, its facts keying on
+/// `DefId`s only that parse mints (WEP 2026-08-12 §1).
 pub(crate) fn reparsed_snapshot_module<'a>(
     snap: &Semantics,
     modules: &'a IndexMap<ModuleSource, crate::ast::Module>,
@@ -299,10 +293,8 @@ mod tests {
         );
     }
 
-    /// The precondition `semantics_with_logger` gates the snapshot on must hold
-    /// for an ordinary compile, or every compile silently re-elaborates the
-    /// stdlib. It fails the moment a module the snapshot caches starts being
-    /// parsed per compile again.
+    /// The precondition must hold for an ordinary compile, or every compile
+    /// silently re-elaborates the stdlib.
     #[test]
     fn a_plain_compile_carries_the_snapshot_parses() {
         let snap = get_or_init_snapshot().expect("not re-entering the builder");

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -141,21 +141,35 @@ fn poll_to_completion<F: Future>(fut: F) -> F::Output {
 pub(crate) fn stdlib_sources(snap: &Semantics) -> IndexSet<ModuleSource> {
     snap.tir_modules
         .keys()
-        .filter(|ms| covers(snap, ms))
+        .filter(|ms| {
+            matches!(
+                ms,
+                ModuleSource::Core { .. } | ModuleSource::Wasi { .. } | ModuleSource::Wasm { .. }
+            )
+        })
         .cloned()
         .collect()
 }
 
-/// Whether the snapshot holds its own parse of `module_source`.
+/// The first module `snap` cached that `modules` carries as a different parse,
+/// if any — the condition that decides whether the snapshot may seed a compile.
 ///
-/// `ModuleSource::EntryPoint` values compare equal regardless of filename, so
-/// the snapshot's synthetic empty entry would match every compile's entry; the
-/// variant gate keeps it out.
-pub(crate) fn covers(snap: &Semantics, module_source: &ModuleSource) -> bool {
-    matches!(
-        module_source,
-        ModuleSource::Core { .. } | ModuleSource::Wasi { .. } | ModuleSource::Wasm { .. }
-    ) && snap.tir_modules.contains_key(module_source)
+/// Restoring a cached module skips its decl pass, so its facts are read back
+/// against `DefId`s minted from the snapshot's own parse; that is sound only
+/// while an `AstId` means the same node in both tables (WEP 2026-08-12 §1).
+/// Every stdlib module is parsed once per process and shared, so the sets agree
+/// — until an entry names itself `#![stdlib("core:…")]` and its own file becomes
+/// a second parse of a cached identity. Such a compile elaborates from source.
+pub(crate) fn reparsed_snapshot_module<'a>(
+    snap: &Semantics,
+    modules: &'a IndexMap<ModuleSource, crate::ast::Module>,
+) -> Option<&'a ModuleSource> {
+    let cached = stdlib_sources(snap);
+    modules.iter().find_map(|(ms, module)| {
+        let reparsed =
+            cached.contains(ms) && snap.space_modules.get(&module.ast_id_space()) != Some(ms);
+        reparsed.then_some(ms)
+    })
 }
 
 /// Deep-clone a cached [`TirModule`] for a per-compile pipeline. A naïve `Clone`
@@ -282,6 +296,28 @@ mod tests {
         assert!(
             entry_count <= 1,
             "expected at most one EntryPoint module, got {entry_count}"
+        );
+    }
+
+    /// The precondition `semantics_with_logger` gates the snapshot on must hold
+    /// for an ordinary compile, or every compile silently re-elaborates the
+    /// stdlib. It fails the moment a module the snapshot caches starts being
+    /// parsed per compile again.
+    #[test]
+    fn a_plain_compile_carries_the_snapshot_parses() {
+        let snap = get_or_init_snapshot().expect("not re-entering the builder");
+        let host = SnapshotHost;
+        let load_result = poll_to_completion(async {
+            ModuleLoader::new(&host, LogLevel::Off)
+                .load_all("fn main() {}", Some("plain.wado"))
+                .await
+        })
+        .expect("loader should succeed");
+
+        assert_eq!(
+            reparsed_snapshot_module(&snap, &load_result.modules),
+            None,
+            "a cached module is being re-parsed per compile"
         );
     }
 

--- a/wado-compiler/src/stdlib_snapshot.rs
+++ b/wado-compiler/src/stdlib_snapshot.rs
@@ -141,14 +141,21 @@ fn poll_to_completion<F: Future>(fut: F) -> F::Output {
 pub(crate) fn stdlib_sources(snap: &Semantics) -> IndexSet<ModuleSource> {
     snap.tir_modules
         .keys()
-        .filter(|ms| {
-            matches!(
-                ms,
-                ModuleSource::Core { .. } | ModuleSource::Wasi { .. } | ModuleSource::Wasm { .. }
-            )
-        })
+        .filter(|ms| covers(snap, ms))
         .cloned()
         .collect()
+}
+
+/// Whether the snapshot holds its own parse of `module_source`.
+///
+/// `ModuleSource::EntryPoint` values compare equal regardless of filename, so
+/// the snapshot's synthetic empty entry would match every compile's entry; the
+/// variant gate keeps it out.
+pub(crate) fn covers(snap: &Semantics, module_source: &ModuleSource) -> bool {
+    matches!(
+        module_source,
+        ModuleSource::Core { .. } | ModuleSource::Wasi { .. } | ModuleSource::Wasm { .. }
+    ) && snap.tir_modules.contains_key(module_source)
 }
 
 /// Deep-clone a cached [`TirModule`] for a per-compile pipeline. A naïve `Clone`

--- a/wado-compiler/tests/integration/compile_errors.rs
+++ b/wado-compiler/tests/integration/compile_errors.rs
@@ -673,3 +673,24 @@ export fn run() {
 
     crate::common::compile_source(source).expect("a non-scalar &mut binding compiles");
 }
+
+#[test]
+fn stdlib_identity_attribute_naming_no_bundled_module_is_an_error() {
+    // `#![stdlib("…")]` pins the entry's module identity; any file can write
+    // it, so an unregistered name is a diagnostic, never a panic.
+    let source = "#![stdlib(\"core:bogus.wado\")]\nfn main() {}\n";
+
+    let Err(err) = crate::common::compile_source(source) else {
+        panic!("an unregistered stdlib identity must be rejected");
+    };
+    match err {
+        CompileError::Analyzer { message, line, .. } => {
+            assert!(
+                message.contains("does not name a bundled stdlib module"),
+                "unexpected message: {message}"
+            );
+            assert_eq!(line, 1, "the attribute's own line");
+        }
+        other => panic!("Expected Analyzer error, got: {other}"),
+    }
+}

--- a/wado-compiler/tests/integration/compile_errors.rs
+++ b/wado-compiler/tests/integration/compile_errors.rs
@@ -675,6 +675,35 @@ export fn run() {
 }
 
 #[test]
+fn stdlib_identity_attribute_is_checked_in_an_imported_module_too() {
+    // Only the entry's identity is consulted, but a file does not become
+    // well-formed by being imported rather than compiled.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("dep.wado"),
+        "#![stdlib]\npub fn helper() -> i32 { return 1 }\n",
+    )
+    .expect("write dep");
+    let entry = "use { helper } from \"./dep.wado\";\ntest \"x\" { assert helper() == 1; }\n";
+
+    let options = wado_compiler::CompilerOptions {
+        target_world: Some("test".to_string()),
+        ..Default::default()
+    };
+    let Err(err) = crate::common::compile_source_with_compiler_options(
+        &dir.path().join("main_test.wado"),
+        entry,
+        options,
+    ) else {
+        panic!("an imported module's malformed `#![stdlib]` must be rejected");
+    };
+    assert!(
+        err.to_string().contains("#![stdlib] takes the name of"),
+        "unexpected message: {err}"
+    );
+}
+
+#[test]
 fn stdlib_identity_attribute_naming_no_bundled_module_is_an_error() {
     // `#![stdlib("…")]` pins the entry's module identity; any file can write
     // it, so an unregistered name is a diagnostic, never a panic.

--- a/wado-compiler/tests/integration/compile_errors.rs
+++ b/wado-compiler/tests/integration/compile_errors.rs
@@ -676,8 +676,6 @@ export fn run() {
 
 #[test]
 fn stdlib_identity_attribute_is_checked_in_an_imported_module_too() {
-    // Only the entry's identity is consulted, but a file does not become
-    // well-formed by being imported rather than compiled.
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(
         dir.path().join("dep.wado"),
@@ -705,8 +703,7 @@ fn stdlib_identity_attribute_is_checked_in_an_imported_module_too() {
 
 #[test]
 fn stdlib_identity_attribute_naming_no_bundled_module_is_an_error() {
-    // `#![stdlib("…")]` pins the entry's module identity; any file can write
-    // it, so an unregistered name is a diagnostic, never a panic.
+    // Any file can write the attribute, so this is a diagnostic, never a panic.
     let source = "#![stdlib(\"core:bogus.wado\")]\nfn main() {}\n";
 
     let Err(err) = crate::common::compile_source(source) else {

--- a/wado-compiler/tests/integration/main.rs
+++ b/wado-compiler/tests/integration/main.rs
@@ -45,6 +45,7 @@ mod remarks;
 mod scalar_read_move;
 mod semantics;
 mod serde_positional;
+mod stdlib_module_as_entry;
 mod stores_check_sem;
 mod stream_canonical_options;
 mod string_templates;

--- a/wado-compiler/tests/integration/stdlib_module_as_entry.rs
+++ b/wado-compiler/tests/integration/stdlib_module_as_entry.rs
@@ -9,29 +9,36 @@ fn core_dir() -> PathBuf {
 }
 
 /// Every bundled `core:` module — the ones an editor opens like any other file.
-/// `*_test.wado` siblings are ordinary entry points, and a `#![wasm_module("…")]`
-/// module is not compilable as an entry at all.
 fn core_modules() -> Vec<PathBuf> {
-    let mut paths: Vec<PathBuf> = [core_dir(), core_dir().join("prelude")]
-        .into_iter()
-        .flat_map(|dir| {
-            std::fs::read_dir(dir)
-                .expect("core dir should be readable")
-                .map(|e| e.expect("dir entry").path())
-        })
-        .filter(|p| {
-            p.extension().is_some_and(|e| e == "wado")
-                && !p
-                    .file_stem()
-                    .is_some_and(|s| s.to_string_lossy().ends_with("_test"))
-                && !std::fs::read_to_string(p)
-                    .expect("module should be readable")
-                    .contains("#![wasm_module(")
-        })
-        .collect();
+    let mut paths = Vec::new();
+    collect_modules(&core_dir(), &mut paths);
     paths.sort();
     assert!(paths.len() > 20, "core modules should be discoverable");
     paths
+}
+
+/// The whole `dir` tree's entry-point modules: a `*_test.wado` is an ordinary
+/// entry point, and a `#![wasm_module("…")]` module is not compilable as one at
+/// all (see `a_wasm_module_entry_is_rejected`).
+fn collect_modules(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("core dir should be readable") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            collect_modules(&path, out);
+        } else if is_entry_point_module(&path) {
+            out.push(path);
+        }
+    }
+}
+
+fn is_entry_point_module(path: &Path) -> bool {
+    path.extension().is_some_and(|e| e == "wado")
+        && !path
+            .file_stem()
+            .is_some_and(|s| s.to_string_lossy().ends_with("_test"))
+        && !std::fs::read_to_string(path)
+            .expect("module should be readable")
+            .contains("#![wasm_module(")
 }
 
 fn compile_as_test_world_entry(

--- a/wado-compiler/tests/integration/stdlib_module_as_entry.rs
+++ b/wado-compiler/tests/integration/stdlib_module_as_entry.rs
@@ -1,0 +1,69 @@
+//! A stdlib module compiled as the entry point (#1875): the fresh parse and the
+//! stdlib snapshot's own parse of that file gave it two identities, so trait
+//! synthesis re-derived an impl it writes by hand and monomorphize panicked.
+
+use std::path::{Path, PathBuf};
+
+fn prelude_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("lib/core/prelude")
+}
+
+/// Every `core:prelude` module, `*_test.wado` siblings excluded — those are
+/// ordinary entry points already covered by `mise run test-wado`.
+fn prelude_modules() -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = std::fs::read_dir(prelude_dir())
+        .expect("prelude dir should be readable")
+        .map(|e| e.expect("dir entry").path())
+        .filter(|p| {
+            p.extension().is_some_and(|e| e == "wado")
+                && !p
+                    .file_stem()
+                    .is_some_and(|s| s.to_string_lossy().ends_with("_test"))
+        })
+        .collect();
+    paths.sort();
+    assert!(!paths.is_empty(), "prelude modules should be discoverable");
+    paths
+}
+
+fn compile_as_test_world_entry(
+    path: &Path,
+    source: &str,
+) -> Result<wado_compiler::CompileResult, wado_compiler::CompileError> {
+    let options = wado_compiler::CompilerOptions {
+        target_world: Some("test".to_string()),
+        ..Default::default()
+    };
+    crate::common::compile_source_with_compiler_options(path, source, options)
+}
+
+#[test]
+fn every_prelude_module_compiles_as_the_entry_point() {
+    for path in prelude_modules() {
+        let source = std::fs::read_to_string(&path).expect("prelude module should be readable");
+        compile_as_test_world_entry(&path, &source).unwrap_or_else(|e| {
+            panic!(
+                "compiling {} as the entry point failed: {e}",
+                path.display()
+            )
+        });
+    }
+}
+
+/// The entry's own source is what gets compiled — never the snapshot's copy of
+/// the module whose identity it claims.
+#[test]
+fn a_stdlib_entry_is_compiled_from_its_source() {
+    let path = prelude_dir().join("string.wado");
+    let source = std::fs::read_to_string(&path).expect("string.wado should be readable");
+    let probed =
+        format!("{source}\nfn snapshot_probe() -> i32 {{\n    return \"not an i32\";\n}}\n");
+
+    let Err(err) = compile_as_test_world_entry(&path, &probed) else {
+        panic!("the injected type error must be reported");
+    };
+    assert!(
+        err.to_string().contains("type mismatch"),
+        "expected the injected type error, got: {err}"
+    );
+}

--- a/wado-compiler/tests/integration/stdlib_module_as_entry.rs
+++ b/wado-compiler/tests/integration/stdlib_module_as_entry.rs
@@ -1,5 +1,5 @@
-//! A stdlib module compiled as the entry point (#1875): the fresh parse and the
-//! stdlib snapshot's own parse of that file gave it two identities, so trait
+//! A stdlib module compiled as the entry point (#1875): its own parse and the
+//! stdlib snapshot's parse of that file gave it two identities, so trait
 //! synthesis re-derived an impl it writes by hand and monomorphize panicked.
 
 use std::path::{Path, PathBuf};

--- a/wado-compiler/tests/integration/stdlib_module_as_entry.rs
+++ b/wado-compiler/tests/integration/stdlib_module_as_entry.rs
@@ -4,25 +4,35 @@
 
 use std::path::{Path, PathBuf};
 
-fn prelude_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("lib/core/prelude")
+fn core_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("lib/core")
 }
 
-/// Every `core:prelude` module, `*_test.wado` siblings excluded — those are
-/// ordinary entry points already covered by `mise run test-wado`.
-fn prelude_modules() -> Vec<PathBuf> {
-    let mut paths: Vec<PathBuf> = std::fs::read_dir(prelude_dir())
-        .expect("prelude dir should be readable")
-        .map(|e| e.expect("dir entry").path())
+/// Every bundled `core:` module — the ones carrying `#![stdlib("core:…")]`,
+/// which an editor opens like any other file. `*_test.wado` siblings are
+/// ordinary entry points already covered by `mise run test-wado`, and a
+/// `#![wasm_module("…")]` module is not compilable as an entry at all (see
+/// `a_wasm_module_entry_is_rejected`).
+fn core_modules() -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = [core_dir(), core_dir().join("prelude")]
+        .into_iter()
+        .flat_map(|dir| {
+            std::fs::read_dir(dir)
+                .expect("core dir should be readable")
+                .map(|e| e.expect("dir entry").path())
+        })
         .filter(|p| {
             p.extension().is_some_and(|e| e == "wado")
                 && !p
                     .file_stem()
                     .is_some_and(|s| s.to_string_lossy().ends_with("_test"))
+                && !std::fs::read_to_string(p)
+                    .expect("module should be readable")
+                    .contains("#![wasm_module(")
         })
         .collect();
     paths.sort();
-    assert!(!paths.is_empty(), "prelude modules should be discoverable");
+    assert!(paths.len() > 20, "core modules should be discoverable");
     paths
 }
 
@@ -37,11 +47,17 @@ fn compile_as_test_world_entry(
     crate::common::compile_source_with_compiler_options(path, source, options)
 }
 
+fn compile_file_as_test_world_entry(
+    path: &Path,
+) -> Result<wado_compiler::CompileResult, wado_compiler::CompileError> {
+    let source = std::fs::read_to_string(path).expect("module should be readable");
+    compile_as_test_world_entry(path, &source)
+}
+
 #[test]
-fn every_prelude_module_compiles_as_the_entry_point() {
-    for path in prelude_modules() {
-        let source = std::fs::read_to_string(&path).expect("prelude module should be readable");
-        compile_as_test_world_entry(&path, &source).unwrap_or_else(|e| {
+fn every_bundled_core_module_compiles_as_the_entry_point() {
+    for path in core_modules() {
+        compile_file_as_test_world_entry(&path).unwrap_or_else(|e| {
             panic!(
                 "compiling {} as the entry point failed: {e}",
                 path.display()
@@ -50,11 +66,26 @@ fn every_prelude_module_compiles_as_the_entry_point() {
     }
 }
 
+/// A `#![wasm_module("mem")]` module's code is emitted into that separate core
+/// module, leaving the program's own module empty — there is no component to
+/// compile, and saying so beats the WIR-emit panic it used to hit.
+#[test]
+fn a_wasm_module_entry_is_rejected() {
+    let path = core_dir().join("allocator.wado");
+    let Err(err) = compile_file_as_test_world_entry(&path) else {
+        panic!("a `#![wasm_module(…)]` entry must be rejected");
+    };
+    assert!(
+        err.to_string().contains("cannot itself be the entry point"),
+        "unexpected error: {err}"
+    );
+}
+
 /// The entry's own source is what gets compiled — never the snapshot's copy of
 /// the module whose identity it claims.
 #[test]
 fn a_stdlib_entry_is_compiled_from_its_source() {
-    let path = prelude_dir().join("string.wado");
+    let path = core_dir().join("prelude/string.wado");
     let source = std::fs::read_to_string(&path).expect("string.wado should be readable");
     let probed =
         format!("{source}\nfn snapshot_probe() -> i32 {{\n    return \"not an i32\";\n}}\n");

--- a/wado-compiler/tests/integration/stdlib_module_as_entry.rs
+++ b/wado-compiler/tests/integration/stdlib_module_as_entry.rs
@@ -17,9 +17,9 @@ fn core_modules() -> Vec<PathBuf> {
     paths
 }
 
-/// The whole `dir` tree's entry-point modules: a `*_test.wado` is an ordinary
-/// entry point, and a `#![wasm_module("…")]` module is not compilable as one at
-/// all (see `a_wasm_module_entry_is_rejected`).
+/// The whole `dir` tree, minus what this sweep is not about: a `*_test.wado`,
+/// an ordinary entry point `mise run test-wado` covers, and a
+/// `#![wasm_module("…")]` module, not compilable as an entry at all.
 fn collect_modules(dir: &Path, out: &mut Vec<PathBuf>) {
     for entry in std::fs::read_dir(dir).expect("core dir should be readable") {
         let path = entry.expect("dir entry").path();

--- a/wado-compiler/tests/integration/stdlib_module_as_entry.rs
+++ b/wado-compiler/tests/integration/stdlib_module_as_entry.rs
@@ -8,11 +8,9 @@ fn core_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("lib/core")
 }
 
-/// Every bundled `core:` module — the ones carrying `#![stdlib("core:…")]`,
-/// which an editor opens like any other file. `*_test.wado` siblings are
-/// ordinary entry points already covered by `mise run test-wado`, and a
-/// `#![wasm_module("…")]` module is not compilable as an entry at all (see
-/// `a_wasm_module_entry_is_rejected`).
+/// Every bundled `core:` module — the ones an editor opens like any other file.
+/// `*_test.wado` siblings are ordinary entry points, and a `#![wasm_module("…")]`
+/// module is not compilable as an entry at all.
 fn core_modules() -> Vec<PathBuf> {
     let mut paths: Vec<PathBuf> = [core_dir(), core_dir().join("prelude")]
         .into_iter()
@@ -66,9 +64,8 @@ fn every_bundled_core_module_compiles_as_the_entry_point() {
     }
 }
 
-/// A `#![wasm_module("mem")]` module's code is emitted into that separate core
-/// module, leaving the program's own module empty — there is no component to
-/// compile, and saying so beats the WIR-emit panic it used to hit.
+/// Its code is emitted into that separate core module, leaving the program's
+/// own module empty — there is no component to compile.
 #[test]
 fn a_wasm_module_entry_is_rejected() {
     let path = core_dir().join("allocator.wado");
@@ -81,8 +78,7 @@ fn a_wasm_module_entry_is_rejected() {
     );
 }
 
-/// The entry's own source is what gets compiled — never the snapshot's copy of
-/// the module whose identity it claims.
+/// The entry's own source is what gets compiled, never the snapshot's copy.
 #[test]
 fn a_stdlib_entry_is_compiled_from_its_source() {
     let path = core_dir().join("prelude/string.wado");

--- a/wado-compiler/wado.toml
+++ b/wado-compiler/wado.toml
@@ -8,24 +8,19 @@ version = "0.1.0"
 # via `tests/e2e.rs`. Skip them in `wado test` discovery; otherwise they
 # would be (re)compiled here under the test world.
 #
-# `lib/core/prelude/**` is the prelude itself: the fragments carry no `test`
-# blocks of their own — the `*_test.wado` siblings below hold those — so
-# discovery has nothing to run in them.
+# `lib/core/prelude/**` carries no `test` blocks of its own — the
+# `*_test.wado` siblings below hold those.
 #
-# `lib/core/allocator.wado` is `#![wasm_module("mem")]` — it is meant to
-# be bundled into the host module's component as a separate core wasm
-# module, not compiled as its own entry. Compiling it standalone is
-# rejected: its code lands in `mem`, leaving no component to emit.
+# `lib/core/allocator.wado` is `#![wasm_module("mem")]`: its code lands in
+# `mem`, leaving no component to emit, so an entry declaring one is rejected.
 exclude = [
     "tests/**",
     "lib/core/prelude/**",
     "lib/core/allocator.wado",
 ]
 
-# `*_test.wado` files inside the excluded stdlib directories *are* meant to
-# be run by `wado test` — they exercise the stdlib via `test "…" { … }`
-# blocks. The include override keeps them visible to discovery despite the
-# directory-level exclude.
+# The `*_test.wado` files inside those excluded directories *are* meant to be
+# run, so this override keeps them visible to discovery.
 include = [
     "lib/**/*_test.wado",
 ]

--- a/wado-compiler/wado.toml
+++ b/wado-compiler/wado.toml
@@ -8,17 +8,14 @@ version = "0.1.0"
 # via `tests/e2e.rs`. Skip them in `wado test` discovery; otherwise they
 # would be (re)compiled here under the test world.
 #
-# `lib/core/prelude/**` is the prelude itself: each fragment defines types
-# (`List`, `String`, ...) that the compiler also auto-imports from the
-# prelude module, so compiling a fragment as its own entry conflicts with
-# the prelude it gets bundled into. They're only valid when reached
-# transitively from `lib/core/prelude.wado` (or from a user file that
-# disables the prelude with `#![no_prelude]`).
+# `lib/core/prelude/**` is the prelude itself: the fragments carry no `test`
+# blocks of their own — the `*_test.wado` siblings below hold those — so
+# discovery has nothing to run in them.
 #
 # `lib/core/allocator.wado` is `#![wasm_module("mem")]` — it is meant to
 # be bundled into the host module's component as a separate core wasm
-# module, not compiled as its own entry. Compiling it standalone trips a
-# WIR-pipeline panic because nothing is exported as `realloc`.
+# module, not compiled as its own entry. Compiling it standalone is
+# rejected: its code lands in `mem`, leaving no component to emit.
 exclude = [
     "tests/**",
     "lib/core/prelude/**",
@@ -27,9 +24,7 @@ exclude = [
 
 # `*_test.wado` files inside the excluded stdlib directories *are* meant to
 # be run by `wado test` — they exercise the stdlib via `test "…" { … }`
-# blocks and only *use* prelude types (`List`, `String`, …) rather than
-# defining them, so the prelude-bundling conflict above does not apply.
-# The include override keeps them visible to discovery despite the
+# blocks. The include override keeps them visible to discovery despite the
 # directory-level exclude.
 include = [
     "lib/**/*_test.wado",

--- a/wado-from-idl/src/main.rs
+++ b/wado-from-idl/src/main.rs
@@ -359,16 +359,9 @@ fn write_flat_reexport_file(
     Ok(())
 }
 
-/// Build the `#![stdlib("...")]` identity string for a generated file, or
-/// `None` when the file lives outside the bundled stdlib namespaces and
-/// therefore must not declare an identity.
-///
-/// `wado-compiler::loader::parse_stdlib_identity_attribute` rejects an identity
-/// that matches no registered stdlib path; `wasmtime:wasi-http` and other
-/// wrapper packages never get registered, so emitting an identity for them
-/// would make their files fail to load at all. The bundled stdlib is the union
-/// of `wasi:*` and `core:*` modules — restrict identity emission to those
-/// namespaces.
+/// Build the `#![stdlib("...")]` identity string for a generated file, `None`
+/// outside the bundled stdlib namespaces (`core:` / `wasi:`) — a wrapper
+/// package is never registered, and the loader rejects an unregistered identity.
 fn stdlib_identity_for(namespace: &str, pkg_name: &str, file: Option<&str>) -> Option<String> {
     if namespace != "wasi" && namespace != "core" {
         return None;

--- a/wado-from-idl/src/main.rs
+++ b/wado-from-idl/src/main.rs
@@ -363,12 +363,12 @@ fn write_flat_reexport_file(
 /// `None` when the file lives outside the bundled stdlib namespaces and
 /// therefore must not declare an identity.
 ///
-/// `wado-compiler::loader::parse_stdlib_identity_attribute` panics when an
-/// identity does not match any registered stdlib path; `wasmtime:wasi-http`
-/// and other wrapper packages never get registered, so emitting an identity
-/// for them would turn an LSP "open file" into a panic. The bundled stdlib
-/// is the union of `wasi:*` and `core:*` modules — restrict identity
-/// emission to those namespaces.
+/// `wado-compiler::loader::parse_stdlib_identity_attribute` rejects an identity
+/// that matches no registered stdlib path; `wasmtime:wasi-http` and other
+/// wrapper packages never get registered, so emitting an identity for them
+/// would make their files fail to load at all. The bundled stdlib is the union
+/// of `wasi:*` and `core:*` modules — restrict identity emission to those
+/// namespaces.
 fn stdlib_identity_for(namespace: &str, pkg_name: &str, file: Option<&str>) -> Option<String> {
     if namespace != "wasi" && namespace != "core" {
         return None;

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -7,6 +7,7 @@ Language service engine for the Wado compiler toolchain.
 - Types follow LSP semantics (0-based positions, standard severity levels).
 - See [LSP Architecture WEP](../docs/wep-2026-04-18-lsp-architecture.md) for crate scope and build targets. The WEP supersedes earlier rules about this crate being IO-free, `wasm32-unknown-unknown`-only, or protocol-agnostic.
 - The crate still compiles for `wasm32-unknown-unknown` (CI-enforced: `cargo check -p wado-lsp --target wasm32-unknown-unknown`), keeping the `Engine` and query path OS-independent so the browser playground can run the language service without a WASI host. Runtime I/O (filesystem source loading) is delegated to the host — `wado-cli` on the desktop, an in-memory host in the browser.
+- No `catch_unwind` around compiler calls, deliberately: unwinding machinery is weight the browser build carries for a case that must not happen. A panic reaching the server is a compiler bug, and taking the server down says so; bad input belongs in a `Diagnostic` instead.
 
 ## Architecture
 

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -7,7 +7,7 @@ Language service engine for the Wado compiler toolchain.
 - Types follow LSP semantics (0-based positions, standard severity levels).
 - See [LSP Architecture WEP](../docs/wep-2026-04-18-lsp-architecture.md) for crate scope and build targets. The WEP supersedes earlier rules about this crate being IO-free, `wasm32-unknown-unknown`-only, or protocol-agnostic.
 - The crate still compiles for `wasm32-unknown-unknown` (CI-enforced: `cargo check -p wado-lsp --target wasm32-unknown-unknown`), keeping the `Engine` and query path OS-independent so the browser playground can run the language service without a WASI host. Runtime I/O (filesystem source loading) is delegated to the host — `wado-cli` on the desktop, an in-memory host in the browser.
-- No `catch_unwind` around compiler calls, deliberately: unwinding machinery is weight the browser build carries for a case that must not happen. A panic reaching the server is a compiler bug, and taking the server down says so; bad input belongs in a `Diagnostic` instead.
+- No `catch_unwind` around compiler calls, deliberately: a panic reaching the server is a compiler bug, and taking the server down says so. Bad input belongs in a `Diagnostic` instead.
 
 ## Architecture
 


### PR DESCRIPTION
Compiling a module bundled in the compiler — `core:prelude/string.wado`, `core:rt`, any of them — produces a component from that file's own source, so `wado check`, `wado dump` and a targeted `wado test` answer for it like any other file, reporting what the file on disk says.

## The snapshot's precondition

The stdlib snapshot caches whole declaration facts keyed by `DefId`s minted from its own parse, and a compile restoring them runs no decl pass for that module. Those facts read back correctly only while an `AstId` means the same node in both tables (WEP 2026-08-12 §1).

`stdlib_snapshot::reparsed_snapshot_module` states that condition and `semantics_with_logger` gates the snapshot on it: a compile holding its own parse of a cached module — an entry whose inner `stdlib` attribute names `core:…` — elaborates the closure from source. Any other way of reaching two parses of one identity is caught by the same check.

Bundled wasm assets meet the condition the way bundled sources do: `core:libm.wat`'s synthesized bindings go through a parse-once-per-process cache, its bytes being fixed at build time. A host-loaded asset can change between compiles, so it is parsed each time and never cached.

## Attribute diagnostics

The inner `stdlib` attribute names one of the modules bundled in the compiler, and every loaded module is held to that rule — an omitted name and a name no bundled module answers to are both spanned diagnostics, wherever the attribute is written. `wado-lsp/AGENTS.md` records why the language server holds no `catch_unwind`, so a malformed attribute has to be a `Diagnostic`.

An entry declaring an inner `wasm_module` attribute is rejected at link: its code is emitted into that separate core module, leaving nothing in the program's own module for the world to export.

Closes #1875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standard-library modules can now be compiled directly as supported entry points.
  * Unsupported WASM module entry points are rejected with a clear diagnostic.

* **Bug Fixes**
  * Added validation for standard-library identity declarations, including malformed or unsupported entries.
  * Improved cached standard-library snapshot validation to prevent stale or mismatched modules from being reused.
  * Replaced failures from invalid declarations with user-facing compilation errors.

* **Documentation**
  * Clarified standard-library identity behavior and project configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->