### PR TITLE
docs(wep): slice `core:icu` by locale, collect it by reachability

### DIFF
--- a/docs/wep-2026-08-09-core-icu.md
+++ b/docs/wep-2026-08-09-core-icu.md
@@ -314,12 +314,22 @@ runtime data dependencies, not taxonomy.
 
   Closing it means giving the prune a symbol graph where it has a wasm index
   graph. The `linking` and `reloc.*` sections carry exactly that — which
-  function references which data symbol — so an asset kept relocatable could be
-  collected from the live exports the way a linker's `--gc-sections` does. Worth
-  ~2.35 MB where one component serves both a grapheme pass and word
-  segmentation and a program reaches only the first, and it would let a
-  component bake its locale-independent data again. Unverified: whether those
-  sections survive the ICU asset's build with the edges intact.
+  function references which data symbol — and wasm-ld already collects over it,
+  `--gc-sections` being its default. Measured on the ICU asset kept relocatable,
+  collecting against one program's exports reproduces the from-source rebuild
+  across every capability — 89 KB for locale + casemap against a ~92 KB rebuild
+  — and the slices are runtime-checked, Turkish casing included, so the graph
+  carries the data edges and not only the code.
+
+  Two things follow. Slicing needs no rebuild, so one asset can serve every
+  program; and the root set can be finer than a rebuild can express, grapheme
+  boundaries alone being 23 KB where segmentation's four operations are 2.31 MB.
+  What remains is implementing the collection in `wado-wasm-embed`, which today
+  reads the wasm index space rather than the symbol table.
+
+  This closes the capability axis only. A locale is reached through the same
+  symbol whatever the program declares, so no collection separates `ja` from the
+  rest — that stays the data image's job.
 
 ## Open questions
 

--- a/docs/wep-2026-08-09-core-icu.md
+++ b/docs/wep-2026-08-09-core-icu.md
@@ -3,17 +3,31 @@
 ## Context
 
 Internationalization is the standard library's largest capability and the one
-least shaped by code. Unicode and CLDR are data: in the measured spike under
-`wado-bundled-icu/`, an all-features ICU4X component is ~3.7 MB, of which
-segmentation is ~2.35 MB and collation ~1.1 MB, against ~44 KB for the character
-property tries. Once the surface widens past text into formatting, the CLDR
-patterns for every locale dwarf even that.
+least shaped by code. Unicode and CLDR are data, and the data separates along
+two axes that behave nothing alike.
 
-Two questions follow. What does a program see, and how does it end up with only
-the data it uses. This WEP answers the first and consumes
+By capability: in the `wado-bundled-icu/` spike an all-features ICU4X component
+is ~3.7 MB, of which segmentation is ~2.35 MB and collation ~1.12 MB, against
+~44 KB for the character property tries.
+
+By locale, measured with `bdp-spike/datagen` against icu4x 2.2 and CLDR 48.2.0:
+
+| markers                                       | root (`und`) | `und,ja` | every locale |
+| --------------------------------------------- | -----------: | -------: | -----------: |
+| collation                                     |       568 KB |   660 KB |      1043 KB |
+| formatting (date/time, number, list, plurals) |        21 KB |    47 KB |      4334 KB |
+
+The two rows invert. Collation is a root table with tailorings hung off it, so
+slicing by locale saves at most 475 KB. Formatting is almost nothing but locale
+data, at a 206× ratio — and that is why this design exists. No amount of
+dead-code elimination substitutes: a locale is reached through the same
+constructor whatever the program declares.
+
+Two questions follow: what a program sees, and how it ends up with only the data
+it uses. This WEP answers both, and the second answer is a lookup in a bundled
+archive rather than a slicing run — most of what
 [compile-time data providers](./wep-2026-06-13-compile-time-data-providers.md)
-for the second — `core:icu` is that mechanism's first consumer, and building it
-is what proves the mechanism against a real slicer.
+offers goes unused here.
 
 Feasibility is settled. The spike established that full ICU4X compiles to wasm
 cleanly, that Rust LTO tree-shakes it by reachability so the WIT surface is the
@@ -53,9 +67,9 @@ The user-visible module is deliberately not the unit of code splitting.
 A free function covers normalization, case folding, `is_nfc`, character
 properties, and one-shot locale-sensitive casing.
 
-What separates the two handle shapes is who ends the object's life. That split is
-the slicer's own line, so a program whose data can be sliced meets no move-only
-handle at all.
+What separates the two handle shapes is who ends the object's life. It is not
+the line the data slicing draws — that one is capability and locale, and it runs
+across both shapes.
 
 Statefulness forces the affine shape for a second, independent reason: copying a
 token aliases its referent, which two copies of a lazy iterator would show by
@@ -86,6 +100,13 @@ lazy segmentation iterator. The far side allocates these per call from input the
 program does not bound, so the object has an end and something must reach it: the
 handle carries a `dtor` and is move-only.
 
+### The capability axis is DCE's, the locale axis is the package's
+
+Nothing in `core:icu` decides which capabilities a program links: reachability
+does, and `wado-wasm-embed` drops what the exports it keeps cannot reach. What
+that prune cannot reach is baked data (Known gaps), which is why the
+implementation components carry none and the package supplies it instead.
+
 ### The code partition is invisible
 
 Underneath the facade sit several prebuilt, data-free implementation components,
@@ -101,7 +122,7 @@ its data both absent.
 The facade carries the coarse split in its types. Where two operations differ in
 data by orders of magnitude — a grapheme pass needs kilobytes where word
 segmentation pulls a multi-megabyte dictionary — they belong to different types,
-so naming a type is already a data decision and the cheap user never mentions the
+so naming a type selects a component and the cheap user never mentions the
 expensive one. That works with reachability as it stands.
 
 Method granularity is the refinement on top, for the residue that type splitting
@@ -139,42 +160,42 @@ defines, with one difference: it ships with the toolchain rather than being
 fetched, so `use icu from "core:icu"` works with nothing to add. That changes
 where the package comes from and nothing about how it works.
 
-Its four parts:
+Its three parts:
 
 - The facade — the Wado source above.
 - Implementation components — the spike's data-free components, promoted to
-  first-party artifacts.
-- The provider — the ICU4X data slicer compiled to wasm. It maps symbols to
-  markers and the declared locales to a locale set, then re-exports the selected
-  markers through ICU's blob exporter, reading the bundled image instead of CLDR.
-  Running from a bundled image needs no network, which is what makes it
-  deterministic and sandboxable — and removes the proxy and TLS non-determinism
-  the spike hit against live CLDR downloads.
-- Data assets — the image below.
+  first-party artifacts. Each carries the marker set it loads, fixed when the
+  component is built.
+- Data assets — the image below, keyed by (component, locale).
 
-The symbol-to-marker map lives entirely in the provider, because it is
-ICU-version-specific: a collator's constructor also pulls the normalizer's NFD
-markers, which no crate-level marker list mentions. Keeping it there is what lets
-the compiler stay ICU-agnostic, passing only Wado symbol names.
+Assembling a program's data is a lookup: the live components name their marker
+sets, the declared locales expand through likely-subtags and the fallback chain,
+and the entries at those keys are handed over as blobs. ICU4X's fork provider
+lets one component read several blobs, so nothing merges or re-encodes them.
 
