### PR TITLE
perf(compiler): answer per-local NIR queries from one body walk

### DIFF
--- a/.claude/skills/profiling-wado-compiler/SKILL.md
+++ b/.claude/skills/profiling-wado-compiler/SKILL.md
@@ -87,7 +87,7 @@ The script:
      `(in <binary>)` filter works on both platforms.
 2. **Weights samples by `threadCPUDelta`** (real CPU), not wall-clock
    `weight` — otherwise parked tokio/rayon worker threads bury everything.
-3. **Reports** four views:
+3. **Reports** five views:
    - **CPU by library (self)** — where the leaf frames land. A high
      `libc.so.6 / libsystem_*` ratio means your hot path is in
      syscalls/`memcpy`, not Rust code.
@@ -100,6 +100,11 @@ The script:
      each non-`wado` leaf stack until it finds a `wado` frame and
      credits the cost there. This is how you find which Rust function
      is responsible for the `__memcpy` / `mmap` / mimalloc hot spots.
+   - **Allocation cost by requesting caller** — every sample crossing an
+     allocator entry, credited above the outermost one, skipping the
+     `Vec`/`HashMap` growth plumbing. The header is allocation's share of
+     total CPU, so "is this allocation-bound at all" is a number, not a
+     guess.
 
 Common invocations:
 

