### PR TITLE
docs: add "fix the class" to the principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ Note: `CLAUDE.md` is a symlink to `AGENTS.md`.
 
 - Succinctly — say and write the least that fully conveys the point.
 - Fix-forward — fix the cause of a defect and move forward; never backtrack.
+- Fix the class — a defect names an instance; fix what admits the class. Fixes
+  that keep drawing new findings are naming the design, not the code.
 
 ## Development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ Note: `CLAUDE.md` is a symlink to `AGENTS.md`.
 
 - Succinctly — say and write the least that fully conveys the point.
 - Fix-forward — fix the cause of a defect and move forward; never backtrack.
-- Fix the class — a defect names an instance; fix what admits the class. Fixes
-  that keep drawing new findings are naming the design, not the code.
+- Fix the class — a defect is one instance; fix what admits the class. Fixes
+  that keep drawing findings name the design, not the code.
 
 ## Development
 

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -12,9 +12,8 @@ optimizer has its own guide: [`docs/optimizer.md`](../docs/optimizer.md).
 - Walk IR through the visitor utilities, not by hand, and answer a question
   once: one resolver total over the IR, rather than partial walkers, which
   multiply until each misses a different shape.
-- Take a finding one altitude up before fixing it. It names a line; ask whether
-  that shape occurs at all, and what else answers the same question. A fix aimed
-  at the line leaves the invariant free to break again elsewhere.
+- Take a finding one altitude up before fixing it: it names a line, so ask
+  whether that shape occurs at all, and what else answers the same question.
 - Optimize as far as correctness allows. A conservatism is a claim about
   precision: measure what it buys before keeping it, and drop the ones that buy
   nothing.

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -12,8 +12,8 @@ optimizer has its own guide: [`docs/optimizer.md`](../docs/optimizer.md).
 - Walk IR through the visitor utilities, not by hand, and answer a question
   once: one resolver total over the IR, rather than partial walkers, which
   multiply until each misses a different shape.
-- Take a finding one altitude up before fixing it: it names a line, so ask
-  whether that shape occurs at all, and what else answers the same question.
+- Take a finding one altitude up: it names a line, so ask whether that shape
+  occurs elsewhere in the IR before fixing there.
 - Optimize as far as correctness allows. A conservatism is a claim about
   precision: measure what it buys before keeping it, and drop the ones that buy
   nothing.


### PR DESCRIPTION
Fix-forward says which direction to fix a defect in. This says at what altitude.

```
- Fix the class — a defect is one instance; fix what admits the class. Fixes
  that keep drawing findings name the design, not the code.
```

The second sentence is the part that is usable while it is happening. "Fix the
class" as an aspiration is easy to agree with and easy to believe you are
already doing; a run of fixes that keeps producing new findings is an
observation, and it says the design is wrong rather than the code.

It sits in Principles because it is not compiler-specific — the same reading
applies to the language service, the CLI, and the Wado packages. It is
compatible with the two rules it sits near: "avoid ad-hoc workarounds" names a
different failure (a patch known to be temporary, rather than a shallow fix
believed complete), and the P0 rule sets priority rather than altitude.

`wado-compiler` already told you to take a finding one altitude up. That keeps
the part this does not carry — whether the shape occurs elsewhere in the IR —
and drops "what else answers the same question", which is the resolver rule one
bullet above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)