-That map is guarded by a recording test rather than by review. A buffer-provider
-wrapper logs every marker each constructor actually requests, so the map is
-derived from observed behaviour instead of documentation. The recorded set is
-request-specific — root collation pulls no tailoring markers — so the map is the
-union over inputs chosen to exercise every path, and the test asserts coverage
-and fails on drift when ICU is upgraded.
+Marker granularity finer than the component is deliberately not pursued. For a
+program declaring `ja` and formatting dates, the locale declaration is worth
+4.3 MB where choosing within datetime's 57 markers is worth tens of KB inside
+the 47 KB that remains. Fixing the marker set per component is what removes the
+ICU-version-specific symbol-to-marker map, and with it the recording test that
+would have had to catch the map drifting on every ICU upgrade.
 
 ### The data image
 
 One compressed, indexed archive, which keeps `wado` a self-contained binary while
 letting the provider extract only what a build needs.
 
-- Entries are per-marker. That granularity is what lets a grapheme-only build
-  never touch segmentation's dictionary and LSTM entries, while keeping the index
-  small — per-(marker, locale) would explode it for collation. A locale-bearing
-  marker's entry holds every locale; the provider slices within it.
+- Entries are per (component, locale), and one per component where the data is
+  locale-independent. An entry is exactly what one component loads for one
+  locale, so a build concatenates entries instead of slicing inside them. The
+  index stays small because components are tens, where a per-(marker, locale)
+  key would run to tens of thousands.
 - The index maps entry name to offset and length. Random access is required for
   selective extraction, so a streamed archive format does not qualify.
+- A locale's entry is stored deduplicated against its fallback parent, which the
+  runtime fallbacker undoes. Measured, that is 5.16 MB down to 4.34 MB on
+  formatting and 23 bytes on collation — CLDR patterns inherit heavily where
+  collation tailorings are genuinely distinct.
 - Compression is per-entry zlib, reversed host-side, so the provider links no
   decompressor. zlib is chosen over zstd deliberately: it is already a compiler
   dependency and pure Rust, where zstd would add a C dependency to an otherwise
@@ -251,10 +272,10 @@ re-cutting it becomes a breaking change.
 ### Baking the data into each component
 
 ICU4X's compiled-data mode, which the original spike used. Simpler, and needs no
-provider at all, but it is ~3.7 MB for the full text surface and cannot slice by
-locale — so a program declaring two locales still carries every locale CLDR
-ships. That is survivable for casing and normalization and hopeless for
-formatting, which is where the surface is going.
+data assets at all, but it cannot slice by locale — a program declaring two
+locales still carries every locale CLDR ships. Survivable for casing and
+normalization; for formatting it is 4.34 MB where the declared locales need
+47 KB.
 
 ### A shared data component
 
@@ -268,27 +289,46 @@ runtime data dependencies, not taxonomy.
 
 - Users learn one module and no partition. The capability-to-component map is an
   implementation detail that can change without a source change.
-- Per-program data is minimal: only the markers for live symbols and the declared
-  locales are embedded, and an unreachable capability contributes nothing.
+- Per-program data is bounded by the live components and the declared locales;
+  an unreachable capability contributes nothing.
 - The API tells the truth about cost. A constructed object is visibly
   constructed, and the one-shot helpers beside it are visibly one-shot.
 - Toolchain size grows by the bundled ICU package, in exchange for a
   zero-dependency `core:` experience.
 - Runtime-loaded data loses zero-copy-from-static and adds a fixed per-capability
   deserialization cost. For a single capability this is roughly size-neutral
-  against baking; the win is across capabilities and from per-program slicing.
+  against baking; the win is the locale axis, which baking cannot reach at all.
+- No ICU code runs at build time, so the build has nothing to sandbox, cache by
+  content, or keep deterministic beyond reading its own archive.
 - The CM import blocker splits. The compile-time-bounded surface needs only a
   `dtor`-less imported handle; the tailored, runtime-configured, and stateful
   surface waits on full resource import, a gap shared with every
   resource-bearing third-party component.
 
+## Known gaps
+
+- **The prune keeps baked data.** `wado-wasm-embed` drops every function,
+  global, table, tag, type and segment unreachable from the exports it keeps,
+  but marks every active data segment live unconditionally: an active segment
+  initialises memory whether or not anything still reads what it wrote.
+
+  Closing it means giving the prune a symbol graph where it has a wasm index
+  graph. The `linking` and `reloc.*` sections carry exactly that — which
+  function references which data symbol — so an asset kept relocatable could be
+  collected from the live exports the way a linker's `--gc-sections` does. Worth
+  ~2.35 MB where one component serves both a grapheme pass and word
+  segmentation and a program reaches only the first, and it would let a
+  component bake its locale-independent data again. Unverified: whether those
+  sections survive the ICU asset's build with the edges intact.
+
 ## Open questions
 
-- [ ] What proves a construction site's configuration compile-time bounded, so
-      the facade may offer the token form there. A combinatorial option space is
-      not the obstacle — a constant at the site is what bounds the interned set —
-      but whether that is a distinct type or a const-argument requirement
-      diagnosing toward the affine form is undecided.
+- [ ] What bounds a token's interned set. Tokens forbid eviction — an entry
+      freed under a live token dangles — so the set is a permanent high-water
+      mark and must be small, not merely finite. The bound wanted is on the key
+      type's cardinality, which is a facade-authoring decision rather than
+      anything the compiler checks; whether it should instead be a distinct type
+      per bounded configuration is undecided. Unrelated to data slicing.
 - [ ] Holding an affine handle in a global, and capturing one in a closure
       ([resource ownership](./wep-2026-05-21-resource-ownership.md)). The token
       form needs neither, so this bounds only the tailored, runtime-configured,
@@ -317,22 +357,24 @@ runtime data dependencies, not taxonomy.
       `borrow<T>` parameters, `resource.drop` — gating the tailored,
       runtime-configured, and stateful surface, not the package.
 - [ ] The [data-provider mechanism](./wep-2026-06-13-compile-time-data-providers.md)
-      itself.
+      itself, reduced here to an archive lookup: `core:icu` runs no provider
+      component and needs no compile-time execution.
 - [ ] Promote the spike's data-free components into first-party prebuilt
       artifacts with their WIT surfaces, partitioned per the inventory.
 - [ ] Write the facade over them: re-exports, the Wado-native shapes (`Ord`,
       iterators, `Display`), and the one-shot helpers.
-- [ ] Build the ICU provider with its symbol-to-marker map and the
-      marker-recording drift test.
-- [ ] Build the data image — per-marker zlib entries plus index — and bundle the
-      package with the toolchain.
+- [ ] Build the data image — per-(component, locale) zlib entries plus index,
+      deduplicated against the fallback parent — and bundle it with the
+      toolchain.
+- [ ] Feed several blobs to one component through ICU4X's fork provider.
 
 ## References
 
 - [Compile-Time Data Providers](./wep-2026-06-13-compile-time-data-providers.md)
-  — the mechanism this consumes.
+  — the mechanism this consumes, here reduced to an archive lookup.
 - [research: splitting large libraries](./research-library-splitting.md) — the
-  measurements behind the partition decisions.
+  capability-axis measurements. The locale-axis table in Context comes from
+  `bdp-spike/datagen`'s `coll-loc` and `fmt-loc` sets, which reproduce it.
 - [Wasm CM Component Import](./wep-2026-06-26-wasm-cm-component-import.md) — how
   the implementation components are consumed and composed.
 - [Provider Metadata](./wep-2026-07-26-provider-metadata.md) — why a `core:*` API

