### PR TITLE
refactor(elaborator): give a body-walk fact one home

### DIFF
--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -85,7 +85,7 @@ The AST is parser-immutable from this point on. The desugar-replacement surface 
 
 The LSP path stops after liveness and builds no TIR.
 
-The result, `Semantics`, carries the TIR modules plus an `AstIndex` and a use→def map (`AstId → AstId`, globally-unique ids). This is what makes the architecture LSP-friendly: facts are attached to AST nodes without mutating them, so cross-file navigation, hover, and rename all fall out of the same data the batch compiler uses. See the [LSP](#lsp) section below.
+The result, `Semantics`, carries the TIR modules plus an `AstIndex`, and answers every fact query — the use→def edges among them — by routing a globally-unique `AstId` to the `ModuleSemantics` whose walk recorded it, rather than holding a copy. This is what makes the architecture LSP-friendly: facts are attached to AST nodes without mutating them, so cross-file navigation, hover, and rename all fall out of the same data the batch compiler uses. See the [LSP](#lsp) section below.
 
 The elaborator covers trait selection, generic inference, method dispatch, coercion, and effect typing. All trait calls are resolved statically — by the end of the pipeline every call targets a concrete monomorphized function. There is no runtime vtable.
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -85,7 +85,7 @@ The AST is parser-immutable from this point on. The desugar-replacement surface 
 
 The LSP path stops after liveness and builds no TIR.
 
-The result, `Semantics`, carries the TIR modules plus an `AstIndex`, and answers every fact query — the use→def edges among them — by routing a globally-unique `AstId` to the `ModuleSemantics` whose walk recorded it, rather than holding a copy. This is what makes the architecture LSP-friendly: facts are attached to AST nodes without mutating them, so cross-file navigation, hover, and rename all fall out of the same data the batch compiler uses. See the [LSP](#lsp) section below.
+The result, `Semantics`, carries the TIR modules plus an `AstIndex`, and answers every fact query — the use→def edges among them — by routing a globally-unique `AstId` and the kind of fact asked for to the `ModuleSemantics` whose walk recorded it, rather than holding a copy. One node's kinds need not come from one walk, which is why the kind routes too; [WEP 2026-05-26](./wep-2026-05-26-elaborator-rearchitecture.md) owns the rest of the rule. This is what makes the architecture LSP-friendly: facts are attached to AST nodes without mutating them, so cross-file navigation, hover, and rename all fall out of the same data the batch compiler uses. See the [LSP](#lsp) section below.
 
 The elaborator covers trait selection, generic inference, method dispatch, coercion, and effect typing. All trait calls are resolved statically — by the end of the pipeline every call targets a concrete monomorphized function. There is no runtime vtable.
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -85,7 +85,7 @@ The AST is parser-immutable from this point on. The desugar-replacement surface 
 
 The LSP path stops after liveness and builds no TIR.
 
-The result, `Semantics`, carries the TIR modules plus an `AstIndex`, and answers every fact query — the use→def edges among them — by routing a globally-unique `AstId` and the kind of fact asked for to the `ModuleSemantics` whose walk recorded it, rather than holding a copy. One node's kinds need not come from one walk, which is why the kind routes too; [WEP 2026-05-26](./wep-2026-05-26-elaborator-rearchitecture.md) owns the rest of the rule. This is what makes the architecture LSP-friendly: facts are attached to AST nodes without mutating them, so cross-file navigation, hover, and rename all fall out of the same data the batch compiler uses. See the [LSP](#lsp) section below.
+The result, `Semantics`, carries the TIR modules plus an `AstIndex`. It holds no fact of its own: a query names a globally-unique `AstId` and a fact kind, and is routed to the `ModuleSemantics` whose walk recorded that fact — the use→def edges among them. The kind is part of the route because one node's kinds need not come from one walk; [WEP 2026-05-26](./wep-2026-05-26-elaborator-rearchitecture.md) owns the rest of the rule. This is what makes the architecture LSP-friendly: facts are attached to AST nodes without mutating them, so cross-file navigation, hover, and rename all fall out of the same data the batch compiler uses. See the [LSP](#lsp) section below.
 
 The elaborator covers trait selection, generic inference, method dispatch, coercion, and effect typing. All trait calls are resolved statically — by the end of the pipeline every call targets a concrete monomorphized function. There is no runtime vtable.
 

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -85,7 +85,7 @@ The AST is parser-immutable from this point on. The desugar-replacement surface 
 
 The LSP path stops after liveness and builds no TIR.
 
-The result, `Semantics`, carries the TIR modules plus an `AstIndex`. It holds no fact of its own: a query names a globally-unique `AstId` and a fact kind, and is routed to the `ModuleSemantics` whose walk recorded that fact — the use→def edges among them. The kind is part of the route because one node's kinds need not come from one walk; [WEP 2026-05-26](./wep-2026-05-26-elaborator-rearchitecture.md) owns the rest of the rule. This is what makes the architecture LSP-friendly: facts are attached to AST nodes without mutating them, so cross-file navigation, hover, and rename all fall out of the same data the batch compiler uses. See the [LSP](#lsp) section below.
+The result, `Semantics`, carries an `AstIndex`, and the `TirModule`s too once reify has run. It holds no fact of its own: a query names a globally-unique `AstId` and a fact kind, and is routed to the `ModuleSemantics` whose walk recorded that fact — the use→def edges among them. The kind is part of the route because one node's kinds need not come from one walk; [WEP 2026-05-26](./wep-2026-05-26-elaborator-rearchitecture.md) owns the rest of the rule. This is what makes the architecture LSP-friendly: facts are attached to AST nodes without mutating them, so cross-file navigation, hover, and rename all fall out of the same data the batch compiler uses. See the [LSP](#lsp) section below.
 
 The elaborator covers trait selection, generic inference, method dispatch, coercion, and effect typing. All trait calls are resolved statically — by the end of the pipeline every call targets a concrete monomorphized function. There is no runtime vtable.
 

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -145,9 +145,11 @@ foreign AST name its node exactly, whichever module's map it lands in.
 A fact has one home, the map the walk wrote it into, and every phase reads it
 there. `Semantics`, keyed by bare `AstId` too, holds no second copy: it routes
 a fact to the module whose walk recorded it. Routing is per fact kind, because
-a node two walks reach has kinds only one of them holds — a callee's parameter
+a node two walks reach splits its kinds across them — a callee's parameter
 default is typed at each call site, while its own module records the edges
-around it.
+around it. Several walks can also hold one kind for one node, that default's
+type among them; the last module in `AnnotateState::module_semantics` order is
+the one routed to.
 
 ### Signatures — every declaration signature is a decl-pass fact
 

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -143,11 +143,11 @@ Every fact map keys by bare `AstId`, which is globally unique
 foreign AST name its node exactly, whichever module's map it lands in.
 
 A fact has one home, the map the walk wrote it into, and every phase reads it
-there. `Semantics` — also keyed by bare `AstId` — holds no second copy: it
-routes a fact to the module whose walk recorded it and reads through. Per fact
-kind, not per node: a node two walks reach — a callee's parameter default,
-typed at each call site while its own module records the edges around it — has
-kinds only one of them holds, so the node alone does not name a walk.
+there. `Semantics`, keyed by bare `AstId` too, holds no second copy: it routes
+a fact to the module whose walk recorded it. Routing is per fact kind, because
+a node two walks reach has kinds only one of them holds — a callee's parameter
+default is typed at each call site, while its own module records the edges
+around it.
 
 ### Signatures — every declaration signature is a decl-pass fact
 

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -144,9 +144,10 @@ foreign AST name its node exactly, whichever module's map it lands in.
 
 A fact has one home, the map the walk wrote it into, and every phase reads it
 there. `Semantics` — also keyed by bare `AstId` — holds no second copy: it
-routes an id to the module whose walk recorded it and reads through. Two walks
-reaching one node (a callee's parameter default, resolved in each caller's
-frame) resolve to the last, so a node's facts all come from one walk.
+routes a fact to the module whose walk recorded it and reads through. Per fact
+kind, not per node: a node two walks reach — a callee's parameter default,
+typed at each call site while its own module records the edges around it — has
+kinds only one of them holds, so the node alone does not name a walk.
 
 ### Signatures — every declaration signature is a decl-pass fact
 

--- a/docs/wep-2026-05-26-elaborator-rearchitecture.md
+++ b/docs/wep-2026-05-26-elaborator-rearchitecture.md
@@ -142,6 +142,12 @@ Every fact map keys by bare `AstId`, which is globally unique
 (`(AstIdSpace, local)`). That is what lets a fact recorded while walking
 foreign AST name its node exactly, whichever module's map it lands in.
 
+A fact has one home, the map the walk wrote it into, and every phase reads it
+there. `Semantics` — also keyed by bare `AstId` — holds no second copy: it
+routes an id to the module whose walk recorded it and reads through. Two walks
+reaching one node (a callee's parameter default, resolved in each caller's
+frame) resolve to the last, so a node's facts all come from one walk.
+
 ### Signatures — every declaration signature is a decl-pass fact
 
 Rule: after `annotate_decls`, no phase re-resolves a declaration signature
@@ -566,19 +572,6 @@ Closing it: bundle the borrowed inputs behind `ElabEnv`, dissolve
 `AnnotateState` — `tysys` and `module_semantics` land on `Semantics`, the rest
 are driver locals — collapse the per-module construction site, and move the
 recursion stack into `Scope` behind a guard.
-
-### One fact, two homes
-
-`TypeAnnotations` carries 31 fields. Five of them — `local_types`,
-`expression_types`, `method_dispatch`, `coercions`, `desugars` — are
-`mem::take`n out of every `ModuleSemantics` and re-published as flat maps on
-`Semantics`, leaving those five empty behind them. The other 26 stay where the
-walker wrote them, and `effect_check` reads them there. Nothing
-in either type says which half is live, so a consumer that guesses wrong reads
-an empty map instead of failing.
-
-Closing it: one home. Either the flat `Semantics` maps become views over
-`ModuleSemantics`, or the five fields leave `TypeAnnotations` outright.
 
 ### Two more implementations of type-parameter substitution
 

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -1304,28 +1304,16 @@ impl SemEffectWalker<'_> {
         self.index.method_param_types(func_ref)
     }
 
-    /// Type of an indirect call's callee. When the callee is an identifier
-    /// bound to a local or parameter, its type lives in `local_types` keyed by
-    /// the binding's def (resolved through `references`); function-typed
-    /// parameters are recorded there, not in `expression_types`. Other callee
-    /// shapes fall back to the expression's recorded type.
+    /// Type of an indirect call's callee, preferring the enclosing function's
+    /// parameter types: a function-typed parameter callee leaves no `references`
+    /// edge or recorded expression type at the call, so nothing else names it.
     fn indirect_callee_type(&self, call: &crate::ast::CallExpr) -> Option<TypeId> {
-        if let Expr::Ident(ident) = &call.callee {
-            // A function-typed parameter callee leaves no `references` edge or
-            // recorded expression type at the call, so resolve it against the
-            // enclosing function's parameter types by name first.
-            if let Some(type_id) = self.param_types.get(&ident.name) {
-                return Some(*type_id);
-            }
-            if let Some(type_id) = self
-                .sem
-                .referenced_symbol(ident.id)
-                .and_then(|def| self.sem.local_type(def))
-            {
-                return Some(type_id);
-            }
+        if let Expr::Ident(ident) = &call.callee
+            && let Some(type_id) = self.param_types.get(&ident.name)
+        {
+            return Some(*type_id);
         }
-        self.sem.expression_type(call.callee.id())
+        expr_type_of(&call.callee, self.sem)
     }
 }
 
@@ -1931,9 +1919,8 @@ struct ReturnedCall<'e> {
     args: Vec<&'e Expr>,
 }
 
-/// Type of `expr`, preferring a binding's declared type (parameters and
-/// function-typed locals live in `local_types`, keyed by the binding's def)
-/// over the expression's recorded type.
+/// Type of `expr`, preferring the type of the binding an identifier names —
+/// where a parameter or a function-typed local has one and the use site does not.
 fn expr_type_of(expr: &Expr, sem: &Semantics) -> Option<TypeId> {
     if let Expr::Ident(ident) = expr
         && let Some(def) = sem.referenced_symbol(ident.id)
@@ -1942,17 +1929,6 @@ fn expr_type_of(expr: &Expr, sem: &Semantics) -> Option<TypeId> {
         return Some(ty);
     }
     sem.expression_type(expr.id())
-}
-
-/// Type of an indirect call's callee identifier (a functor local / param).
-fn indirect_callee_type_of(callee: &Expr, sem: &Semantics) -> Option<TypeId> {
-    if let Expr::Ident(ident) = callee
-        && let Some(def) = sem.referenced_symbol(ident.id)
-        && let Some(ty) = sem.local_type(def)
-    {
-        return Some(ty);
-    }
-    sem.expression_type(callee.id())
 }
 
 /// The parameter positions the *place* operand of `&` is rooted at, ignoring
@@ -2069,7 +2045,7 @@ fn resolve_returned_args<'e>(
                     args,
                 });
             }
