### PR TITLE
fix(lsp): keep the receiver's argument slot in path-form parameter hints

### DIFF
--- a/.claude/skills/wado-cli/SKILL.md
+++ b/.claude/skills/wado-cli/SKILL.md
@@ -177,7 +177,14 @@ wado query definition --symbol core:cbor#CborDeserializer.peek_byte
 wado query references --symbol core:cli#println --base example     # all uses (workspace)
 wado query hover --line 5 --column 10 file.wado                   # position-based
 wado query diagnostics file.wado                                  # errors/warnings
+wado query inlay-hints file.wado                                  # hints, spliced into the source
 ```
+
+`inlay-hints` takes a file, not a symbol, and prints every line that carries a
+hint with the labels spliced in at the anchors an editor would render them at
+(`let x‹: i32› = add(‹a: ›1, ‹b: ›2);`), in the LSP's default UTF-16 encoding.
+That is how to check anchor placement — against `example/`, say — without
+reading positions off a list.
 
 Common options:
 

--- a/.claude/skills/wado-cli/SKILL.md
+++ b/.claude/skills/wado-cli/SKILL.md
@@ -182,9 +182,9 @@ wado query inlay-hints file.wado                                  # hints, splic
 
 `inlay-hints` takes a file, not a symbol, and prints every line that carries a
 hint with the labels spliced in at the anchors an editor would render them at
-(`let x‹: i32› = add(‹a: ›1, ‹b: ›2);`), in the LSP's default UTF-16 encoding.
-That is how to check anchor placement — against `example/`, say — without
-reading positions off a list.
+(`let x‹: i32› = add(‹a: ›1, ‹b: ›2);`). That is how to check anchor placement —
+against `example/`, say — without reading positions off a list. `--json` prints
+the raw hints instead, positioned in the LSP's default UTF-16 encoding.
 
 Common options:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ The ones you reach for while developing the toolchain:
 - `test` — run the `test` blocks in Wado source files.
 - `serve` — compile and serve an HTTP service.
 - `dump` — dump compiler internal state at every stage: AST, modules, symbols, types, TIR, NIR, WIR.
-- `query` — ask the language service for hover / definition / references / diagnostics, by position or by `MODULE#SYMBOL` notation.
+- `query` — ask the language service for hover / definition / references / diagnostics, by position or by `MODULE#SYMBOL` notation. `query inlay-hints` splices the hints into the source, so a misplaced anchor is visible rather than a number to check by hand.
 - `format` — format Wado source code.
 
 The rest (`init`, `update`, `fetch`, `build`, `publish`, `doc`, `wit`, `syntax`, `lsp`, `clean`) serve packaging, registry, and editor integration.

--- a/wado-cli/src/query.rs
+++ b/wado-cli/src/query.rs
@@ -15,6 +15,55 @@ enum QueryKind {
     InlayHints,
 }
 