--- a/docs/wep-2026-08-09-core-icu.md
+++ b/docs/wep-2026-08-09-core-icu.md
@@ -100,36 +100,35 @@ lazy segmentation iterator. The far side allocates these per call from input the
 program does not bound, so the object has an end and something must reach it: the
 handle carries a `dtor` and is move-only.
 
-### The capability axis is DCE's, the locale axis is the package's
+### One implementation asset, collected per program
 
-Nothing in `core:icu` decides which capabilities a program links: reachability
-does, and `wado-wasm-embed` drops what the exports it keeps cannot reach. What
-that prune cannot reach is baked data (Known gaps), which is why the
-implementation components carry none and the package supplies it instead.
+Underneath the facade sits a single prebuilt ICU asset, not a partition. It is
+shipped relocatable, so the `linking` and `reloc.*` sections survive and the
+collection that produced it can run again against the exports one program
+reaches (Known gaps). Measured, that reproduces what rebuilding the asset with a
+narrower WIT surface would produce, and reaches granularity a rebuild cannot: a
+grapheme pass is 23 KB where segmentation's four operations are 2.31 MB.
 
-### The code partition is invisible
-
-Underneath the facade sit several prebuilt, data-free implementation components,
-partitioned so that an unused capability contributes no code. Users never name
-them, and the partition can be re-cut without touching a single source file.
-
-Which components a program links follows from reachability, not from what the
-user imported: a capability with no live symbol is dropped whole, its code and
-its data both absent.
+So the capability axis is reachability's, end to end: code, and the data that
+does not vary by locale, which is baked into the asset and collected away when
+unreached. What no collection separates is locales, which a constructor reaches
+through the same symbol whatever the program declares. That axis alone is the
+package's.
 
 ### Reachability granularity
 
 The facade carries the coarse split in its types. Where two operations differ in
 data by orders of magnitude — a grapheme pass needs kilobytes where word
 segmentation pulls a multi-megabyte dictionary — they belong to different types,
-so naming a type selects a component and the cheap user never mentions the
-expensive one. That works with reachability as it stands.
+so naming a type is already a data decision and the cheap user never mentions
+the expensive one.
 
-Method granularity is the refinement on top, for the residue that type splitting
-would fragment absurdly. It is not available yet: the `liveness` pass seeds every
-method as a live root by design, so a live type implies every one of its methods.
-Depending on it before that changes would silently over-bundle, which is why the
-type-level split is the load-bearing half.
+That split stays load-bearing, because the collection's root set is not free of
+Wado's own liveness: the roots are the asset's exports that surviving Wado code
+calls, and the `liveness` pass seeds every method of a live type as a live root
+by design. A single `Segmenter` type carrying all four operations would keep all
+four exports rooted and collect nothing, whatever the program called. Method
+granularity is the refinement that would lift that.
 
 ### Locales are a compile-time declaration
 
@@ -139,8 +138,8 @@ use icu from "core:icu" with { locales: ["ja", "en-US"] };
 
 - Omitted means root only — collation's root UCA, no tailorings. Minimal by
   default.
-- The declared set is the union across all use sites. The provider expands it
-  with likely-subtags and the fallback chain.
+- The declared set is the union across all use sites, expanded with
+  likely-subtags and the fallback chain.
 - A runtime langid outside the set falls back per ICU, to the nearest available
   and ultimately to root. A literal langid outside the set is a compile-time
   diagnostic.
@@ -163,54 +162,51 @@ where the package comes from and nothing about how it works.
 Its three parts:
 
 - The facade — the Wado source above.
-- Implementation components — the spike's data-free components, promoted to
-  first-party artifacts. Each carries the marker set it loads, fixed when the
-  component is built.
-- Data assets — the image below, keyed by (component, locale).
+- The implementation asset — the spike's ICU component, promoted to a
+  first-party artifact and shipped relocatable. Its locale-independent data is
+  baked in; its locale-bearing capabilities take a buffer provider.
+- Data assets — the image below, keyed by (capability, locale).
 
-Assembling a program's data is a lookup: the live components name their marker
-sets, the declared locales expand through likely-subtags and the fallback chain,
-and the entries at those keys are handed over as blobs. ICU4X's fork provider
-lets one component read several blobs, so nothing merges or re-encodes them.
+Assembling a program's data is a lookup: the reached locale-bearing capabilities
+name their marker sets, the declared locales expand through likely-subtags and
+the fallback chain, and the entries at those keys are handed over as blobs.
+ICU4X's fork provider lets the asset read several blobs, so nothing merges or
+re-encodes them.
 
-Marker granularity finer than the component is deliberately not pursued. For a
+Marker granularity finer than the capability is deliberately not pursued. For a
 program declaring `ja` and formatting dates, the locale declaration is worth
 4.3 MB where choosing within datetime's 57 markers is worth tens of KB inside
-the 47 KB that remains. Fixing the marker set per component is what removes the
+the 47 KB that remains. Fixing the marker set per capability is what removes the
 ICU-version-specific symbol-to-marker map, and with it the recording test that
 would have had to catch the map drifting on every ICU upgrade.
 
 ### The data image
 
-One compressed, indexed archive, which keeps `wado` a self-contained binary while
-letting the provider extract only what a build needs.
+One compressed, indexed archive of the locale-bearing data, which keeps `wado` a
+self-contained binary while letting a build extract only the entries it needs.
 
-- Entries are per (component, locale), and one per component where the data is
-  locale-independent. An entry is exactly what one component loads for one
-  locale, so a build concatenates entries instead of slicing inside them. The
-  index stays small because components are tens, where a per-(marker, locale)
-  key would run to tens of thousands.
+- An entry is exactly what one capability loads for one locale, so a build
+  concatenates entries instead of slicing inside them. The index stays small
+  because capabilities are tens, where a per-(marker, locale) key would run to
+  tens of thousands.
 - The index maps entry name to offset and length. Random access is required for
   selective extraction, so a streamed archive format does not qualify.
 - A locale's entry is stored deduplicated against its fallback parent, which the
   runtime fallbacker undoes. Measured, that is 5.16 MB down to 4.34 MB on
   formatting and 23 bytes on collation — CLDR patterns inherit heavily where
   collation tailorings are genuinely distinct.
-- Compression is per-entry zlib, reversed host-side, so the provider links no
-  decompressor. zlib is chosen over zstd deliberately: it is already a compiler
-  dependency and pure Rust, where zstd would add a C dependency to an otherwise
-  runtime-free compiler. Measured on the ICU blobs, zstd-19 beats zlib-9 by ~9%
-  on the dominant, near-incompressible segmentation data and ~8% on the small
-  feature blobs, with its best case ~24% on mid-size locale data — not enough to
-  buy the dependency. Compression happens once at toolchain-build so its speed is
-  irrelevant; decompression is ~2–3× faster with zstd but already negligible (the
-  largest 4 MB entry takes ~24 ms, and a build pulls few entries). zlib runs at
-  its default level: higher levels bought no measurable ratio on this data.
+- Compression is per-entry zlib, reversed host-side, so nothing the program
+  carries links a decompressor. zlib is chosen over zstd deliberately: it is
+  already a compiler dependency and pure Rust, where zstd would add a C
+  dependency to an otherwise runtime-free compiler. Measured on the ICU blobs,
+  zstd-19's best case is ~24% on mid-size locale data and less elsewhere — not
+  enough to buy that. Compression happens once at toolchain-build so its speed
+  is irrelevant, and decompression is already negligible against a build that
+  pulls a handful of entries.
 
