### PR TITLE
perf(optimizer): converge the NIR fixed-point loop and stop rebuilding whole-program tables

### DIFF
--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -22,7 +22,7 @@ All levels run DCE on functions, types, and globals.
 
 The inline budget counts emitted Wasm instructions on the callee's hot path, not NIR nodes — see [`inline`](#nir-passes) for the weights.
 
-The fixed-point loop exits early on convergence — which holds only while each pass reports a change when it changed something, not when it merely found work to look at. The backend-required rewrites (`select_lowering`, `multi_value_return`, `freeze_pure_arith`) and `match_to_switch` run at every level, including `-O0`.
+The fixed-point loop exits early on convergence, so a pass must report a change only when it made one, never when it merely found work to look at; a `gate_only!` pass reports to the dirty-set gate alone and never extends the loop. The backend-required rewrites (`select_lowering`, `multi_value_return`, `freeze_pure_arith`) and `match_to_switch` run at every level, including `-O0`.
 
 ## Architecture
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -22,7 +22,7 @@ All levels run DCE on functions, types, and globals.
 
 The inline budget counts emitted Wasm instructions on the callee's hot path, not NIR nodes — see [`inline`](#nir-passes) for the weights.
 
-The fixed-point loop exits early on convergence, which holds only while every pass reports a change when it changed something and not merely when it found work to look at — a pass that reports on the finding never lets the loop settle, and re-dirties its functions for every other pass each round. The backend-required rewrites (`select_lowering`, `multi_value_return`, `freeze_pure_arith`) and `match_to_switch` run at every level, including `-O0`.
+The fixed-point loop exits early on convergence — which holds only while each pass reports a change when it changed something, not when it merely found work to look at. The backend-required rewrites (`select_lowering`, `multi_value_return`, `freeze_pure_arith`) and `match_to_switch` run at every level, including `-O0`.
 
 ## Architecture
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -22,7 +22,7 @@ All levels run DCE on functions, types, and globals.
 
 The inline budget counts emitted Wasm instructions on the callee's hot path, not NIR nodes — see [`inline`](#nir-passes) for the weights.
 
