### PR TITLE
chore(cloudflare-worker): enforce the npm floor

### DIFF
--- a/cloudflare-worker/.npmrc
+++ b/cloudflare-worker/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/cloudflare-worker/package.json
+++ b/cloudflare-worker/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "type": "module",
   "description": "Serve a Wado wasi:http/service component from a Cloudflare Worker.",
+  "engines": {
+    "node": ">=24",
+    "npm": ">=12"
+  },
   "dependencies": {
     "@bytecodealliance/preview3-shim": "^0.3.2"
   },


### PR DESCRIPTION
`cloudflare-worker/` declares `engines` (`node >=24`, `npm >=12`) and sets
`engine-strict=true` in `.npmrc`, so npm refuses to install under a version
below the floor instead of warning past it. Both match `wado-vscode/`.

npm 12 is where the supply-chain defaults land: install scripts are blocked
unless allowlisted, so a dependency cannot run arbitrary code at install time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)