-Collation's dependency on the normalizer's NFD markers — ~37 KB, the one real
-cross-capability data dependency measured — is satisfied by including them in
-collation's own slice. At that size a shared data component is not worth its
-composition cost.
+Collation's runtime dependency on the normalizer's NFD markers — ~37 KB, the one
+real cross-capability data dependency measured — needs nothing here: NFD does
+not vary by locale, so it is baked into the asset and collation reads it there.
 
 ## Alternatives considered
 
@@ -262,12 +258,11 @@ per-instance table.
 
 An earlier plan split the surface into `core:text`, `core:collation`, and
 `core:segmentation` so that unused capabilities linked nothing. Rejected: it
-conflated a code partition with a naming decision. Data slicing is per-symbol
-regardless of module and reachability already selects components, so the split
-bought nothing reachability does not — while costing users a memorized map from
-capability to module, spreading the locale declaration across three `use` sites
-to be unioned, and freezing an internal partition into the public API where
-re-cutting it becomes a breaking change.
+conflated a code partition with a naming decision. Reachability already decides
+what a program carries, so the split bought nothing — while costing users a
+memorized map from capability to module, spreading the locale declaration across
+three `use` sites to be unioned, and freezing an internal boundary into the
+public API where moving it becomes a breaking change.
 
 ### Baking the data into each component
 
@@ -277,20 +272,25 @@ locales still carries every locale CLDR ships. Survivable for casing and
 normalization; for formatting it is 4.34 MB where the declared locales need
 47 KB.
 
-### A shared data component
+### Splitting the asset into components
 
-Data common to several capabilities could live in one component the others
-import. Measured, the sharing is not there: the collator/normalizer overlap is
-~37 KB and the casemap, properties, and segmenter sets overlap by essentially
-nothing, against a ~10 KB floor per additional component. Dedup follows genuine
-runtime data dependencies, not taxonomy.
+Several prebuilt components, one per capability, so an unused one is never
+composed. Rejected: it coarsens what the collection already does. A partition
+is guessed when the artifacts are built and then freezes each capability's
+granularity at that guess, where the collection's root set is whatever the
+program reached; it also costs a ~10 KB floor per line drawn.
+
+It would additionally need a shared data component to recover what one asset
+shares for free — measured, that sharing is ~37 KB between collator and
+normalizer and essentially nothing between casemap, properties and segmenter,
+dedup following genuine runtime data dependencies rather than taxonomy.
 
 ## Consequences
 
-- Users learn one module and no partition. The capability-to-component map is an
-  implementation detail that can change without a source change.
-- Per-program data is bounded by the live components and the declared locales;
-  an unreachable capability contributes nothing.
+- Users learn one module, and there is no partition to learn or to maintain: one
+  asset serves every program.
+- Per-program data is bounded by what the program reached and the locales it
+  declared; an unreached capability contributes nothing, code and data alike.
 - The API tells the truth about cost. A constructed object is visibly
   constructed, and the one-shot helpers beside it are visibly one-shot.
 - Toolchain size grows by the bundled ICU package, in exchange for a
@@ -322,10 +322,9 @@ runtime data dependencies, not taxonomy.
   carries the data edges and not only the code.
 
   Two things follow. Slicing needs no rebuild, so one asset can serve every
-  program; and the root set can be finer than a rebuild can express, grapheme
-  boundaries alone being 23 KB where segmentation's four operations are 2.31 MB.
-  What remains is implementing the collection in `wado-wasm-embed`, which today
-  reads the wasm index space rather than the symbol table.
+  program; and the root set can be finer than any WIT surface a rebuild could
+  express. What remains is implementing the collection in `wado-wasm-embed`,
+  which today reads the wasm index space rather than the symbol table.
 
   This closes the capability axis only. A locale is reached through the same
   symbol whatever the program declares, so no collection separates `ja` from the
@@ -350,10 +349,10 @@ runtime data dependencies, not taxonomy.
 - [ ] Where the facade's date/time formatting meets
       [`core:temporal`](./wep-2026-06-05-core-temporal.md), and how its
       time-zone view relates to the WASI-provided one.
-- [ ] The full capability inventory and its component partition. The first cut
-      covers what the spikes measured — locale identity, normalization, case
-      mapping, character properties, segmentation, collation — with formatting,
-      plural rules, and transliteration following.
+- [ ] The full capability inventory, and which of its data is locale-bearing.
+      The first cut covers what the spikes measured — locale identity,
+      normalization, case mapping, character properties, segmentation,
+      collation — with formatting, plural rules, and transliteration following.
 
 ## Implementation
 
@@ -369,8 +368,9 @@ runtime data dependencies, not taxonomy.
 - [ ] The [data-provider mechanism](./wep-2026-06-13-compile-time-data-providers.md)
       itself, reduced here to an archive lookup: `core:icu` runs no provider
       component and needs no compile-time execution.
-- [ ] Promote the spike's data-free components into first-party prebuilt
-      artifacts with their WIT surfaces, partitioned per the inventory.
+- [ ] Promote the spike's ICU component into a first-party prebuilt artifact,
+      shipped relocatable, with the locale-bearing capabilities moved onto a
+      buffer provider and the rest left baked.
 - [ ] Write the facade over them: re-exports, the Wado-native shapes (`Ord`,
       iterators, `Display`), and the one-shot helpers.
 - [ ] Build the data image — per-(component, locale) zlib entries plus index,
@@ -386,7 +386,7 @@ runtime data dependencies, not taxonomy.
   capability-axis measurements. The locale-axis table in Context comes from
   `bdp-spike/datagen`'s `coll-loc` and `fmt-loc` sets, which reproduce it.
 - [Wasm CM Component Import](./wep-2026-06-26-wasm-cm-component-import.md) — how
-  the implementation components are consumed and composed.
+  the implementation asset is consumed and composed.
 - [Provider Metadata](./wep-2026-07-26-provider-metadata.md) — why a `core:*` API
   need no longer be CM-representable.
 - [Resource Ownership](./wep-2026-05-21-resource-ownership.md) — the token and

--- a/docs/wep-2026-08-09-core-icu.md
+++ b/docs/wep-2026-08-09-core-icu.md
@@ -30,11 +30,11 @@ archive rather than a slicing run — most of what
 offers goes unused here.
 
 Feasibility is settled. The spike established that full ICU4X compiles to wasm
-cleanly, that Rust LTO tree-shakes it by reachability so the WIT surface is the
-size knob, and that a `no_std` build yields a zero-import self-contained
-component. The `bdp-spike/` follow-up established the separation this design
-rests on: a data-free component loading a sliced postcard blob at run time, with
-the blob supplied either by the host or by a component composed in.
+cleanly, that it tree-shakes by reachability, and that a `no_std` build yields a
+zero-import self-contained component. The `bdp-spike/` follow-up established the
+other half this design rests on: a capability can take its data from a postcard
+blob at run time instead of baking it, with the blob supplied by a component
+composed in.
 
 ## Decision
 
@@ -53,8 +53,6 @@ for the boundary rather than for users. Concretely, the facade is where ICU
 capabilities acquire Wado shapes: a collator that satisfies `Ord`, segmentation
 exposed through the iterator traits, `Display` and `Inspect` on locale
 identifiers.