+impl QueryKind {
+    /// Every kind, in the order the help lists them. The parse arm, the help
+    /// text, and the "Available:" error all read from here.
+    const ALL: &[Self] = &[
+        Self::Diagnostics,
+        Self::References,
+        Self::DocumentHighlight,
+        Self::Definition,
+        Self::Hover,
+        Self::InlayHints,
+    ];
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Diagnostics => "diagnostics",
+            Self::References => "references",
+            Self::DocumentHighlight => "document-highlight",
+            Self::Definition => "definition",
+            Self::Hover => "hover",
+            Self::InlayHints => "inlay-hints",
+        }
+    }
+
+    const fn desc(self) -> &'static str {
+        match self {
+            Self::Diagnostics => "Show errors and warnings",
+            Self::References => "Find references to the symbol at --line/--column",
+            Self::DocumentHighlight => "Highlight occurrences of the symbol at --line/--column",
+            Self::Definition => "Jump to the definition of the symbol at --line/--column",
+            Self::Hover => "Show the signature of the symbol at --line/--column",
+            Self::InlayHints => "Show the inferred-type and parameter-name hints, in the source",
+        }
+    }
+
+    fn parse(name: &str) -> Result<Self, CliExit> {
+        Self::ALL
+            .iter()
+            .find(|kind| kind.name() == name)
+            .copied()
+            .ok_or_else(|| {
+                let available: Vec<&str> = Self::ALL.iter().map(|k| k.name()).collect();
+                CliExit::error(format!(
+                    "unknown query kind '{name}'. Available: {}",
+                    available.join(", ")
+                ))
+            })
+    }
+}
+
 pub struct QueryOptions {
     kind: QueryKind,
     input: Option<String>,
@@ -112,32 +161,9 @@ fn format_usage() -> String {
     writeln!(buf, "Query compiler information about a source file.").unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Kinds:").unwrap();
-    writeln!(buf, "  diagnostics          Show errors and warnings").unwrap();
-    writeln!(
-        buf,
-        "  references           Find references to the symbol at --line/--column"
-    )
-    .unwrap();
-    writeln!(
-        buf,
-        "  document-highlight   Highlight occurrences of the symbol at --line/--column"
-    )
-    .unwrap();
-    writeln!(
-        buf,
-        "  definition           Jump to the definition of the symbol at --line/--column"
-    )
-    .unwrap();
-    writeln!(
-        buf,
-        "  hover                Show the signature of the symbol at --line/--column"
-    )
-    .unwrap();
-    writeln!(
-        buf,
-        "  inlay-hints          Show the inferred-type and parameter-name hints, spliced into the source"
-    )
-    .unwrap();
+    for kind in QueryKind::ALL {
+        writeln!(buf, "  {:<20} {}", kind.name(), kind.desc()).unwrap();
+    }
     writeln!(buf).unwrap();
     writeln!(buf, "Options:").unwrap();
     write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
@@ -185,19 +211,7 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<QueryOptions, CliExit> {
         } else if let Value(val) = arg {
             let val_str = val.to_string_lossy();
             if kind.is_none() {
-                kind = Some(match val_str.as_ref() {
-                    "diagnostics" => QueryKind::Diagnostics,
-                    "references" => QueryKind::References,
-                    "document-highlight" => QueryKind::DocumentHighlight,
-                    "definition" => QueryKind::Definition,
-                    "hover" => QueryKind::Hover,
-                    "inlay-hints" => QueryKind::InlayHints,
-                    other => {
-                        return Err(CliExit::error(format!(
-                            "unknown query kind '{other}'. Available: diagnostics, references, document-highlight, definition, hover, inlay-hints"
-                        )));
-                    }
-                });
+                kind = Some(QueryKind::parse(val_str.as_ref())?);
             } else {
                 args::reject_multiple_inputs(&input)?;
                 input = Some(val_str.into_owned());

--- a/wado-cli/src/query.rs
+++ b/wado-cli/src/query.rs
@@ -12,6 +12,7 @@ enum QueryKind {
     DocumentHighlight,
     Definition,
     Hover,
+    InlayHints,
 }
 
 pub struct QueryOptions {
@@ -132,6 +133,11 @@ fn format_usage() -> String {
         "  hover                Show the signature of the symbol at --line/--column"
     )
     .unwrap();
+    writeln!(
+        buf,
+        "  inlay-hints          Show the inferred-type and parameter-name hints, spliced into the source"
+    )
+    .unwrap();
     writeln!(buf).unwrap();
     writeln!(buf, "Options:").unwrap();
     write!(buf, "{}", args::format_opts_help(Opt::ALL, |o| o.spec())).unwrap();
@@ -185,9 +191,10 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<QueryOptions, CliExit> {
                     "document-highlight" => QueryKind::DocumentHighlight,
                     "definition" => QueryKind::Definition,
                     "hover" => QueryKind::Hover,
+                    "inlay-hints" => QueryKind::InlayHints,
                     other => {
                         return Err(CliExit::error(format!(
-                            "unknown query kind '{other}'. Available: diagnostics, references, document-highlight, definition, hover"
+                            "unknown query kind '{other}'. Available: diagnostics, references, document-highlight, definition, hover, inlay-hints"
                         )));
                     }
                 });
@@ -215,9 +222,9 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<QueryOptions, CliExit> {
                 &usage,
             ));
         }
-        if matches!(kind, QueryKind::Diagnostics) {
+        if matches!(kind, QueryKind::Diagnostics | QueryKind::InlayHints) {
             return Err(CliExit::error_with_usage(
-                "--symbol is not supported for the `diagnostics` kind",
+                "--symbol is not supported for the `diagnostics` / `inlay-hints` kinds",
                 &usage,
             ));
         }
@@ -308,7 +315,9 @@ pub async fn run(opts: QueryOptions) -> Result<(), CliExit> {
             QueryKind::Hover => {
                 query_adapter::run_hover_by_symbol(notation, base, public_only, opts.json).await
             }
-            QueryKind::Diagnostics => unreachable!("--symbol rejected for diagnostics"),
+            QueryKind::Diagnostics | QueryKind::InlayHints => {
+                unreachable!("--symbol rejected for diagnostics / inlay-hints")
+            }
         };
     }
 
@@ -316,6 +325,7 @@ pub async fn run(opts: QueryOptions) -> Result<(), CliExit> {
     let input = opts.input.as_deref().unwrap_or_default();
     match opts.kind {
         QueryKind::Diagnostics => query_adapter::run_diagnostics(input, opts.json).await,
+        QueryKind::InlayHints => query_adapter::run_inlay_hints(input, opts.json).await,
         QueryKind::References => {
             query_adapter::run_references(
                 input,

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -1,3 +1,5 @@
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
@@ -831,24 +833,15 @@ fn print_highlights_text(filename: &str, highlights: &[DocumentHighlight]) {
     }
 }
 
-/// Whole-document window: `inlay_hints` filters by the requested range, and a
-/// CLI query has no viewport to narrow it to.
-const WHOLE_DOCUMENT: wado_lsp::Range = wado_lsp::Range {
-    start: Position {
-        line: 0,
-        character: 0,
-    },
-    end: Position {
-        line: u32::MAX,
-        character: u32::MAX,
-    },
-};
-
 pub async fn run_inlay_hints(filename: &str, json_output: bool) -> Result<(), CliExit> {
     let prepared = prepare_query(filename).await?;
     let hints = prepared
         .engine
-        .inlay_hints(&prepared.uri, WHOLE_DOCUMENT, &prepared.host)
+        .inlay_hints(
+            &prepared.uri,
+            wado_lsp::Range::WHOLE_DOCUMENT,
+            &prepared.host,
+        )
         .await;
     let source = prepared
         .engine
@@ -890,8 +883,7 @@ fn print_inlay_hints_json(filename: &str, hints: &[wado_lsp::InlayHint]) {
 }
 
 /// Print every line that carries a hint, with the hints spliced in at the
-/// anchors the client would render them at. Reading the positions off a list
-/// leaves a misplaced anchor to be checked by hand; splicing shows it.
+/// anchors the client would render them at.
 fn print_inlay_hints_text(
     source: &str,
     encoding: wado_lsp::PositionEncoding,
@@ -902,31 +894,20 @@ fn print_inlay_hints_text(
         return;
     }
     let lines: Vec<&str> = source.lines().collect();
-    let mut by_line: std::collections::BTreeMap<u32, Vec<(usize, &wado_lsp::InlayHint)>> =
-        std::collections::BTreeMap::new();
+    let mut by_line: BTreeMap<u32, Vec<&wado_lsp::InlayHint>> = BTreeMap::new();
     for hint in hints {
-        let line = lines
-            .get(hint.position.line as usize)
-            .copied()
-            .unwrap_or("");
-        let byte =
-            wado_lsp::text::character_to_byte_offset(line, hint.position.character, encoding);
-        by_line
-            .entry(hint.position.line)
-            .or_default()
-            .push((byte, hint));
+        by_line.entry(hint.position.line).or_default().push(hint);
     }
-    for (line_index, mut anchors) in by_line {
-        let mut rendered = lines
-            .get(line_index as usize)
-            .copied()
-            .unwrap_or_default()
-            .to_string();
+    for (index, mut anchored) in by_line {
+        let line = lines.get(index as usize).copied().unwrap_or_default();
+        let mut rendered = line.to_string();
         // Right to left, so each splice leaves the offsets still to come valid.
-        anchors.sort_by_key(|(byte, _)| std::cmp::Reverse(*byte));
-        for (byte, hint) in &anchors {
-            rendered.insert_str(*byte, &format!("‹{}›", hint.label));
+        anchored.sort_by_key(|h| Reverse(h.position.character));
+        for hint in anchored {
+            let byte =
+                wado_lsp::text::character_to_byte_offset(line, hint.position.character, encoding);
+            rendered.insert_str(byte, &format!("‹{}›", hint.label));
         }
-        println!("{:>5} | {rendered}", line_index + 1);
+        println!("{:>5} | {rendered}", index + 1);
     }
 }

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -830,3 +830,106 @@ fn print_highlights_text(filename: &str, highlights: &[DocumentHighlight]) {
         );
     }
 }
+
+/// Whole-document window: `inlay_hints` filters by the requested range, and a
+/// CLI query has no viewport to narrow it to.
+const WHOLE_DOCUMENT: wado_lsp::Range = wado_lsp::Range {
+    start: Position {
+        line: 0,
+        character: 0,
+    },
+    end: Position {
+        line: u32::MAX,
+        character: u32::MAX,
+    },
+};
+
+pub async fn run_inlay_hints(filename: &str, json_output: bool) -> Result<(), CliExit> {
+    let prepared = prepare_query(filename).await?;
+    let hints = prepared
+        .engine
+        .inlay_hints(&prepared.uri, WHOLE_DOCUMENT, &prepared.host)
+        .await;
+    let source = prepared
+        .engine
+        .get_document(&prepared.uri)
+        .expect("prepare_query opened the document");
+
+    if json_output {
+        print_inlay_hints_json(filename, &hints);
+    } else {
+        print_inlay_hints_text(source, prepared.engine.position_encoding(), &hints);
+    }
+
+    warn_on_compile_errors(&prepared.host, hints.is_empty());
+    Ok(())
+}
+
+fn inlay_hint_kind_str(kind: wado_lsp::InlayHintKind) -> &'static str {
+    match kind {
+        wado_lsp::InlayHintKind::Type => "type",
+        wado_lsp::InlayHintKind::Parameter => "parameter",
+    }
+}
+
+fn print_inlay_hints_json(filename: &str, hints: &[wado_lsp::InlayHint]) {
+    let json_hints: Vec<serde_json::Value> = hints
+        .iter()
+        .map(|h| {
+            json!({
+                "file": filename,
+                "position": { "line": h.position.line, "character": h.position.character },
+                "label": h.label,
+                "kind": inlay_hint_kind_str(h.kind),
+                "paddingLeft": h.padding_left,
+                "paddingRight": h.padding_right,
+            })
+        })
+        .collect();
+    println!("{}", serde_json::to_string_pretty(&json_hints).unwrap());
+}
+
+/// Print every line that carries a hint, with the hints spliced in at the
+/// anchors the client would render them at. Reading the positions off a list
+/// leaves a misplaced anchor to be checked by hand; splicing shows it.
+fn print_inlay_hints_text(
+    source: &str,
+    encoding: wado_lsp::PositionEncoding,
+    hints: &[wado_lsp::InlayHint],
+) {
+    if hints.is_empty() {
+        println!("No inlay hints.");
+        return;
+    }
+    let lines: Vec<&str> = source.lines().collect();
+    let mut by_line: std::collections::BTreeMap<u32, Vec<(usize, &wado_lsp::InlayHint)>> =
+        std::collections::BTreeMap::new();
+    for hint in hints {
+        let line = lines
+            .get(hint.position.line as usize)
+            .copied()
+            .unwrap_or("");
+        let (_, column) = wado_lsp::text::lsp_position_to_line_col(source, hint.position, encoding);
+        let byte = line
+            .char_indices()
+            .nth(column.saturating_sub(1))
+            .map_or(line.len(), |(i, _)| i);
+        by_line
+            .entry(hint.position.line)
+            .or_default()
+            .push((byte, hint));
+    }
+    for (line_index, mut anchors) in by_line {
+        let mut rendered = lines
+            .get(line_index as usize)
+            .copied()
+            .unwrap_or_default()
+            .to_string();
+        // Right to left, so each splice leaves the offsets still to come valid.
+        anchors.sort_by_key(|(byte, _)| std::cmp::Reverse(*byte));
+        for (byte, hint) in &anchors {
+            rendered.insert_str(*byte, &format!("‹{}›", hint.label));
+        }
+        println!("{:>5} | {rendered}", line_index + 1);
+    }
+}

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -909,11 +909,8 @@ fn print_inlay_hints_text(
             .get(hint.position.line as usize)
             .copied()
             .unwrap_or("");
-        let (_, column) = wado_lsp::text::lsp_position_to_line_col(source, hint.position, encoding);
-        let byte = line
-            .char_indices()
-            .nth(column.saturating_sub(1))
-            .map_or(line.len(), |(i, _)| i);
+        let byte =
+            wado_lsp::text::character_to_byte_offset(line, hint.position.character, encoding);
         by_line
             .entry(hint.position.line)
             .or_default()

--- a/wado-cli/src/query_adapter.rs
+++ b/wado-cli/src/query_adapter.rs
@@ -869,14 +869,23 @@ fn print_inlay_hints_json(filename: &str, hints: &[wado_lsp::InlayHint]) {
     let json_hints: Vec<serde_json::Value> = hints
         .iter()
         .map(|h| {
-            json!({
+            let mut hint = json!({
                 "file": filename,
                 "position": { "line": h.position.line, "character": h.position.character },
                 "label": h.label,
                 "kind": inlay_hint_kind_str(h.kind),
-                "paddingLeft": h.padding_left,
-                "paddingRight": h.padding_right,
-            })
+            });
+            // Absent, not null: the wire omits an unset padding flag, and this
+            // output is here to show what the client receives.
+            for (key, flag) in [
+                ("paddingLeft", h.padding_left),
+                ("paddingRight", h.padding_right),
+            ] {
+                if let Some(flag) = flag {
+                    hint[key] = flag.into();
+                }
+            }
+            hint
         })
         .collect();
     println!("{}", serde_json::to_string_pretty(&json_hints).unwrap());

--- a/wado-cli/tests/integration/lsp.rs
+++ b/wado-cli/tests/integration/lsp.rs
@@ -2454,6 +2454,12 @@ fn query_inlay_hints_json_output() {
     // `    let x = 1;` — the hint anchors right after the binding name.
     assert_eq!(hint["position"]["line"], 1);
     assert_eq!(hint["position"]["character"], 9);
+    // A type hint sets no padding, and the wire omits an unset flag rather
+    // than sending null; this output mirrors what the client receives.
+    assert!(
+        hint.get("paddingLeft").is_none() && hint.get("paddingRight").is_none(),
+        "unset padding must be absent, not null; got {hint}",
+    );
 }
 
 /// A hint's anchor is a position in the negotiated encoding, so a line with

--- a/wado-cli/tests/integration/lsp.rs
+++ b/wado-cli/tests/integration/lsp.rs
@@ -1850,7 +1850,7 @@ fn query_unknown_kind_lists_available_kinds() {
     let stderr = String::from_utf8(output).unwrap();
     assert_eq!(
         stderr,
-        "Error: unknown query kind 'signature'. Available: diagnostics, references, document-highlight, definition, hover\n",
+        "Error: unknown query kind 'signature'. Available: diagnostics, references, document-highlight, definition, hover, inlay-hints\n",
     );
 }
 
@@ -2477,8 +2477,7 @@ fn query_inlay_hints_anchor_past_a_surrogate_pair() {
         .stdout(predicate::str::contains("return take(‹s: ›\"😀\", ‹n: ›1)"));
 }
 
-/// The receiver of a path-form method call occupies argument slot 0, so the
-/// remaining labels must not shift left onto it.
+/// End to end, through the splice: the receiver holds argument slot 0.
 #[test]
 fn query_inlay_hints_path_form_call_keeps_the_receiver_slot() {
     let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();

--- a/wado-cli/tests/integration/lsp.rs
+++ b/wado-cli/tests/integration/lsp.rs
@@ -2400,3 +2400,111 @@ fn query_degrades_when_generator_cannot_run() {
         .stderr(predicate::str::contains("kiln generators could not run"))
         .stdout(predicate::str::contains("KILN_STALE_CACHE"));
 }
+
+#[test]
+fn query_inlay_hints_splices_labels_into_the_source() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "fn add(a: i32, b: i32) -> i32 { return a + b }\n\
+         export fn run() -> i32 {\n\
+         \x20   let x = add(1, 2);\n\
+         \x20   return x\n\
+         }\n",
+    )
+    .unwrap();
+
+    wado()
+        .args(["query", "inlay-hints", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "let x‹: i32› = add(‹a: ›1, ‹b: ›2);",
+        ));
+}
+
+#[test]
+fn query_inlay_hints_json_output() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "export fn run() -> i32 {\n    let x = 1;\n    return x\n}\n",
+    )
+    .unwrap();
+
+    let output = wado()
+        .args([
+            "query",
+            "inlay-hints",
+            "--json",
+            tmp.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let parsed: Vec<Value> = serde_json::from_slice(&output).unwrap();
+    let hint = parsed
+        .iter()
+        .find(|h| h["label"] == ": i32")
+        .expect("the unannotated `let x = 1` should carry a type hint");
+    assert_eq!(hint["kind"], "type");
+    // `    let x = 1;` — the hint anchors right after the binding name.
+    assert_eq!(hint["position"]["line"], 1);
+    assert_eq!(hint["position"]["character"], 9);
+}
+
+/// A hint's anchor is a position in the negotiated encoding, so a line with
+/// non-BMP text must still splice where the client would render it.
+#[test]
+fn query_inlay_hints_anchor_past_a_surrogate_pair() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "fn take(s: String, n: i32) -> i32 { return n }\n\
+         export fn run() -> i32 {\n\
+         \x20   return take(\"😀\", 1)\n\
+         }\n",
+    )
+    .unwrap();
+
+    wado()
+        .args(["query", "inlay-hints", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("return take(‹s: ›\"😀\", ‹n: ›1)"));
+}
+
+/// The receiver of a path-form method call occupies argument slot 0, so the
+/// remaining labels must not shift left onto it.
+#[test]
+fn query_inlay_hints_path_form_call_keeps_the_receiver_slot() {
+    let tmp = tempfile::NamedTempFile::with_suffix(".wado").unwrap();
+    std::fs::write(
+        tmp.path(),
+        "trait Scale {\n\
+         \x20   fn scaled(&self, factor: i32, bias: i32) -> i32;\n\
+         }\n\
+         struct P { x: i32 }\n\
+         impl Scale for P {\n\
+         \x20   fn scaled(&self, factor: i32, bias: i32) -> i32 {\n\
+         \x20       return self.x * factor + bias\n\
+         \x20   }\n\
+         }\n\
+         export fn run() -> i32 {\n\
+         \x20   let p = P { x: 1 };\n\
+         \x20   return Scale::scaled(&p, 2, 3)\n\
+         }\n",
+    )
+    .unwrap();
+
+    wado()
+        .args(["query", "inlay-hints", tmp.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "return Scale::scaled(&p, ‹factor: ›2, ‹bias: ›3)",
+        ));
+}

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -292,6 +292,16 @@ impl<'a> Lexer<'a> {
         }
     }
 
+    /// The cursor as a [`Position`], for scans that must anchor their spans
+    /// before the dispatch consumed a prefix.
+    fn position(&self) -> Position {
+        Position {
+            offset: self.pos,
+            line: self.line,
+            column: self.column,
+        }
+    }
+
     /// Build a span from a saved start position to the current cursor.
     /// Captures `(start, self.pos, start_line, start_column, self.line,
     /// self.column)` — the recurring pattern at every error site and every
@@ -1328,21 +1338,29 @@ impl<'a> Lexer<'a> {
     }
 
     fn lex_char(&mut self) -> TokenKind {
-        TokenKind::CharLit(self.scan_char_raw())
+        let start = self.position();
+        TokenKind::CharLit(self.scan_char_raw(start))
     }
 
     /// Lex a byte literal `b'x'`; lowers to a `u8` integer literal.
     fn lex_byte_char(&mut self) -> TokenKind {
+        // Taken before the `b`: the literal is `b'x'`, so an error span that
+        // opens at the quote underlines part of the literal, not the literal.
+        let start = self.position();
         self.advance(); // consume `b`
-        TokenKind::ByteCharLit(self.scan_char_raw())
+        TokenKind::ByteCharLit(self.scan_char_raw(start))
     }
 
     /// Scan a single-quoted literal (opening `'` current), returning the raw
     /// text between the quotes. Shared by char `'x'` and byte `b'x'` literals.
-    fn scan_char_raw(&mut self) -> String {
-        let start = self.pos;
-        let start_line = self.line;
-        let start_column = self.column;
+    /// `open` is where the literal opens — the `b` of a byte literal, the
+    /// quote otherwise — and anchors every error span this recovers with.
+    fn scan_char_raw(&mut self, open: Position) -> String {
+        let Position {
+            offset: start,
+            line: start_line,
+            column: start_column,
+        } = open;
 
         self.advance(); // consume opening '
         let inner_start = self.pos;

--- a/wado-compiler/src/lexer.rs
+++ b/wado-compiler/src/lexer.rs
@@ -1344,8 +1344,6 @@ impl<'a> Lexer<'a> {
 
     /// Lex a byte literal `b'x'`; lowers to a `u8` integer literal.
     fn lex_byte_char(&mut self) -> TokenKind {
-        // Taken before the `b`: the literal is `b'x'`, so an error span that
-        // opens at the quote underlines part of the literal, not the literal.
         let start = self.position();
         self.advance(); // consume `b`
         TokenKind::ByteCharLit(self.scan_char_raw(start))

--- a/wado-compiler/tests/integration/lexer_recovery.rs
+++ b/wado-compiler/tests/integration/lexer_recovery.rs
@@ -231,3 +231,26 @@ fn error_spans_are_correct() {
     assert_eq!(err.span.line, 1);
     assert_eq!(err.span.column, 4);
 }
+
+#[test]
+fn byte_char_error_span_covers_the_b_prefix() {
+    // `b'ab'` is one literal, `b` included. A span that starts at the quote
+    // draws the squiggle inside the literal instead of under it.
+    let r = lex("let b = b'ab';");
+    assert_eq!(r.errors.len(), 1);
+    assert_matches!(r.errors[0].kind, LexErrorKind::CharLiteralTooLong);
+    assert_eq!(r.errors[0].span.start, 8);
+    assert_eq!(r.errors[0].span.end, 13);
+    assert_eq!(r.errors[0].span.column, 9);
+    assert_eq!(r.errors[0].span.end_column, 14);
+}
+
+#[test]
+fn empty_byte_char_error_span_covers_the_b_prefix() {
+    let r = lex("let b = b'';");
+    assert_eq!(r.errors.len(), 1);
+    assert_matches!(r.errors[0].kind, LexErrorKind::EmptyCharLiteral);
+    assert_eq!(r.errors[0].span.start, 8);
+    assert_eq!(r.errors[0].span.end, 11);
+    assert_eq!(r.errors[0].span.column, 9);
+}

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -112,8 +112,9 @@ passthrough) → UTF-8 → UTF-16 (LSP default; only chosen when the
 client offers nothing else). The codepoint semantics come from
 `lexer.rs::Lexer::advance`, which increments `column` per Unicode
 scalar value, not per byte and not per UTF-16 code unit. Every
-conversion lives in `text.rs`: `character_to_codepoint_offset` inbound,
-`range_from_codepoints` / `codepoints_to_code_units` outbound.
+conversion lives in `text.rs`: `character_to_codepoint_offset` /
+`character_to_byte_offset` inbound, `range_from_codepoints` /
+`codepoints_to_code_units` outbound.
 
 ### Diagnostics
 

--- a/wado-lsp/src/diagnostics.rs
+++ b/wado-lsp/src/diagnostics.rs
@@ -38,6 +38,21 @@ pub struct Range {
     pub end: Position,
 }
 
+impl Range {
+    /// Every position in a document, for callers with no viewport to narrow a
+    /// range-filtered query (`inlay_hints`) to.
+    pub const WHOLE_DOCUMENT: Self = Self {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: u32::MAX,
+            character: u32::MAX,
+        },
+    };
+}
+
 /// A diagnostic message (error, warning, etc.) for a text document.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Diagnostic {

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -1,26 +1,5 @@
-//! Inlay hints — inline annotations rendered next to source positions to
-//! surface types and parameter names the user did not write.
-//!
-//! Three kinds of hints are produced:
-//!
-//! 1. **Type hints** on `let` patterns, closure parameters, and `for x of …`
-//!    bindings that lack an explicit `: T` annotation. Tuple / struct /
-//!    variant / or-patterns recurse into their leaves so each bound
-//!    identifier hints with the elaborator's inferred type for that leaf.
-//!    Types come from [`Semantics::local_type_name`], populated by the
-//!    elaborator via `record_local_symbol`.
-//! 2. **Parameter-name hints** at free-function call sites. The callee's
-//!    `FunctionSymbol::params` (set up by the analyzer) drives the labels.
-//! 3. **Parameter-name hints at method / static-method call sites.** The
-//!    callee's `Function` AST node is reached by following the elaborator's
-//!    use→def edge from the method-name token's `AstId` to the declaring
-//!    impl method, then reading `Function::params` directly from the AST.
-//!    Impl methods are not registered in the symbol table, so the AST is
-//!    the source of truth here.
-//!
-//! All hint positions are produced as `Position`s in the LSP-negotiated
-//! [`PositionEncoding`]. Hints whose anchor falls outside the requested
-//! `range` are filtered out at the end of [`inlay_hints`].
+//! Inlay hints — inferred types on unannotated bindings, parameter names at
+//! call sites. Positions are in the LSP-negotiated [`PositionEncoding`].
 
 use serde::{Deserialize, Serialize};
 use wado_compiler::ast::{
@@ -41,9 +20,8 @@ lsp_repr_u32_enum!(
     }
 );
 
-/// The name a receiver parameter carries in a positional name list. `self` is
-/// reserved in Wado, so no declared parameter collides with it, and the symbol
-/// table spells a resource method's receiver exactly this way.
+/// What a receiver is called in a positional name list — by the parser and by
+/// the symbol table alike. Reserved in Wado, so no declared parameter collides.
 const SELF_PARAM: &str = "self";
 
 /// An inlay hint produced for the requesting document.
@@ -95,7 +73,7 @@ struct HintCollector<'a> {
     hints: Vec<InlayHint>,
 }
 
-impl HintCollector<'_> {
+impl<'a> HintCollector<'a> {
     /// Position immediately after `span` ends — where a `: T` label is anchored.
     fn position_after(&self, span: Span) -> Position {
         self.position(
@@ -199,10 +177,9 @@ impl HintCollector<'_> {
     ///    looks the `Function` AST node up through the per-module
     ///    [`AstIndex`] in O(1); we read its params from there.
     ///
-    /// Both routes name a path-form call, so a receiver passed positionally
-    /// (`Scale::scaled(&p, …)`) keeps its argument slot — see
-    /// [`path_form_param_names`].
-    fn callee_param_names(&self, callee: &Expr) -> Option<Vec<String>> {
+    /// Both routes name a path-form call, so a positionally passed receiver
+    /// (`Scale::scaled(&p, …)`) keeps its slot — see [`path_form_param_names`].
+    fn callee_param_names(&self, callee: &Expr) -> Option<Vec<&'a str>> {
         let ident = match callee {
             Expr::Ident(i) => i,
             _ => return None,
@@ -221,18 +198,13 @@ impl HintCollector<'_> {
         if let Some(symbol) = self.ctx.sem.symbol_at(def_key)
             && let SymbolKind::Function(f) = &symbol.kind
         {
-            return Some(f.params.clone());
+            return Some(f.params.iter().map(String::as_str).collect());
         }
         let func = self.ctx.sem.function_at(def_key)?;
         Some(path_form_param_names(func))
     }
 
     /// Hint parameters for a `MethodCallExpr` (`receiver.method(args)`).
-    ///
-    /// Impl methods are not present in the symbol table, so the use→def
-    /// edge points at the declaring `Function`'s `AstId`. The per-module
-    /// [`AstIndex`] indexes that mapping so `Semantics::function_at`
-    /// resolves it in O(1).
     fn hint_method_call_args(&mut self, call: &ast::MethodCallExpr) {
         let Some(func) = self.method_decl(call.method_id) else {
             return;
@@ -252,20 +224,18 @@ impl HintCollector<'_> {
 
     /// The impl/trait method whose declaration `AstId` is the use→def target
     /// of `method_id_at_call`. `None` for synthetic / unresolved call sites.
-    fn method_decl(&self, method_id_at_call: ast::AstId) -> Option<&'_ Function> {
+    fn method_decl(&self, method_id_at_call: ast::AstId) -> Option<&'a Function> {
         let def_key = self.ctx.sem.referenced_symbol(method_id_at_call)?;
         self.ctx.sem.function_at(def_key)
     }
 
-    fn emit_arg_param_hints(&mut self, param_names: &[String], args: &[Expr]) {
+    fn emit_arg_param_hints(&mut self, param_names: &[&str], args: &[Expr]) {
         // Align positional args with their parameter names. An arity
         // mismatch (more args than params) terminates the loop early; the
         // elaborator flags that as a diagnostic on its own path.
         for (param_name, arg) in param_names.iter().zip(args.iter()) {
-            // The receiver of a path-form method call reads as the receiver;
-            // `self:` in front of it is noise. `self` is reserved, so no
-            // declared parameter can collide with the name.
-            if param_name == SELF_PARAM {
+            // A receiver reads as the receiver; `self:` in front of it is noise.
+            if *param_name == SELF_PARAM {
                 continue;
             }
             self.push_param_hint(param_name, arg.span());
@@ -280,32 +250,26 @@ impl HintCollector<'_> {
 }
 
 /// Parameter names of `func` positioned for a call that does **not** pass the
-/// receiver in `args` — the dot form, `recv.m(a, b)`.
-///
-/// `&self` / `&mut self` are surfaced as `SelfKind::Ref` / `SelfKind::MutRef`
-/// by the parser; dropping them lines the remaining names up with `args`.
-fn dot_form_param_names(func: &Function) -> Vec<String> {
+/// receiver in `args` — the dot form, `recv.m(a, b)`, so the receiver is gone.
+fn dot_form_param_names(func: &Function) -> Vec<&str> {
     func.params
         .iter()
         .filter(|p| matches!(p.self_kind, ast::SelfKind::None))
-        .map(|p| p.name.clone())
+        .map(|p| p.name.as_str())
         .collect()
 }
 
 /// Parameter names of `func` positioned for a call written in path form —
-/// `Scale::scaled(&p, 2, 3)`, where the receiver *is* `args[0]`.
-///
-/// The self param keeps its slot so every later argument still meets its own
-/// name; the parser names it [`SELF_PARAM`], so the receiver goes unlabelled.
-/// Dropping it instead shifts every label one argument to the left.
-fn path_form_param_names(func: &Function) -> Vec<String> {
+/// `Scale::scaled(&p, 2, 3)`, where the receiver *is* `args[0]` and so keeps
+/// its slot. Dropping it shifts every label one argument to the left.
+fn path_form_param_names(func: &Function) -> Vec<&str> {
     debug_assert!(
         func.params
             .iter()
             .all(|p| (p.self_kind == ast::SelfKind::None) == (p.name != SELF_PARAM)),
         "a receiver is named `self` and nothing else can be",
     );
-    func.params.iter().map(|p| p.name.clone()).collect()
+    func.params.iter().map(|p| p.name.as_str()).collect()
 }
 
 impl AstVisitor for HintCollector<'_> {
@@ -379,20 +343,9 @@ mod tests {
     use crate::text::PositionEncoding;
     use futures::executor::block_on;
 
-    const WHOLE_DOCUMENT: Range = Range {
-        start: Position {
-            line: 0,
-            character: 0,
-        },
-        end: Position {
-            line: u32::MAX,
-            character: u32::MAX,
-        },
-    };
-
     async fn hints_for(source: &str) -> Vec<InlayHint> {
         with_ctx(source, PositionEncoding::Utf16, |ctx| {
-            inlay_hints(ctx, WHOLE_DOCUMENT)
+            inlay_hints(ctx, Range::WHOLE_DOCUMENT)
         })
         .await
     }
@@ -792,17 +745,7 @@ mod tests {
         let host = MapHost::single(path, src);
         let sem = futures::executor::block_on(wado_compiler::semantics(src, &host, Some(path)));
         let ctx = QueryContext::new(&sem, src, &uri, PositionEncoding::Utf16);
-        let max_range = Range {
-            start: Position {
-                line: 0,
-                character: 0,
-            },
-            end: Position {
-                line: u32::MAX,
-                character: u32::MAX,
-            },
-        };
-        let hints = inlay_hints(&ctx, max_range);
+        let hints = inlay_hints(&ctx, Range::WHOLE_DOCUMENT);
         let h = hints
             .iter()
             .find(|h| h.label == ": i32" && h.kind == InlayHintKind::Type)
@@ -866,17 +809,7 @@ mod tests {
             let host = MapHost::with_files(&[("./other.wado", other), (path, entry)]);
             let sem = wado_compiler::semantics(entry, &host, Some(path)).await;
             let ctx = QueryContext::new(&sem, entry, &uri, PositionEncoding::Utf16);
-            let max_range = Range {
-                start: Position {
-                    line: 0,
-                    character: 0,
-                },
-                end: Position {
-                    line: u32::MAX,
-                    character: u32::MAX,
-                },
-            };
-            let hints = inlay_hints(&ctx, max_range);
+            let hints = inlay_hints(&ctx, Range::WHOLE_DOCUMENT);
             let param_labels: Vec<_> = labels(&hints)
                 .into_iter()
                 .filter(|(_, k)| *k == InlayHintKind::Parameter)
@@ -890,8 +823,8 @@ mod tests {
         });
     }
 
-    /// Sugar: parameter-name labels paired with the 0-based character the
-    /// hint anchors at, for the call shapes where alignment is the point.
+    /// Sugar: parameter-name labels paired with the 0-based character each
+    /// anchors at, for the tests where alignment is the point.
     fn param_anchors(hints: &[InlayHint]) -> Vec<(String, u32)> {
         hints
             .iter()
@@ -902,10 +835,7 @@ mod tests {
 
     #[test]
     fn path_form_method_call_aligns_names_past_the_receiver() {
-        // `Scale::scaled(&p, 2, 3)` passes the receiver positionally, so the
-        // declared `&self` still occupies argument slot 0. Dropping it from
-        // the name list labelled `&p` as `factor` and left the last argument
-        // unlabelled — every hint one argument to the left of its parameter.
+        // The receiver is passed positionally, so `&self` occupies slot 0.
         block_on(async {
             let src = concat!(
                 "trait Scale {\n",
@@ -936,8 +866,7 @@ mod tests {
 
     #[test]
     fn method_call_syntax_still_skips_the_receiver_param() {
-        // The dot form does not pass the receiver in `args`, so the declared
-        // `&self` must be dropped rather than consuming an argument slot.
+        // The dot form leaves the receiver out of `args`, so `&self` is dropped.
         block_on(async {
             let src = concat!(
                 "struct P { x: i32 }\n",

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -296,18 +296,16 @@ fn dot_form_param_names(func: &Function) -> Vec<String> {
 /// `Scale::scaled(&p, 2, 3)`, where the receiver *is* `args[0]`.
 ///
 /// The self param keeps its slot so every later argument still meets its own
-/// name; it is named [`SELF_PARAM`] so the receiver itself goes unlabelled.
+/// name; the parser names it [`SELF_PARAM`], so the receiver goes unlabelled.
 /// Dropping it instead shifts every label one argument to the left.
 fn path_form_param_names(func: &Function) -> Vec<String> {
-    func.params
-        .iter()
-        .map(|p| match p.self_kind {
-            ast::SelfKind::None => p.name.clone(),
-            ast::SelfKind::Value | ast::SelfKind::Ref | ast::SelfKind::MutRef => {
-                SELF_PARAM.to_string()
-            }
-        })
-        .collect()
+    debug_assert!(
+        func.params
+            .iter()
+            .all(|p| (p.self_kind == ast::SelfKind::None) == (p.name != SELF_PARAM)),
+        "a receiver is named `self` and nothing else can be",
+    );
+    func.params.iter().map(|p| p.name.clone()).collect()
 }
 
 impl AstVisitor for HintCollector<'_> {

--- a/wado-lsp/src/inlay_hints.rs
+++ b/wado-lsp/src/inlay_hints.rs
@@ -41,8 +41,14 @@ lsp_repr_u32_enum!(
     }
 );
 
+/// The name a receiver parameter carries in a positional name list. `self` is
+/// reserved in Wado, so no declared parameter collides with it, and the symbol
+/// table spells a resource method's receiver exactly this way.
+const SELF_PARAM: &str = "self";
+
 /// An inlay hint produced for the requesting document.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InlayHint {
     pub position: Position,
     pub label: String,
@@ -191,8 +197,11 @@ impl HintCollector<'_> {
     /// 2. The use→def edge points at an impl method's `AstId`, which the
     ///    analyzer does not register as a symbol. `Semantics::function_at`
     ///    looks the `Function` AST node up through the per-module
-    ///    [`AstIndex`] in O(1); we read its params from there (self
-    ///    params filtered out).
+    ///    [`AstIndex`] in O(1); we read its params from there.
+    ///
+    /// Both routes name a path-form call, so a receiver passed positionally
+    /// (`Scale::scaled(&p, …)`) keeps its argument slot — see
+    /// [`path_form_param_names`].
     fn callee_param_names(&self, callee: &Expr) -> Option<Vec<String>> {
         let ident = match callee {
             Expr::Ident(i) => i,
@@ -215,7 +224,7 @@ impl HintCollector<'_> {
             return Some(f.params.clone());
         }
         let func = self.ctx.sem.function_at(def_key)?;
-        Some(filter_non_self_param_names(func))
+        Some(path_form_param_names(func))
     }
 
     /// Hint parameters for a `MethodCallExpr` (`receiver.method(args)`).
@@ -225,29 +234,27 @@ impl HintCollector<'_> {
     /// [`AstIndex`] indexes that mapping so `Semantics::function_at`
     /// resolves it in O(1).
     fn hint_method_call_args(&mut self, call: &ast::MethodCallExpr) {
-        let Some(param_names) = self.method_param_names(call.method_id) else {
+        let Some(func) = self.method_decl(call.method_id) else {
             return;
         };
-        self.emit_arg_param_hints(&param_names, &call.args);
+        self.emit_arg_param_hints(&dot_form_param_names(func), &call.args);
     }
 
     /// Hint parameters for a `StaticMethodCallExpr` (`Type::method(args)`).
-    /// Same resolution as `hint_method_call_args` — the elaborator records
-    /// the same use→def edge for both call shapes.
+    /// Same resolution as `hint_method_call_args`, but the receiver of a
+    /// method reached this way is `args[0]`, so its slot is kept.
     fn hint_static_method_call_args(&mut self, call: &ast::StaticMethodCallExpr) {
-        let Some(param_names) = self.method_param_names(call.method_id) else {
+        let Some(func) = self.method_decl(call.method_id) else {
             return;
         };
-        self.emit_arg_param_hints(&param_names, &call.args);
+        self.emit_arg_param_hints(&path_form_param_names(func), &call.args);
     }
 
-    /// Parameter names of the impl/trait method whose declaration `AstId`
-    /// is the use→def target of `method_id_at_call`. Returns `None` for
-    /// synthetic / unresolved call sites.
-    fn method_param_names(&self, method_id_at_call: ast::AstId) -> Option<Vec<String>> {
+    /// The impl/trait method whose declaration `AstId` is the use→def target
+    /// of `method_id_at_call`. `None` for synthetic / unresolved call sites.
+    fn method_decl(&self, method_id_at_call: ast::AstId) -> Option<&'_ Function> {
         let def_key = self.ctx.sem.referenced_symbol(method_id_at_call)?;
-        let func = self.ctx.sem.function_at(def_key)?;
-        Some(filter_non_self_param_names(func))
+        self.ctx.sem.function_at(def_key)
     }
 
     fn emit_arg_param_hints(&mut self, param_names: &[String], args: &[Expr]) {
@@ -255,6 +262,12 @@ impl HintCollector<'_> {
         // mismatch (more args than params) terminates the loop early; the
         // elaborator flags that as a diagnostic on its own path.
         for (param_name, arg) in param_names.iter().zip(args.iter()) {
+            // The receiver of a path-form method call reads as the receiver;
+            // `self:` in front of it is noise. `self` is reserved, so no
+            // declared parameter can collide with the name.
+            if param_name == SELF_PARAM {
+                continue;
+            }
             self.push_param_hint(param_name, arg.span());
         }
     }
@@ -266,16 +279,34 @@ impl HintCollector<'_> {
     }
 }
 
-/// Parameter names of `func` with self params filtered out.
+/// Parameter names of `func` positioned for a call that does **not** pass the
+/// receiver in `args` — the dot form, `recv.m(a, b)`.
 ///
 /// `&self` / `&mut self` are surfaced as `SelfKind::Ref` / `SelfKind::MutRef`
-/// by the parser; only `SelfKind::None` params can ever appear as positional
-/// call arguments.
-fn filter_non_self_param_names(func: &Function) -> Vec<String> {
+/// by the parser; dropping them lines the remaining names up with `args`.
+fn dot_form_param_names(func: &Function) -> Vec<String> {
     func.params
         .iter()
         .filter(|p| matches!(p.self_kind, ast::SelfKind::None))
         .map(|p| p.name.clone())
+        .collect()
+}
+
+/// Parameter names of `func` positioned for a call written in path form —
+/// `Scale::scaled(&p, 2, 3)`, where the receiver *is* `args[0]`.
+///
+/// The self param keeps its slot so every later argument still meets its own
+/// name; it is named [`SELF_PARAM`] so the receiver itself goes unlabelled.
+/// Dropping it instead shifts every label one argument to the left.
+fn path_form_param_names(func: &Function) -> Vec<String> {
+    func.params
+        .iter()
+        .map(|p| match p.self_kind {
+            ast::SelfKind::None => p.name.clone(),
+            ast::SelfKind::Value | ast::SelfKind::Ref | ast::SelfKind::MutRef => {
+                SELF_PARAM.to_string()
+            }
+        })
         .collect()
 }
 
@@ -857,6 +888,79 @@ mod tests {
                 param_labels.contains(&"a: ".to_string())
                     && param_labels.contains(&"b: ".to_string()),
                 "cross-module `add(1, 2)` should still surface `a:`/`b:`; got {param_labels:?}",
+            );
+        });
+    }
+
+    /// Sugar: parameter-name labels paired with the 0-based character the
+    /// hint anchors at, for the call shapes where alignment is the point.
+    fn param_anchors(hints: &[InlayHint]) -> Vec<(String, u32)> {
+        hints
+            .iter()
+            .filter(|h| h.kind == InlayHintKind::Parameter)
+            .map(|h| (h.label.clone(), h.position.character))
+            .collect()
+    }
+
+    #[test]
+    fn path_form_method_call_aligns_names_past_the_receiver() {
+        // `Scale::scaled(&p, 2, 3)` passes the receiver positionally, so the
+        // declared `&self` still occupies argument slot 0. Dropping it from
+        // the name list labelled `&p` as `factor` and left the last argument
+        // unlabelled — every hint one argument to the left of its parameter.
+        block_on(async {
+            let src = concat!(
+                "trait Scale {\n",
+                "    fn scaled(&self, factor: i32, bias: i32) -> i32;\n",
+                "}\n",
+                "struct P { x: i32 }\n",
+                "impl Scale for P {\n",
+                "    fn scaled(&self, factor: i32, bias: i32) -> i32 {\n",
+                "        return self.x * factor + bias\n",
+                "    }\n",
+                "}\n",
+                "fn f() -> i32 {\n",
+                "    let p = P { x: 1 };\n",
+                "    return Scale::scaled(&p, 2, 3);\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            let anchors = param_anchors(&hints);
+            // `    return Scale::scaled(&p, 2, 3);`
+            //                           ^25 ^29 ^32
+            assert_eq!(
+                anchors,
+                vec![("factor: ".to_string(), 29), ("bias: ".to_string(), 32)],
+                "the receiver takes no label and the rest keep their own; got {anchors:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn method_call_syntax_still_skips_the_receiver_param() {
+        // The dot form does not pass the receiver in `args`, so the declared
+        // `&self` must be dropped rather than consuming an argument slot.
+        block_on(async {
+            let src = concat!(
+                "struct P { x: i32 }\n",
+                "impl P {\n",
+                "    fn scaled(&self, factor: i32, bias: i32) -> i32 {\n",
+                "        return self.x * factor + bias\n",
+                "    }\n",
+                "}\n",
+                "fn f() -> i32 {\n",
+                "    let p = P { x: 1 };\n",
+                "    return p.scaled(2, 3);\n",
+                "}\n",
+            );
+            let hints = hints_for(src).await;
+            let anchors = param_anchors(&hints);
+            // `    return p.scaled(2, 3);`
+            //                      ^20 ^23
+            assert_eq!(
+                anchors,
+                vec![("factor: ".to_string(), 20), ("bias: ".to_string(), 23)],
+                "dot-form args align with the non-self params; got {anchors:?}",
             );
         });
     }

--- a/wado-lsp/src/text.rs
+++ b/wado-lsp/src/text.rs
@@ -200,6 +200,20 @@ fn character_to_codepoint_offset(line: &str, character: u32, encoding: PositionE
     line.chars().count()
 }
 
+/// Byte offset inside `line` of an LSP `character` (0-based, in `encoding`
+/// code units), saturating at the end of the line.
+///
+/// For callers that already hold the line and want to splice text into it.
+/// Re-deriving the offset through [`lsp_position_to_line_col`] rescans the
+/// whole document per item, which is `O(items × document length)`.
+#[must_use]
+pub fn character_to_byte_offset(line: &str, character: u32, encoding: PositionEncoding) -> usize {
+    let codepoint = character_to_codepoint_offset(line, character, encoding);
+    line.char_indices()
+        .nth(codepoint)
+        .map_or(line.len(), |(byte, _)| byte)
+}
+
 /// Code units `ch` occupies in `encoding`.
 fn code_units_of(ch: char, encoding: PositionEncoding) -> usize {
     match encoding {
@@ -449,5 +463,30 @@ mod tests {
     fn negotiate_falls_back_to_utf16_for_unknown_encodings() {
         let off = ["utf-7".to_string(), "utf-1024".to_string()];
         assert_eq!(PositionEncoding::negotiate(&off), PositionEncoding::Utf16);
+    }
+
+    #[test]
+    fn character_to_byte_offset_counts_code_units_and_returns_bytes() {
+        // `😀` is 2 UTF-16 units, 1 UTF-32 unit, and 4 UTF-8 bytes; the
+        // character after it must land on the same byte in every encoding.
+        let line = "a😀b";
+        assert_eq!(
+            character_to_byte_offset(line, 3, PositionEncoding::Utf16),
+            5
+        );
+        assert_eq!(
+            character_to_byte_offset(line, 2, PositionEncoding::Utf32),
+            5
+        );
+        assert_eq!(character_to_byte_offset(line, 5, PositionEncoding::Utf8), 5);
+    }
+
+    #[test]
+    fn character_to_byte_offset_saturates_past_the_line_end() {
+        assert_eq!(
+            character_to_byte_offset("ab", 99, PositionEncoding::Utf16),
+            2
+        );
+        assert_eq!(character_to_byte_offset("", 0, PositionEncoding::Utf16), 0);
     }
 }

--- a/wado-lsp/src/text.rs
+++ b/wado-lsp/src/text.rs
@@ -201,11 +201,8 @@ fn character_to_codepoint_offset(line: &str, character: u32, encoding: PositionE
 }
 
 /// Byte offset inside `line` of an LSP `character` (0-based, in `encoding`
-/// code units), saturating at the end of the line.
-///
-/// For callers that already hold the line and want to splice text into it.
-/// Re-deriving the offset through [`lsp_position_to_line_col`] rescans the
-/// whole document per item, which is `O(items × document length)`.
+/// code units), saturating at the end of the line. For callers holding a line
+/// already: [`lsp_position_to_line_col`] rescans the document to find it.
 #[must_use]
 pub fn character_to_byte_offset(line: &str, character: u32, encoding: PositionEncoding) -> usize {
     let codepoint = character_to_codepoint_offset(line, character, encoding);

--- a/wado-lsp/tests/inlay_hints.rs
+++ b/wado-lsp/tests/inlay_hints.rs
@@ -8,21 +8,10 @@
 use wado_lsp::test_support::{self, MapHost};
 use wado_lsp::{Engine, InlayHint, InlayHintKind, Position, Range};
 
-const WHOLE_DOCUMENT: Range = Range {
-    start: Position {
-        line: 0,
-        character: 0,
-    },
-    end: Position {
-        line: u32::MAX,
-        character: u32::MAX,
-    },
-};
-
 async fn hints(source: &str) -> Vec<InlayHint> {
     let doc = test_support::open(source);
     doc.engine
-        .inlay_hints(&doc.uri, WHOLE_DOCUMENT, &doc.host)
+        .inlay_hints(&doc.uri, Range::WHOLE_DOCUMENT, &doc.host)
         .await
 }
 
@@ -124,17 +113,7 @@ fn engine_returns_empty_for_unknown_document() {
         let uri = format!("file://{path}");
         let host = MapHost::empty();
         let engine = Engine::new();
-        let range = Range {
-            start: Position {
-                line: 0,
-                character: 0,
-            },
-            end: Position {
-                line: u32::MAX,
-                character: u32::MAX,
-            },
-        };
-        let hints = engine.inlay_hints(&uri, range, &host).await;
+        let hints = engine.inlay_hints(&uri, Range::WHOLE_DOCUMENT, &host).await;
         assert!(
             hints.is_empty(),
             "closed/unknown document must produce no hints; got {hints:?}",

--- a/wado-lsp/tests/inlay_hints.rs
+++ b/wado-lsp/tests/inlay_hints.rs
@@ -120,3 +120,29 @@ fn engine_returns_empty_for_unknown_document() {
         );
     });
 }
+
+/// LSP reads an absent `paddingLeft` / `paddingRight` as "no padding"; `null`
+/// is not the same value to every client, so an unset flag leaves the wire
+/// form entirely, and both names are camelCase.
+#[test]
+fn unset_padding_is_absent_from_the_wire_form() {
+    let hint = InlayHint {
+        position: Position {
+            line: 0,
+            character: 0,
+        },
+        label: ": i32".to_string(),
+        kind: InlayHintKind::Type,
+        padding_left: None,
+        padding_right: Some(true),
+    };
+    let wire = serde_json::to_string(&hint).unwrap();
+    assert!(
+        !wire.contains("padding_left") && !wire.contains("paddingLeft"),
+        "an unset padding flag must not reach the wire at all; got {wire}",
+    );
+    assert!(
+        wire.contains(r#""paddingRight":true"#),
+        "a set padding flag is camelCase on the wire; got {wire}",
+    );
+}


### PR DESCRIPTION
A method call written in path form passes its receiver positionally, so the
declared `&self` occupies argument slot 0 and the remaining parameters line up
one slot later:

```
Scale::scaled(&p, factor: 2, bias: 3)   // the receiver goes unlabelled
p.scaled(factor: 2, bias: 3)            // the dot form omits it from `args`
```

The two shapes get their own name lists. `dot_form_param_names` drops the
receiver, since it is not in `args`; `path_form_param_names` keeps its slot,
named `self` so `emit_arg_param_hints` skips it. `self` is reserved in Wado and
the symbol table spells a resource method's receiver the same way, so the one
skip covers both the AST route and the symbol-table route, and a `debug_assert`
states the naming invariant it rests on.

Two more defects along the same path:

- `InlayHint` serializes `paddingLeft` / `paddingRight`, the names LSP reads.
- A recovered `b'ab'` underlines the whole literal, `b` included.
  `scan_char_raw` takes the opening position from its caller, so the byte and
  char forms anchor their error spans the same way.

## `wado query inlay-hints`

A new query kind splices the labels into the source at the anchors a client
would render them at, which is how a misplaced anchor shows up as something to
look at rather than a number to check by hand:

```
  116 |     out.sort_by(‹cmp: ›|a: &DirectoryEntry, b: &DirectoryEntry| a.name.cmp(‹other: ›&b.name));
  119 |     assert render(‹template: ›"こんにちは、{{名前}}さん！", ‹context: ›&ctx) == "こんにちは、太郎さん！";
```

`--json` prints the raw hints, positioned in the LSP's default UTF-16 encoding.
`QueryKind::ALL` with `name()` / `desc()` feeds the parse arm, the help text and
the "Available:" error, so a kind is declared once.

`text::character_to_byte_offset` converts an LSP `character` against a line the
caller already holds, keeping the splice off the document-wide rescan that
`lsp_position_to_line_col` performs. `Range::WHOLE_DOCUMENT` names the range a
caller with no viewport asks a range-filtered query for.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YN2Pewa2xb9rhf9G43Y8rK)_