--- a/.claude/skills/profiling-wado-compiler/scripts/analyze_native_profile.ts
+++ b/.claude/skills/profiling-wado-compiler/scripts/analyze_native_profile.ts
@@ -242,8 +242,20 @@ function main(): void {
   const inclBy = new Map<string, number>();
   const libSelf = new Map<string, number>();
   const attr = new Map<string, number>(); // syscall/alloc leaf -> nearest Rust caller
+  const allocBy = new Map<string, number>(); // allocation cost -> requesting caller
+  let allocTotal = 0.0;
   let total = 0.0;
   let usedWallclock = false;
+
+  // Entry into the allocator: every frame below one is allocation cost.
+  const ALLOC_ENTRY =
+    /mimalloc|MiMalloc|GlobalAlloc|__rust_(alloc|dealloc|realloc)|alloc::alloc::(alloc|dealloc|realloc)|__libc_(malloc|free|calloc|realloc)/;
+  // Plumbing between the request and the entry: the container whose growth
+  // allocated names its element type but not the site, so credit the frame
+  // above it. mimalloc's own internals carry no DWARF and surface as bare
+  // `[bin]+0x…`.
+  const ALLOC_PLUMBING =
+    /alloc::alloc::|alloc::vec::|alloc::raw_vec::|RawVec|RawTable|hashbrown::|indexmap::|::reserve|finish_grow|\+0x/;
 
   const add = (m: Map<string, number>, k: string, w: number) =>
     m.set(k, (m.get(k) ?? 0) + w);
@@ -288,6 +300,27 @@ function main(): void {
           add(inclBy, n, w);
         }
         cur = stPrefix[cur];
+      }
+      // Every sample crossing an allocator entry, credited above the outermost
+      // one — the code that asked for the memory, not the plumbing between.
+      {
+        let node: number | null = leaf;
+        let requester: string | null = null;
+        let sawEntry = false;
+        while (node != null) {
+          const n = name(node);
+          if (ALLOC_ENTRY.test(n)) {
+            sawEntry = true;
+            requester = null; // outermost entry wins
+          } else if (sawEntry && requester == null && !ALLOC_PLUMBING.test(n)) {
+            requester = n;
+          }
+          node = stPrefix[node];
+        }
+        if (sawEntry) {
+          add(allocBy, requester ?? "[no caller above allocator]", w);
+          allocTotal += w;
+        }
       }
       // attribute non-main-binary leaf CPU to nearest main-binary caller
       if (libName(leaf) !== binary) {
@@ -347,6 +380,9 @@ function main(): void {
   show(
     "Syscall/alloc CPU attributed to nearest Rust caller", attr,
     (n) => n.includes(inBin),
+  );
+  show(
+    `Allocation cost by requesting caller (${pct(allocTotal)} of total)`, allocBy,
   );
 }
 

--- a/wado-compiler/src/optimize/const_object_globalization.rs
+++ b/wado-compiler/src/optimize/const_object_globalization.rs
@@ -1553,18 +1553,17 @@ fn is_readonly_body(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
 /// Whether a write reaches local `idx`: an assignment rooted at it, a `&mut` of
 /// it or of one of its projections, or a call that mutates it as a receiver.
 fn written_through(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
+    let rooted_at_idx = |e: ExprId| projection_root_of(body, e, gate) == Some(idx);
     reachable_nodes(body).into_iter().any(|node| {
         let NodeRef::Expr(e) = node else {
             return false;
         };
         match &body.exprs[e].kind {
-            ExprKind::Assign { target, .. } => projection_roots_at(body, *target, idx, gate),
+            ExprKind::Assign { target, .. } => rooted_at_idx(*target),
             ExprKind::Unary {
                 op: NirUnaryOp::MutRef,
                 expr: inner,
-            } => inner
-                .as_expr()
-                .is_some_and(|i| projection_roots_at(body, i, idx, gate)),
+            } => inner.as_expr().is_some_and(rooted_at_idx),
             ExprKind::Call {
                 func_id,
                 args,
@@ -1573,7 +1572,7 @@ fn written_through(body: &Body, idx: u32, gate: &Gate<'_>) -> bool {
             } => args.first().is_some_and(|recv| {
                 recv.expr
                     .as_expr()
-                    .is_some_and(|r| projection_roots_at(body, strip_refs(body, r), idx, gate))
+                    .is_some_and(|r| rooted_at_idx(strip_refs(body, r)))
                     && gate.callee_mutates_self(*func_id) != Some(false)
             }),
             _ => false,
@@ -1690,61 +1689,78 @@ enum AliasRoots {
     WithReassigned,
 }
 
+/// One binding site: the locals it binds, and the roots its source can yield.
+/// Neither depends on the alias set, so the walk that finds them runs once.
+struct AliasSite {
+    yields: Vec<u32>,
+    binds: Vec<u32>,
+}
+
 fn projection_alias_roots(body: &Body, idx: u32, gate: &Gate<'_>, which: AliasRoots) -> Vec<u32> {
+    let mut sites: Vec<AliasSite> = Vec::new();
+    let mut site = |value: Operand, binds: Vec<u32>| {
+        if binds.is_empty() {
+            return;
+        }
+        let yields = yielded_roots(body, value, gate);
+        if !yields.is_empty() {
+            sites.push(AliasSite { yields, binds });
+        }
+    };
+    let mut stack = vec![NodeRef::Block(body.root)];
+    while let Some(node) = stack.pop() {
+        match node {
+            NodeRef::Stmt(s) => match &body.stmts[s].kind {
+                StmtKind::Let {
+                    local_index, value, ..
+                } => site(*value, vec![*local_index]),
+                StmtKind::LetDestructure { pattern, value, .. } => {
+                    let mut binds = Vec::new();
+                    collect_pattern_bindings(body, *pattern, &mut binds);
+                    site(*value, binds);
+                }
+                StmtKind::Expr(_)
+                | StmtKind::Return { .. }
+                | StmtKind::Break { .. }
+                | StmtKind::If { .. }
+                | StmtKind::Loop { .. }
+                | StmtKind::LabeledBlock { .. }
+                | StmtKind::Continue => {}
+            },
+            NodeRef::Expr(e) => match &body.exprs[e].kind {
+                ExprKind::Match { expr, arms } => {
+                    let mut binds = Vec::new();
+                    for arm in arms {
+                        collect_pattern_bindings(body, arm.pattern, &mut binds);
+                    }
+                    site(*expr, binds);
+                }
+                // A local re-assigned from a projection names the same storage
+                // as one bound by `let` — the shape `licm` leaves when it
+                // hoists a field read out of a loop and refreshes it after each
+                // call that could have changed it.
+                ExprKind::Assign { target, value } if which == AliasRoots::WithReassigned => {
+                    let binds = assign_target_local(body, *target).into_iter().collect();
+                    site(*value, binds);
+                }
+                _ => {}
+            },
+            NodeRef::Block(_) | NodeRef::Pat(_) => {}
+        }
+        body.for_each_child(node, |c| stack.push(c));
+    }
     let mut roots = vec![idx];
     let mut i = 0;
     while i < roots.len() {
         let root = roots[i];
-        let mut stack = vec![NodeRef::Block(body.root)];
-        while let Some(node) = stack.pop() {
-            match node {
-                NodeRef::Stmt(s) => match &body.stmts[s].kind {
-                    StmtKind::Let {
-                        local_index, value, ..
-                    } => {
-                        if yields_projection_of(body, *value, root, gate)
-                            && !roots.contains(local_index)
-                        {
-                            roots.push(*local_index);
-                        }
-                    }
-                    StmtKind::LetDestructure { pattern, value, .. } => {
-                        if yields_projection_of(body, *value, root, gate) {
-                            collect_pattern_bindings(body, *pattern, &mut roots);
-                        }
-                    }
-                    StmtKind::Expr(_)
-                    | StmtKind::Return { .. }
-                    | StmtKind::Break { .. }
-                    | StmtKind::If { .. }
-                    | StmtKind::Loop { .. }
-                    | StmtKind::LabeledBlock { .. }
-                    | StmtKind::Continue => {}
-                },
-                NodeRef::Expr(e) => {
-                    if let ExprKind::Match { expr, arms } = &body.exprs[e].kind
-                        && yields_projection_of(body, *expr, root, gate)
-                    {
-                        for arm in arms {
-                            collect_pattern_bindings(body, arm.pattern, &mut roots);
-                        }
-                    }
-                    // A local re-assigned from a projection names the same
-                    // storage as one bound by `let` — the shape `licm` leaves
-                    // when it hoists a field read out of a loop and refreshes
-                    // it after each call that could have changed it.
-                    if which == AliasRoots::WithReassigned
-                        && let ExprKind::Assign { target, value } = &body.exprs[e].kind
-                        && let Some(local) = assign_target_local(body, *target)
-                        && yields_projection_of(body, *value, root, gate)
-                        && !roots.contains(&local)
-                    {
-                        roots.push(local);
+        for s in &sites {
+            if s.yields.contains(&root) {
+                for &b in &s.binds {
+                    if !roots.contains(&b) {
+                        roots.push(b);
                     }
                 }
-                NodeRef::Block(_) | NodeRef::Pat(_) => {}
             }
-            body.for_each_child(node, |c| stack.push(c));
         }
         i += 1;
     }
@@ -1775,9 +1791,7 @@ fn delivers_projection_operand(body: &Body, op: Operand, roots: &[u32], gate: &G
 /// `match`/`switch`'s is its arm's — the same rule the freshness side follows.
 fn delivers_projection(body: &Body, expr: ExprId, roots: &[u32], gate: &Gate<'_>) -> bool {
     if gate.is_reference_type(body.exprs[expr].type_id)
-        && roots
-            .iter()
-            .any(|&r| projection_roots_at(body, expr, r, gate))
+        && projection_root_of(body, expr, gate).is_some_and(|r| roots.contains(&r))
     {
         return true;
     }
@@ -1831,36 +1845,38 @@ fn collect_pattern_bindings(body: &Body, pattern: crate::nir_arena::PatId, out: 
     }
 }
 
-/// Whether evaluating `op` can produce the storage of `root` itself: it is, or
-/// contains, a reference-typed projection rooted there. A scalar projection
-/// (`s.used`) copies its value out and does not count.
-fn yields_projection_of(body: &Body, op: Operand, root: u32, gate: &Gate<'_>) -> bool {
+/// Every local whose storage evaluating `op` can produce: the root of each
+/// reference-typed projection in its subtree. A scalar projection (`s.used`)
+/// copies its value out and does not count.
+fn yielded_roots(body: &Body, op: Operand, gate: &Gate<'_>) -> Vec<u32> {
+    let mut out = Vec::new();
     let Some(expr) = op.as_expr() else {
-        return false;
+        return out;
     };
     let mut stack = vec![NodeRef::Expr(expr)];
     while let Some(node) = stack.pop() {
         if let NodeRef::Expr(e) = node
-            && projection_roots_at(body, e, root, gate)
             && gate.is_reference_type(body.exprs[e].type_id)
+            && let Some(root) = projection_root_of(body, e, gate)
+            && !out.contains(&root)
         {
-            return true;
+            out.push(root);
         }
         body.for_each_child(node, |c| stack.push(c));
     }
-    false
+    out
 }
 
-/// Whether `expr` is a projection chain (`x`, `x.f`, `x[i].f`) rooted at local
-/// `idx`.
-fn projection_roots_at(body: &Body, expr: ExprId, idx: u32, gate: &Gate<'_>) -> bool {
+/// The local a projection chain (`x`, `x.f`, `x[i].f`) is rooted at, or `None`
+/// when `expr` is not one.
+fn projection_root_of(body: &Body, expr: ExprId, gate: &Gate<'_>) -> Option<u32> {
     match &body.exprs[expr].kind {
-        ExprKind::Local { index, .. } => *index == idx,
+        ExprKind::Local { index, .. } => Some(*index),
         ExprKind::FieldAccess { expr: base, .. }
         | ExprKind::Index { expr: base, .. }
         | ExprKind::Cast { expr: base, .. } => base
             .as_expr()
-            .is_some_and(|e| projection_roots_at(body, e, idx, gate)),
+            .and_then(|e| projection_root_of(body, e, gate)),
         // A borrow and a deref both name the referent's storage, not a copy of
         // it: whether the caller keeps a copy is the ownership analysis's call,
         // and for a fresh literal it elides one.
@@ -1869,14 +1885,14 @@ fn projection_roots_at(body: &Body, expr: ExprId, idx: u32, gate: &Gate<'_>) -> 
             expr: base,
         } => base
             .as_expr()
-            .is_some_and(|e| projection_roots_at(body, e, idx, gate)),
+            .and_then(|e| projection_root_of(body, e, gate)),
         // An element accessor names the array's storage as an `Index` node
         // does; it is the same projection, spelled as a call.
         ExprKind::Call { func_id, args, .. } if gate.element_accessor(*func_id) => args
             .first()
             .and_then(|a| a.expr.as_expr())
-            .is_some_and(|e| projection_roots_at(body, e, idx, gate)),
-        _ => false,
+            .and_then(|e| projection_root_of(body, e, gate)),
+        _ => None,
     }
 }
 

--- a/wado-compiler/src/optimize/labeled_block_fusion.rs
+++ b/wado-compiler/src/optimize/labeled_block_fusion.rs
@@ -945,12 +945,7 @@ fn break_tag_value(body: &Body, elements: &[Operand]) -> Option<i128> {
 /// The slots `op` reads off `local_idx`, or `None` if it reads the local any
 /// other way — the fused block has no aggregate left to hand such a read.
 fn slot_reads_in_operand(body: &Body, op: Operand, local_idx: u32) -> Option<Vec<SlotRead>> {
-    let mut v = SlotReadCollector {
-        local_idx,
-        slots: IndexMap::default(),
-        direct_uses: 0,
-        slot_uses: 0,
-    };
+    let mut v = SlotReadCollector::in_operand(local_idx);
     match op {
         Operand::Expr(e) => v.visit_node(body, NodeRef::Expr(e)),
         // The operand itself is the read: no `FieldAccess` slot to hand it.
@@ -978,31 +973,80 @@ fn slot_reads_in_operand(body: &Body, op: Operand, local_idx: u32) -> Option<Vec
 /// and pool alike, and `slot_uses` counts those that are a `FieldAccess`
 /// receiver. Equal tallies mean every read is a slot read, which is the only
 /// shape the fused block can serve.
+///
+/// `lets` counts the `let`s declaring the temp, riding along because the
+/// whole-body census already runs the traversal that answers it.
+#[derive(Default)]
 struct SlotReadCollector {
     local_idx: u32,
     slots: IndexMap<u32, TypeId>,
     direct_uses: usize,
     slot_uses: usize,
+    lets: usize,
+    /// Stop once a non-slot read is proven to exist. A `FieldAccess` is visited
+    /// before the `Local` it reads, so `direct_uses - slot_uses` is the non-slot
+    /// reads seen minus the receivers still to be descended into: above zero,
+    /// one exists and the final tallies cannot match.
+    stop_on_excess: bool,
+    stopped: bool,
+}
+
+impl SlotReadCollector {
+    /// Census of the whole body, which may stop early: its verdict is a
+    /// yes/no, so partial tallies past a proven mismatch decide nothing.
+    fn whole_body(local_idx: u32) -> Self {
+        SlotReadCollector {
+            local_idx,
+            stop_on_excess: true,
+            ..Self::default()
+        }
+    }
+
+    /// Tally within one operand, which runs to completion — the caller needs
+    /// the exact slot list, not just the verdict.
+    fn in_operand(local_idx: u32) -> Self {
+        SlotReadCollector {
+            local_idx,
+            ..Self::default()
+        }
+    }
 }
 
 impl NirRefVisitor for SlotReadCollector {
     fn visit_node(&mut self, body: &Body, node: NodeRef) {
-        if let NodeRef::Expr(e) = node {
-            if is_local(body, e, self.local_idx) {
-                self.direct_uses += 1;
+        if self.stopped {
+            return;
+        }
+        match node {
+            NodeRef::Expr(e) => {
+                if is_local(body, e, self.local_idx) {
+                    self.direct_uses += 1;
+                }
+                if let ExprKind::FieldAccess {
+                    expr: inner,
+                    field_index,
+                    ..
+                } = &body.exprs[e].kind
+                    && is_local_operand(body, *inner, self.local_idx)
+                {
+                    self.slot_uses += 1;
+                    self.slots.insert(*field_index, body.exprs[e].type_id);
+                }
             }
-            if let ExprKind::FieldAccess {
-                expr: inner,
-                field_index,
-                ..
-            } = &body.exprs[e].kind
-                && is_local_operand(body, *inner, self.local_idx)
-            {
-                self.slot_uses += 1;
-                self.slots.insert(*field_index, body.exprs[e].type_id);
+            NodeRef::Stmt(s) => {
+                if let StmtKind::Let { local_index, .. } = &body.stmts[s].kind
+                    && *local_index == self.local_idx
+                {
+                    self.lets += 1;
+                }
             }
+            NodeRef::Block(_) | NodeRef::Pat(_) => {}
         }
         self.direct_uses += promoted_read_count_at(body, node, self.local_idx);
+        if self.stop_on_excess && self.direct_uses > self.slot_uses {
+            self.stopped = true;
+            return;
+        }
         self.walk_node(body, node);
     }
 }
@@ -2516,14 +2560,6 @@ fn plan_slot_temp_sroa(
     };
     let (label, lb_block) = (label.clone(), *lb_block);
 
-    // One `let` for the temp, or the rewrite is unsound: `clone_block` (fusion's
-    // own duplication) copies `local_index` verbatim, and a second copy's
-    // `temp.k` reads would be rewritten to slot locals that only the first
-    // copy's exits declare and assign.
-    if declaration_count(body, temp_local) != 1 {
-        return None;
-    }
-
     // The block's value must arrive through `break L:` exits the transform can
     // reach, so the tail has to terminate rather than fall through with one.
     // Checked before the read census below, which walks the whole body.
@@ -2535,16 +2571,22 @@ fn plan_slot_temp_sroa(
         return None;
     }
 
-    // Every read of the temp, anywhere in the body, must be a `temp.k`
-    // projection: the block has no aggregate left to hand any other read.
-    let mut reads = SlotReadCollector {
-        local_idx: temp_local,
-        slots: IndexMap::default(),
-        direct_uses: 0,
-        slot_uses: 0,
-    };
+    // Every read of the temp must be a `temp.k` projection — the block has no
+    // aggregate left to hand any other — and exactly one `let` may declare it:
+    // `clone_block` copies `local_index` verbatim, and a second copy's reads
+    // would be rewritten to slot locals only the first copy's exits assign.
+    let mut reads = SlotReadCollector::whole_body(temp_local);
     reads.visit_node(body, NodeRef::Block(body.root));
-    if reads.slot_uses == 0 || reads.direct_uses != reads.slot_uses {
+    assert!(
+        reads.stopped || reads.slot_uses <= reads.direct_uses,
+        "every slot read is also a direct read, so a completed census cannot \
+         count more slot reads than direct ones"
+    );
+    if reads.stopped
+        || reads.slot_uses == 0
+        || reads.direct_uses != reads.slot_uses
+        || reads.lets != 1
+    {
         return None;
     }
     let mut fields: Vec<(u32, TypeId)> = reads.slots.into_iter().collect();
@@ -2684,26 +2726,6 @@ fn perform_slot_temp_sroa(
     kept.extend_from_slice(&stmts[i + 1..]);
     engine.set_block_stmts(outer_block, kept);
     engine.note_elided_local(plan.temp_local);
-}
-
-/// How many `let` statements declare `idx`, capped at two — the callers only
-/// need to tell "exactly one" from "more".
-fn declaration_count(body: &Body, idx: u32) -> usize {
-    let mut count = 0;
-    let mut stack = vec![NodeRef::Block(body.root)];
-    while let Some(node) = stack.pop() {
-        if let NodeRef::Stmt(s) = node
-            && let StmtKind::Let { local_index, .. } = &body.stmts[s].kind
-            && *local_index == idx
-        {
-            count += 1;
-            if count > 1 {
-                return count;
-            }
-        }
-        body.for_each_child(node, |c| stack.push(c));
-    }
-    count
 }
 
 /// Replace each `break L: [e0, …]` with the slot assignments the projections


### PR DESCRIPTION
Two NIR passes answer per-local questions from a single traversal of the
function body, rather than one traversal per query. A large Gale-generated
parser at `-O3` spends correspondingly less time in the optimizer, for
byte-identical output.

## `const_object_globalization`

`projection_alias_roots` collects the binding sites (`let`, destructuring
`let`, `match`, re-assignment) in one walk, each carrying the roots its source
can yield, then closes the alias set over that list. A site's yielded roots do
not depend on the alias set, so the walk that finds them runs once however far
the set grows.

`projection_root_of(expr) -> Option<u32>` is the single resolver for "which
local is this projection chain rooted at". Callers compare its result, so
neither `written_through` nor `delivers_projection` re-walks a chain per
candidate root.

## `labeled_block_fusion`

`SlotReadCollector` answers the whole-body census — every read of the temp is a
`temp.k` projection, and exactly one `let` declares it — from one traversal. It
stops as soon as a non-slot read is proven: a `FieldAccess` is visited before
the `Local` it reads, so `direct_uses - slot_uses` above zero is a non-slot
read that no later node can pair off, and the final tallies cannot match. An
`assert!` states the pairing invariant the early exit rests on.

## Profiling

`analyze_native_profile.ts` reports allocation cost by requesting caller: every
sample whose stack crosses an allocator entry, credited above the outermost
one, skipping the `Vec` / `HashMap` growth plumbing. The section header is
allocation's share of total CPU, so whether a workload is allocation-bound is a
number rather than a guess. mimalloc's internals carry no DWARF, so crediting
by leaf frame would scatter the cost across raw addresses.

## Measured

Release-equivalent (`profiling`) build, interleaved A/B against `main`, USER
CPU on an otherwise idle host. Sources are the Gale-generated parsers in
`package-gale/tests/generated/`.

| target                | `main`  | this branch |
| --------------------- | ------: | ----------: |
| SQLite parser (`-O2`) |  6.35 s |      4.54 s |
| SQLite parser (`-O3`) |  17.7 s |      14.7 s |
| CSS3 parser (`-O3`)   |  25.3 s |      24.0 s |

Emitted Wasm is byte-identical at `-O0` … `-O3` and `-Os` for both parsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