-
-The user-visible module is deliberately not the unit of code splitting.
 
 ### Three API shapes, chosen by what the thing is
 
@@ -87,7 +85,7 @@ paid.
 A collator over a declared locale, plural rules, a formatter over a fixed
 skeleton, a segmenter: immutable, and configured only from what
 `with { locales: [...] }` and the program's types already bound. The
-implementation component interns these, so the set is finite by construction and
+implementation asset interns these, so the set is finite by construction and
 never needs freeing, and the handle keeps the value semantics the rest of
 `core:*` has — it sits in a global, and a closure captures it by copy, so
 `list.sort_by(|a, b| c.compare(a, b))` is written the obvious way.
@@ -212,7 +210,7 @@ not vary by locale, so it is baked into the asset and collation reads it there.
 
 ### A resource-free surface keyed by (locale, options)
 
-Every ICU object could be a pure function of a key, with the component memoizing
+Every ICU object could be a pure function of a key, with the asset memoizing
 internally: `compare(locale, options, a, b)` instead of a constructed collator.
 Attractive because it keeps the surface value-semantic and needs no resource
 support in the CM import path. Rejected on four grounds.
@@ -258,19 +256,19 @@ per-instance table.
 
 An earlier plan split the surface into `core:text`, `core:collation`, and
 `core:segmentation` so that unused capabilities linked nothing. Rejected: it
-conflated a code partition with a naming decision. Reachability already decides
-what a program carries, so the split bought nothing — while costing users a
-memorized map from capability to module, spreading the locale declaration across
-three `use` sites to be unioned, and freezing an internal boundary into the
-public API where moving it becomes a breaking change.
+made a naming decision out of what reachability already decides, so the split
+bought nothing — while costing users a memorized map from capability to module,
+spreading the locale declaration across three `use` sites to be unioned, and
+freezing an internal boundary into the public API where moving it becomes a
+breaking change.
 
-### Baking the data into each component
+### Baking all of the data
 
-ICU4X's compiled-data mode, which the original spike used. Simpler, and needs no
-data assets at all, but it cannot slice by locale — a program declaring two
-locales still carries every locale CLDR ships. Survivable for casing and
-normalization; for formatting it is 4.34 MB where the declared locales need
-47 KB.
+ICU4X's compiled-data mode throughout, which the original spike used. Simpler,
+and needs no data assets at all, but it cannot slice by locale — a program
+declaring two locales still carries every locale CLDR ships. Survivable for
+casing and normalization; for formatting it is 4.34 MB where the declared
+locales need 47 KB. So baking stays, for the data that does not vary by locale.
 
 ### Splitting the asset into components
 
@@ -295,9 +293,9 @@ dedup following genuine runtime data dependencies rather than taxonomy.
   constructed, and the one-shot helpers beside it are visibly one-shot.
 - Toolchain size grows by the bundled ICU package, in exchange for a
   zero-dependency `core:` experience.
-- Runtime-loaded data loses zero-copy-from-static and adds a fixed per-capability
-  deserialization cost. For a single capability this is roughly size-neutral
-  against baking; the win is the locale axis, which baking cannot reach at all.
+- Only locale-bearing data is runtime-loaded, and it pays for that in
+  zero-copy-from-static and a deserialization cost per capability. Baking is
+  otherwise preferred, being what the collection can reach.
 - No ICU code runs at build time, so the build has nothing to sandbox, cache by
   content, or keep deterministic beyond reading its own archive.
 - The CM import blocker splits. The compile-time-bounded surface needs only a
@@ -371,12 +369,12 @@ dedup following genuine runtime data dependencies rather than taxonomy.
 - [ ] Promote the spike's ICU component into a first-party prebuilt artifact,
       shipped relocatable, with the locale-bearing capabilities moved onto a
       buffer provider and the rest left baked.