-            if let Some(callee_ty) = indirect_callee_type_of(&call.callee, sem) {
+            if let Some(callee_ty) = expr_type_of(&call.callee, sem) {
                 let returned = match sem.types.get(callee_ty) {
                     ResolvedType::Function { stores, .. } => stores.iter().copied().collect(),
                     _ => (0..u32::try_from(args.len()).unwrap()).collect(),
@@ -2181,10 +2157,6 @@ fn carries_of(
 }
 
 impl RefFlow<'_, '_> {
-    fn expr_type(&self, expr: &Expr) -> Option<TypeId> {
-        expr_type_of(expr, self.ctx.sem)
-    }
-
     /// Parameter positions the reference produced by `expr` carries — the escape
     /// walk's view, sharing [`carries_of`] with the return-provenance fixpoint so
     /// both fold calls at the same return-provenance positions.
@@ -2228,7 +2200,7 @@ impl RefFlow<'_, '_> {
                         args,
                     });
                 }
-                if let Some(callee_ty) = self.indirect_callee_type(&call.callee) {
+                if let Some(callee_ty) = expr_type_of(&call.callee, self.ctx.sem) {
                     let stored = match self.ctx.sem.types.get(callee_ty) {
                         ResolvedType::Function { stores, .. } => stores.clone(),
                         _ => (0..u32::try_from(args.len()).unwrap()).collect(),
@@ -2275,11 +2247,6 @@ impl RefFlow<'_, '_> {
             .unwrap_or_default()
     }
 
-    /// Type of an indirect call's callee identifier (a functor local / param).
-    fn indirect_callee_type(&self, callee: &Expr) -> Option<TypeId> {
-        indirect_callee_type_of(callee, self.ctx.sem)
-    }
-
     fn sink_value(&mut self, value: &Expr, sink: Sink) {
         let carried = self.carries(value);
         self.mark(&carried, value.span(), &sink);
@@ -2295,8 +2262,7 @@ impl RefFlow<'_, '_> {
         let Some(call) = self.call_stored_args(expr) else {
             return;
         };
-        if self
-            .expr_type(expr)
+        if expr_type_of(expr, self.ctx.sem)
             .is_some_and(|ty| self.ctx.tyctx.can_hold_ref(&self.ctx.sem.types, ty))
         {
             return;
@@ -2376,12 +2342,6 @@ impl RefFlow<'_, '_> {
             }
             _ => None,
         }
-    }
-
-    /// Whether an identifier's binding is a reference (`&T` / `&mut T`), so a
-    /// write into its projection reaches caller-visible memory.
-    fn ident_is_ref(&self, ident: &ast::IdentExpr) -> bool {
-        ident_is_ref_of(ident, self.ctx.sem)
     }
 
     /// Reject a named-function reference argument whose declared `stores`
@@ -2496,7 +2456,7 @@ impl AstVisitor for RefFlow<'_, '_> {
                                 if let Some(def) = self.ctx.sem.referenced_symbol(ident.id) {
                                     self.carries.entry(def).or_default().extend(carried);
                                 }
-                            } else if through_deref || self.ident_is_ref(ident) {
+                            } else if through_deref || ident_is_ref_of(ident, self.ctx.sem) {
                                 self.mark(&carried, span, &Sink::ThroughRef);
                             } else if let Some(def) = self.ctx.sem.referenced_symbol(ident.id) {
                                 self.carries.entry(def).or_default().extend(carried);

--- a/wado-compiler/src/effect_check.rs
+++ b/wado-compiler/src/effect_check.rs
@@ -1090,7 +1090,7 @@ impl SemEffectWalker<'_> {
             {
                 continue;
             }
-            let Some(arg_type) = self.sem.expression_types.get(&arg.id()).copied() else {
+            let Some(arg_type) = self.sem.expression_type(arg.id()) else {
                 continue;
             };
             let ResolvedType::Function {
@@ -1197,11 +1197,11 @@ impl AstVisitor for SemEffectWalker<'_> {
                 // functions also appear in `static_method_dispatch`, so try
                 // `references` first — it is the authoritative free-call edge.)
                 let free = if let Expr::Ident(ident) = &call.callee {
-                    self.sem.references.get(&ident.id).and_then(|def| {
+                    self.sem.referenced_symbol(ident.id).and_then(|def| {
                         self.index
                             .fn_effects
-                            .get(def)
-                            .map(|effects| (*def, effects.clone(), ident.name.clone()))
+                            .get(&def)
+                            .map(|effects| (def, effects.clone(), ident.name.clone()))
                     })
                 } else {
                     None
@@ -1242,7 +1242,7 @@ impl AstVisitor for SemEffectWalker<'_> {
             }
             Expr::MethodCall(method_call) => {
                 let call_key = method_call.id;
-                if let Some(dispatch) = self.sem.method_dispatch.get(&call_key) {
+                if let Some(dispatch) = self.sem.method_dispatch_at(call_key) {
                     let func_ref = dispatch.function_ref.clone();
                     let mut effects = self.method_effects(&func_ref);
                     effects.extend(self.effect_op_requirement(&func_ref, None));
@@ -1319,14 +1319,13 @@ impl SemEffectWalker<'_> {
             }
             if let Some(type_id) = self
                 .sem
-                .references
-                .get(&ident.id)
-                .and_then(|def| self.sem.local_types.get(def))
+                .referenced_symbol(ident.id)
+                .and_then(|def| self.sem.local_type(def))
             {
-                return Some(*type_id);
+                return Some(type_id);
             }
         }
-        self.sem.expression_types.get(&call.callee.id()).copied()
+        self.sem.expression_type(call.callee.id())
     }
 }
 
@@ -1691,9 +1690,9 @@ impl AstVisitor for ReturnFlow<'_> {
                         && !through_deref
                         && global_name_of(ident, self.annotations).is_none()
                         && !ident_is_ref_of(ident, self.sem)
-                        && let Some(def) = self.sem.references.get(&ident.id)
+                        && let Some(def) = self.sem.referenced_symbol(ident.id)
                     {
-                        self.carries.entry(*def).or_default().extend(carried);
+                        self.carries.entry(def).or_default().extend(carried);
                     }
                 }
             }
@@ -1851,7 +1850,7 @@ impl StoresCtx<'_> {
     /// Obligation #2: a closure may not store any of its reference parameters
     /// (allowance `[]`).
     fn check_closure(&self, closure: &ast::ClosureExpr, out: &mut Vec<StoresError>) {
-        let Some(&type_id) = self.sem.expression_types.get(&closure.id) else {
+        let Some(type_id) = self.sem.expression_type(closure.id) else {
             return;
         };
         let ResolvedType::Function { params, .. } = self.sem.types.get(type_id) else {
@@ -1937,23 +1936,23 @@ struct ReturnedCall<'e> {
 /// over the expression's recorded type.
 fn expr_type_of(expr: &Expr, sem: &Semantics) -> Option<TypeId> {
     if let Expr::Ident(ident) = expr
-        && let Some(def) = sem.references.get(&ident.id)
-        && let Some(&ty) = sem.local_types.get(def)
+        && let Some(def) = sem.referenced_symbol(ident.id)
+        && let Some(ty) = sem.local_type(def)
     {
         return Some(ty);
     }
-    sem.expression_types.get(&expr.id()).copied()
+    sem.expression_type(expr.id())
 }
 
 /// Type of an indirect call's callee identifier (a functor local / param).
 fn indirect_callee_type_of(callee: &Expr, sem: &Semantics) -> Option<TypeId> {
     if let Expr::Ident(ident) = callee
-        && let Some(def) = sem.references.get(&ident.id)
-        && let Some(&ty) = sem.local_types.get(def)
+        && let Some(def) = sem.referenced_symbol(ident.id)
+        && let Some(ty) = sem.local_type(def)
     {
         return Some(ty);
     }
-    sem.expression_types.get(&callee.id()).copied()
+    sem.expression_type(callee.id())
 }
 
 /// The parameter positions the *place* operand of `&` is rooted at, ignoring
@@ -1965,9 +1964,8 @@ fn place_roots_of(
 ) -> IndexSet<u32> {
     match place {
         Expr::Ident(ident) => sem
-            .references
-            .get(&ident.id)
-            .and_then(|def| carries.get(def))
+            .referenced_symbol(ident.id)
+            .and_then(|def| carries.get(&def))
             .cloned()
             .unwrap_or_default(),
         Expr::Unary(u) if u.op == ast::UnaryOp::Deref => place_roots_of(&u.expr, sem, carries),
@@ -2007,10 +2005,9 @@ fn global_name_of(
 
 /// Whether an identifier's binding is a reference (`&T` / `&mut T`).
 fn ident_is_ref_of(ident: &ast::IdentExpr, sem: &Semantics) -> bool {
-    sem.references
-        .get(&ident.id)
-        .and_then(|def| sem.local_types.get(def))
-        .is_some_and(|&ty| {
+    sem.referenced_symbol(ident.id)
+        .and_then(|def| sem.local_type(def))
+        .is_some_and(|ty| {
             matches!(
                 sem.types.get(ty),
                 ResolvedType::Ref(_) | ResolvedType::MutRef(_)
@@ -2030,9 +2027,8 @@ fn ident_returns(
     std::iter::once(ident.id)
         .chain(ident.segments.iter().map(|s| s.id))
         .find_map(|use_id| {
-            sem.references
-                .get(&use_id)
-                .and_then(|def| fn_returns.get(def))
+            sem.referenced_symbol(use_id)
+                .and_then(|def| fn_returns.get(&def))
                 .cloned()
         })
 }
@@ -2089,8 +2085,7 @@ fn resolve_returned_args<'e>(
             let mut args: Vec<&Expr> = vec![&mc.receiver];
             args.extend(mc.args.iter());
             let returned = sem
-                .method_dispatch
-                .get(&mc.id)
+                .method_dispatch_at(mc.id)
                 .map(|d| mangled(&d.function_ref))
                 .unwrap_or_default();
             Some(ReturnedCall { returned, args })
@@ -2142,9 +2137,8 @@ fn carries_of(
     };
     match expr {
         Expr::Ident(ident) => sem
-            .references
-            .get(&ident.id)
-            .and_then(|def| carries.get(def))
+            .referenced_symbol(ident.id)
+            .and_then(|def| carries.get(&def))
             .cloned()
             .unwrap_or_default(),
         Expr::Unary(u) if matches!(u.op, ast::UnaryOp::Ref | ast::UnaryOp::MutRef) => {
@@ -2188,13 +2182,7 @@ fn carries_of(
 
 impl RefFlow<'_, '_> {
     fn expr_type(&self, expr: &Expr) -> Option<TypeId> {
-        if let Expr::Ident(ident) = expr
-            && let Some(def) = self.ctx.sem.references.get(&ident.id)
-            && let Some(&ty) = self.ctx.sem.local_types.get(def)
-        {
-            return Some(ty);
-        }
-        self.ctx.sem.expression_types.get(&expr.id()).copied()
+        expr_type_of(expr, self.ctx.sem)
     }
 
     /// Parameter positions the reference produced by `expr` carries — the escape
@@ -2220,8 +2208,8 @@ impl RefFlow<'_, '_> {
             Expr::Call(call) => {
                 let args: Vec<&Expr> = call.args.iter().collect();
                 if let Expr::Ident(ident) = &call.callee
-                    && let Some(def) = self.ctx.sem.references.get(&ident.id)
-                    && let Some(stored) = self.ctx.oracle.fn_stores.get(def)
+                    && let Some(def) = self.ctx.sem.referenced_symbol(ident.id)
+                    && let Some(stored) = self.ctx.oracle.fn_stores.get(&def)
                 {
                     return Some(ResolvedCall {
                         stored: stored.clone(),
@@ -2258,8 +2246,7 @@ impl RefFlow<'_, '_> {
                 let stored = self
                     .ctx
                     .sem
-                    .method_dispatch
-                    .get(&mc.id)
+                    .method_dispatch_at(mc.id)
                     .map(|d| self.mangled_stored(&d.function_ref))
                     .unwrap_or_default();
                 Some(ResolvedCall { stored, args })
@@ -2290,13 +2277,7 @@ impl RefFlow<'_, '_> {
 
     /// Type of an indirect call's callee identifier (a functor local / param).
     fn indirect_callee_type(&self, callee: &Expr) -> Option<TypeId> {
-        if let Expr::Ident(ident) = callee
-            && let Some(def) = self.ctx.sem.references.get(&ident.id)
-            && let Some(&ty) = self.ctx.sem.local_types.get(def)
-        {
-            return Some(ty);
-        }
-        self.ctx.sem.expression_types.get(&callee.id()).copied()
+        indirect_callee_type_of(callee, self.ctx.sem)
     }
 
     fn sink_value(&mut self, value: &Expr, sink: Sink) {
@@ -2400,17 +2381,7 @@ impl RefFlow<'_, '_> {
     /// Whether an identifier's binding is a reference (`&T` / `&mut T`), so a
     /// write into its projection reaches caller-visible memory.
     fn ident_is_ref(&self, ident: &ast::IdentExpr) -> bool {
-        self.ctx
-            .sem
-            .references
-            .get(&ident.id)
-            .and_then(|def| self.ctx.sem.local_types.get(def))
-            .is_some_and(|&ty| {
-                matches!(
-                    self.ctx.sem.types.get(ty),
-                    ResolvedType::Ref(_) | ResolvedType::MutRef(_)
-                )
-            })
+        ident_is_ref_of(ident, self.ctx.sem)
     }
 
     /// Reject a named-function reference argument whose declared `stores`
@@ -2432,9 +2403,8 @@ impl RefFlow<'_, '_> {
             let Some(declared) = self
                 .ctx
                 .sem
-                .references
-                .get(&ident.id)
-                .and_then(|def| self.ctx.oracle.fn_stores.get(def))
+                .referenced_symbol(ident.id)
+                .and_then(|def| self.ctx.oracle.fn_stores.get(&def))
             else {
                 continue;
             };
@@ -2523,13 +2493,13 @@ impl AstVisitor for RefFlow<'_, '_> {
                             if let Some(name) = self.global_name(ident) {
                                 self.mark(&carried, span, &Sink::Global(&name));
                             } else if is_ident(&assign.target) && !through_deref {
-                                if let Some(def) = self.ctx.sem.references.get(&ident.id) {
-                                    self.carries.entry(*def).or_default().extend(carried);
+                                if let Some(def) = self.ctx.sem.referenced_symbol(ident.id) {
+                                    self.carries.entry(def).or_default().extend(carried);
                                 }
                             } else if through_deref || self.ident_is_ref(ident) {
                                 self.mark(&carried, span, &Sink::ThroughRef);
-                            } else if let Some(def) = self.ctx.sem.references.get(&ident.id) {
-                                self.carries.entry(*def).or_default().extend(carried);
+                            } else if let Some(def) = self.ctx.sem.referenced_symbol(ident.id) {
+                                self.carries.entry(def).or_default().extend(carried);
                             }
                         }
                         None => self.mark(&carried, span, &Sink::ThroughRef),
@@ -2687,9 +2657,8 @@ impl AstVisitor for PurityWalker<'_> {
             Expr::Call(call) => {
                 let free = if let Expr::Ident(ident) = &call.callee {
                     self.sem
-                        .references
-                        .get(&ident.id)
-                        .and_then(|def| self.index.fn_effects.get(def))
+                        .referenced_symbol(ident.id)
+                        .and_then(|def| self.index.fn_effects.get(&def))
                         .map(|effects| (effects.clone(), ident.name.clone()))
                 } else {
                     None
@@ -2706,7 +2675,7 @@ impl AstVisitor for PurityWalker<'_> {
                 }
             }
             Expr::MethodCall(method_call) => {
-                if let Some(dispatch) = self.sem.method_dispatch.get(&method_call.id) {
+                if let Some(dispatch) = self.sem.method_dispatch_at(method_call.id) {
                     let effects = self.index.method_effects(&dispatch.function_ref);
                     self.flag_if_effectful(&effects, &method_call.method, method_call.span);
                 }

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -1388,13 +1388,18 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         }
         if let Some(snap_state) = snapshot_state {
             for (ms, snap_sem) in &snap_state.module_semantics {
-                if let Some(sem) = module_semantics.get_mut(ms) {
-                    sem.types = snap_sem.types.clone();
-                    sem.bindings = snap_sem.bindings.clone();
-                    // A snapshot module runs no decl pass this compile;
-                    // its digests must come from the snapshot.
-                    sem.decls.clone_digests_from(&snap_sem.decls);
-                }
+                let Some(sem) = module_semantics.get_mut(ms) else {
+                    debug_assert!(
+                        snap_sem.routed_facts().next().is_none(),
+                        "a snapshot module carrying facts must be in the current compile's loaded set: {ms}"
+                    );
+                    continue;
+                };
+                sem.types = snap_sem.types.clone();
+                sem.bindings = snap_sem.bindings.clone();
+                // A snapshot module runs no decl pass this compile;
+                // its digests must come from the snapshot.
+                sem.decls.clone_digests_from(&snap_sem.decls);
             }
         }
 

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -3793,8 +3793,9 @@ fn spelled_references(
     (direct, inherited)
 }
 
-/// The callees a dispatch fact names. Only the facts `Semantics` drains are
-/// re-seeded into a snapshot module's `ModuleSemantics`, so both are read.
+/// The callees a dispatch fact names. Seeding copies a snapshot module's
+/// `types` but not the per-impl `default_method_semantics` hanging off it, so
+/// the snapshot is read alongside this compile's own state.
 fn dispatched_callee_edges(
     state: &AnnotateState,
     snapshot: Option<&crate::semantics::Semantics>,

--- a/wado-compiler/src/elaborator/orchestration.rs
+++ b/wado-compiler/src/elaborator/orchestration.rs
@@ -1375,10 +1375,9 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
 
         // Seed per-module semantics with the snapshot's pre-resolved stdlib
         // entries so the LSP edges remain consistent and the body walk on
-        // user modules can extend on top. The snapshot stores `references` /
-        // `locals` / `local_types` as flat maps keyed by `AstId`; we
-        // split them by `key.module` because each module's data now lives in
-        // its own [`super::sem::ModuleSemantics`].
+        // user modules can extend on top. The snapshot holds them per module
+        // already, so each lands in the [`super::sem::ModuleSemantics`] whose
+        // walk recorded it.
         let mut module_semantics: IndexMap<ModuleSource, super::sem::ModuleSemantics> =
             IndexMap::default();
         // Ensure every loaded module has an entry; the body walk in
@@ -1387,98 +1386,15 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         for ms in modules.keys() {
             module_semantics.entry(ms.clone()).or_default();
         }
-        if let Some(snap) = snapshot {
-            // Seed each stdlib module's `types` facts from the snapshot. The
-            // flattened `snap` maps below carry only what `semantics_of` drained
-            // into `Semantics`; signatures, effects and the dispatch maps live
-            // only here, and the effect check needs them for stdlib. The drained
-            // fields are re-seeded from `snap` afterwards.
-            if let Some(snap_state) = snapshot_state {
-                for (ms, snap_sem) in &snap_state.module_semantics {
-                    if let Some(sem) = module_semantics.get_mut(ms) {
-                        sem.types = snap_sem.types.clone();
-                        // A snapshot module runs no decl pass this compile;
-                        // its digests must come from the snapshot.
-                        sem.decls.clone_digests_from(&snap_sem.decls);
-                    }
+        if let Some(snap_state) = snapshot_state {
+            for (ms, snap_sem) in &snap_state.module_semantics {
+                if let Some(sem) = module_semantics.get_mut(ms) {
+                    sem.types = snap_sem.types.clone();
+                    sem.bindings = snap_sem.bindings.clone();
+                    // A snapshot module runs no decl pass this compile;
+                    // its digests must come from the snapshot.
+                    sem.decls.clone_digests_from(&snap_sem.decls);
                 }
-            }
-            // A snapshot id routes back to a per-module `ModuleSemantics` through
-            // the snapshot's `AstIdSpace → ModuleSource` registry: stdlib ASTs
-            // are parsed once per process and shared, so its spaces are this
-            // compile's. Every key must name a module in the current `modules`
-            // set, so `get_mut`'s miss fails a `debug_assert` rather than minting.
-            let snapshot_invariant =
-                "snapshot id must belong to a module in the current compile's loaded set";
-            for (use_id, def_key) in &snap.references {
-                let Some(sem) = snap
-                    .module_of_id(*use_id)
-                    .and_then(|ms| module_semantics.get_mut(ms))
-                else {
-                    debug_assert!(false, "{snapshot_invariant}: {use_id:?}");
-                    continue;
-                };
-                sem.bindings.references.insert(*use_id, *def_key);
-            }
-            for (id, sym) in &snap.locals {
-                let Some(sem) = snap
-                    .module_of_id(*id)
-                    .and_then(|ms| module_semantics.get_mut(ms))
-                else {
-                    debug_assert!(false, "{snapshot_invariant}: {id:?}");
-                    continue;
-                };
-                sem.bindings.local_symbols.insert(*id, sym.clone());
-            }
-            for (id, type_id) in &snap.local_types {
-                let Some(sem) = snap
-                    .module_of_id(*id)
-                    .and_then(|ms| module_semantics.get_mut(ms))
-                else {
-                    debug_assert!(false, "{snapshot_invariant}: {id:?}");
-                    continue;
-                };
-                sem.types.local_types.insert(*id, *type_id);
-            }
-            for (id, type_id) in &snap.expression_types {
-                let Some(sem) = snap
-                    .module_of_id(*id)
-                    .and_then(|ms| module_semantics.get_mut(ms))
-                else {
-                    debug_assert!(false, "{snapshot_invariant}: {id:?}");
-                    continue;
-                };
-                sem.types.expression_types.insert(*id, *type_id);
-            }
-            for (id, dispatch) in &snap.method_dispatch {
-                let Some(sem) = snap
-                    .module_of_id(*id)
-                    .and_then(|ms| module_semantics.get_mut(ms))
-                else {
-                    debug_assert!(false, "{snapshot_invariant}: {id:?}");
-                    continue;
-                };
-                sem.types.method_dispatch.insert(*id, dispatch.clone());
-            }
-            for (id, choice) in &snap.coercions {
-                let Some(sem) = snap
-                    .module_of_id(*id)
-                    .and_then(|ms| module_semantics.get_mut(ms))
-                else {
-                    debug_assert!(false, "{snapshot_invariant}: {id:?}");
-                    continue;
-                };
-                sem.types.coercions.insert(*id, choice.clone());
-            }
-            for (id, kind) in &snap.desugars {
-                let Some(sem) = snap
-                    .module_of_id(*id)
-                    .and_then(|ms| module_semantics.get_mut(ms))
-                else {
-                    debug_assert!(false, "{snapshot_invariant}: {id:?}");
-                    continue;
-                };
-                sem.types.desugars.insert(*id, *kind);
             }
         }
 

--- a/wado-compiler/src/elaborator/sem.rs
+++ b/wado-compiler/src/elaborator/sem.rs
@@ -34,6 +34,39 @@ pub(crate) struct ModuleSemantics {
     pub(crate) default_method_semantics: IndexMap<(AstId, AstId), ModuleSemantics>,
 }
 
+impl ModuleSemantics {
+    /// Every node this module's walk recorded a fact for that
+    /// [`crate::semantics::Semantics`] answers from — the list its routing is
+    /// built over, and the same list [`Self::routed_fact_kinds`] reports on.
+    pub(crate) fn routed_fact_ids(&self) -> impl Iterator<Item = &AstId> {
+        self.bindings
+            .references
+            .keys()
+            .chain(self.bindings.local_symbols.keys())
+            .chain(self.types.local_types.keys())
+            .chain(self.types.expression_types.keys())
+            .chain(self.types.method_dispatch.keys())
+            .chain(self.types.coercions.keys())
+            .chain(self.types.desugars.keys())
+    }
+
+    /// Which of those fact kinds this walk recorded for `id`. Routing sends
+    /// every kind to one walk, so a later walk over the same node must record
+    /// at least what an earlier one did.
+    #[cfg(debug_assertions)]
+    pub(crate) fn routed_fact_kinds(&self, id: AstId) -> [bool; 7] {
+        [
+            self.bindings.references.contains_key(&id),
+            self.bindings.local_symbols.contains_key(&id),
+            self.types.local_types.contains_key(&id),
+            self.types.expression_types.contains_key(&id),
+            self.types.method_dispatch.contains_key(&id),
+            self.types.coercions.contains_key(&id),
+            self.types.desugars.contains_key(&id),
+        ]
+    }
+}
+
 #[cfg(debug_assertions)]
 impl ModuleSemantics {
     /// How many facts have been recorded, for the guard that a *query* left no

--- a/wado-compiler/src/elaborator/sem.rs
+++ b/wado-compiler/src/elaborator/sem.rs
@@ -34,36 +34,51 @@ pub(crate) struct ModuleSemantics {
     pub(crate) default_method_semantics: IndexMap<(AstId, AstId), ModuleSemantics>,
 }
 
+/// The fact kinds [`crate::semantics::Semantics`] answers by `AstId`, and so
+/// routes to a module by. One node's kinds do not all come from one walk — a
+/// module records the use→def edges around a parameter default while each
+/// caller types the expression itself — so the kind is part of the key.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum FactKind {
+    Reference,
+    LocalSymbol,
+    LocalType,
+    ExpressionType,
+    MethodDispatch,
+    Coercion,
+    Desugar,
+}
+
 impl ModuleSemantics {
-    /// Every node this module's walk recorded a fact for that
-    /// [`crate::semantics::Semantics`] answers from — the list its routing is
-    /// built over, and the same list [`Self::routed_fact_kinds`] reports on.
-    pub(crate) fn routed_fact_ids(&self) -> impl Iterator<Item = &AstId> {
+    /// Every fact this module's walk recorded that `Semantics` answers from —
+    /// the list its routing is built over.
+    pub(crate) fn routed_facts(&self) -> impl Iterator<Item = (AstId, FactKind)> + '_ {
+        let keys = |kind| move |id: &AstId| (*id, kind);
         self.bindings
             .references
             .keys()
-            .chain(self.bindings.local_symbols.keys())
-            .chain(self.types.local_types.keys())
-            .chain(self.types.expression_types.keys())
-            .chain(self.types.method_dispatch.keys())
-            .chain(self.types.coercions.keys())
-            .chain(self.types.desugars.keys())
-    }
-
-    /// Which of those fact kinds this walk recorded for `id`. Routing sends
-    /// every kind to one walk, so a later walk over the same node must record
-    /// at least what an earlier one did.
-    #[cfg(debug_assertions)]
-    pub(crate) fn routed_fact_kinds(&self, id: AstId) -> [bool; 7] {
-        [
-            self.bindings.references.contains_key(&id),
-            self.bindings.local_symbols.contains_key(&id),
-            self.types.local_types.contains_key(&id),
-            self.types.expression_types.contains_key(&id),
-            self.types.method_dispatch.contains_key(&id),
-            self.types.coercions.contains_key(&id),
-            self.types.desugars.contains_key(&id),
-        ]
+            .map(keys(FactKind::Reference))
+            .chain(
+                self.bindings
+                    .local_symbols
+                    .keys()
+                    .map(keys(FactKind::LocalSymbol)),
+            )
+            .chain(self.types.local_types.keys().map(keys(FactKind::LocalType)))
+            .chain(
+                self.types
+                    .expression_types
+                    .keys()
+                    .map(keys(FactKind::ExpressionType)),
+            )
+            .chain(
+                self.types
+                    .method_dispatch
+                    .keys()
+                    .map(keys(FactKind::MethodDispatch)),
+            )
+            .chain(self.types.coercions.keys().map(keys(FactKind::Coercion)))
+            .chain(self.types.desugars.keys().map(keys(FactKind::Desugar)))
     }
 }
 

--- a/wado-compiler/src/elaborator/sem.rs
+++ b/wado-compiler/src/elaborator/sem.rs
@@ -17,6 +17,8 @@ pub(crate) use types::TypeAnnotations;
 
 use crate::ast::AstId;
 use crate::hashmap::IndexMap;
+use crate::symbol::Symbol;
+use crate::tir::TypeId;
 
 /// Per-module semantic facts. See the module-level documentation for the
 /// membership rules and ownership story.
@@ -38,7 +40,7 @@ pub(crate) struct ModuleSemantics {
 /// routes to a module by. One node's kinds do not all come from one walk — a
 /// module records the use→def edges around a parameter default while each
 /// caller types the expression itself — so the kind is part of the key.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(crate) enum FactKind {
     Reference,
     LocalSymbol,
@@ -49,36 +51,52 @@ pub(crate) enum FactKind {
     Desugar,
 }
 
+/// A routed fact kind and the map it lives in, paired once. A query names a
+/// [`Fact`], never a kind and a map separately, so it cannot route by one and
+/// read the other.
+#[derive(Clone, Copy)]
+pub(crate) struct Fact<V: 'static> {
+    pub(crate) kind: FactKind,
+    pub(crate) map: fn(&ModuleSemantics) -> &IndexMap<AstId, V>,
+}
+
+impl<V> Fact<V> {
+    const fn new(kind: FactKind, map: fn(&ModuleSemantics) -> &IndexMap<AstId, V>) -> Self {
+        Self { kind, map }
+    }
+
+    fn keys(self, sem: &ModuleSemantics) -> impl Iterator<Item = (AstId, FactKind)> + '_ {
+        (self.map)(sem).keys().map(move |id| (*id, self.kind))
+    }
+}
+
 impl ModuleSemantics {
+    pub(crate) const REFERENCES: Fact<AstId> =
+        Fact::new(FactKind::Reference, |sem| &sem.bindings.references);
+    pub(crate) const LOCAL_SYMBOLS: Fact<Symbol> =
+        Fact::new(FactKind::LocalSymbol, |sem| &sem.bindings.local_symbols);
+    pub(crate) const LOCAL_TYPES: Fact<TypeId> =
+        Fact::new(FactKind::LocalType, |sem| &sem.types.local_types);
+    pub(crate) const EXPRESSION_TYPES: Fact<TypeId> =
+        Fact::new(FactKind::ExpressionType, |sem| &sem.types.expression_types);
+    pub(crate) const METHOD_DISPATCH: Fact<types::MethodDispatch> =
+        Fact::new(FactKind::MethodDispatch, |sem| &sem.types.method_dispatch);
+    pub(crate) const COERCIONS: Fact<types::CoercionChoice> =
+        Fact::new(FactKind::Coercion, |sem| &sem.types.coercions);
+    pub(crate) const DESUGARS: Fact<types::DesugarKind> =
+        Fact::new(FactKind::Desugar, |sem| &sem.types.desugars);
+
     /// Every fact this module's walk recorded that `Semantics` answers from —
     /// the list its routing is built over.
     pub(crate) fn routed_facts(&self) -> impl Iterator<Item = (AstId, FactKind)> + '_ {
-        let keys = |kind| move |id: &AstId| (*id, kind);
-        self.bindings
-            .references
-            .keys()
-            .map(keys(FactKind::Reference))
-            .chain(
-                self.bindings
-                    .local_symbols
-                    .keys()
-                    .map(keys(FactKind::LocalSymbol)),
-            )
-            .chain(self.types.local_types.keys().map(keys(FactKind::LocalType)))
-            .chain(
-                self.types
-                    .expression_types
-                    .keys()
-                    .map(keys(FactKind::ExpressionType)),
-            )
-            .chain(
-                self.types
-                    .method_dispatch
-                    .keys()
-                    .map(keys(FactKind::MethodDispatch)),
-            )
-            .chain(self.types.coercions.keys().map(keys(FactKind::Coercion)))
-            .chain(self.types.desugars.keys().map(keys(FactKind::Desugar)))
+        Self::REFERENCES
+            .keys(self)
+            .chain(Self::LOCAL_SYMBOLS.keys(self))
+            .chain(Self::LOCAL_TYPES.keys(self))
+            .chain(Self::EXPRESSION_TYPES.keys(self))
+            .chain(Self::METHOD_DISPATCH.keys(self))
+            .chain(Self::COERCIONS.keys(self))
+            .chain(Self::DESUGARS.keys(self))
     }
 }
 

--- a/wado-compiler/src/elaborator/sem.rs
+++ b/wado-compiler/src/elaborator/sem.rs
@@ -37,9 +37,7 @@ pub(crate) struct ModuleSemantics {
 }
 
 /// The fact kinds [`crate::semantics::Semantics`] answers by `AstId`, and so
-/// routes to a module by. One node's kinds do not all come from one walk — a
-/// module records the use→def edges around a parameter default while each
-/// caller types the expression itself — so the kind is part of the key.
+/// routes to a module by.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub(crate) enum FactKind {
     Reference,
@@ -51,9 +49,8 @@ pub(crate) enum FactKind {
     Desugar,
 }
 
-/// A routed fact kind and the map it lives in, paired once. A query names a
-/// [`Fact`], never a kind and a map separately, so it cannot route by one and
-/// read the other.
+/// A routed fact kind and the map it lives in, paired once: a query names a
+/// [`Fact`], so it cannot route by one kind and read another.
 #[derive(Clone, Copy)]
 pub(crate) struct Fact<V: 'static> {
     pub(crate) kind: FactKind,

--- a/wado-compiler/src/elaborator/sem/bindings.rs
+++ b/wado-compiler/src/elaborator/sem/bindings.rs
@@ -14,13 +14,10 @@ use crate::symbol::Symbol;
 
 /// `use → def` edges and locally defined symbols for one module.
 ///
-/// Keys are bare [`AstId`]s — globally unique, so an edge recorded while a
-/// walk visits foreign AST (e.g. under
-/// [`super::super::Elaborator::with_module_perspective_for`]) still names its node
-/// exactly, whichever module's `ModuleBindings` it lands in — which is where it
-/// stays, [`crate::semantics::Semantics`] routing a query to it rather than
-/// holding a copy. Def-side values are bare `AstId`s too; navigation
-/// recovers a def's module from its space (`Semantics::module_of_id`).
+/// Keys and def-side values are bare [`AstId`]s — globally unique, so an edge
+/// recorded while a walk visits foreign AST (e.g. under
+/// [`super::super::Elaborator::with_module_perspective_for`]) names its node
+/// exactly, whichever module's `ModuleBindings` it lands in and stays in.
 #[derive(Default, Clone)]
 pub(crate) struct ModuleBindings {
     /// `IdentExpr.id → defining AstId`.

--- a/wado-compiler/src/elaborator/sem/bindings.rs
+++ b/wado-compiler/src/elaborator/sem/bindings.rs
@@ -17,9 +17,9 @@ use crate::symbol::Symbol;
 /// Keys are bare [`AstId`]s — globally unique, so an edge recorded while a
 /// walk visits foreign AST (e.g. under
 /// [`super::super::Elaborator::with_module_perspective_for`]) still names its node
-/// exactly, whichever module's `ModuleBindings` it lands in; the sole consumer
-/// ([`crate::semantics::semantics_with_logger`]) flattens them into single
-/// `Semantics` maps. Def-side values are bare `AstId`s too; navigation
+/// exactly, whichever module's `ModuleBindings` it lands in — which is where it
+/// stays, [`crate::semantics::Semantics`] routing a query to it rather than
+/// holding a copy. Def-side values are bare `AstId`s too; navigation
 /// recovers a def's module from its space (`Semantics::module_of_id`).
 #[derive(Default, Clone)]
 pub(crate) struct ModuleBindings {

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -272,13 +272,25 @@ impl Semantics {
         Some(sem)
     }
 
-    /// Every loaded module's facts, in load order — the iteration side of
-    /// [`Self::facts_of`].
-    fn all_facts(&self) -> impl Iterator<Item = &crate::elaborator::sem::ModuleSemantics> {
+    /// Every entry of one fact map that [`Self::facts_of`] would answer with —
+    /// the iteration side of the same routing, so what an `iter_*` yields is
+    /// exactly what a point lookup returns. An entry a later walk shadowed is
+    /// left out; the module it lands in is the whole of what makes it live.
+    fn iter_live<'s, V: 's>(
+        &'s self,
+        map: impl Fn(&'s crate::elaborator::sem::ModuleSemantics) -> &'s IndexMap<AstId, V> + 's,
+    ) -> impl Iterator<Item = (AstId, &'s V)> + 's {
         self.state
             .as_ref()
             .into_iter()
-            .flat_map(|state| state.module_semantics.values())
+            .flat_map(|state| state.module_semantics.values().enumerate())
+            .flat_map(move |(home, sem)| {
+                let home = u32::try_from(home).expect("module count fits in u32");
+                map(sem)
+                    .iter()
+                    .filter(move |(id, _)| self.fact_home.get(*id) == Some(&home))
+                    .map(|(id, value)| (*id, value))
+            })
     }
 
     /// Symbol for the given key, or `None` if the key does not refer to a
@@ -307,10 +319,10 @@ impl Semantics {
     /// semantic-token highlighting to classify declaration sites in one pass
     /// instead of a positional lookup per token.
     pub fn iter_symbols(&self) -> impl Iterator<Item = (AstId, &Symbol)> {
-        self.symbols.iter().map(|(id, s)| (*id, s)).chain(
-            self.all_facts()
-                .flat_map(|sem| sem.bindings.local_symbols.iter().map(|(id, s)| (*id, s))),
-        )
+        self.symbols
+            .iter()
+            .map(|(id, s)| (*id, s))
+            .chain(self.iter_live(|sem| &sem.bindings.local_symbols))
     }
 
     /// Iterate every recorded use-site `(use_key, def_key)` edge.
@@ -320,12 +332,8 @@ impl Semantics {
     /// item-level definitions (functions, types, globals) and imported items
     /// are all recorded here.
     pub fn iter_references(&self) -> impl Iterator<Item = (AstId, AstId)> {
-        self.all_facts().flat_map(|sem| {
-            sem.bindings
-                .references
-                .iter()
-                .map(|(use_id, def_id)| (*use_id, *def_id))
-        })
+        self.iter_live(|sem| &sem.bindings.references)
+            .map(|(use_id, def_id)| (use_id, *def_id))
     }
 
     /// Find every use-site `AstId` whose definition is `def_id`.
@@ -387,8 +395,8 @@ impl Semantics {
     /// Iterate every expression the body walk typed, as `(AstId, TypeId)`.
     /// Pair with [`Self::module_of_id`] to filter by module.
     pub fn iter_expression_types(&self) -> impl Iterator<Item = (AstId, TypeId)> + '_ {
-        self.all_facts()
-            .flat_map(|sem| sem.types.expression_types.iter().map(|(id, ty)| (*id, *ty)))
+        self.iter_live(|sem| &sem.types.expression_types)
+            .map(|(id, ty)| (id, *ty))
     }
 
     /// Method-dispatch decision recorded for the `MethodCallExpr` at
@@ -448,8 +456,8 @@ impl Semantics {
     /// [`Self::method_dispatch_view`] for the stable public view onto
     /// each entry.
     pub fn iter_method_dispatch(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.all_facts()
-            .flat_map(|sem| sem.types.method_dispatch.keys().copied())
+        self.iter_live(|sem| &sem.types.method_dispatch)
+            .map(|(id, _)| id)
     }
 
     /// Stable public view onto the recorded coercion choice:
@@ -477,8 +485,7 @@ impl Semantics {
     /// expression's `(module, AstId)`. Pair with [`Self::coercion_view`]
     /// for the stable public view onto each entry.
     pub fn iter_coercions(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.all_facts()
-            .flat_map(|sem| sem.types.coercions.keys().copied())
+        self.iter_live(|sem| &sem.types.coercions).map(|(id, _)| id)
     }
 
     /// WEP 2026-05-26: stable public view onto the recorded
@@ -518,8 +525,7 @@ impl Semantics {
     /// node's `(module, AstId)`. Pair with [`Self::desugar_view`] for the
     /// stable public view onto each entry.
     pub fn iter_desugars(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.all_facts()
-            .flat_map(|sem| sem.types.desugars.keys().copied())
+        self.iter_live(|sem| &sem.types.desugars).map(|(id, _)| id)
     }
 
     /// URI (filename) of a module, when the module has one.
@@ -1219,17 +1225,19 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     let mut fact_home: IndexMap<AstId, u32> = IndexMap::default();
     for (home, sem) in state.module_semantics.values().enumerate() {
         let home = u32::try_from(home).expect("module count fits in u32");
-        let ids = sem
-            .bindings
-            .references
-            .keys()
-            .chain(sem.bindings.local_symbols.keys())
-            .chain(sem.types.local_types.keys())
-            .chain(sem.types.expression_types.keys())
-            .chain(sem.types.method_dispatch.keys())
-            .chain(sem.types.coercions.keys())
-            .chain(sem.types.desugars.keys());
-        for id in ids {
+        for id in sem.routed_fact_ids() {
+            #[cfg(debug_assertions)]
+            if let Some(prev) = fact_home
+                .get(id)
+                .and_then(|prev| state.module_semantics.get_index(*prev as usize))
+            {
+                let (before, after) = (prev.1.routed_fact_kinds(*id), sem.routed_fact_kinds(*id));
+                debug_assert!(
+                    before.iter().zip(after).all(|(had, has)| !had || has),
+                    "a later walk over {id:?} records fewer fact kinds than {}'s, so routing to it would drop one",
+                    prev.0
+                );
+            }
             fact_home.insert(*id, home);
         }
     }
@@ -1350,5 +1358,41 @@ mod tests {
                 !sem.types.expression_types.is_empty() && !sem.bindings.references.is_empty()
             });
         assert!(stdlib_facts);
+    }
+
+    /// What an `iter_*` yields is what a point lookup answers. A node two walks
+    /// reached is recorded in both modules' maps; only the one it routes to is
+    /// live, so iterating the raw maps would hand out an entry no query returns.
+    #[test]
+    fn iteration_yields_only_live_facts() {
+        let host = InMemoryCompilerHost::new();
+        let sem = block_on(semantics(
+            "fn main() { let x = 1 + 2; println(`${x}`); }",
+            &host,
+            Some("entry.wado"),
+        ));
+
+        let mut live: crate::hashmap::IndexSet<AstId> = crate::hashmap::IndexSet::default();
+        for (id, type_id) in sem.iter_expression_types() {
+            assert!(live.insert(id), "iteration yielded {id:?} twice");
+            assert_eq!(sem.expression_type(id), Some(type_id));
+        }
+        let mut seen_uses: crate::hashmap::IndexSet<AstId> = crate::hashmap::IndexSet::default();
+        for (use_id, def_id) in sem.iter_references() {
+            assert!(seen_uses.insert(use_id), "iteration yielded {use_id:?} twice");
+            assert_eq!(sem.referenced_symbol(use_id), Some(def_id));
+        }
+
+        // The dedup is load-bearing here, not vacuous: this program does have
+        // nodes two walks reached.
+        let recorded: usize = sem
+            .state
+            .as_ref()
+            .expect("annotate state")
+            .module_semantics
+            .values()
+            .map(|module_sem| module_sem.types.expression_types.len())
+            .sum();
+        assert!(recorded > live.len());
     }
 }

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -58,24 +58,10 @@ pub struct Semantics {
     /// resolved back to their owning module (spans, URIs) without carrying a
     /// module in every key.
     pub(crate) space_modules: IndexMap<crate::ast::AstIdSpace, ModuleSource>,
-    /// Which module's [`ModuleSemantics`](crate::elaborator::sem::ModuleSemantics)
-    /// holds a given fact — the routing every `AstId`-keyed query below goes
-    /// through. The facts themselves have one home, the map the walk wrote them
-    /// into; this says which one that is.
-    ///
-    /// A fact lives in the module whose walk recorded it, which is its node's
-    /// own module for everything but the foreign AST a walk crosses into (a
-    /// callee's parameter default, resolved in the caller's frame). Keyed by
-    /// [`FactKind`] as well as node, because one node's kinds need not come
-    /// from one walk; where two walks do record the same kind, the last wins.
-    ///
-    /// The value is a position in [`AnnotateState::module_semantics`], which
-    /// the body walk reorders (`swap_remove` + `insert`); it is minted after
-    /// the last such move and `state` is immutable from then on. [`Self::fact_at`]
-    /// asserts the routed module really holds the fact, so a stale index fails
-    /// rather than answering `None`.
-    ///
-    /// Empty when resolve did not run or bailed before recording any fact.
+    /// The [`ModuleSemantics`] holding each fact the body walk recorded, as a
+    /// position in [`AnnotateState::module_semantics`] — the routing every
+    /// `AstId`-keyed query below reads through, in place of a second copy.
+    /// Keyed by [`FactKind`] too: one node's kinds need not come from one walk.
     pub(crate) fact_home: IndexMap<(AstId, FactKind), u32>,
     /// TIR modules produced by [`crate::elaborator::Elaborator::build_tir_from_state`].
     /// The batch compiler consumes these directly; LSP queries ignore them.
@@ -234,11 +220,7 @@ impl Semantics {
         modules: IndexMap<ModuleSource, Module>,
         ast_indices: IndexMap<ModuleSource, AstIndex>,
         symbols: SymbolTable,
-        types: TypeTable,
         interner: std::rc::Rc<std::cell::RefCell<ModuleSourceInterner>>,
-        state: Option<AnnotateState>,
-        fact_home: IndexMap<(AstId, FactKind), u32>,
-        tir_modules: IndexMap<ModuleSource, TirModule>,
     ) -> Self {
         let space_modules = modules
             .iter()
@@ -248,13 +230,13 @@ impl Semantics {
             entry_module_source,
             modules,
             symbols,
-            types,
+            types: TypeTable::new(),
             interner,
             ast_indices,
-            state,
+            state: None,
             space_modules,
-            fact_home,
-            tir_modules,
+            fact_home: IndexMap::default(),
+            tir_modules: IndexMap::default(),
             liveness: crate::elaborator::liveness::Liveness::default(),
             is_complete: false,
             wit_contract: None,
@@ -285,10 +267,8 @@ impl Semantics {
         found
     }
 
-    /// Every entry of one fact map that [`Self::fact_at`] would answer with —
-    /// the iteration side of the same routing, so what an `iter_*` yields is
-    /// exactly what a point lookup returns. An entry a later walk shadowed is
-    /// left out; the module it lands in is the whole of what makes it live.
+    /// Every entry [`Self::fact_at`] would answer with — iteration through the
+    /// same routing, so a shadowed entry no query returns is left out.
     fn iter_live<V>(&self, fact: Fact<V>) -> impl Iterator<Item = (AstId, &V)> {
         self.state
             .as_ref()
@@ -1072,11 +1052,7 @@ impl Semantics {
             IndexMap::default(),
             IndexMap::default(),
             SymbolTable::new(),
-            TypeTable::new(),
             interner,
-            None,
-            IndexMap::default(),
-            IndexMap::default(),
         )
     }
 }
@@ -1161,11 +1137,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
             load_result.modules,
             ast_indices,
             symbols,
-            TypeTable::new(),
             interner,
-            None,
-            IndexMap::default(),
-            IndexMap::default(),
         );
     }
 
@@ -1191,11 +1163,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
             load_result.modules,
             ast_indices,
             symbols,
-            TypeTable::new(),
             interner,
-            None,
-            IndexMap::default(),
-            IndexMap::default(),
         );
     };
 
@@ -1226,12 +1194,8 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // `state.tysys.type_table`.
     let types = state.tysys.type_table.borrow().clone();
 
-    // Route each fact the body walk recorded to the module that holds it. The
-    // `Semantics` API is keyed by bare `AstId` while the facts stay in the
-    // per-module `ModuleSemantics` the walk wrote them into — one home,
-    // whichever phase reads them. A node reached by two walks (a callee's
-    // parameter default, typed at each call site while its own module records
-    // the edges around it) routes each kind to the walk that has it.
+    // Route each fact to the module that holds it, rather than copying it out:
+    // where two walks reached a node, each kind goes to the walk that has it.
     let mut fact_home: IndexMap<(AstId, FactKind), u32> = IndexMap::default();
     for (home, sem) in state.module_semantics.values().enumerate() {
         let home = u32::try_from(home).expect("module count fits in u32");
@@ -1310,10 +1274,8 @@ mod tests {
         tokio::runtime::Runtime::new().unwrap().block_on(future)
     }
 
-    /// One home: the body walk's facts stay in the [`ModuleSemantics`] that
-    /// recorded them, and `Semantics` reads through to it. A second copy leaves
-    /// the first empty, so a consumer reading the wrong one gets no facts
-    /// instead of a failure (WEP 2026-05-26 "One fact, two homes").
+    /// The body walk's facts stay in the [`ModuleSemantics`] that recorded
+    /// them, and `Semantics` reads through to it rather than holding a copy.
     #[test]
     fn body_facts_have_one_home() {
         let host = InMemoryCompilerHost::new();
@@ -1354,9 +1316,8 @@ mod tests {
         assert!(stdlib_facts);
     }
 
-    /// What an `iter_*` yields is what a point lookup answers. A node two walks
-    /// reached is recorded in both modules' maps; only the one it routes to is
-    /// live, so iterating the raw maps would hand out an entry no query returns.
+    /// What an `iter_*` yields is what a point lookup answers, so the entry a
+    /// node's other walk recorded is not handed out.
     #[test]
     fn iteration_yields_only_live_facts() {
         let host = InMemoryCompilerHost::new();

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -57,50 +57,19 @@ pub struct Semantics {
     /// resolved back to their owning module (spans, URIs) without carrying a
     /// module in every key.
     pub(crate) space_modules: IndexMap<crate::ast::AstIdSpace, ModuleSource>,
-    /// Use→def map populated by the real elaborator as it walks function
-    /// bodies in `build_tir_from_state`. Maps `IdentExpr.id` to the
-    /// binding's defining `AstId`. Empty when resolve did not run or
-    /// bailed before recording any edges.
-    pub(crate) references: IndexMap<AstId, AstId>,
-    /// Local binding [`Symbol`] entries (let / param / closure param)
-    /// emitted by the elaborator alongside `references`. Keyed by the
-    /// binding's defining [`AstId`]; consulted by
-    /// [`Semantics::symbol_at`] when the key does not name an item-level
-    /// symbol. Empty when resolve did not run or bailed early.
-    pub(crate) locals: IndexMap<AstId, Symbol>,
-    /// Inferred [`TypeId`] for each local binding (let / param / closure
-    /// param), keyed by the binding's defining [`AstId`]. Populated
-    /// alongside `Self::locals` from the elaborator. Consumed by LSP
-    /// inlay-hint queries via [`Semantics::local_type_name`] to render
-    /// the inferred type on bindings without explicit annotation. Empty
-    /// when resolve did not run or bailed before recording any bindings.
-    pub local_types: IndexMap<AstId, TypeId>,
-    /// Resolved [`TypeId`] for every expression visited by the elaborator
-    /// body walk, keyed by the expression's `(module, AstId)` pair. The
-    /// reify pass reads this map to set `TirExpr::type_id` without re-running
-    /// inference; LSP hover can consult it for a type at the cursor.
-    /// Empty when resolve did not run or bailed before any expression was
-    /// visited.
-    pub expression_types: IndexMap<AstId, TypeId>,
-    /// Method-dispatch decisions recorded for each AST
-    /// [`crate::ast::MethodCallExpr`] visited by the body walk, keyed by
-    /// the call expression's `(module, AstId)` pair. See
-    /// [`crate::elaborator::sem::types::MethodDispatch`] for the contract
-    /// (synthetic calls and short-circuiting paths leave no entry).
-    pub(crate) method_dispatch: IndexMap<AstId, crate::elaborator::sem::types::MethodDispatch>,
-    /// Coercion choices recorded for each expression that
-    /// [`crate::elaborator::Elaborator::try_coerce`] adapted into its
-    /// expected type, keyed by the source expression's `(module, AstId)`.
-    /// Expressions that did not need coercion leave no entry. See
-    /// [`crate::elaborator::sem::types::CoercionChoice`] for the data
-    /// shape.
-    pub(crate) coercions: IndexMap<AstId, crate::elaborator::sem::types::CoercionChoice>,
-    /// TIR-direct desugar tags recorded by the body walk at each
-    /// `assert` / `matches` / comparison-chain / for-of / `while` /
-    /// compound-assignment site, keyed by the enclosing AST node's
-    /// `(module, AstId)`. See
-    /// [`crate::elaborator::sem::types::DesugarKind`].
-    pub(crate) desugars: IndexMap<AstId, crate::elaborator::sem::types::DesugarKind>,
+    /// Which module's [`ModuleSemantics`](crate::elaborator::sem::ModuleSemantics)
+    /// holds the body-walk facts for a node — the routing every `AstId`-keyed
+    /// query below goes through. The facts themselves have one home, the map the
+    /// walk wrote them into; this says which one that is.
+    ///
+    /// A node's facts live in the module whose walk recorded them, which is its
+    /// own module for everything but the foreign AST a walk crosses into (a
+    /// callee's parameter default, resolved in the caller's frame). Two walks
+    /// reaching one such node each record it; the last one wins, and every kind
+    /// of fact for that node is then read from that one walk.
+    ///
+    /// Empty when resolve did not run or bailed before recording any fact.
+    pub(crate) fact_home: IndexMap<AstId, u32>,
     /// TIR modules produced by [`crate::elaborator::Elaborator::build_tir_from_state`].
     /// The batch compiler consumes these directly; LSP queries ignore them.
     /// Empty when `build_tir` did not run or bailed.
@@ -261,13 +230,7 @@ impl Semantics {
         types: TypeTable,
         interner: std::rc::Rc<std::cell::RefCell<ModuleSourceInterner>>,
         state: Option<AnnotateState>,
-        references: IndexMap<AstId, AstId>,
-        locals: IndexMap<AstId, Symbol>,
-        local_types: IndexMap<AstId, TypeId>,
-        expression_types: IndexMap<AstId, TypeId>,
-        method_dispatch: IndexMap<AstId, crate::elaborator::sem::types::MethodDispatch>,
-        coercions: IndexMap<AstId, crate::elaborator::sem::types::CoercionChoice>,
-        desugars: IndexMap<AstId, crate::elaborator::sem::types::DesugarKind>,
+        fact_home: IndexMap<AstId, u32>,
         tir_modules: IndexMap<ModuleSource, TirModule>,
     ) -> Self {
         let space_modules = modules
@@ -283,13 +246,7 @@ impl Semantics {
             ast_indices,
             state,
             space_modules,
-            references,
-            locals,
-            local_types,
-            expression_types,
-            method_dispatch,
-            coercions,
-            desugars,
+            fact_home,
             tir_modules,
             liveness: crate::elaborator::liveness::Liveness::default(),
             is_complete: false,
@@ -307,12 +264,31 @@ impl Semantics {
         self.ast_indices.get(module)?.ast_id_at(line, column)
     }
 
+    /// The body-walk facts for `id`, from the module whose walk recorded them.
+    /// `None` when no walk reached the node. See [`Self::fact_home`].
+    fn facts_of(&self, id: AstId) -> Option<&crate::elaborator::sem::ModuleSemantics> {
+        let home = *self.fact_home.get(&id)? as usize;
+        let (_source, sem) = self.state.as_ref()?.module_semantics.get_index(home)?;
+        Some(sem)
+    }
+
+    /// Every loaded module's facts, in load order — the iteration side of
+    /// [`Self::facts_of`].
+    fn all_facts(&self) -> impl Iterator<Item = &crate::elaborator::sem::ModuleSemantics> {
+        self.state
+            .as_ref()
+            .into_iter()
+            .flat_map(|state| state.module_semantics.values())
+    }
+
     /// Symbol for the given key, or `None` if the key does not refer to a
     /// declared symbol. Falls back to the synthetic local table when the key
     /// names a `let` / parameter binding rather than an item.
     #[must_use]
     pub fn symbol_at(&self, id: AstId) -> Option<&Symbol> {
-        self.symbols.get(&id).or_else(|| self.locals.get(&id))
+        self.symbols
+            .get(&id)
+            .or_else(|| self.facts_of(id)?.bindings.local_symbols.get(&id))
     }
 
     /// Resolve a use-site `AstId` (typically an [`IdentExpr`](crate::ast::IdentExpr) id) to the
@@ -321,7 +297,7 @@ impl Semantics {
     /// fall back to name-based lookup via the symbol table.
     #[must_use]
     pub fn referenced_symbol(&self, id: AstId) -> Option<AstId> {
-        self.references.get(&id).copied()
+        self.facts_of(id)?.bindings.references.get(&id).copied()
     }
 
     /// Iterate every declared symbol with its canonical key, across all
@@ -331,10 +307,10 @@ impl Semantics {
     /// semantic-token highlighting to classify declaration sites in one pass
     /// instead of a positional lookup per token.
     pub fn iter_symbols(&self) -> impl Iterator<Item = (AstId, &Symbol)> {
-        self.symbols
-            .iter()
-            .map(|(id, s)| (*id, s))
-            .chain(self.locals.iter().map(|(id, s)| (*id, s)))
+        self.symbols.iter().map(|(id, s)| (*id, s)).chain(
+            self.all_facts()
+                .flat_map(|sem| sem.bindings.local_symbols.iter().map(|(id, s)| (*id, s))),
+        )
     }
 
     /// Iterate every recorded use-site `(use_key, def_key)` edge.
@@ -344,9 +320,12 @@ impl Semantics {
     /// item-level definitions (functions, types, globals) and imported items
     /// are all recorded here.
     pub fn iter_references(&self) -> impl Iterator<Item = (AstId, AstId)> {
-        self.references
-            .iter()
-            .map(|(use_id, def_id)| (*use_id, *def_id))
+        self.all_facts().flat_map(|sem| {
+            sem.bindings
+                .references
+                .iter()
+                .map(|(use_id, def_id)| (*use_id, *def_id))
+        })
     }
 
     /// Find every use-site `AstId` whose definition is `def_id`.
@@ -382,8 +361,16 @@ impl Semantics {
     /// the binding's body.
     #[must_use]
     pub fn local_type_name(&self, id: AstId) -> Option<String> {
-        let type_id = self.local_types.get(&id).copied()?;
-        Some(self.types.type_name(type_id))
+        Some(self.types.type_name(self.local_type(id)?))
+    }
+
+    /// Inferred [`TypeId`] for the local binding at `id` (a `let` pattern, a
+    /// function / closure parameter, a `for x of …` element), as the body walk
+    /// recorded it. `None` for anything that is not a local binding the walk
+    /// reached.
+    #[must_use]
+    pub fn local_type(&self, id: AstId) -> Option<TypeId> {
+        self.facts_of(id)?.types.local_types.get(&id).copied()
     }
 
     /// Resolved [`TypeId`] for the expression at `key`, recorded by the
@@ -394,7 +381,14 @@ impl Semantics {
     /// id or a body the elaborator bailed on.
     #[must_use]
     pub fn expression_type(&self, id: AstId) -> Option<TypeId> {
-        self.expression_types.get(&id).copied()
+        self.facts_of(id)?.types.expression_types.get(&id).copied()
+    }
+
+    /// Iterate every expression the body walk typed, as `(AstId, TypeId)`.
+    /// Pair with [`Self::module_of_id`] to filter by module.
+    pub fn iter_expression_types(&self) -> impl Iterator<Item = (AstId, TypeId)> + '_ {
+        self.all_facts()
+            .flat_map(|sem| sem.types.expression_types.iter().map(|(id, ty)| (*id, *ty)))
     }
 
     /// Method-dispatch decision recorded for the `MethodCallExpr` at
@@ -404,15 +398,12 @@ impl Semantics {
     /// static-method-as-instance error) leave no entry. See
     /// [`crate::elaborator::sem::types::MethodDispatch`] for the data
     /// shape.
-    ///
-    /// `#[allow(dead_code)]` until `reify` consumes it.
-    #[allow(dead_code)]
     #[must_use]
     pub(crate) fn method_dispatch_at(
         &self,
         id: AstId,
     ) -> Option<&crate::elaborator::sem::types::MethodDispatch> {
-        self.method_dispatch.get(&id)
+        self.facts_of(id)?.types.method_dispatch.get(&id)
     }
 
     /// Stable public view onto the recorded method-dispatch decision:
@@ -421,7 +412,7 @@ impl Semantics {
     /// full `crate::elaborator::sem::types::MethodDispatch` instead.
     #[must_use]
     pub fn method_dispatch_view(&self, id: AstId) -> Option<(String, ModuleSource, String)> {
-        let dispatch = self.method_dispatch.get(&id)?;
+        let dispatch = self.method_dispatch_at(id)?;
         let self_kind = match dispatch.self_kind {
             crate::ast::SelfKind::None => "none",
             crate::ast::SelfKind::Value => "value",
@@ -448,8 +439,7 @@ impl Semantics {
     /// move check uses this to treat the receiver as consumed.
     #[must_use]
     pub fn method_call_consumes_receiver(&self, id: AstId) -> bool {
-        self.method_dispatch
-            .get(&id)
+        self.method_dispatch_at(id)
             .is_some_and(|dispatch| dispatch.consumes_self)
     }
 
@@ -458,7 +448,8 @@ impl Semantics {
     /// [`Self::method_dispatch_view`] for the stable public view onto
     /// each entry.
     pub fn iter_method_dispatch(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.method_dispatch.keys().copied()
+        self.all_facts()
+            .flat_map(|sem| sem.types.method_dispatch.keys().copied())
     }
 
     /// Stable public view onto the recorded coercion choice:
@@ -469,7 +460,7 @@ impl Semantics {
     #[must_use]
     pub fn coercion_view(&self, id: AstId) -> Option<(String, TypeId)> {
         use crate::elaborator::sem::types::CoercionKind;
-        let choice = self.coercions.get(&id)?;
+        let choice = self.facts_of(id)?.types.coercions.get(&id)?;
         let kind = match choice.kind {
             CoercionKind::NumericLiteral => "numeric_literal",
             CoercionKind::NullToOption => "null_to_option",
@@ -486,7 +477,8 @@ impl Semantics {
     /// expression's `(module, AstId)`. Pair with [`Self::coercion_view`]
     /// for the stable public view onto each entry.
     pub fn iter_coercions(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.coercions.keys().copied()
+        self.all_facts()
+            .flat_map(|sem| sem.types.coercions.keys().copied())
     }
 
     /// WEP 2026-05-26: stable public view onto the recorded
@@ -501,7 +493,7 @@ impl Semantics {
     #[must_use]
     pub fn desugar_view(&self, id: AstId) -> Option<String> {
         use crate::elaborator::sem::types::DesugarKind;
-        let kind = self.desugars.get(&id)?;
+        let kind = self.facts_of(id)?.types.desugars.get(&id)?;
         let name = match kind {
             DesugarKind::Assert => "assert",
             DesugarKind::Matches => "matches",
@@ -526,7 +518,8 @@ impl Semantics {
     /// node's `(module, AstId)`. Pair with [`Self::desugar_view`] for the
     /// stable public view onto each entry.
     pub fn iter_desugars(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.desugars.keys().copied()
+        self.all_facts()
+            .flat_map(|sem| sem.types.desugars.keys().copied())
     }
 
     /// URI (filename) of a module, when the module has one.
@@ -1068,12 +1061,6 @@ impl Semantics {
             None,
             IndexMap::default(),
             IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
         )
     }
 }
@@ -1163,12 +1150,6 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
             None,
             IndexMap::default(),
             IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
         );
     }
 
@@ -1199,19 +1180,13 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
             None,
             IndexMap::default(),
             IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
-            IndexMap::default(),
         );
     };
 
     // Run the full body-level resolve pass, the single source of truth for
     // use→def edges: LSP and batch compilation both read what the elaborator
     // recorded, with no second lexical scan to drift out of sync. On Bail the
-    // partial maps are still drained so cursor queries work against whatever
+    // partial facts are still routed so cursor queries work against whatever
     // bodies were reached. `build_tir == false` stops after `annotate_bodies`.
     let (tir_modules, lower_ok) = {
         let _span = logger.span("elaborate/build_tir");
@@ -1235,35 +1210,28 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // `state.tysys.type_table`.
     let types = state.tysys.type_table.borrow().clone();
 
-    // Flatten the per-module `ModuleSemantics` into the maps LSP queries
-    // consume directly. The Semantics API is keyed by bare `AstId`; the
-    // per-module storage on `AnnotateState` is the elaborator-side detail
-    // that replaces the previous `Rc<RefCell<…>>` plumbing. The
-    // `expression_types` / `method_dispatch` / `coercions` maps are stored
-    // per-module keyed by raw `AstId` (the body walk's natural index); the
-    // rebind here pairs each id with its owning module so the
-    // Semantics-level lookup matches the other flat maps.
-    let mut references: IndexMap<AstId, AstId> = IndexMap::default();
-    let mut locals: IndexMap<AstId, Symbol> = IndexMap::default();
-    let mut local_types: IndexMap<AstId, TypeId> = IndexMap::default();
-    let mut expression_types: IndexMap<AstId, TypeId> = IndexMap::default();
-    let mut method_dispatch: IndexMap<AstId, crate::elaborator::sem::types::MethodDispatch> =
-        IndexMap::default();
-    let mut coercions: IndexMap<AstId, crate::elaborator::sem::types::CoercionChoice> =
-        IndexMap::default();
-    let mut desugars: IndexMap<AstId, crate::elaborator::sem::types::DesugarKind> =
-        IndexMap::default();
-    for (_module_source, sem) in &mut state.module_semantics {
-        references.extend(std::mem::take(&mut sem.bindings.references));
-        locals.extend(std::mem::take(&mut sem.bindings.local_symbols));
-        local_types.extend(std::mem::take(&mut sem.types.local_types));
-        // All body-level maps are keyed by globally-unique `AstId`, so the
-        // per-module maps merge into the flat Semantics maps directly —
-        // entries can never collide across modules.
-        expression_types.extend(std::mem::take(&mut sem.types.expression_types));
-        method_dispatch.extend(std::mem::take(&mut sem.types.method_dispatch));
-        coercions.extend(std::mem::take(&mut sem.types.coercions));
-        desugars.extend(std::mem::take(&mut sem.types.desugars));
+    // Route each node the body walk reached to the module that recorded its
+    // facts. The `Semantics` API is keyed by bare `AstId` while the facts stay
+    // in the per-module `ModuleSemantics` the walk wrote them into — one home,
+    // whichever phase reads them. A node walked by two modules (a callee's
+    // parameter default, resolved in each caller's frame) resolves to the last,
+    // and every kind of fact for it then comes from that one walk.
+    let mut fact_home: IndexMap<AstId, u32> = IndexMap::default();
+    for (home, sem) in state.module_semantics.values().enumerate() {
+        let home = u32::try_from(home).expect("module count fits in u32");
+        let ids = sem
+            .bindings
+            .references
+            .keys()
+            .chain(sem.bindings.local_symbols.keys())
+            .chain(sem.types.local_types.keys())
+            .chain(sem.types.expression_types.keys())
+            .chain(sem.types.method_dispatch.keys())
+            .chain(sem.types.coercions.keys())
+            .chain(sem.types.desugars.keys());
+        for id in ids {
+            fact_home.insert(*id, home);
+        }
     }
 
     // A recovered syntax error anywhere in the loaded set means the parse was
@@ -1290,13 +1258,7 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
         ast_indices,
         state: Some(state),
         space_modules,
-        references,
-        locals,
-        local_types,
-        expression_types,
-        method_dispatch,
-        coercions,
-        desugars,
+        fact_home,
         tir_modules,
         liveness,
         is_complete: lower_ok && no_syntax_errors,
@@ -1331,4 +1293,62 @@ pub(crate) fn member_visible(
     visibility: crate::ast::Visibility,
 ) -> bool {
     !public_only || !inherent || visibility.is_public()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler_host::InMemoryCompilerHost;
+
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Runtime::new().unwrap().block_on(future)
+    }
+
+    /// One home: the body walk's facts stay in the [`ModuleSemantics`] that
+    /// recorded them, and `Semantics` reads through to it. A second copy leaves
+    /// the first empty, so a consumer reading the wrong one gets no facts
+    /// instead of a failure (WEP 2026-05-26 "One fact, two homes").
+    #[test]
+    fn body_facts_have_one_home() {
+        let host = InMemoryCompilerHost::new();
+        let sem = block_on(semantics(
+            "fn main() { let x = 1 + 2; let y = x + 3; }",
+            &host,
+            Some("entry.wado"),
+        ));
+        let entry = sem.entry_module_source.clone();
+        let module_sem = &sem
+            .state
+            .as_ref()
+            .expect("annotate state")
+            .module_semantics[&entry];
+
+        assert!(!module_sem.types.expression_types.is_empty());
+        assert!(!module_sem.types.local_types.is_empty());
+        assert!(!module_sem.bindings.references.is_empty());
+        assert!(!module_sem.bindings.local_symbols.is_empty());
+
+        let expr_id = *module_sem.types.expression_types.keys().next().unwrap();
+        assert!(sem.expression_type(expr_id).is_some());
+        let local_id = *module_sem.types.local_types.keys().next().unwrap();
+        assert!(sem.local_type_name(local_id).is_some());
+        let use_id = *module_sem.bindings.references.keys().next().unwrap();
+        assert!(sem.referenced_symbol(use_id).is_some());
+        let sym_id = *module_sem.bindings.local_symbols.keys().next().unwrap();
+        assert!(sem.symbol_at(sym_id).is_some());
+
+        // The same holds for a module seeded from the stdlib snapshot, which
+        // carries its facts per module rather than re-splitting flat ones.
+        let stdlib_facts = sem
+            .state
+            .as_ref()
+            .expect("annotate state")
+            .module_semantics
+            .iter()
+            .filter(|(source, _)| **source != entry)
+            .any(|(_, sem)| {
+                !sem.types.expression_types.is_empty() && !sem.bindings.references.is_empty()
+            });
+        assert!(stdlib_facts);
+    }
 }

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -62,6 +62,9 @@ pub struct Semantics {
     /// position in [`AnnotateState::module_semantics`] — the routing every
     /// `AstId`-keyed query below reads through, in place of a second copy.
     /// Keyed by [`FactKind`] too: one node's kinds need not come from one walk.
+    /// Several walks can still hold one kind for one node — a callee's
+    /// parameter default is typed once per call site — and the last module in
+    /// [`AnnotateState::module_semantics`] order is the one routed to.
     pub(crate) fact_home: IndexMap<(AstId, FactKind), u32>,
     /// TIR modules produced by [`crate::elaborator::Elaborator::build_tir_from_state`].
     /// The batch compiler consumes these directly; LSP queries ignore them.
@@ -1195,7 +1198,8 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     let types = state.tysys.type_table.borrow().clone();
 
     // Route each fact to the module that holds it, rather than copying it out:
-    // where two walks reached a node, each kind goes to the walk that has it.
+    // where two walks reached a node, each kind goes to the walk that has it,
+    // and a kind both hold to the later module.
     let mut fact_home: IndexMap<(AstId, FactKind), u32> = IndexMap::default();
     for (home, sem) in state.module_semantics.values().enumerate() {
         let home = u32::try_from(home).expect("module count fits in u32");

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -11,6 +11,7 @@ use crate::compiler_host::{CompilerHost, LogLevel};
 use crate::component_model::CmInterfaceRegistry;
 use crate::elaborator::Elaborator;
 use crate::elaborator::orchestration::AnnotateState;
+use crate::elaborator::sem::FactKind;
 use crate::hashmap::IndexMap;
 use crate::loader;
 use crate::logger::Logger;
@@ -58,18 +59,18 @@ pub struct Semantics {
     /// module in every key.
     pub(crate) space_modules: IndexMap<crate::ast::AstIdSpace, ModuleSource>,
     /// Which module's [`ModuleSemantics`](crate::elaborator::sem::ModuleSemantics)
-    /// holds the body-walk facts for a node — the routing every `AstId`-keyed
-    /// query below goes through. The facts themselves have one home, the map the
-    /// walk wrote them into; this says which one that is.
+    /// holds a given fact — the routing every `AstId`-keyed query below goes
+    /// through. The facts themselves have one home, the map the walk wrote them
+    /// into; this says which one that is.
     ///
-    /// A node's facts live in the module whose walk recorded them, which is its
+    /// A fact lives in the module whose walk recorded it, which is its node's
     /// own module for everything but the foreign AST a walk crosses into (a
-    /// callee's parameter default, resolved in the caller's frame). Two walks
-    /// reaching one such node each record it; the last one wins, and every kind
-    /// of fact for that node is then read from that one walk.
+    /// callee's parameter default, resolved in the caller's frame). Keyed by
+    /// [`FactKind`] as well as node, because one node's kinds need not come
+    /// from one walk; where two walks do record the same kind, the last wins.
     ///
     /// Empty when resolve did not run or bailed before recording any fact.
-    pub(crate) fact_home: IndexMap<AstId, u32>,
+    pub(crate) fact_home: IndexMap<(AstId, FactKind), u32>,
     /// TIR modules produced by [`crate::elaborator::Elaborator::build_tir_from_state`].
     /// The batch compiler consumes these directly; LSP queries ignore them.
     /// Empty when `build_tir` did not run or bailed.
@@ -230,7 +231,7 @@ impl Semantics {
         types: TypeTable,
         interner: std::rc::Rc<std::cell::RefCell<ModuleSourceInterner>>,
         state: Option<AnnotateState>,
-        fact_home: IndexMap<AstId, u32>,
+        fact_home: IndexMap<(AstId, FactKind), u32>,
         tir_modules: IndexMap<ModuleSource, TirModule>,
     ) -> Self {
         let space_modules = modules
@@ -264,10 +265,14 @@ impl Semantics {
         self.ast_indices.get(module)?.ast_id_at(line, column)
     }
 
-    /// The body-walk facts for `id`, from the module whose walk recorded them.
-    /// `None` when no walk reached the node. See [`Self::fact_home`].
-    fn facts_of(&self, id: AstId) -> Option<&crate::elaborator::sem::ModuleSemantics> {
-        let home = *self.fact_home.get(&id)? as usize;
+    /// The module holding the `kind` fact for `id`. `None` when no walk
+    /// recorded one. See [`Self::fact_home`].
+    fn facts_of(
+        &self,
+        id: AstId,
+        kind: FactKind,
+    ) -> Option<&crate::elaborator::sem::ModuleSemantics> {
+        let home = *self.fact_home.get(&(id, kind))? as usize;
         let (_source, sem) = self.state.as_ref()?.module_semantics.get_index(home)?;
         Some(sem)
     }
@@ -278,6 +283,7 @@ impl Semantics {
     /// left out; the module it lands in is the whole of what makes it live.
     fn iter_live<'s, V: 's>(
         &'s self,
+        kind: FactKind,
         map: impl Fn(&'s crate::elaborator::sem::ModuleSemantics) -> &'s IndexMap<AstId, V> + 's,
     ) -> impl Iterator<Item = (AstId, &'s V)> + 's {
         self.state
@@ -288,7 +294,7 @@ impl Semantics {
                 let home = u32::try_from(home).expect("module count fits in u32");
                 map(sem)
                     .iter()
-                    .filter(move |(id, _)| self.fact_home.get(*id) == Some(&home))
+                    .filter(move |(id, _)| self.fact_home.get(&(**id, kind)) == Some(&home))
                     .map(|(id, value)| (*id, value))
             })
     }
@@ -300,7 +306,10 @@ impl Semantics {
     pub fn symbol_at(&self, id: AstId) -> Option<&Symbol> {
         self.symbols
             .get(&id)
-            .or_else(|| self.facts_of(id)?.bindings.local_symbols.get(&id))
+            .or_else(|| self.facts_of(id, FactKind::LocalSymbol)?
+                    .bindings
+                    .local_symbols
+                    .get(&id))
     }
 
     /// Resolve a use-site `AstId` (typically an [`IdentExpr`](crate::ast::IdentExpr) id) to the
@@ -309,7 +318,11 @@ impl Semantics {
     /// fall back to name-based lookup via the symbol table.
     #[must_use]
     pub fn referenced_symbol(&self, id: AstId) -> Option<AstId> {
-        self.facts_of(id)?.bindings.references.get(&id).copied()
+        self.facts_of(id, FactKind::Reference)?
+            .bindings
+            .references
+            .get(&id)
+            .copied()
     }
 
     /// Iterate every declared symbol with its canonical key, across all
@@ -322,7 +335,7 @@ impl Semantics {
         self.symbols
             .iter()
             .map(|(id, s)| (*id, s))
-            .chain(self.iter_live(|sem| &sem.bindings.local_symbols))
+            .chain(self.iter_live(FactKind::LocalSymbol, |sem| &sem.bindings.local_symbols))
     }
 
     /// Iterate every recorded use-site `(use_key, def_key)` edge.
@@ -332,7 +345,7 @@ impl Semantics {
     /// item-level definitions (functions, types, globals) and imported items
     /// are all recorded here.
     pub fn iter_references(&self) -> impl Iterator<Item = (AstId, AstId)> {
-        self.iter_live(|sem| &sem.bindings.references)
+        self.iter_live(FactKind::Reference, |sem| &sem.bindings.references)
             .map(|(use_id, def_id)| (use_id, *def_id))
     }
 
@@ -378,7 +391,11 @@ impl Semantics {
     /// reached.
     #[must_use]
     pub fn local_type(&self, id: AstId) -> Option<TypeId> {
-        self.facts_of(id)?.types.local_types.get(&id).copied()
+        self.facts_of(id, FactKind::LocalType)?
+            .types
+            .local_types
+            .get(&id)
+            .copied()
     }
 
     /// Resolved [`TypeId`] for the expression at `key`, recorded by the
@@ -389,13 +406,17 @@ impl Semantics {
     /// id or a body the elaborator bailed on.
     #[must_use]
     pub fn expression_type(&self, id: AstId) -> Option<TypeId> {
-        self.facts_of(id)?.types.expression_types.get(&id).copied()
+        self.facts_of(id, FactKind::ExpressionType)?
+            .types
+            .expression_types
+            .get(&id)
+            .copied()
     }
 
     /// Iterate every expression the body walk typed, as `(AstId, TypeId)`.
     /// Pair with [`Self::module_of_id`] to filter by module.
     pub fn iter_expression_types(&self) -> impl Iterator<Item = (AstId, TypeId)> + '_ {
-        self.iter_live(|sem| &sem.types.expression_types)
+        self.iter_live(FactKind::ExpressionType, |sem| &sem.types.expression_types)
             .map(|(id, ty)| (id, *ty))
     }
 
@@ -411,7 +432,10 @@ impl Semantics {
         &self,
         id: AstId,
     ) -> Option<&crate::elaborator::sem::types::MethodDispatch> {
-        self.facts_of(id)?.types.method_dispatch.get(&id)
+        self.facts_of(id, FactKind::MethodDispatch)?
+            .types
+            .method_dispatch
+            .get(&id)
     }
 
     /// Stable public view onto the recorded method-dispatch decision:
@@ -456,7 +480,7 @@ impl Semantics {
     /// [`Self::method_dispatch_view`] for the stable public view onto
     /// each entry.
     pub fn iter_method_dispatch(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.iter_live(|sem| &sem.types.method_dispatch)
+        self.iter_live(FactKind::MethodDispatch, |sem| &sem.types.method_dispatch)
             .map(|(id, _)| id)
     }
 
@@ -468,7 +492,7 @@ impl Semantics {
     #[must_use]
     pub fn coercion_view(&self, id: AstId) -> Option<(String, TypeId)> {
         use crate::elaborator::sem::types::CoercionKind;
-        let choice = self.facts_of(id)?.types.coercions.get(&id)?;
+        let choice = self.facts_of(id, FactKind::Coercion)?.types.coercions.get(&id)?;
         let kind = match choice.kind {
             CoercionKind::NumericLiteral => "numeric_literal",
             CoercionKind::NullToOption => "null_to_option",
@@ -485,7 +509,7 @@ impl Semantics {
     /// expression's `(module, AstId)`. Pair with [`Self::coercion_view`]
     /// for the stable public view onto each entry.
     pub fn iter_coercions(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.iter_live(|sem| &sem.types.coercions).map(|(id, _)| id)
+        self.iter_live(FactKind::Coercion, |sem| &sem.types.coercions).map(|(id, _)| id)
     }
 
     /// WEP 2026-05-26: stable public view onto the recorded
@@ -500,7 +524,7 @@ impl Semantics {
     #[must_use]
     pub fn desugar_view(&self, id: AstId) -> Option<String> {
         use crate::elaborator::sem::types::DesugarKind;
-        let kind = self.facts_of(id)?.types.desugars.get(&id)?;
+        let kind = self.facts_of(id, FactKind::Desugar)?.types.desugars.get(&id)?;
         let name = match kind {
             DesugarKind::Assert => "assert",
             DesugarKind::Matches => "matches",
@@ -525,7 +549,7 @@ impl Semantics {
     /// node's `(module, AstId)`. Pair with [`Self::desugar_view`] for the
     /// stable public view onto each entry.
     pub fn iter_desugars(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.iter_live(|sem| &sem.types.desugars).map(|(id, _)| id)
+        self.iter_live(FactKind::Desugar, |sem| &sem.types.desugars).map(|(id, _)| id)
     }
 
     /// URI (filename) of a module, when the module has one.
@@ -1216,29 +1240,17 @@ pub(crate) fn semantics_with_logger<H: CompilerHost>(
     // `state.tysys.type_table`.
     let types = state.tysys.type_table.borrow().clone();
 
-    // Route each node the body walk reached to the module that recorded its
-    // facts. The `Semantics` API is keyed by bare `AstId` while the facts stay
-    // in the per-module `ModuleSemantics` the walk wrote them into — one home,
-    // whichever phase reads them. A node walked by two modules (a callee's
-    // parameter default, resolved in each caller's frame) resolves to the last,
-    // and every kind of fact for it then comes from that one walk.
-    let mut fact_home: IndexMap<AstId, u32> = IndexMap::default();
+    // Route each fact the body walk recorded to the module that holds it. The
+    // `Semantics` API is keyed by bare `AstId` while the facts stay in the
+    // per-module `ModuleSemantics` the walk wrote them into — one home,
+    // whichever phase reads them. A node reached by two walks (a callee's
+    // parameter default, typed at each call site while its own module records
+    // the edges around it) routes each kind to the walk that has it.
+    let mut fact_home: IndexMap<(AstId, FactKind), u32> = IndexMap::default();
     for (home, sem) in state.module_semantics.values().enumerate() {
         let home = u32::try_from(home).expect("module count fits in u32");
-        for id in sem.routed_fact_ids() {
-            #[cfg(debug_assertions)]
-            if let Some(prev) = fact_home
-                .get(id)
-                .and_then(|prev| state.module_semantics.get_index(*prev as usize))
-            {
-                let (before, after) = (prev.1.routed_fact_kinds(*id), sem.routed_fact_kinds(*id));
-                debug_assert!(
-                    before.iter().zip(after).all(|(had, has)| !had || has),
-                    "a later walk over {id:?} records fewer fact kinds than {}'s, so routing to it would drop one",
-                    prev.0
-                );
-            }
-            fact_home.insert(*id, home);
+        for fact in sem.routed_facts() {
+            fact_home.insert(fact, home);
         }
     }
 

--- a/wado-compiler/src/semantics.rs
+++ b/wado-compiler/src/semantics.rs
@@ -11,7 +11,7 @@ use crate::compiler_host::{CompilerHost, LogLevel};
 use crate::component_model::CmInterfaceRegistry;
 use crate::elaborator::Elaborator;
 use crate::elaborator::orchestration::AnnotateState;
-use crate::elaborator::sem::FactKind;
+use crate::elaborator::sem::{Fact, FactKind, ModuleSemantics};
 use crate::hashmap::IndexMap;
 use crate::loader;
 use crate::logger::Logger;
@@ -68,6 +68,12 @@ pub struct Semantics {
     /// callee's parameter default, resolved in the caller's frame). Keyed by
     /// [`FactKind`] as well as node, because one node's kinds need not come
     /// from one walk; where two walks do record the same kind, the last wins.
+    ///
+    /// The value is a position in [`AnnotateState::module_semantics`], which
+    /// the body walk reorders (`swap_remove` + `insert`); it is minted after
+    /// the last such move and `state` is immutable from then on. [`Self::fact_at`]
+    /// asserts the routed module really holds the fact, so a stale index fails
+    /// rather than answering `None`.
     ///
     /// Empty when resolve did not run or bailed before recording any fact.
     pub(crate) fact_home: IndexMap<(AstId, FactKind), u32>,
@@ -265,36 +271,34 @@ impl Semantics {
         self.ast_indices.get(module)?.ast_id_at(line, column)
     }
 
-    /// The module holding the `kind` fact for `id`. `None` when no walk
-    /// recorded one. See [`Self::fact_home`].
-    fn facts_of(
-        &self,
-        id: AstId,
-        kind: FactKind,
-    ) -> Option<&crate::elaborator::sem::ModuleSemantics> {
-        let home = *self.fact_home.get(&(id, kind))? as usize;
+    /// The `fact` recorded for `id`, read from the module [`Self::fact_home`]
+    /// routes it to. `None` when no walk recorded one.
+    fn fact_at<V>(&self, fact: Fact<V>, id: AstId) -> Option<&V> {
+        let home = *self.fact_home.get(&(id, fact.kind))? as usize;
         let (_source, sem) = self.state.as_ref()?.module_semantics.get_index(home)?;
-        Some(sem)
+        let found = (fact.map)(sem).get(&id);
+        debug_assert!(
+            found.is_some(),
+            "fact_home routed {id:?}/{:?} to a module that does not hold it",
+            fact.kind
+        );
+        found
     }
 
-    /// Every entry of one fact map that [`Self::facts_of`] would answer with —
+    /// Every entry of one fact map that [`Self::fact_at`] would answer with —
     /// the iteration side of the same routing, so what an `iter_*` yields is
     /// exactly what a point lookup returns. An entry a later walk shadowed is
     /// left out; the module it lands in is the whole of what makes it live.
-    fn iter_live<'s, V: 's>(
-        &'s self,
-        kind: FactKind,
-        map: impl Fn(&'s crate::elaborator::sem::ModuleSemantics) -> &'s IndexMap<AstId, V> + 's,
-    ) -> impl Iterator<Item = (AstId, &'s V)> + 's {
+    fn iter_live<V>(&self, fact: Fact<V>) -> impl Iterator<Item = (AstId, &V)> {
         self.state
             .as_ref()
             .into_iter()
             .flat_map(|state| state.module_semantics.values().enumerate())
             .flat_map(move |(home, sem)| {
                 let home = u32::try_from(home).expect("module count fits in u32");
-                map(sem)
+                (fact.map)(sem)
                     .iter()
-                    .filter(move |(id, _)| self.fact_home.get(&(**id, kind)) == Some(&home))
+                    .filter(move |(id, _)| self.fact_home.get(&(**id, fact.kind)) == Some(&home))
                     .map(|(id, value)| (*id, value))
             })
     }
@@ -306,10 +310,7 @@ impl Semantics {
     pub fn symbol_at(&self, id: AstId) -> Option<&Symbol> {
         self.symbols
             .get(&id)
-            .or_else(|| self.facts_of(id, FactKind::LocalSymbol)?
-                    .bindings
-                    .local_symbols
-                    .get(&id))
+            .or_else(|| self.fact_at(ModuleSemantics::LOCAL_SYMBOLS, id))
     }
 
     /// Resolve a use-site `AstId` (typically an [`IdentExpr`](crate::ast::IdentExpr) id) to the
@@ -318,11 +319,7 @@ impl Semantics {
     /// fall back to name-based lookup via the symbol table.
     #[must_use]
     pub fn referenced_symbol(&self, id: AstId) -> Option<AstId> {
-        self.facts_of(id, FactKind::Reference)?
-            .bindings
-            .references
-            .get(&id)
-            .copied()
+        self.fact_at(ModuleSemantics::REFERENCES, id).copied()
     }
 
     /// Iterate every declared symbol with its canonical key, across all
@@ -335,7 +332,7 @@ impl Semantics {
         self.symbols
             .iter()
             .map(|(id, s)| (*id, s))
-            .chain(self.iter_live(FactKind::LocalSymbol, |sem| &sem.bindings.local_symbols))
+            .chain(self.iter_live(ModuleSemantics::LOCAL_SYMBOLS))
     }
 
     /// Iterate every recorded use-site `(use_key, def_key)` edge.
@@ -345,7 +342,7 @@ impl Semantics {
     /// item-level definitions (functions, types, globals) and imported items
     /// are all recorded here.
     pub fn iter_references(&self) -> impl Iterator<Item = (AstId, AstId)> {
-        self.iter_live(FactKind::Reference, |sem| &sem.bindings.references)
+        self.iter_live(ModuleSemantics::REFERENCES)
             .map(|(use_id, def_id)| (use_id, *def_id))
     }
 
@@ -391,11 +388,7 @@ impl Semantics {
     /// reached.
     #[must_use]
     pub fn local_type(&self, id: AstId) -> Option<TypeId> {
-        self.facts_of(id, FactKind::LocalType)?
-            .types
-            .local_types
-            .get(&id)
-            .copied()
+        self.fact_at(ModuleSemantics::LOCAL_TYPES, id).copied()
     }
 
     /// Resolved [`TypeId`] for the expression at `key`, recorded by the
@@ -406,17 +399,13 @@ impl Semantics {
     /// id or a body the elaborator bailed on.
     #[must_use]
     pub fn expression_type(&self, id: AstId) -> Option<TypeId> {
-        self.facts_of(id, FactKind::ExpressionType)?
-            .types
-            .expression_types
-            .get(&id)
-            .copied()
+        self.fact_at(ModuleSemantics::EXPRESSION_TYPES, id).copied()
     }
 
     /// Iterate every expression the body walk typed, as `(AstId, TypeId)`.
     /// Pair with [`Self::module_of_id`] to filter by module.
     pub fn iter_expression_types(&self) -> impl Iterator<Item = (AstId, TypeId)> + '_ {
-        self.iter_live(FactKind::ExpressionType, |sem| &sem.types.expression_types)
+        self.iter_live(ModuleSemantics::EXPRESSION_TYPES)
             .map(|(id, ty)| (id, *ty))
     }
 
@@ -432,10 +421,7 @@ impl Semantics {
         &self,
         id: AstId,
     ) -> Option<&crate::elaborator::sem::types::MethodDispatch> {
-        self.facts_of(id, FactKind::MethodDispatch)?
-            .types
-            .method_dispatch
-            .get(&id)
+        self.fact_at(ModuleSemantics::METHOD_DISPATCH, id)
     }
 
     /// Stable public view onto the recorded method-dispatch decision:
@@ -480,7 +466,7 @@ impl Semantics {
     /// [`Self::method_dispatch_view`] for the stable public view onto
     /// each entry.
     pub fn iter_method_dispatch(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.iter_live(FactKind::MethodDispatch, |sem| &sem.types.method_dispatch)
+        self.iter_live(ModuleSemantics::METHOD_DISPATCH)
             .map(|(id, _)| id)
     }
 
@@ -492,7 +478,7 @@ impl Semantics {
     #[must_use]
     pub fn coercion_view(&self, id: AstId) -> Option<(String, TypeId)> {
         use crate::elaborator::sem::types::CoercionKind;
-        let choice = self.facts_of(id, FactKind::Coercion)?.types.coercions.get(&id)?;
+        let choice = self.fact_at(ModuleSemantics::COERCIONS, id)?;
         let kind = match choice.kind {
             CoercionKind::NumericLiteral => "numeric_literal",
             CoercionKind::NullToOption => "null_to_option",
@@ -509,7 +495,7 @@ impl Semantics {
     /// expression's `(module, AstId)`. Pair with [`Self::coercion_view`]
     /// for the stable public view onto each entry.
     pub fn iter_coercions(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.iter_live(FactKind::Coercion, |sem| &sem.types.coercions).map(|(id, _)| id)
+        self.iter_live(ModuleSemantics::COERCIONS).map(|(id, _)| id)
     }
 
     /// WEP 2026-05-26: stable public view onto the recorded
@@ -524,7 +510,7 @@ impl Semantics {
     #[must_use]
     pub fn desugar_view(&self, id: AstId) -> Option<String> {
         use crate::elaborator::sem::types::DesugarKind;
-        let kind = self.facts_of(id, FactKind::Desugar)?.types.desugars.get(&id)?;
+        let kind = self.fact_at(ModuleSemantics::DESUGARS, id)?;
         let name = match kind {
             DesugarKind::Assert => "assert",
             DesugarKind::Matches => "matches",
@@ -549,7 +535,7 @@ impl Semantics {
     /// node's `(module, AstId)`. Pair with [`Self::desugar_view`] for the
     /// stable public view onto each entry.
     pub fn iter_desugars(&self) -> impl Iterator<Item = AstId> + '_ {
-        self.iter_live(FactKind::Desugar, |sem| &sem.types.desugars).map(|(id, _)| id)
+        self.iter_live(ModuleSemantics::DESUGARS).map(|(id, _)| id)
     }
 
     /// URI (filename) of a module, when the module has one.
@@ -1337,11 +1323,7 @@ mod tests {
             Some("entry.wado"),
         ));
         let entry = sem.entry_module_source.clone();
-        let module_sem = &sem
-            .state
-            .as_ref()
-            .expect("annotate state")
-            .module_semantics[&entry];
+        let module_sem = &sem.state.as_ref().expect("annotate state").module_semantics[&entry];
 
         assert!(!module_sem.types.expression_types.is_empty());
         assert!(!module_sem.types.local_types.is_empty());
@@ -1391,7 +1373,10 @@ mod tests {
         }
         let mut seen_uses: crate::hashmap::IndexSet<AstId> = crate::hashmap::IndexSet::default();
         for (use_id, def_id) in sem.iter_references() {
-            assert!(seen_uses.insert(use_id), "iteration yielded {use_id:?} twice");
+            assert!(
+                seen_uses.insert(use_id),
+                "iteration yielded {use_id:?} twice"
+            );
             assert_eq!(sem.referenced_symbol(use_id), Some(def_id));
         }
 

--- a/wado-compiler/tests/integration/semantics.rs
+++ b/wado-compiler/tests/integration/semantics.rs
@@ -556,15 +556,15 @@ export fn run() {
     // Every recorded i32 literal in the user module would be a regression
     // (the only literals are the two `1` / `2` args, which must surface as
     // i64 after type-arg inference).
-    let any_i32 = sem.expression_types.iter().any(|(id, &type_id)| {
-        sem.module_of_id(*id) == Some(&entry) && sem.types.type_name(type_id) == "i32"
+    let any_i32 = sem.iter_expression_types().any(|(id, type_id)| {
+        sem.module_of_id(id) == Some(&entry) && sem.types.type_name(type_id) == "i32"
     });
     assert!(
         !any_i32,
         "post-inference recoerce_literal_args must overwrite the pre-inference i32 entry",
     );
-    let saw_i64 = sem.expression_types.iter().any(|(id, &type_id)| {
-        sem.module_of_id(*id) == Some(&entry) && sem.types.type_name(type_id) == "i64"
+    let saw_i64 = sem.iter_expression_types().any(|(id, type_id)| {
+        sem.module_of_id(id) == Some(&entry) && sem.types.type_name(type_id) == "i64"
     });
     assert!(
         saw_i64,

--- a/wado-compiler/tests/integration/semantics.rs
+++ b/wado-compiler/tests/integration/semantics.rs
@@ -153,10 +153,10 @@ fn semantics_resolves_position_to_ast_id() {
 
 /// Verify that calls into stdlib resolve via the same `referenced_symbol`
 /// edge whether or not the stdlib snapshot cache served the stdlib
-/// module.  The semantics pipeline seeds `state.references` from the
-/// snapshot's drained `references` map and the per-compile elaborator
-/// walks the entry module's body to add the user-side use→def edges on
-/// top — both halves are needed for the cross-module jump-to-def to
+/// module.  Seeding clones each snapshot module's bindings into the
+/// `ModuleSemantics` its walk recorded them in, and the per-compile
+/// elaborator walks the entry module's body to add the user-side use→def
+/// edges — both halves are needed for the cross-module jump-to-def to
 /// work.
 #[test]
 fn semantics_resolves_stdlib_call_to_stdlib_def() {


### PR DESCRIPTION
A fact the body walk records lives in exactly one map: the `ModuleSemantics`
of the module whose walk wrote it. `Semantics`, whose API is keyed by bare
`AstId`, answers a query by routing to that map and reading through it, so no
phase reads a fact from a place another phase can empty.

Closes the "One fact, two homes" gap in
[WEP 2026-05-26](docs/wep-2026-05-26-elaborator-rearchitecture.md).

## Routing

`Semantics::fact_home` maps `(AstId, FactKind)` to a position in
`AnnotateState::module_semantics`. The kind is part of the key because one
node's kinds need not come from one walk: a callee's parameter default is
typed at each call site, while the module that declares it records the use→def
edges around it. Several walks can also hold the same kind for one node — that
default's type among them — and the last module in `module_semantics` order is
the one routed to.

`Fact<V>` pairs a kind with the map it lives in, and the seven pairings are
stated once as `ModuleSemantics` constants. A query names a `Fact`, so it
cannot route by one kind and read another. `fact_at` asserts in debug builds
that the module it routed to holds the fact; `iter_live` filters through the
same routing, so what an `iter_*` yields is what a point lookup answers.

## Seeding

A snapshot module's facts are cloned into the `ModuleSemantics` its walk
recorded them in — `types`, `bindings`, and the decl digests. A snapshot
module outside the current compile's loaded set carries no facts, asserted in
debug builds.

## Also here

- `effect_check` reads facts through the `Semantics` accessors
  (`referenced_symbol`, `local_type`, `expression_type`, `method_dispatch_at`).
  `expr_type_of` is the single implementation of "type of this expression,
  preferring the binding an identifier names".
- `Semantics::partial` takes the five values that vary across its call sites.
- Two unit tests in `semantics.rs`: facts stay in the module that recorded
  them, and iteration yields only what routing answers with.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PJVkJ5P7Gsw4n71TXfho6j)_