-The fixed-point loop exits early on convergence. The backend-required rewrites (`select_lowering`, `multi_value_return`, `freeze_pure_arith`) and `match_to_switch` run at every level, including `-O0`.
+The fixed-point loop exits early on convergence, which holds only while every pass reports a change when it changed something and not merely when it found work to look at — a pass that reports on the finding never lets the loop settle, and re-dirties its functions for every other pass each round. The backend-required rewrites (`select_lowering`, `multi_value_return`, `freeze_pure_arith`) and `match_to_switch` run at every level, including `-O0`.
 
 ## Architecture
 

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -168,9 +168,12 @@ impl EngineBuffers {
         // keeps `build_indices`, which visits locals in body order, from growing
         // `uses` through several reallocations.
         for entry in &mut self.uses[..self.dirty_uses] {
-            entry.def = None;
-            entry.defs = 0;
-            entry.reads.clear();
+            let mut reads = std::mem::take(&mut entry.reads);
+            reads.clear();
+            *entry = LocalUses {
+                reads,
+                ..LocalUses::default()
+            };
         }
         if self.uses.len() < local_count {
             self.uses.resize_with(local_count, LocalUses::default);

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -114,9 +114,7 @@ pub struct EngineBuffers {
     /// `IndexMap` here would pay a hash + probe for every read/def recorded by
     /// `build_indices`, run on every one of the tens-of-thousands of sessions.
     uses: Vec<LocalUses>,
-    /// How many leading `uses` entries the last session may have written.
-    /// [`EngineBuffers::reset_for`] resets exactly those, so a small body does
-    /// not pay for the largest one seen.
+    /// Every `uses` entry at or past this index is already reset.
     dirty_uses: usize,
     worklist: VecDeque<NodeRef>,
     /// Traversal scratch for [`Engine::build_indices`], owned here for the same
@@ -161,12 +159,9 @@ impl EngineBuffers {
         fill_bit(&mut self.stmt_queued, body.stmts.len());
         fill_bit(&mut self.block_queued, body.blocks.len());
         fill_bit(&mut self.pat_queued, body.pats.len());
-        // Reset in place rather than `clear()`: dropping the entries frees every
-        // `reads` Vec, which `build_indices` then allocates all over again.
-        // Entries past `local_count` stay reset, reading the same as absent —
-        // every access is a bounds-checked `get`. Pre-sizing to `local_count`
-        // keeps `build_indices`, which visits locals in body order, from growing
-        // `uses` through several reallocations.
+        // Not `clear()`: that frees every `reads` Vec `build_indices` then
+        // reallocates. Entries past `local_count` stay reset, which every
+        // `uses.get` reads as absent.
         for entry in &mut self.uses[..self.dirty_uses] {
             let mut reads = std::mem::take(&mut entry.reads);
             reads.clear();

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -114,6 +114,10 @@ pub struct EngineBuffers {
     /// `IndexMap` here would pay a hash + probe for every read/def recorded by
     /// `build_indices`, run on every one of the tens-of-thousands of sessions.
     uses: Vec<LocalUses>,
+    /// How many leading `uses` entries the last session may have written.
+    /// [`EngineBuffers::reset_for`] resets exactly those, so a small body does
+    /// not pay for the largest one seen.
+    dirty_uses: usize,
     worklist: VecDeque<NodeRef>,
     /// Traversal scratch for [`Engine::build_indices`], owned here for the same
     /// reason as everything else in this struct: a session per pass per
@@ -157,12 +161,21 @@ impl EngineBuffers {
         fill_bit(&mut self.stmt_queued, body.stmts.len());
         fill_bit(&mut self.block_queued, body.blocks.len());
         fill_bit(&mut self.pat_queued, body.pats.len());
-        // Pre-sized to `local_count` like the vecs above, so `build_indices`
-        // (which visits locals in body order, not index order) doesn't grow
-        // `uses` through several reallocations; `uses_entry` still grows it
-        // further on demand for a local `alloc_local`d past this count.
-        self.uses.clear();
-        self.uses.resize_with(local_count, LocalUses::default);
+        // Reset in place rather than `clear()`: dropping the entries frees every
+        // `reads` Vec, which `build_indices` then allocates all over again.
+        // Entries past `local_count` stay reset, reading the same as absent —
+        // every access is a bounds-checked `get`. Pre-sizing to `local_count`
+        // keeps `build_indices`, which visits locals in body order, from growing
+        // `uses` through several reallocations.
+        for entry in &mut self.uses[..self.dirty_uses] {
+            entry.def = None;
+            entry.defs = 0;
+            entry.reads.clear();
+        }
+        if self.uses.len() < local_count {
+            self.uses.resize_with(local_count, LocalUses::default);
+        }
+        self.dirty_uses = local_count;
         self.worklist.clear();
         self.elided_locals.clear();
     }
@@ -174,6 +187,7 @@ impl EngineBuffers {
         if self.uses.len() <= i {
             self.uses.resize_with(i + 1, LocalUses::default);
         }
+        self.dirty_uses = self.dirty_uses.max(i + 1);
         &mut self.uses[i]
     }
 

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -473,6 +473,9 @@ fn run_optimization_passes(
     // changes; see `ConstFoldCache`.
     let mut const_fold_cache: Option<ConstFoldCache> = None;
     let mut param_spec_state = param_spec::ParamSpecState::default();
+    // Callee descriptors, appended to rather than rebuilt each round; see
+    // `DescriptorCache`.
+    let mut descriptor_cache = dce::DescriptorCache::default();
     // Dense `Match` → `Switch` in global initializer bodies. Functions are
     // lowered by `MatchToSwitchRule` inside the unified peephole session; the
     // function-level loop never mutates global initializer bodies, so a single
@@ -531,7 +534,11 @@ fn run_optimization_passes(
         // it. Runs before `nir/inline`, where the `$value_copy$T(arg)` shape it
         // matches disappears. (Copies are inserted precisely at the lower phase,
         // so there is no elision pass to sequence against.)
-        gate_only!("nir/value_copy_demote", demote_value_copies);
+        gate_only!("nir/value_copy_demote", |p, g| demote_value_copies(
+            p,
+            g,
+            &mut descriptor_cache
+        ));
         // Single-field parameter SROA: rewrite functions whose parameter type
         // is `&S` for a single-field struct (`Box<T>` being the canonical
         // case) to take the inner scalar directly. Runs before `nir/inline`
@@ -551,7 +558,7 @@ fn run_optimization_passes(
         // re-examine just those (and their neighbours).
         {
             let c = run_pass("nir/inline", project, profiler, |p| {
-                inline_functions(p, threshold, &mut gate)
+                inline_functions(p, threshold, &mut gate, &mut descriptor_cache)
             });
             if c {
                 changed = true;

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -473,8 +473,6 @@ fn run_optimization_passes(
     // changes; see `ConstFoldCache`.
     let mut const_fold_cache: Option<ConstFoldCache> = None;
     let mut param_spec_state = param_spec::ParamSpecState::default();
-    // Callee descriptors, appended to rather than rebuilt each round; see
-    // `DescriptorCache`.
     let mut descriptor_cache = dce::DescriptorCache::default();
     // Dense `Match` → `Switch` in global initializer bodies. Functions are
     // lowered by `MatchToSwitchRule` inside the unified peephole session; the

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -150,6 +150,42 @@ pub fn analyze_dce(project: &mut NirPackage) -> DceAnalysis {
 /// The callee [`FunctionRef`] descriptor for every function, indexed by
 /// `func_id.index()` (== store position). Used so a call site's identity is read
 /// by its stamped `func_id` rather than the call node's own `FunctionRef`.
+/// The descriptor table, reused across the fixed-point loop's rounds. Inside the
+/// loop a function's identity is fixed and the store only grows — `dce`, the one
+/// pass that removes and renumbers functions, runs outside it — so a round
+/// appends the newcomers instead of rebuilding all of them. Rebuilding cost the
+/// gale compile ~3% of its wall clock: `inline` and `value_copy_demote` each
+/// rebuilt every round, cloning a name, a `MonomorphInfo` and a
+/// `LocalMethodName` per function.
+#[derive(Default)]
+pub(super) struct DescriptorCache {
+    refs: Vec<FunctionRef>,
+}
+
+impl DescriptorCache {
+    pub(super) fn descriptors(&mut self, project: &NirPackage) -> &[FunctionRef] {
+        debug_assert!(
+            self.refs.len() <= project.functions.len(),
+            "descriptor cache outlived a function removal"
+        );
+        for func_rc in &project.functions[self.refs.len()..] {
+            let f = func_rc.borrow();
+            self.refs
+                .push(FunctionRef::from_resolved(&f, f.module_source.clone()));
+        }
+        debug_assert!(
+            self.refs.iter().zip(&project.functions).all(|(d, f)| {
+                let f = f.borrow();
+                d.name == f.name
+                    && d.method_info.as_ref().map(|i| &i.method_name)
+                        == f.method_info.as_ref().map(|i| &i.method_name)
+            }),
+            "a cached descriptor went stale: a function was renamed in place"
+        );
+        &self.refs
+    }
+}
+
 pub(super) fn build_callee_descriptors(project: &NirPackage) -> Vec<FunctionRef> {
     project
         .functions

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -147,12 +147,8 @@ pub fn analyze_dce(project: &mut NirPackage) -> DceAnalysis {
     analysis
 }
 
-/// The table of [`build_callee_descriptors`], reused across the fixed-point
-/// loop's rounds. Inside the loop a function's identity is fixed and the store
-/// only grows — `dce`, the one pass that removes and renumbers functions, runs
-/// outside it — so a round appends the newcomers instead of rebuilding every
-/// entry, each of which clones a name, a `MonomorphInfo` and a
-/// `LocalMethodName`.
+/// The table of [`build_callee_descriptors`], appended to across the fixed-point
+/// loop's rounds rather than rebuilt.
 #[derive(Default)]
 pub(super) struct DescriptorCache {
     refs: Vec<FunctionRef>,

--- a/wado-compiler/src/optimize/dce.rs
+++ b/wado-compiler/src/optimize/dce.rs
@@ -147,16 +147,12 @@ pub fn analyze_dce(project: &mut NirPackage) -> DceAnalysis {
     analysis
 }
 
-/// The callee [`FunctionRef`] descriptor for every function, indexed by
-/// `func_id.index()` (== store position). Used so a call site's identity is read
-/// by its stamped `func_id` rather than the call node's own `FunctionRef`.
-/// The descriptor table, reused across the fixed-point loop's rounds. Inside the
-/// loop a function's identity is fixed and the store only grows — `dce`, the one
-/// pass that removes and renumbers functions, runs outside it — so a round
-/// appends the newcomers instead of rebuilding all of them. Rebuilding cost the
-/// gale compile ~3% of its wall clock: `inline` and `value_copy_demote` each
-/// rebuilt every round, cloning a name, a `MonomorphInfo` and a
-/// `LocalMethodName` per function.
+/// The table of [`build_callee_descriptors`], reused across the fixed-point
+/// loop's rounds. Inside the loop a function's identity is fixed and the store
+/// only grows — `dce`, the one pass that removes and renumbers functions, runs
+/// outside it — so a round appends the newcomers instead of rebuilding every
+/// entry, each of which clones a name, a `MonomorphInfo` and a
+/// `LocalMethodName`.
 #[derive(Default)]
 pub(super) struct DescriptorCache {
     refs: Vec<FunctionRef>,
@@ -186,6 +182,9 @@ impl DescriptorCache {
     }
 }
 
+/// The callee [`FunctionRef`] descriptor for every function, indexed by
+/// `func_id.index()` (== store position). Used so a call site's identity is read
+/// by its stamped `func_id` rather than the call node's own `FunctionRef`.
 pub(super) fn build_callee_descriptors(project: &NirPackage) -> Vec<FunctionRef> {
     project
         .functions

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -1036,11 +1036,12 @@ pub fn inline_functions(
     project: &mut NirPackage,
     inline_threshold: usize,
     gate: &mut FunctionGate,
+    descriptor_cache: &mut super::dce::DescriptorCache,
 ) -> bool {
     // Callee identity by `func_id` (descriptor table built once from the records,
     // borrow-safe), so a call site is recognized by its stamped id rather than the
     // call node's `FunctionRef`. Indexed by `func_id.index()` (== store position).
-    let descriptors = super::dce::build_callee_descriptors(project);
+    let descriptors = descriptor_cache.descriptors(project);
     let recursive_functions = find_recursive_functions(&project.functions);
 
     // Collect inline candidates from all modules, keyed by `FuncId` (the

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -1094,7 +1094,7 @@ pub fn inline_functions(
             &recursive_functions,
             &type_table,
             inline_threshold,
-            &descriptors,
+            descriptors,
             &foldable,
             &loopy,
         );
@@ -1178,7 +1178,7 @@ pub fn inline_functions(
                     body,
                     root,
                     &inline_candidates,
-                    &descriptors,
+                    descriptors,
                     &mut frame,
                     &project.type_table.borrow(),
                     &mut inlined_funcs,

--- a/wado-compiler/src/optimize/mod_ref.rs
+++ b/wado-compiler/src/optimize/mod_ref.rs
@@ -801,7 +801,16 @@ pub(super) fn compute_fn_effects(
     use cranelift_entity::EntityRef;
 
     let mut effects = vec![FnEffect::default(); funcs.len()];
-    let mut callees: Vec<IndexSet<usize>> = vec![IndexSet::default(); funcs.len()];
+    // Callee edges as one flat run per function (`callee_edges[range_of[i]]`)
+    // rather than a per-function `IndexSet`: this runs three times per
+    // fixed-point round over every function in the package, and an owned set
+    // each would be tens of thousands of allocations per call. `last_seen`
+    // dedups within a run — a repeat would only re-merge a summary already
+    // absorbed.
+    let mut callee_edges: Vec<usize> = Vec::new();
+    let mut edge_ranges: Vec<(usize, usize)> = vec![(0, 0); funcs.len()];
+    let mut last_seen: Vec<usize> = vec![usize::MAX; funcs.len()];
+    let mut stack: Vec<NodeRef> = Vec::new();
 
     for (i, f) in funcs.iter().enumerate() {
         let f = f.borrow();
@@ -810,7 +819,9 @@ pub(super) fn compute_fn_effects(
             continue;
         };
         let mut own = FnEffect::default();
-        let mut stack = vec![NodeRef::Block(body.root)];
+        let edge_start = callee_edges.len();
+        stack.clear();
+        stack.push(NodeRef::Block(body.root));
         while let Some(node) = stack.pop() {
             if let NodeRef::Expr(id) = node {
                 match &body.exprs[id].kind {
@@ -822,7 +833,11 @@ pub(super) fn compute_fn_effects(
                     }
                     // A direct call's trap arrives with its callee's summary.
                     ExprKind::Call { func_id, .. } => {
-                        callees[i].insert(func_id.index());
+                        let callee = func_id.index();
+                        if last_seen.get(callee).is_some_and(|&run| run != i) {
+                            last_seen[callee] = i;
+                            callee_edges.push(callee);
+                        }
                     }
                     _ => own.may_trap |= super::arena_query::expr_node_may_trap(body, id),
                 }
@@ -835,12 +850,14 @@ pub(super) fn compute_fn_effects(
             own.opaque = true;
         }
         effects[i] = own;
+        edge_ranges[i] = (edge_start, callee_edges.len());
     }
 
     loop {
         let mut changed = false;
         for i in 0..effects.len() {
-            let merged = callees[i]
+            let (lo, hi) = edge_ranges[i];
+            let merged = callee_edges[lo..hi]
                 .iter()
                 .filter_map(|&c| effects.get(c).copied())
                 .fold(effects[i], |mut acc, e| {

--- a/wado-compiler/src/optimize/mod_ref.rs
+++ b/wado-compiler/src/optimize/mod_ref.rs
@@ -801,12 +801,8 @@ pub(super) fn compute_fn_effects(
     use cranelift_entity::EntityRef;
 
     let mut effects = vec![FnEffect::default(); funcs.len()];
-    // Callee edges as one flat run per function (`callee_edges[range_of[i]]`)
-    // rather than a per-function `IndexSet`: this runs three times per
-    // fixed-point round over every function in the package, and an owned set
-    // each would be tens of thousands of allocations per call. `last_seen`
-    // dedups within a run — a repeat would only re-merge a summary already
-    // absorbed.
+    // Callee edges as one flat run per function rather than an `IndexSet` each:
+    // this walks every function in the package three times per fixed-point round.
     let mut callee_edges: Vec<usize> = Vec::new();
     let mut edge_ranges: Vec<(usize, usize)> = vec![(0, 0); funcs.len()];
     let mut last_seen: Vec<usize> = vec![usize::MAX; funcs.len()];

--- a/wado-compiler/src/optimize/sroa_variant_return.rs
+++ b/wado-compiler/src/optimize/sroa_variant_return.rs
@@ -136,7 +136,7 @@ pub fn scalarize_variant_returns(project: &mut NirPackage, gate: &mut FunctionGa
     let scalarized = scalarized_returns(project);
     let mut all = candidates.clone();
     for (&key, (variant_type, layout)) in &scalarized {
-        all.entry(key).or_insert(Candidate {
+        all.entry(key).or_insert_with(|| Candidate {
             layout: layout.clone(),
             variant_type: *variant_type,
         });

--- a/wado-compiler/src/optimize/sroa_variant_return.rs
+++ b/wado-compiler/src/optimize/sroa_variant_return.rs
@@ -133,11 +133,12 @@ pub fn scalarize_variant_returns(project: &mut NirPackage, gate: &mut FunctionGa
     // round would otherwise revisit — and those sites are usually perfectly
     // handleable, just not yet bound. Reboxing them without trying would give
     // up the optimization on the very sites inlining just made hot.
+    let scalarized = scalarized_returns(project);
     let mut all = candidates.clone();
-    for (key, (variant_type, layout)) in scalarized_returns(project) {
+    for (&key, (variant_type, layout)) in &scalarized {
         all.entry(key).or_insert(Candidate {
-            layout,
-            variant_type,
+            layout: layout.clone(),
+            variant_type: *variant_type,
         });
     }
     rewrite_call_sites(project, &all, &mut touched);
@@ -152,7 +153,7 @@ pub fn scalarize_variant_returns(project: &mut NirPackage, gate: &mut FunctionGa
     }
     // Only now: whatever the rewrite above declined is a straggler, and it is
     // one the moment its callee's signature changed — not an iteration later.
-    changed |= rebox_stragglers(project, gate);
+    changed |= rebox_stragglers(project, &scalarized, gate);
     debug_assert_call_sites_rewritten(project);
     changed
 }
@@ -166,8 +167,11 @@ pub fn scalarize_variant_returns(project: &mut NirPackage, gate: &mut FunctionGa
 /// `f(x)` ⇒ `{ let __t = f(x); match __t.0 { 0 => Ok(__t.1!), _ => Err(__t.2!) } }`.
 /// This is what makes the rewrite sound without validation — `nir/inline` keeps
 /// planting call sites after a callee's signature is already committed.
-fn rebox_stragglers(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
-    let scalarized = scalarized_returns(project);
+fn rebox_stragglers(
+    project: &mut NirPackage,
+    scalarized: &IndexMap<FuncId, (TypeId, Layout)>,
+    gate: &mut FunctionGate,
+) -> bool {
     if scalarized.is_empty() {
         return false;
     }
@@ -178,20 +182,26 @@ fn rebox_stragglers(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
         let Some(mut body) = func.body.take() else {
             continue;
         };
+        // Every step below keys on a call to a scalarized callee; without one
+        // they all walk the body to find nothing.
+        if !calls_any(&body, scalarized) {
+            func.body = Some(body);
+            continue;
+        }
         let span = func.span;
-        let bound = handled_call_sites(&body, &scalarized, own_return);
+        let bound = handled_call_sites(&body, scalarized, own_return);
         let mut targets: Vec<ExprId> = Vec::new();
         collect_straggler_calls(
             &body,
             NodeRef::Block(body.root),
-            &scalarized,
+            scalarized,
             &bound,
             &mut targets,
         );
         let reboxed = !targets.is_empty();
         for call in targets {
             crate::compiler_trace!("sroa_variant_return", "reboxing a call in {}", func.name);
-            rebox_call(&mut body, &mut func.locals, call, &scalarized, span);
+            rebox_call(&mut body, &mut func.locals, call, scalarized, span);
         }
         func.body = Some(body);
         if reboxed {
@@ -199,8 +209,17 @@ fn rebox_stragglers(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
             changed = true;
         }
     }
-    changed |= rebox_stragglers_in_globals(project, &scalarized);
+    changed |= rebox_stragglers_in_globals(project, scalarized);
     changed
+}
+
+/// Whether `body` calls any function in `targets` — an arena scan that decides
+/// in one pass whether the tree walks keyed on such a call have anything to
+/// find. Nearly every function in a package calls none of them.
+fn calls_any<V>(body: &Body, targets: &IndexMap<FuncId, V>) -> bool {
+    body.exprs.values().any(|node| {
+        matches!(&node.kind, ExprKind::Call { func_id, .. } if targets.contains_key(func_id))
+    })
 }
 
 /// The same repair over the global initializers. They are never rewritten —
@@ -2043,6 +2062,12 @@ fn rewrite_call_sites(
         let Some(mut body) = func.body.take() else {
             continue;
         };
+        // Every step below keys on a call to a candidate; without one they all
+        // walk the body to find nothing.
+        if !calls_any(&body, candidates) {
+            func.body = Some(body);
+            continue;
+        }
         let span = func.span;
         let mut changed = retype_candidate_calls(&mut body, candidates);
         // Hoisting appends the tuple temps; it never renumbers an existing

--- a/wado-compiler/src/optimize/sroa_variant_return.rs
+++ b/wado-compiler/src/optimize/sroa_variant_return.rs
@@ -2062,8 +2062,10 @@ fn rewrite_call_sites(
         if !bound.is_empty() {
             for (&local, &f) in &bound {
                 let tuple_type = candidates[&f].layout.tuple_type;
-                func.locals[local as usize].type_id = tuple_type;
-                retype_let(&mut body, local, tuple_type);
+                let slot = &mut func.locals[local as usize].type_id;
+                changed |= *slot != tuple_type;
+                *slot = tuple_type;
+                changed |= retype_let(&mut body, local, tuple_type);
             }
             let names: Vec<String> = func.locals.iter().map(|l| l.name.clone()).collect();
             let root = body.root;
@@ -2074,8 +2076,7 @@ fn rewrite_call_sites(
                 rebind: &rebind,
                 span,
             };
-            rewrite_temp_uses(&mut body, NodeRef::Block(root), &mut cx);
-            changed = true;
+            changed |= rewrite_temp_uses(&mut body, NodeRef::Block(root), &mut cx);
         }
         func.body = Some(body);
         if changed {
@@ -2107,7 +2108,8 @@ fn retype_candidate_calls(body: &mut Body, candidates: &IndexMap<FuncId, Candida
 /// Retype the binding statement and every read of the bound temp. The local's
 /// own entry is retyped by the caller; a `Let` and each `Local` node carry
 /// their own copy.
-fn retype_let(body: &mut Body, local: u32, tuple_type: TypeId) {
+fn retype_let(body: &mut Body, local: u32, tuple_type: TypeId) -> bool {
+    let mut changed = false;
     for stmt in body.stmts.values_mut() {
         if let StmtKind::Let {
             local_index,
@@ -2115,17 +2117,22 @@ fn retype_let(body: &mut Body, local: u32, tuple_type: TypeId) {
             ..
         } = &mut stmt.kind
             && *local_index == local
+            && *type_id != tuple_type
         {
             *type_id = tuple_type;
+            changed = true;
         }
     }
     for node in body.exprs.values_mut() {
         if let ExprKind::Local { index, .. } = &node.kind
             && *index == local
+            && node.type_id != tuple_type
         {
             node.type_id = tuple_type;
+            changed = true;
         }
     }
+    changed
 }
 
 /// Read-only context for the call-site rewrite over one body.
@@ -2256,7 +2263,8 @@ fn collect_call_scrutinees(
 }
 
 /// Rewrite every destructuring read of a tuple-bound temp.
-fn rewrite_temp_uses(body: &mut Body, node: NodeRef, cx: &mut SiteCx) {
+fn rewrite_temp_uses(body: &mut Body, node: NodeRef, cx: &mut SiteCx) -> bool {
+    let mut changed = false;
     if let NodeRef::Expr(e) = node {
         match body.exprs[e].kind.clone() {
             ExprKind::VariantTag { expr } => {
@@ -2265,7 +2273,7 @@ fn rewrite_temp_uses(body: &mut Body, node: NodeRef, cx: &mut SiteCx) {
                     let kind = tag_read(body, local, tuple_type, cx);
                     body.exprs[e].kind = kind;
                     body.exprs[e].type_id = TypeTable::I32;
-                    return;
+                    return true;
                 }
             }
             ExprKind::VariantTest {
@@ -2290,7 +2298,7 @@ fn rewrite_temp_uses(body: &mut Body, node: NodeRef, cx: &mut SiteCx) {
                         right: k,
                     };
                     body.exprs[e].type_id = TypeTable::BOOL;
-                    return;
+                    return true;
                 }
             }
             ExprKind::VariantPayload {
@@ -2301,19 +2309,20 @@ fn rewrite_temp_uses(body: &mut Body, node: NodeRef, cx: &mut SiteCx) {
                     let read = slot_read(body, local, &layout, case_index, cx);
                     body.exprs[e].kind = body.exprs[read].kind.clone();
                     body.exprs[e].type_id = body.exprs[read].type_id;
-                    return;
+                    return true;
                 }
             }
             ExprKind::Match { expr: scrut, arms } => {
                 if let Some(local) = temp_local(body, scrut, cx.bound) {
                     let layout = cx.layout_of(local).clone();
                     rewrite_match_on_temp(body, e, local, &layout, arms, cx);
+                    changed = true;
                 }
             }
             // The destructure itself: leaving it alone keeps a rebuild from
             // nesting under the field reads it planted, which it cannot tell apart.
             ExprKind::FieldAccess { expr, .. } if temp_local(body, expr, cx.bound).is_some() => {
-                return;
+                return false;
             }
             // A read of the temp wants the variant whole; the tuple holds it.
             ExprKind::Local { index, .. } if cx.bound.contains_key(&index) => {
@@ -2323,7 +2332,7 @@ fn rewrite_temp_uses(body: &mut Body, node: NodeRef, cx: &mut SiteCx) {
                 let rebuilt = rebuild_variant(body, index, &name, variant_type, &layout, cx.span);
                 body.exprs[e].kind = body.exprs[rebuilt].kind.clone();
                 body.exprs[e].type_id = variant_type;
-                return;
+                return true;
             }
             _ => {}
         }
@@ -2331,8 +2340,9 @@ fn rewrite_temp_uses(body: &mut Body, node: NodeRef, cx: &mut SiteCx) {
     let mut kids = Vec::new();
     body.for_each_child(node, |c| kids.push(c));
     for c in kids {
-        rewrite_temp_uses(body, c, cx);
+        changed |= rewrite_temp_uses(body, c, cx);
     }
+    changed
 }
 
 /// Whether every mention of `local` is one the rewrite lowers: a destructure, or

--- a/wado-compiler/src/optimize/sroa_variant_return.rs
+++ b/wado-compiler/src/optimize/sroa_variant_return.rs
@@ -2107,12 +2107,10 @@ fn rewrite_call_sites(
     }
 }
 
-/// Retype every reachable call to a rewritten callee. The node's own `type_id`
-/// is what downstream passes and `wir_build` read; leaving the variant there
-/// would make a tuple-returning call claim to produce a boxed variant. Reports
-/// `changed` only when a type actually moved, and only over the nodes that run
-/// — retyping one an earlier rewrite orphaned re-dirties the caller for a node
-/// no consumer reads.
+/// Retype every reachable call to a rewritten callee: the node's own `type_id` is
+/// what downstream passes and `wir_build` read, and a variant left there makes a
+/// tuple-returning call claim to produce a boxed one. Reports `changed` only when
+/// a type moved on a node that runs.
 fn retype_candidate_calls(body: &mut Body, candidates: &IndexMap<FuncId, Candidate>) -> bool {
     let mut changed = false;
     for e in crate::nir_visitor::reachable_exprs(body) {

--- a/wado-compiler/src/optimize/sroa_variant_return.rs
+++ b/wado-compiler/src/optimize/sroa_variant_return.rs
@@ -182,8 +182,7 @@ fn rebox_stragglers(
         let Some(mut body) = func.body.take() else {
             continue;
         };
-        // Every step below keys on a call to a scalarized callee; without one
-        // they all walk the body to find nothing.
+        // Every step below keys on a call to a scalarized callee.
         if !calls_any(&body, scalarized) {
             func.body = Some(body);
             continue;
@@ -213,9 +212,8 @@ fn rebox_stragglers(
     changed
 }
 
-/// Whether `body` calls any function in `targets` — an arena scan that decides
-/// in one pass whether the tree walks keyed on such a call have anything to
-/// find. Nearly every function in a package calls none of them.
+/// Whether `body` calls any function in `targets` — one arena scan, far cheaper
+/// than the tree walks it gates.
 fn calls_any<V>(body: &Body, targets: &IndexMap<FuncId, V>) -> bool {
     body.exprs.values().any(|node| {
         matches!(&node.kind, ExprKind::Call { func_id, .. } if targets.contains_key(func_id))
@@ -2062,8 +2060,7 @@ fn rewrite_call_sites(
         let Some(mut body) = func.body.take() else {
             continue;
         };
-        // Every step below keys on a call to a candidate; without one they all
-        // walk the body to find nothing.
+        // Every step below keys on a call to a candidate.
         if !calls_any(&body, candidates) {
             func.body = Some(body);
             continue;

--- a/wado-compiler/src/optimize/sroa_variant_return.rs
+++ b/wado-compiler/src/optimize/sroa_variant_return.rs
@@ -2107,15 +2107,16 @@ fn rewrite_call_sites(
     }
 }
 
-/// Retype every call to a rewritten callee. The node's own `type_id` is what
-/// downstream passes and `wir_build` read; leaving the variant there would make
-/// a tuple-returning call claim to produce a boxed variant.
-/// Reports `changed` only when a type actually moved. Reporting the write
-/// itself re-dirties every caller of every scalarized function on each round,
-/// and the gate then never quiesces.
+/// Retype every reachable call to a rewritten callee. The node's own `type_id`
+/// is what downstream passes and `wir_build` read; leaving the variant there
+/// would make a tuple-returning call claim to produce a boxed variant. Reports
+/// `changed` only when a type actually moved, and only over the nodes that run
+/// — retyping one an earlier rewrite orphaned re-dirties the caller for a node
+/// no consumer reads.
 fn retype_candidate_calls(body: &mut Body, candidates: &IndexMap<FuncId, Candidate>) -> bool {
     let mut changed = false;
-    for node in body.exprs.values_mut() {
+    for e in crate::nir_visitor::reachable_exprs(body) {
+        let node = &mut body.exprs[e];
         if let ExprKind::Call { func_id, .. } = &node.kind
             && let Some(cand) = candidates.get(func_id)
             && node.type_id != cand.layout.tuple_type

--- a/wado-compiler/src/optimize/value_copy_demote.rs
+++ b/wado-compiler/src/optimize/value_copy_demote.rs
@@ -38,7 +38,11 @@ fn builtin_gname(func: &FunctionRef) -> Option<String> {
 /// Returns whether anything changed (a binding was retargeted or a shallow
 /// specialization was added), so the optimizer's dirty-set gate can re-examine
 /// the touched functions and accommodate the new ones.
-pub fn demote_value_copies(project: &mut NirPackage, gate: &mut FunctionGate) -> bool {
+pub fn demote_value_copies(
+    project: &mut NirPackage,
+    gate: &mut FunctionGate,
+    descriptor_cache: &mut super::dce::DescriptorCache,
+) -> bool {
     // Intern the `array_clone_shallow` builtin the synthesized twins call, so
     // those calls are born resolved. One id serves all instantiations (the key
     // ignores type args, which ride the node).
@@ -54,7 +58,7 @@ pub fn demote_value_copies(project: &mut NirPackage, gate: &mut FunctionGate) ->
     // stamped `func_id`, not the call node's `FunctionRef`. Built after the
     // `array_clone_shallow` intern so it includes that stub; the later synthesis
     // (Phase 2a) appends shallow twins, but no recognizer reads those by id.
-    let descriptors = super::dce::build_callee_descriptors(project);
+    let descriptors = descriptor_cache.descriptors(project);
 
     // Identify `$value_copy$T` helpers whose body is an `List<E>` wrapper
     // copy: `return StructLiteral { repr: array_clone(v.repr), used: ... }`,

--- a/wado-compiler/src/optimize/value_copy_demote.rs
+++ b/wado-compiler/src/optimize/value_copy_demote.rs
@@ -66,12 +66,12 @@ pub fn demote_value_copies(
     let mut list_wrapper_copies: IndexSet<FuncKey> = IndexSet::default();
     {
         let type_table = project.type_table.borrow();
-        let variant_reaching = helpers_reaching_variant_copies(project, &descriptors, &type_table);
+        let variant_reaching = helpers_reaching_variant_copies(project, descriptors, &type_table);
         for f in &project.functions {
             let f = f.borrow();
             if f.value_copy_type().is_some()
                 && let Some(body) = &f.body
-                && body_is_list_wrapper_copy(body, &descriptors)
+                && body_is_list_wrapper_copy(body, descriptors)
                 && let Some(id) = f.id
                 && !variant_reaching.contains(&id)
             {
@@ -91,7 +91,7 @@ pub fn demote_value_copies(
     let type_table = project.type_table.clone();
     let mut analyzer = Analyzer {
         funcs: &project.functions,
-        descriptors: &descriptors,
+        descriptors,
         type_table: &type_table,
         eimm_memo: IndexMap::default(),
     };
@@ -172,7 +172,7 @@ pub fn demote_value_copies(
         next += 1;
         shallow.id = Some(id);
         if let Some(body) = &mut shallow.body {
-            rewrite_array_clone_to_shallow(body, array_clone_shallow_id, &descriptors);
+            rewrite_array_clone_to_shallow(body, array_clone_shallow_id, descriptors);
         }
         let key = FunctionRef::from_resolved(&shallow, shallow.module_source.clone()).function_id();
         project.func_index.insert(key, id);

--- a/wado-compiler/tests/integration/main.rs
+++ b/wado-compiler/tests/integration/main.rs
@@ -40,6 +40,7 @@ mod literals;
 mod loader_canonical_identity;
 mod match_place_scrutinee;
 mod niri;
+mod opt_loop_convergence;
 mod redundant_bce;
 mod remarks;
 mod scalar_read_move;

--- a/wado-compiler/tests/integration/opt_loop_convergence.rs
+++ b/wado-compiler/tests/integration/opt_loop_convergence.rs
@@ -1,0 +1,79 @@
+//! The NIR fixed-point loop must converge, not run to its iteration cap.
+//!
+//! `sroa_variant_return` reported a change on every round for a call site it
+//! had already rewritten, so the loop ran the full cap (10 rounds at `-O2`,
+//! 30 at `-O3`) on any program with a scalarized variant return — and every
+//! other gated pass re-scanned the functions it re-dirtied.
+
+use wado_compiler::{Code, CompilerOptions, LogLevel, OptLevel, Severity};
+
+const SOURCE: &str = r#"
+#[inline("never")]
+fn lookup(xs: &List<i32>, key: i32) -> Result<i32, String> {
+    let mut i = 0;
+    while i < xs.len() {
+        if xs[i] == key {
+            return Result::<i32, String>::Ok(i as i32);
+        }
+        i = i + 1;
+    }
+    return Result::<i32, String>::Err(`missing ${key}`);
+}
+
+#[inline("never")]
+fn describe(xs: &List<i32>, key: i32) -> String {
+    let found = lookup(xs, key);
+    match found {
+        Ok(i) => { return `at ${i}`; }
+        Err(e) => { return e; }
+    }
+}
+
+export fn run() {
+    let xs: List<i32> = [3, 1, 4, 1, 5];
+    assert describe(&xs, 4) == "at 2";
+    assert describe(&xs, 9) == "missing 9";
+}
+"#;
+
+/// How many `nir/iteration N` spans the optimizer opened.
+fn iterations_run(opt_level: OptLevel) -> usize {
+    let host = crate::common::InMemoryHost::new();
+    let options = CompilerOptions {
+        opt_level,
+        log_level: Some(LogLevel::Debug),
+        ..Default::default()
+    };
+    crate::common::runtime()
+        .block_on(wado_compiler::compile_with_options(
+            SOURCE,
+            &host,
+            Some("opt_loop_convergence.wado"),
+            options,
+        ))
+        .expect("compilation should succeed");
+
+    host.diagnostics()
+        .iter()
+        .filter(|d| {
+            d.severity == Severity::Debug
+                && d.code == Code::SpanStart
+                && d.message.starts_with("nir/iteration ")
+        })
+        .count()
+}
+
+#[test]
+fn nir_loop_converges_before_the_cap() {
+    let o2 = iterations_run(OptLevel::O2);
+    assert!(
+        o2 < 10,
+        "-O2 ran the full iteration cap ({o2}); the loop did not converge"
+    );
+
+    let o3 = iterations_run(OptLevel::O3);
+    assert!(
+        o3 < 30,
+        "-O3 ran the full iteration cap ({o3}); the loop did not converge"
+    );
+}

--- a/wado-compiler/tests/integration/opt_loop_convergence.rs
+++ b/wado-compiler/tests/integration/opt_loop_convergence.rs
@@ -1,9 +1,6 @@
 //! The NIR fixed-point loop must converge, not run to its iteration cap.
-//!
-//! `sroa_variant_return` reported a change on every round for a call site it
-//! had already rewritten, so the loop ran the full cap (10 rounds at `-O2`,
-//! 30 at `-O3`) on any program with a scalarized variant return — and every
-//! other gated pass re-scanned the functions it re-dirtied.
+//! `sroa_variant_return` reported a change every round for a call site it had
+//! already rewritten, which held the loop open to the cap.
 
 use wado_compiler::{Code, CompilerOptions, LogLevel, OptLevel, Severity};
 
@@ -36,7 +33,6 @@ export fn run() {
 }
 "#;
 
-/// How many `nir/iteration N` spans the optimizer opened.
 fn iterations_run(opt_level: OptLevel) -> usize {
     let host = crate::common::InMemoryHost::new();
     let options = CompilerOptions {


### PR DESCRIPTION
A loop pass reports a change when it changed something, not when it found work to look at. `sroa_variant_return`'s call-site rewrite reports on a type it actually moved or a use it actually rewrote, so the fixed-point loop settles instead of running to its iteration cap on any program with a scalarized variant return. `wado compile package-gale/src/main.wado` converges at round 7 at both `-O2` (cap 10) and `-O3` (cap 30).

The rest is work the loop was doing over and over:

- `sroa_variant_return` decides with one arena scan whether a body calls a scalarized callee at all, and takes `scalarized_returns` once per invocation. Every step of the call-site rewrite and the straggler rebox keys on such a call, and nearly no function has one.
- `DescriptorCache` (`optimize/dce.rs`) holds the callee-descriptor table across the loop's rounds. Inside the loop no entry's identity changes and the store only grows — `dce`, which removes and renumbers functions, runs outside it — so `inline` and `value_copy_demote` append the newcomers rather than rebuild 27k entries each, every one of which clones a name, a `MonomorphInfo` and a `LocalMethodName`. Two debug assertions hold the preconditions.
- `compute_fn_effects` carries callee edges as one flat run per function and one hoisted walk stack, instead of an `IndexSet` and a stack per function. It walks the whole package three times per round.
- `EngineBuffers::reset_for` resets the dirty prefix of the local-use index in place, keeping each `LocalUses`'s `reads` allocation across the tens of thousands of engine sessions a compile opens.

`tests/integration/opt_loop_convergence.rs` pins the contract: a program with a variant-returning callee bound to a `match` temp must converge under the cap at `-O2` and `-O3`.

## Effect

Dev-profile `wado compile`, min of N on a 4-core host:

| | |
| --- | ---: |
| `package-gale/src/main.wado` `-O2` | 35.5s |
| `package-gale/src/main.wado` `-O3` | 104.6s |
| `package-gale-highlight-wado/src/main.wado` `-O2`, warm Kiln | 9.0s |

`optimize` is ~70% of a `package-gale` compile, and the loop is most of that.

These are scheduling and allocation changes only — no pass decides differently. The emitted Wasm for `package-gale` is byte-identical at `-O1`, `-O2`, `-Os` and `-O3`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQEY7FS4tkpct3E8pq4fA8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved optimization convergence and prevented unnecessary repeated rewrites.
  - Ensured required compiler transformations run consistently across optimization levels, including `-O0`.
  - Improved handling of local-use tracking, function effects, and return-value rewriting.

- **Performance**
  - Reduced repeated optimization work to improve compilation efficiency.

- **Documentation**
  - Clarified how optimization passes report changes and affect convergence.

- **Tests**
  - Added coverage verifying optimization completes within expected iteration limits for complex return-value transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->