-- [ ] Write the facade over them: re-exports, the Wado-native shapes (`Ord`,
+- [ ] Write the facade over it: re-exports, the Wado-native shapes (`Ord`,
       iterators, `Display`), and the one-shot helpers.
-- [ ] Build the data image — per-(component, locale) zlib entries plus index,
+- [ ] Build the data image — per-(capability, locale) zlib entries plus index,
       deduplicated against the fallback parent — and bundle it with the
       toolchain.
-- [ ] Feed several blobs to one component through ICU4X's fork provider.
+- [ ] Feed several blobs to the asset through ICU4X's fork provider.
 
 ## References
 

--- a/wado-bundled-icu/README.md
+++ b/wado-bundled-icu/README.md
@@ -29,7 +29,7 @@ It exercises every marshalling shape Wado needs: `string` in/out, `list<u32>`,
 ## Size
 
 Import-free component, **~3.7 MB** with all six interfaces. Because Rust LTO
-slices ICU by reachability, the WIT surface is the size knob. Per-interface
+slices ICU by reachability, the WIT surface is the size knob when rebuilding. Per-interface
 attribution (measured by building with interfaces removed):
 
 | interface          | added size | notes                                                        |

--- a/wado-bundled-icu/README.md
+++ b/wado-bundled-icu/README.md
@@ -43,6 +43,55 @@ attribution (measured by building with interfaces removed):
 So segmenter+collator are ~93% of the bytes; dropping word/line segmentation
 (the `auto` dictionary) or collation shrinks the bundle dramatically.
 
+## Post-hoc slicing: one asset, sliced per program
+
+The per-interface table above comes from rebuilding with interfaces removed. The
+same slicing is reachable **without rebuilding**, which is what lets a toolchain
+carry one ICU asset and give each program only what it reaches.
+
+wasm-ld's `--gc-sections` (its default) collects over the symbol graph the
+`linking` and `reloc.*` sections carry. Keeping that graph in the asset lets the
+collection run again later against a narrower root set:
+
+```sh
+# Ship the asset as a relocatable object (keeps linking + reloc.*)
+RUSTFLAGS="-C link-arg=--relocatable -C link-arg=--no-gc-sections" \
+  CARGO_PROFILE_RELEASE_STRIP=none cargo build --release   # 4.05 MB
+
+# Collect it against the exports one program actually reaches
+rust-lld -flavor wasm --no-entry --gc-sections --strip-all \
+  --export=cabi_realloc_wit_bindgen_0_58_0 --export=__wasm_call_ctors \
+  --export='wado:icu/casemap@0.1.0#uppercase' ... \
+  -o casemap.wasm wado_bundled_icu.wasm                    # 89 KB
+```
+
+Measured against the 4.05 MB relocatable object:
+
+| roots kept         |      size | rebuild equivalent       |
+| ------------------ | --------: | ------------------------ |
+| locale             |     35 KB | —                        |
+| locale + casemap   |     89 KB | ~92 KB                   |
+| properties         |     67 KB | —                        |
+| normalizer         |    134 KB | ~125 KB                  |
+| collator           |   1.17 MB | ~1.12 MB                 |
+| segmenter (all 4)  |   2.31 MB | ~2.35 MB                 |
+| **graphemes only** | **23 KB** | not reachable by rebuild |
+| every export       |   3.63 MB | ~3.7 MB                  |
+
+Each slice lands on its from-source rebuild, so the graph carries everything the
+collection needs, data included. And the root set can be finer than a rebuild
+can express: `graphemes only` would need the WIT surface split first.
+
+Correctness is checked, not inferred. `runtime-check` passes against the
+all-exports re-link, and its `casemap-only` binary asserts Turkish, German and
+en-US casing against the 93 KB component built from the re-linked slice
+(`wit-casemap/` narrows the world) — locale-aware data that survived the
+collection.
+
+```sh
+cd runtime-check && cargo run --release --bin casemap-only -- <component.wasm>
+```
+
 ## Build (no_std, zero-import, self-contained — the libm model)
 
 The crate is `#![no_std]`, supplies its own global allocator (dlmalloc), and

--- a/wado-bundled-icu/bdp-spike/build.sh
+++ b/wado-bundled-icu/bdp-spike/build.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 echo "== [1/5] datagen: slice casemap markers into a postcard blob =="
-( cd datagen && cargo run --release -- ../casemap.blob )
+( cd datagen && cargo run --release -- casemap ../casemap.blob )
 
 echo "== [2/5] build data-free casemap feature component =="
 ( cd casemap && cargo build --release )

--- a/wado-bundled-icu/bdp-spike/datagen/Cargo.lock
+++ b/wado-bundled-icu/bdp-spike/datagen/Cargo.lock
@@ -42,8 +42,12 @@ dependencies = [
  "anyhow",
  "icu_casemap",
  "icu_collator",
+ "icu_datetime",
+ "icu_decimal",
+ "icu_list",
  "icu_locale_core",
  "icu_normalizer",
+ "icu_plurals",
  "icu_properties",
  "icu_provider",
  "icu_provider_export",
@@ -376,6 +380,8 @@ dependencies = [
  "calendrical_calculations",
  "databake",
  "displaydoc",
+ "icu_calendar_data",
+ "icu_locale",
  "icu_locale_core",
  "icu_provider",
  "ixdtf",
@@ -383,6 +389,12 @@ dependencies = [
  "tinystr",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_calendar_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d"
 
 [[package]]
 name = "icu_casemap"
@@ -473,7 +485,9 @@ dependencies = [
  "displaydoc",
  "fixed_decimal",
  "icu_calendar",
+ "icu_datetime_data",
  "icu_decimal",
+ "icu_locale",
  "icu_locale_core",
  "icu_pattern",
  "icu_plurals",
@@ -489,6 +503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_datetime_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d3cc1b690d9703202bc319692ac8a1f3a6390686f0930ff40542450fa34f0b"
+
+[[package]]
 name = "icu_decimal"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +517,8 @@ dependencies = [
  "databake",
  "displaydoc",
  "fixed_decimal",
+ "icu_decimal_data",
+ "icu_locale",
  "icu_locale_core",
  "icu_pattern",
  "icu_plurals",
@@ -505,6 +527,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_decimal_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f14a5ca9e8af29eef62064f269078424283d90dbaffeac5225addf62aaabc22"
 
 [[package]]
 name = "icu_experimental"
@@ -548,12 +576,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeeaf517689324395bed4767f7c65504f5455942ed4c14ee54c2087ca00b816e"
 dependencies = [
  "databake",
+ "icu_list_data",
+ "icu_locale",
  "icu_provider",
  "regex-automata",
  "serde",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_list_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed62dbf114db9a4163481ed071509c4cd52cbcef9cb85979eba08a95549d73f3"
 
 [[package]]
 name = "icu_locale"
@@ -642,10 +678,18 @@ dependencies = [
  "databake",
  "displaydoc",
  "fixed_decimal",
+ "icu_locale",
+ "icu_plurals_data",
  "icu_provider",
  "serde",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_plurals_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8485497155dc865f901decb93ecc20d3e467df67bfeceb91e3ba34e2b11e8e1d"
 
 [[package]]
 name = "icu_properties"
@@ -830,11 +874,18 @@ dependencies = [
  "icu_calendar",
  "icu_locale_core",
  "icu_provider",
+ "icu_time_data",
  "ixdtf",
  "serde",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_time_data"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e0ee79a0bb29772465234bfbad6ea04fbc5220bef9fa4f318cc53eb8897070e"
 
 [[package]]
 name = "indexmap"

--- a/wado-bundled-icu/bdp-spike/datagen/Cargo.toml
+++ b/wado-bundled-icu/bdp-spike/datagen/Cargo.toml
@@ -13,6 +13,10 @@ publish = false
 [dependencies]
 icu_casemap = "2.2"
 icu_collator = "2.2"
+icu_datetime = "2.2"
+icu_decimal = "2.2"
+icu_list = "2.2"
+icu_plurals = "2.2"
 icu_normalizer = "2.2"
 icu_properties = "2.2"
 icu_segmenter = { version = "2.2", features = ["auto"] }

--- a/wado-bundled-icu/bdp-spike/datagen/src/main.rs
+++ b/wado-bundled-icu/bdp-spike/datagen/src/main.rs
@@ -1,6 +1,6 @@
 //! Generate sliced ICU4X postcard *blobs* for the BDP separation experiment.
 //!
-//! Usage: `cargo run --release -- <set> <out.blob>`
+//! Usage: `cargo run --release -- <set> <out.blob> [locales] [dedup]`
 //!
 //! Marker sets:
 //!   casemap   casemap markers
@@ -9,6 +9,10 @@
 //!             (root collation only) — i.e. exactly what a collator feature loads
 //!   shared    collator markers + ALL normalizer markers (root collation) —
 //!             one blob serving both a collator feature and a normalizer feature
+//!   coll-loc  collator markers alone — the locale axis
+//!   fmt-loc   datetime + decimal + list + plurals, same arguments
+//!
+//! `[locales]` is `und,ja,…` or `FULL`; `[dedup]` is `none` or `maximal`.
 //!
 //! Comparing sizes of `coll`, `norm` and `shared` quantifies the marker dedup:
 //! `size(coll) + size(norm) - size(shared)` is the normalization data that
@@ -50,14 +54,6 @@ fn main() -> Result<()> {
 
     let provider = SourceDataProvider::new();
 
-    // Collation data is locale-bearing; restrict it to root ("und") so the blob
-    // stays focused on the normalization-dedup story. Normalizer/casemap data is
-    // locale-agnostic, so FULL there is just the root payload.
-    // `coll-loc`: collator markers only (no normalizer), with the locale set and
-    // dedup strategy given on the command line — the locale-axis measurement.
-    //   cargo run -- coll-loc <out.blob> <und,ja,... | FULL> [none|maximal]
-    // `fmt-loc`: the formatting surface (datetime + decimal + list + plurals),
-    // same locale/dedup CLI — does CLDR pattern data dwarf collation?
     if set == "coll-loc" || set == "fmt-loc" {
         let locales = std::env::args().nth(3).unwrap_or_else(|| "und".into());
         let dedup = std::env::args().nth(4).unwrap_or_else(|| "none".into());
@@ -104,6 +100,9 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Collation data is locale-bearing; restrict it to root ("und") so the blob
+    // stays focused on the normalization-dedup story. Normalizer/casemap data is
+    // locale-agnostic, so FULL there is just the root payload.
     let (markers, family): (Vec<DataMarkerInfo>, DataLocaleFamily) = match set.as_str() {
         "casemap" => (icu_casemap::provider::MARKERS.to_vec(), DataLocaleFamily::FULL),
         "norm" => (icu_normalizer::provider::MARKERS.to_vec(), DataLocaleFamily::FULL),

--- a/wado-bundled-icu/bdp-spike/datagen/src/main.rs
+++ b/wado-bundled-icu/bdp-spike/datagen/src/main.rs
@@ -53,6 +53,57 @@ fn main() -> Result<()> {
     // Collation data is locale-bearing; restrict it to root ("und") so the blob
     // stays focused on the normalization-dedup story. Normalizer/casemap data is
     // locale-agnostic, so FULL there is just the root payload.
+    // `coll-loc`: collator markers only (no normalizer), with the locale set and
+    // dedup strategy given on the command line — the locale-axis measurement.
+    //   cargo run -- coll-loc <out.blob> <und,ja,... | FULL> [none|maximal]
+    // `fmt-loc`: the formatting surface (datetime + decimal + list + plurals),
+    // same locale/dedup CLI — does CLDR pattern data dwarf collation?
+    if set == "coll-loc" || set == "fmt-loc" {
+        let locales = std::env::args().nth(3).unwrap_or_else(|| "und".into());
+        let dedup = std::env::args().nth(4).unwrap_or_else(|| "none".into());
+        let families: Vec<DataLocaleFamily> = if locales == "FULL" {
+            vec![DataLocaleFamily::FULL]
+        } else {
+            locales
+                .split(',')
+                .map(|l| DataLocaleFamily::single(l.parse().unwrap()))
+                .collect()
+        };
+        let strategy = match dedup.as_str() {
+            "none" => DeduplicationStrategy::None,
+            "maximal" => DeduplicationStrategy::Maximal,
+            other => anyhow::bail!("unknown dedup strategy: {other}"),
+        };
+        let markers: Vec<DataMarkerInfo> = if set == "fmt-loc" {
+            let mut m = icu_datetime::provider::MARKERS.to_vec();
+            m.extend_from_slice(icu_decimal::provider::MARKERS);
+            m.extend_from_slice(icu_list::provider::MARKERS);
+            m.extend_from_slice(icu_plurals::provider::MARKERS);
+            m
+        } else {
+            icu_collator::provider::MARKERS.to_vec()
+        };
+        ExportDriver::new(
+            families,
+            strategy.into(),
+            LocaleFallbacker::try_new_unstable(&provider).context("fallbacker")?,
+        )
+        .with_markers(markers.iter().copied())
+        .export(
+            &provider,
+            BlobExporter::new_with_sink(Box::new(
+                File::create(&out).with_context(|| format!("create {out}"))?,
+            )),
+        )
+        .context("export blob")?;
+        let bytes = std::fs::metadata(&out)?.len();
+        println!(
+            "wrote {out} ({bytes} bytes) — set={set}, locales={locales}, dedup={dedup}, {} markers",
+            markers.len()
+        );
+        return Ok(());
+    }
+
     let (markers, family): (Vec<DataMarkerInfo>, DataLocaleFamily) = match set.as_str() {
         "casemap" => (icu_casemap::provider::MARKERS.to_vec(), DataLocaleFamily::FULL),
         "norm" => (icu_normalizer::provider::MARKERS.to_vec(), DataLocaleFamily::FULL),

--- a/wado-bundled-icu/bdp-spike/datagen/src/main.rs
+++ b/wado-bundled-icu/bdp-spike/datagen/src/main.rs
@@ -62,8 +62,13 @@ fn main() -> Result<()> {
         } else {
             locales
                 .split(',')
-                .map(|l| DataLocaleFamily::single(l.parse().unwrap()))
-                .collect()
+                .map(|l| {
+                    let langid = l
+                        .parse()
+                        .with_context(|| format!("locale {l:?} in {locales:?}"))?;
+                    Ok(DataLocaleFamily::single(langid))
+                })
+                .collect::<Result<_>>()?
         };
         let strategy = match dedup.as_str() {
             "none" => DeduplicationStrategy::None,

--- a/wado-bundled-icu/runtime-check/Cargo.lock
+++ b/wado-bundled-icu/runtime-check/Cargo.lock
@@ -24,19 +24,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -93,70 +84,44 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cap-fs-ext"
-version = "3.4.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-net-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "rustix",
- "smallvec",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "3.4.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "ipnet",
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
 [[package]]
 name = "cap-std"
-version = "3.4.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "rustix",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix",
- "winx",
 ]
 
 [[package]]
@@ -198,16 +163,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -232,21 +191,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -254,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "serde",
  "serde_derive",
@@ -263,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -278,10 +237,13 @@ dependencies = [
  "hashbrown 0.17.1",
  "libm",
  "log",
+ "postcard",
  "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
+ "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -289,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -300,18 +262,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.0"
+version = "0.134.3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -321,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -332,11 +294,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.0"
+version = "0.134.3"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.0"
+version = "0.134.3"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -345,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.0"
+version = "0.134.3"
 
 [[package]]
 name = "crc32fast"
@@ -536,7 +498,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix",
  "windows-sys 0.59.0",
 ]
@@ -711,30 +673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu-runtime-check"
 version = "0.0.0"
 dependencies = [
@@ -866,11 +804,11 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.18.4"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "windows-sys 0.59.0",
 ]
 
@@ -879,6 +817,12 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
@@ -1119,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1129,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1216,6 +1160,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -1683,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b089037d7eb453ed57b560fe7833de0707411c8b9fdc429745ced77e2a1bacb9"
+checksum = "d59b710751a35d54732a63851cdfacbfb2266b7160ce174faf269d3f4e84e31b"
 dependencies = [
  "anyhow",
  "heck",
@@ -1693,8 +1638,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wat",
 ]
 
@@ -1706,16 +1651,6 @@ checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.251.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -1754,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags",
  "hashbrown 0.17.1",
@@ -1766,30 +1701,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
+name = "wasmprinter"
 version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
-dependencies = [
- "bitflags",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.251.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
+checksum = "7142797de29b35ab8dbf15c00f55fda75d409da4c423a8ab8bd6b667a785824b"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.251.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -1820,8 +1744,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -1833,15 +1757,14 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
- "wit-parser 0.251.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -1861,8 +1784,8 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -1870,7 +1793,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "base64",
  "directories-next",
@@ -1888,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1896,16 +1819,16 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.251.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.0"
+version = "47.0.3"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -1915,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -1931,7 +1854,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.251.0",
+ "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -1940,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1953,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "cc",
  "object",
@@ -1963,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1973,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -1984,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1992,47 +1915,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "46.0.0"
-dependencies = [
- "cranelift-codegen",
- "gimli",
- "log",
- "object",
- "target-lexicon",
- "wasmparser 0.251.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap",
- "wit-parser 0.251.0",
+ "wit-parser 0.252.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "async-trait",
  "bitflags",
  "bytes",
  "cap-fs-ext",
- "cap-net-ext",
  "cap-std",
- "cap-time-ext",
  "cfg-if",
- "fs-set-times",
  "futures",
- "io-extras",
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "rand",
  "rustix",
  "thiserror 2.0.18",
@@ -2047,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2089,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "bitflags",
  "thiserror 2.0.18",
@@ -2101,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2113,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "46.0.0"
+version = "47.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2153,80 +2057,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "winch-codegen"
-version = "46.0.0"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.251.0",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2428,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.251.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -2441,8 +2275,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.251.0",
+ "unicode-ident",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]

--- a/wado-bundled-icu/runtime-check/src/bin/casemap-only.rs
+++ b/wado-bundled-icu/runtime-check/src/bin/casemap-only.rs
@@ -1,0 +1,74 @@
+//! Runtime proof for a post-hoc slice of the bundled ICU component: the
+//! casemap-only artifact re-linked from the whole asset, never rebuilt.
+
+use anyhow::{Result, anyhow};
+use wasmtime::component::{Component, Linker};
+use wasmtime::{Config, Engine, Store};
+use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+
+wasmtime::component::bindgen!({
+    world: "icu-casemap",
+    path: "../wit-casemap",
+});
+
+struct Host {
+    ctx: WasiCtx,
+    table: ResourceTable,
+}
+
+impl WasiView for Host {
+    fn ctx(&mut self) -> WasiCtxView<'_> {
+        WasiCtxView {
+            ctx: &mut self.ctx,
+            table: &mut self.table,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let path = std::env::args()
+        .nth(1)
+        .ok_or_else(|| anyhow!("usage: casemap-only <component.wasm>"))?;
+
+    let mut config = Config::new();
+    config.wasm_component_model(true);
+    let engine = Engine::new(&config)?;
+    let component = Component::from_file(&engine, &path)?;
+
+    let mut linker = Linker::new(&engine);
+    wasmtime_wasi::p2::add_to_linker_sync(&mut linker)?;
+    let mut store = Store::new(
+        &engine,
+        Host {
+            ctx: WasiCtxBuilder::new().inherit_stdio().build(),
+            table: ResourceTable::new(),
+        },
+    );
+
+    let icu = IcuCasemap::instantiate(&mut store, &component, &linker)?;
+    let locale = icu.wado_icu_locale();
+    let casemap = icu.wado_icu_casemap();
+
+    let tr = locale
+        .locale()
+        .call_parse(&mut store, "tr-TR")?
+        .map_err(|e| anyhow!("parse tr-TR: {e}"))?;
+    let upper = casemap.call_uppercase(&mut store, "istanbul", tr)?;
+    assert_eq!(upper, "İSTANBUL", "Turkish dotted capital I");
+    println!("[OK] casemap.uppercase(\"istanbul\", tr) = {upper:?}");
+
+    let fold = casemap.call_fold(&mut store, "Straße")?;
+    assert_eq!(fold, "strasse", "sharp s folds to ss");
+    println!("[OK] casemap.fold(\"Straße\") = {fold:?}");
+
+    let en = locale
+        .locale()
+        .call_parse(&mut store, "en-US")?
+        .map_err(|e| anyhow!("parse en-US: {e}"))?;
+    let lower = casemap.call_lowercase(&mut store, "İSTANBUL", en)?;
+    assert_eq!(lower, "i\u{307}stanbul", "en-US keeps the combining dot Turkish drops");
+    println!("[OK] casemap.lowercase(\"İSTANBUL\", en) = {lower:?}");
+
+    println!("\nALL OK — the re-linked slice's ICU4X data is correct");
+    Ok(())
+}

--- a/wado-bundled-icu/wit-casemap/world.wit
+++ b/wado-bundled-icu/wit-casemap/world.wit
@@ -1,0 +1,31 @@
+// `wit/world.wit` narrowed to the locale + casemap interfaces, so a slice
+// re-linked to those exports alone can be componentized and run.
+package wado:icu@0.1.0;
+
+interface locale {
+  /// A parsed BCP-47 locale (opaque handle).
+  resource locale {
+    /// Parse a BCP-47 language tag (e.g. "en-US", "ja", "tr-TR").
+    parse: static func(tag: string) -> result<locale, string>;
+    /// Canonical string form.
+    to-string: func() -> string;
+  }
+}
+
+interface casemap {
+  use locale.{locale};
+
+  /// Locale-aware full uppercase mapping.
+  uppercase: func(text: string, loc: borrow<locale>) -> string;
+  /// Locale-aware full lowercase mapping.
+  lowercase: func(text: string, loc: borrow<locale>) -> string;
+  /// Locale-aware titlecase of the first segment.
+  titlecase: func(text: string, loc: borrow<locale>) -> string;
+  /// Locale-independent full case folding (for caseless matching).
+  fold: func(text: string) -> string;
+}
+
+world icu-casemap {
+  export locale;
+  export casemap;
+}


### PR DESCRIPTION
`core:icu`'s data separates along two axes, and this measures both, then shapes the design around what each is worth.

## The measurement

The locale axis, from `bdp-spike/datagen`'s new `coll-loc` and `fmt-loc` sets (icu4x 2.2, CLDR 48.2.0):

| markers | root (`und`) | `und,ja` | every locale |
|---|---:|---:|---:|
| collation | 568 KB | 660 KB | 1043 KB |
| formatting (date/time, number, list, plurals) | 21 KB | 47 KB | 4334 KB |

The rows invert. Collation is a root table with tailorings hung off it, so slicing by locale saves at most 475 KB. Formatting is almost nothing but locale data, at a 206× ratio: a program that formats one date and declares one locale pays 47 KB where an unsliced build pays 4.34 MB. No dead-code elimination substitutes, because a locale is reached through the same constructor whatever the program declares.

Fallback dedup follows the same split — 5.16 MB down to 4.34 MB on formatting, 23 bytes on collation.

## The capability axis is reachability's

wasm-ld collects over the symbol graph that `linking` and `reloc.*` carry, and `--gc-sections` is already its default. Keeping that graph in the asset lets the collection run again later against whatever exports one program reaches. Measured against the ICU asset kept relocatable (4.05 MB), every slice lands on its from-source rebuild — 89 KB for locale + casemap against ~92 KB, 1.17 MB for collation against ~1.12 MB, 2.31 MB for segmentation against ~2.35 MB — and the root set reaches granularity a rebuild cannot express: a grapheme pass alone is 23 KB.

The slices are runtime-checked, not inferred. `runtime-check` covers the all-exports re-link, and its `casemap-only` binary asserts Turkish, German and en-US casing against a 93 KB component built from a re-linked slice, with `wit-casemap/` narrowing the world so the slice can be componentized.

## What the WEP now specifies

One prebuilt ICU asset, shipped relocatable and collected per program. Data that does not vary by locale is baked into it and collected away when unreached; only locale-bearing data is external, keyed by (capability, locale). Collation reads the normalizer's NFD markers from the baked side.

Assembling a program's data is an archive lookup: the reached locale-bearing capabilities name their marker sets, the declared locales expand through likely-subtags and the fallback chain, and ICU4X's fork provider hands the asset the entries at those keys. No ICU code runs at build time, and the marker set is fixed per capability, so nothing maps Wado symbols to ICU markers.

The type-level split in the facade carries its weight for a specific reason: the collection's roots are the asset's exports that surviving Wado code calls, and `liveness` seeds every method of a live type, so one `Segmenter` carrying four operations would root all four.

`wado-wasm-embed` keeps every active data segment live unconditionally, so implementing the collection there is recorded as a known gap with its mechanism settled.

Docs and spike only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnWpa5xAokEXRNZSExZaF2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added locale-aware Unicode case mapping for uppercase, lowercase, titlecase, and case folding.
  * Added locale parsing and string conversion support.
  * Added locale-specific collation and formatting data generation with deduplication options.
* **Documentation**
  * Expanded guidance on ICU data sizing, post-build slicing, archive lookup, and runtime loading.
* **Validation**
  * Added runtime checks for Turkish casing and Unicode sharp-s behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->