### PR TITLE
feat(highlight): hold the grammar to the identifier classes it colours

### DIFF
--- a/package-gale-highlight-wado/README.md
+++ b/package-gale-highlight-wado/README.md
@@ -41,10 +41,13 @@ the tree-sitter capture vocabulary, so any tree-sitter theme applies:
 | `constant builtin` | `true` / `false` / `null` / `self`           |
 
 A plain identifier stays uncoloured: telling a function from a variable takes
-name resolution, which no context-free grammar has. A `::` segment is the same
-case — `Option::None`'s case and `Foo::new`'s static method are one shape, and
-the call's `(` sits outside the path rule — so it stays plain too. `.method()`
-does not: the grammar matches the `(` in the same alternative as the name.
+name resolution, which no context-free grammar has.
+
+A `::` segment stays uncoloured for the same reason. `Option::None` and
+`Foo::new` are one shape to the grammar, and the call's `(` sits outside the
+path rule, so it cannot tell a variant case from a static method. `.method()`
+is different: there the grammar matches the `(` alongside the name, so the call
+is a fact rather than a guess.
 
 A dotted capture like `constant.builtin` becomes `class="constant builtin"`.
 See [`example/standalone.wado`](./example/standalone.wado) for a full styled

--- a/package-gale-highlight-wado/README.md
+++ b/package-gale-highlight-wado/README.md
@@ -47,9 +47,9 @@ A `::` segment naming an identifier stays uncoloured for the same reason.
 `Option::None` and `Foo::new` are one shape to the grammar, and the call's `(`
 sits outside the path rule, so it cannot tell a variant case from a static
 method. A segment spelled with a keyword stays a keyword: `Foo::from` colours
-`from` as one, which is what the compiler lexes it as. `.method()` is different
-again: there the grammar matches the `(` alongside the name, so the call is a
-fact rather than a guess.
+`from` as one, which is what the compiler lexes it as. `.method()` is not the
+same case: there the grammar matches the `(` alongside the name, so the call is
+certain.
 
 A dotted capture like `constant.builtin` becomes `class="constant builtin"`.
 See [`example/standalone.wado`](./example/standalone.wado) for a full styled

--- a/package-gale-highlight-wado/README.md
+++ b/package-gale-highlight-wado/README.md
@@ -35,12 +35,16 @@ the tree-sitter capture vocabulary, so any tree-sitter theme applies:
 | `keyword`          | `fn`, `let`, `if`, …                         |
 | `operator`         | `matches`, `+`, `==`, `->`, …                |
 | `type`             | type references and type parameters          |
-| `property`         | `.field`, `.method()`, struct literal fields |
-| `variable`         | identifiers in an interpolation              |
+| `property`         | `.field`, struct literal fields              |
+| `function method`  | `.method()`                                  |
+| `variable`         | `stores[p]`, a contextual keyword as a name  |
 | `constant builtin` | `true` / `false` / `null` / `self`           |
 
 A plain identifier stays uncoloured: telling a function from a variable takes
-name resolution, which no context-free grammar has.
+name resolution, which no context-free grammar has. A `::` segment is the same
+case — `Option::None`'s case and `Foo::new`'s static method are one shape, and
+the call's `(` sits outside the path rule — so it stays plain too. `.method()`
+does not: the grammar matches the `(` in the same alternative as the name.
 
 A dotted capture like `constant.builtin` becomes `class="constant builtin"`.
 See [`example/standalone.wado`](./example/standalone.wado) for a full styled

--- a/package-gale-highlight-wado/README.md
+++ b/package-gale-highlight-wado/README.md
@@ -35,7 +35,7 @@ the tree-sitter capture vocabulary, so any tree-sitter theme applies:
 | `keyword`          | `fn`, `let`, `if`, …                         |
 | `operator`         | `matches`, `+`, `==`, `->`, …                |
 | `type`             | type references and type parameters          |
-| `property`         | `.field`, struct literal fields              |
+| `property`         | `.field`, literal and pattern field names    |
 | `function method`  | `.method()`                                  |
 | `variable`         | `stores[p]`, a contextual keyword as a name  |
 | `constant builtin` | `true` / `false` / `null` / `self`           |

--- a/package-gale-highlight-wado/README.md
+++ b/package-gale-highlight-wado/README.md
@@ -43,11 +43,13 @@ the tree-sitter capture vocabulary, so any tree-sitter theme applies:
 A plain identifier stays uncoloured: telling a function from a variable takes
 name resolution, which no context-free grammar has.
 
-A `::` segment stays uncoloured for the same reason. `Option::None` and
-`Foo::new` are one shape to the grammar, and the call's `(` sits outside the
-path rule, so it cannot tell a variant case from a static method. `.method()`
-is different: there the grammar matches the `(` alongside the name, so the call
-is a fact rather than a guess.
+A `::` segment naming an identifier stays uncoloured for the same reason.
+`Option::None` and `Foo::new` are one shape to the grammar, and the call's `(`
+sits outside the path rule, so it cannot tell a variant case from a static
+method. A segment spelled with a keyword stays a keyword: `Foo::from` colours
+`from` as one, which is what the compiler lexes it as. `.method()` is different
+again: there the grammar matches the `(` alongside the name, so the call is a
+fact rather than a guess.
 
 A dotted capture like `constant.builtin` becomes `class="constant builtin"`.
 See [`example/standalone.wado`](./example/standalone.wado) for a full styled

--- a/package-gale-highlight-wado/grammar/Wado.g4
+++ b/package-gale-highlight-wado/grammar/Wado.g4
@@ -279,10 +279,8 @@ path
     ;
 
 // `memberName` is the token set. Each use site wraps it in a rule naming what
-// the name is there, and the query captures those wrappers. A capture on
-// `memberName` itself would fire under every use site at once, because an
-// override matches anywhere below its rule. Each wrapper holds one token, so
-// no capture on it reaches the argument list or type arguments beside it.
+// the name is there, and the query captures those wrappers rather than
+// `memberName`, which would fire under every use site at once.
 
 // The name in `.name(...)`.
 methodName

--- a/package-gale-highlight-wado/grammar/Wado.g4
+++ b/package-gale-highlight-wado/grammar/Wado.g4
@@ -498,8 +498,8 @@ exprPath
     ;
 
 // A `::` segment: a variant case, a static method, or the middle of a module
-// path. Named so it stays off `memberName`, which is a field and is coloured;
-// nothing captures this, matching `patternPath` and `path`.
+// path. It has its own rule so no capture on `fieldName` or `methodName`
+// reaches it; nothing captures this one, matching `patternPath` and `path`.
 pathSegment
     : memberName
     ;

--- a/package-gale-highlight-wado/grammar/Wado.g4
+++ b/package-gale-highlight-wado/grammar/Wado.g4
@@ -278,12 +278,11 @@ path
     : IDENTIFIER ('::' IDENTIFIER)*
     ;
 
-// `memberName` is the token set; each use site wraps it in a rule naming what
-// the name *is* there, and the query captures those rather than `memberName`.
-// An override fires anywhere under its rule, so a capture on `memberName`
-// itself would reach every use site at once — including the `::` segments that
-// must stay uncoloured. Each wrapper holds one token, so no capture on it can
-// reach the argument list or type arguments beside it.
+// `memberName` is the token set. Each use site wraps it in a rule naming what
+// the name is there, and the query captures those wrappers. A capture on
+// `memberName` itself would fire under every use site at once, because an
+// override matches anywhere below its rule. Each wrapper holds one token, so
+// no capture on it reaches the argument list or type arguments beside it.
 
 // The name in `.name(...)`.
 methodName
@@ -500,11 +499,9 @@ exprPath
     : identifier ('::' (typeArgs | pathSegment))*
     ;
 
-// A `::` segment: `Option::None`'s case, `Foo::new`'s static method, or the
-// middle of a module path. Telling them apart takes name resolution — the call
-// form's `(` is a `postfixOp`, outside this rule — so the query leaves it
-// uncoloured rather than guessing, as `patternPath` and `path` already do.
-// Naming it keeps it off `memberName`, which is a field and is coloured.
+// A `::` segment: a variant case, a static method, or the middle of a module
+// path. Named so it stays off `memberName`, which is a field and is coloured;
+// nothing captures this, matching `patternPath` and `path`.
 pathSegment
     : memberName
     ;

--- a/package-gale-highlight-wado/grammar/Wado.g4
+++ b/package-gale-highlight-wado/grammar/Wado.g4
@@ -278,6 +278,23 @@ path
     : IDENTIFIER ('::' IDENTIFIER)*
     ;
 
+// `memberName` is the token set; each use site wraps it in a rule naming what
+// the name *is* there, and the query captures those rather than `memberName`.
+// An override fires anywhere under its rule, so a capture on `memberName`
+// itself would reach every use site at once — including the `::` segments that
+// must stay uncoloured. Each wrapper holds one token, so no capture on it can
+// reach the argument list or type arguments beside it.
+
+// The name in `.name(...)`.
+methodName
+    : memberName
+    ;
+
+// The name in `.name`, a struct literal's `name:`, and a pattern's `name:`.
+fieldName
+    : memberName
+    ;
+
 memberName
     : IDENTIFIER
     | 'use' | 'from' | 'as' | 'fn' | 'with' | 'let' | 'mut' | 'return'
@@ -437,7 +454,7 @@ postfix
 postfixOp
     : '(' argumentList? ')'
     | '::' typeArgs '(' argumentList? ')'
-    | '.' (memberName ('::' typeArgs)? ('(' argumentList? ')')? | INTEGER | FLOAT)
+    | '.' (methodName ('::' typeArgs)? '(' argumentList? ')' | fieldName ('::' typeArgs)? | INTEGER | FLOAT)
     | '[' expression ']'
     | '?'
     ;
@@ -478,7 +495,16 @@ braceLiteral
     ;
 
 exprPath
-    : identifier ('::' (typeArgs | memberName))*
+    : identifier ('::' (typeArgs | pathSegment))*
+    ;
+
+// A `::` segment: `Option::None`'s case, `Foo::new`'s static method, or the
+// middle of a module path. Telling them apart takes name resolution — the call
+// form's `(` is a `postfixOp`, outside this rule — so the query leaves it
+// uncoloured rather than guessing, as `patternPath` and `path` already do.
+// Naming it keeps it off `memberName`, which is a field and is coloured.
+pathSegment
+    : memberName
     ;
 
 compileTimeExpr
@@ -535,7 +561,7 @@ fieldInitList
     ;
 
 fieldInit
-    : (memberName | STRING_LITERAL) (':' expression)?
+    : (fieldName | STRING_LITERAL) (':' expression)?
     | '..' expression
     ;
 
@@ -622,7 +648,7 @@ patternFieldList
     ;
 
 patternField
-    : (memberName | STRING_LITERAL) (':' pattern)?
+    : (fieldName | STRING_LITERAL) (':' pattern)?
     ;
 
 literal

--- a/package-gale-highlight-wado/grammar/Wado.g4
+++ b/package-gale-highlight-wado/grammar/Wado.g4
@@ -454,7 +454,9 @@ postfix
 postfixOp
     : '(' argumentList? ')'
     | '::' typeArgs '(' argumentList? ')'
-    | '.' (methodName ('::' typeArgs)? '(' argumentList? ')' | fieldName ('::' typeArgs)? | INTEGER | FLOAT)
+    // A turbofish after a `.` belongs to a call: the parser demands the `(`
+    // after it, so a field read carries no type arguments.
+    | '.' (methodName ('::' typeArgs)? '(' argumentList? ')' | fieldName | INTEGER | FLOAT)
     | '[' expression ']'
     | '?'
     ;

--- a/package-gale-highlight-wado/grammar/Wado.highlights.scm
+++ b/package-gale-highlight-wado/grammar/Wado.highlights.scm
@@ -58,17 +58,16 @@
 ; context-free grammar has. `mise run check-highlight` reports what stays
 ; uncoloured, by the kind the compiler resolved it to.
 (formatSpec (IDENTIFIER) @comment)
-; `stores[b]` names a parameter, not a type — and it sits inside the `fn(…)
-; with stores[b]` type that the rule below would otherwise paint.
+; `stores[b]` names a parameter, not a type. It sits inside the `fn(…) with
+; stores[b]` type that the rule below would otherwise paint.
 (storesItem (IDENTIFIER) @variable)
 (typeRef (IDENTIFIER) @type)
 (genericParam (IDENTIFIER) @type)
-; `.method()` and `.field` / a struct literal's or pattern's field name. Both
-; capture their use-site wrapper, never the shared `memberName` an override
-; would reach every use site through — including the `::` segments, which go
-; through `pathSegment` and stay uncoloured because `Option::None`'s case and
-; `Foo::new`'s static method are one shape that only name resolution splits.
-; The call form is a fact, not a guess: the grammar matches its `(`.
+; `.method()`, and `.field` with a struct literal's and a pattern's field name.
+; Each captures its use-site wrapper rather than the shared `memberName`; see
+; `Wado.g4`. A `::` segment goes through `pathSegment` and nothing captures it,
+; because `Option::None` and `Foo::new` are one shape that only name resolution
+; splits. The call form is a fact instead: the grammar matches its `(`.
 ;
 ; Each wrapper also spells out the contextual keywords usable as a name; only
 ; those need listing, because they are the ones the compiler lexes as plain
@@ -87,8 +86,8 @@
 (fieldName "forward" @property)
 ; An interpolation holds ordinary code, so its names take the classes the rules
 ; above give them and nothing more. Painting the rest `@variable` would reach
-; every identifier under `${…}` — the `::` segments included — and colour
-; inside a template what the same name is left plain outside one.
+; every identifier under `${…}`, the `::` segments included, and colour inside
+; a template what the same name is left plain outside one.
 
 ; The contextual keywords the `identifier` rule also accepts as names. In that
 ; position they are not keywords — the compiler lexes them as identifiers and

--- a/package-gale-highlight-wado/grammar/Wado.highlights.scm
+++ b/package-gale-highlight-wado/grammar/Wado.highlights.scm
@@ -58,21 +58,37 @@
 ; context-free grammar has. `mise run check-highlight` reports what stays
 ; uncoloured, by the kind the compiler resolved it to.
 (formatSpec (IDENTIFIER) @comment)
+; `stores[b]` names a parameter, not a type — and it sits inside the `fn(…)
+; with stores[b]` type that the rule below would otherwise paint.
+(storesItem (IDENTIFIER) @variable)
 (typeRef (IDENTIFIER) @type)
 (genericParam (IDENTIFIER) @type)
-; `.field`, `.method()`, a struct literal's field names, and — the minority
-; case this over-reaches on — the `::Case` of a variant path. `memberName`
-; also spells out every keyword usable as a member name; only the contextual
-; ones need listing, because those are the ones the compiler lexes as plain
+; `.method()` and `.field` / a struct literal's or pattern's field name. Both
+; capture their use-site wrapper, never the shared `memberName` an override
+; would reach every use site through — including the `::` segments, which go
+; through `pathSegment` and stay uncoloured because `Option::None`'s case and
+; `Foo::new`'s static method are one shape that only name resolution splits.
+; The call form is a fact, not a guess: the grammar matches its `(`.
+;
+; Each wrapper also spells out the contextual keywords usable as a name; only
+; those need listing, because they are the ones the compiler lexes as plain
 ; identifiers (a real keyword stays a keyword on both sides).
-(memberName (IDENTIFIER) @property)
-(memberName "test" @property)
-(memberName "do" @property)
-(memberName "task" @property)
-(memberName "trap" @property)
-(memberName "forward" @property)
-; The rest of an interpolation is a name the grammar cannot place further.
-(interpolation (IDENTIFIER) @variable)
+(methodName (IDENTIFIER) @function.method)
+(methodName "test" @function.method)
+(methodName "do" @function.method)
+(methodName "task" @function.method)
+(methodName "trap" @function.method)
+(methodName "forward" @function.method)
+(fieldName (IDENTIFIER) @property)
+(fieldName "test" @property)
+(fieldName "do" @property)
+(fieldName "task" @property)
+(fieldName "trap" @property)
+(fieldName "forward" @property)
+; An interpolation holds ordinary code, so its names take the classes the rules
+; above give them and nothing more. Painting the rest `@variable` would reach
+; every identifier under `${…}` — the `::` segments included — and colour
+; inside a template what the same name is left plain outside one.
 
 ; The contextual keywords the `identifier` rule also accepts as names. In that
 ; position they are not keywords — the compiler lexes them as identifiers and

--- a/package-gale-highlight-wado/grammar/Wado.highlights.scm
+++ b/package-gale-highlight-wado/grammar/Wado.highlights.scm
@@ -44,15 +44,14 @@
 ; `matches` lexes as a keyword but is a binary pattern-test operator.
 "matches" @operator
 
-; Identifiers the grammar can classify on its own, most specific first: an
-; override matches anywhere *under* its rule and the first one declared wins,
-; so a rule nested inside another has to be listed above it. `formatSpec` is
-; above these for that reason; `interpolation` is below them.
+; Identifiers the grammar can classify on its own, most specific first. An
+; override matches anywhere under its rule and the first one declared wins, so
+; a rule nested inside another is listed above it.
 ;
 ; Only a rule whose whole subtree is of one nature can carry an override.
-; `typeRef` and `genericParam` hold nothing but types, and `memberName` is a
-; leaf; the call and index forms are out, because `postfixOp` contains the
-; argument list and `@function` there would repaint every argument.
+; `typeRef` and `genericParam` hold nothing but types. For a member name the
+; subtree is whatever `postfixOp` holds beside it, so `Wado.g4` wraps each use
+; site in a one-token rule and those carry the captures instead.
 ;
 ; Telling a function from a variable takes name resolution, which no
 ; context-free grammar has. `mise run check-highlight` reports what stays
@@ -64,10 +63,9 @@
 (typeRef (IDENTIFIER) @type)
 (genericParam (IDENTIFIER) @type)
 ; `.method()`, and `.field` with a struct literal's and a pattern's field name.
-; Each captures its use-site wrapper rather than the shared `memberName`; see
-; `Wado.g4`. A `::` segment goes through `pathSegment` and nothing captures it,
-; because `Option::None` and `Foo::new` are one shape that only name resolution
-; splits. The call form is a fact instead: the grammar matches its `(`.
+; A `::` segment is deliberately absent: it goes through `pathSegment`, which
+; nothing captures, because `Option::None` and `Foo::new` are one shape that
+; only name resolution splits.
 ;
 ; Each wrapper also spells out the contextual keywords usable as a name; only
 ; those need listing, because they are the ones the compiler lexes as plain
@@ -85,9 +83,8 @@
 (fieldName "trap" @property)
 (fieldName "forward" @property)
 ; An interpolation holds ordinary code, so its names take the classes the rules
-; above give them and nothing more. Painting the rest `@variable` would reach
-; every identifier under `${…}`, the `::` segments included, and colour inside
-; a template what the same name is left plain outside one.
+; above give them and nothing more. Painting the rest `@variable` would colour
+; inside a template what the same name is left plain outside one.
 
 ; The contextual keywords the `identifier` rule also accepts as names. In that
 ; position they are not keywords — the compiler lexes them as identifiers and

--- a/package-gale-highlight-wado/src/lib_test.wado
+++ b/package-gale-highlight-wado/src/lib_test.wado
@@ -30,12 +30,15 @@ fn assert_highlights(src: &String) {
 }
 
 test "highlight template interpolation expression" {
+    // An interpolation holds ordinary code, so its names take the classes the
+    // code rules give them and nothing more: `n` is bare inside `${}` exactly
+    // as it is in the `let` before it.
     let src = "fn f() { let n = 1; let s = `n = ${n}, at ${self.now()}`; }\n";
     assert parse(&src).ok(), "parse failed";
     let html = highlight(src);
-    assert html.contains("<span class=\"variable\">n</span>"), "interp identifier -> variable";
     assert html.contains("<span class=\"constant builtin\">self</span>"), "self is a constant";
-    assert html.contains("<span class=\"property\">now</span>"), "interp member -> property";
+    assert html.contains("<span class=\"function method\">now</span>"), "interp call -> function method";
+    assert !html.contains(">n</span>"), "a bare name is uncoloured inside an interpolation too";
 }
 
 test "highlight identifiers the grammar can place" {
@@ -65,15 +68,16 @@ test "highlight template format spec" {
     let src = "fn f() -> String { let x = 1.5; return `v = ${x:0.2}`; }\n";
     assert parse(&src).ok(), "parse failed";
     let html = highlight(src);
-    assert html.contains("<span class=\"variable\">x</span>"), "interp expr -> variable";
     assert html.contains("<span class=\"comment\">0.2</span>"), "format spec muted";
+    assert !html.contains(">x</span>"), "the expression before the spec is ordinary code";
 }
 
 test "highlight struct literal in interpolation" {
     let src = "struct P { x: i32 }\nfn f() -> String { return `p = ${P { x: 1 }}!`; }\n";
     assert parse(&src).ok(), "parse failed";
     let html = highlight(src);
-    assert html.contains("<span class=\"variable\">P</span>"), "interp struct name -> variable";
+    assert html.contains("<span class=\"property\">x</span>"), "interp literal field -> property";
+    assert !html.contains(">P</span>"), "which kind the struct name is takes name resolution";
 }
 
 test "highlight nested template string" {
@@ -84,8 +88,8 @@ test "highlight fragment: unterminated fn body keeps interpolation context" {
     let src = "fn f() { let x = 1.5; let s = `v = ${x:0.2}`;\n";
     assert !parse(&src).ok(), "fragment should not parse cleanly";
     let html = highlight(src);
-    assert html.contains("<span class=\"variable\">x</span>"), "interp expr -> variable in fragment";
     assert html.contains("<span class=\"comment\">0.2</span>"), "format spec muted in fragment";
+    assert html.contains("<span class=\"keyword\">let</span>"), "surrounding code still classified";
     assert visible_text(&html) == src, "fragment highlighting is text-preserving";
 }
 
@@ -101,17 +105,19 @@ test "highlight fragment: bare statement recovers interpolation context" {
     let src = "let name = 1;\nlet s = `hi ${name} ${name:0.2}`;\n";
     let html = highlight(src);
     assert !parse(&src).ok(), "fragment should not parse cleanly";
-    assert html.contains("<span class=\"variable\">name</span>"), "interp id -> variable in bare fragment";
     assert html.contains("<span class=\"comment\">0.2</span>"), "format spec muted in bare fragment";
     assert html.contains("<span class=\"keyword\">let</span>"), "surrounding keyword still highlighted";
+    assert !html.contains(">name</span>"), "interp id uncoloured in a fragment, as outside one";
     assert visible_text(&html) == src, "bare-statement fragment is text-preserving";
 }
 
 test "highlight fragment: bare expression recovers interpolation context" {
     let src = "`hi ${name}` + compute(1, 2)\n";
     let html = highlight(src);
-    assert html.contains("class=\"string\""), "template text -> string";
-    assert html.contains("<span class=\"variable\">name</span>"), "interp id -> variable in bare expression";
+    // `${` spans on its own only once the interpolation is recognised: an
+    // unrecovered fragment swallows the whole `${name}` as template text.
+    assert html.contains("<span class=\"string\">${</span>"), "interpolation opened, not text";
+    assert !html.contains(">name</span>"), "interp id uncoloured in a bare expression";
     assert visible_text(&html) == src, "bare-expression fragment is text-preserving";
 }
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -933,12 +933,16 @@ pub fn walk_trait_bounds<V: AstVisitor>(v: &mut V, bounds: &[TraitBound]) {
             v.visit_id(assoc.id, assoc.span);
             v.visit_type(&assoc.ty);
         }
-        // `T: fn(i32) -> i32` carries its signature's types here.
+        // `T: fn(i32) -> i32 with E` carries its signature's types — and the
+        // effects it names — here, exactly as `Type::Function` does.
         if let Some(signature) = &bound.fn_signature {
             for param in &signature.params {
                 v.visit_type(param);
             }
             v.visit_type(&signature.return_type);
+            for (id, span) in &signature.effect_ids {
+                v.visit_id(*id, *span);
+            }
         }
     }
 }
@@ -1643,8 +1647,9 @@ pub fn attr_value<'a>(object: &'a AttrObject, key: &str) -> Option<&'a AttrValue
 
 /// One `key: value` entry of an attribute object.
 ///
-/// The key's own span is what lets a diagnostic — and the highlighter — point
-/// at the key rather than at the whole `with { … }`.
+/// The key's own span is what lets the highlighter — and, once `options_check`
+/// carries a file, a diagnostic — point at the key rather than at the whole
+/// `with { … }`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AttrEntry {
     pub key_span: Span,
@@ -1695,7 +1700,9 @@ pub struct ImportAttributes {
 
 impl ImportAttributes {
     fn get_str(&self, key: &str) -> Option<String> {
-        self.get(key).and_then(AttrValue::as_str).map(str::to_string)
+        self.get(key)
+            .and_then(AttrValue::as_str)
+            .map(str::to_string)
     }
 
     #[must_use]

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -557,12 +557,10 @@ pub fn walk_item<V: AstVisitor>(v: &mut V, item: &Item) {
         }
         Item::World(w) => {
             v.visit_id(w.id, w.span);
-            // An exported signature is types like any other.
+            // An exported signature declares parameters like any other.
             for export in &w.exports {
                 if let WorldExport::Function(f) = export {
-                    for param in &f.params {
-                        v.visit_type(&param.ty);
-                    }
+                    walk_params(v, &f.params);
                     if let Some(return_type) = &f.return_type {
                         v.visit_type(return_type);
                     }
@@ -582,10 +580,10 @@ pub fn walk_item<V: AstVisitor>(v: &mut V, item: &Item) {
     }
 }
 
-pub fn walk_function<V: AstVisitor>(v: &mut V, func: &Function) {
-    v.visit_id(func.id, func.span);
-    v.visit_generic_params(&func.type_params);
-    for param in &func.params {
+/// A parameter list, wherever one is declared: its bindings, their types, and
+/// the default arguments beside them.
+fn walk_params<V: AstVisitor>(v: &mut V, params: &[Param]) {
+    for param in params {
         v.visit_id(param.id, param.span);
         v.visit_type(&param.ty);
         // A default argument is an expression written in the declaring
@@ -595,6 +593,12 @@ pub fn walk_function<V: AstVisitor>(v: &mut V, func: &Function) {
             v.visit_expr(default);
         }
     }
+}
+
+pub fn walk_function<V: AstVisitor>(v: &mut V, func: &Function) {
+    v.visit_id(func.id, func.span);
+    v.visit_generic_params(&func.type_params);
+    walk_params(v, &func.params);
     if let Some(ret) = &func.return_type {
         v.visit_type(ret);
     }

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -505,7 +505,10 @@ pub fn walk_item<V: AstVisitor>(v: &mut V, item: &Item) {
             v.visit_generic_params(&n.type_params);
             v.visit_type(&n.ty);
         }
-        Item::TupleTypeDecl(t) => v.visit_id(t.id, t.span),
+        Item::TupleTypeDecl(t) => {
+            v.visit_id(t.id, t.span);
+            v.visit_type(&t.head);
+        }
         Item::BuiltinTypeDecl(d) => {
             v.visit_id(d.id, d.span);
             v.visit_generic_params(&d.type_params);
@@ -552,7 +555,20 @@ pub fn walk_item<V: AstVisitor>(v: &mut V, item: &Item) {
                 v.visit_function(m);
             }
         }
-        Item::World(w) => v.visit_id(w.id, w.span),
+        Item::World(w) => {
+            v.visit_id(w.id, w.span);
+            // An exported signature is types like any other.
+            for export in &w.exports {
+                if let WorldExport::Function(f) = export {
+                    for param in &f.params {
+                        v.visit_type(&param.ty);
+                    }
+                    if let Some(return_type) = &f.return_type {
+                        v.visit_type(return_type);
+                    }
+                }
+            }
+        }
         Item::Test(t) => {
             v.visit_id(t.id, t.span);
             v.visit_block(&t.body);
@@ -704,6 +720,10 @@ pub fn walk_expr<V: AstVisitor>(v: &mut V, expr: &Expr) {
         Expr::Ident(i) => {
             for segment in &i.segments {
                 v.visit_id(segment.id, segment.span);
+            }
+            // `Opt::<V>::None` pins its turbofish here rather than on a call.
+            for ty in &i.type_args {
+                v.visit_type(ty);
             }
         }
         Expr::Literal(_) => {}
@@ -912,6 +932,13 @@ pub fn walk_trait_bounds<V: AstVisitor>(v: &mut V, bounds: &[TraitBound]) {
         for assoc in &bound.assoc_types {
             v.visit_id(assoc.id, assoc.span);
             v.visit_type(&assoc.ty);
+        }
+        // `T: fn(i32) -> i32` carries its signature's types here.
+        if let Some(signature) = &bound.fn_signature {
+            for param in &signature.params {
+                v.visit_type(param);
+            }
+            v.visit_type(&signature.return_type);
         }
     }
 }
@@ -1601,7 +1628,27 @@ pub enum AttrValue {
     Float(f64),
     Bool(bool),
     Array(Vec<AttrValue>),
-    Object(IndexMap<String, AttrValue>),
+    Object(AttrObject),
+}
+
+/// An attribute object's entries, in parse order, each keyed by its name.
+pub type AttrObject = IndexMap<String, AttrEntry>;
+
+/// The value at `key`, for a reader that wants the value and not the key span
+/// stored beside it.
+#[must_use]
+pub fn attr_value<'a>(object: &'a AttrObject, key: &str) -> Option<&'a AttrValue> {
+    object.get(key).map(|entry| &entry.value)
+}
+
+/// One `key: value` entry of an attribute object.
+///
+/// The key's own span is what lets a diagnostic — and the highlighter — point
+/// at the key rather than at the whole `with { … }`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AttrEntry {
+    pub key_span: Span,
+    pub value: AttrValue,
 }
 
 impl AttrValue {
@@ -1616,7 +1663,7 @@ impl AttrValue {
 
     /// Borrow the inner object, if this is a [`AttrValue::Object`].
     #[must_use]
-    pub fn as_object(&self) -> Option<&IndexMap<String, AttrValue>> {
+    pub fn as_object(&self) -> Option<&AttrObject> {
         match self {
             AttrValue::Object(o) => Some(o),
             _ => None,
@@ -1643,15 +1690,12 @@ impl AttrValue {
 #[derive(Debug, Clone, Default)]
 pub struct ImportAttributes {
     /// Top-level key/value entries, in parse order.
-    pub entries: IndexMap<String, AttrValue>,
+    pub entries: AttrObject,
 }
 
 impl ImportAttributes {
     fn get_str(&self, key: &str) -> Option<String> {
-        self.entries
-            .get(key)
-            .and_then(AttrValue::as_str)
-            .map(str::to_string)
+        self.get(key).and_then(AttrValue::as_str).map(str::to_string)
     }
 
     #[must_use]
@@ -1706,8 +1750,8 @@ impl ImportAttributes {
 
     /// Inline Kiln generator configuration (`with { generator: { ... } }`).
     #[must_use]
-    pub fn generator(&self) -> Option<&IndexMap<String, AttrValue>> {
-        self.entries.get("generator").and_then(AttrValue::as_object)
+    pub fn generator(&self) -> Option<&AttrObject> {
+        self.get("generator").and_then(AttrValue::as_object)
     }
 
     /// Inline provider source (`with { provider: "./ext.wado" }`): a Wado file
@@ -1715,13 +1759,13 @@ impl ImportAttributes {
     /// dependency's guest-effect imports (research-cm-boundary-callbacks.md).
     #[must_use]
     pub fn provider_path(&self) -> Option<&str> {
-        self.entries.get("provider").and_then(AttrValue::as_str)
+        self.get("provider").and_then(AttrValue::as_str)
     }
 
     /// Raw lookup for any top-level attribute.
     #[must_use]
     pub fn get(&self, key: &str) -> Option<&AttrValue> {
-        self.entries.get(key)
+        self.entries.get(key).map(|entry| &entry.value)
     }
 }
 
@@ -3219,6 +3263,9 @@ pub struct NamespacedGenericType {
     pub namespace: String,
     /// Type name (e.g., "Value")
     pub name: String,
+    /// Span of just the type name token. `span` covers the whole `ns::Value<T>`,
+    /// so only this locates the second segment.
+    pub name_span: Span,
     /// Generic arguments
     pub args: Vec<Type>,
     pub span: Span,
@@ -3519,6 +3566,10 @@ pub struct TupleTypeDecl {
     pub id: AstId,
     pub visibility: Visibility,
     pub attrs: Vec<Attribute>,
+    /// The declared head, `[..T]`. The declaration carries no meaning beyond
+    /// anchoring the family, but keeping the type it was written as is what
+    /// lets a walk reach the `T` it binds.
+    pub head: Type,
     pub span: Span,
 }
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -3112,8 +3112,10 @@ pub struct FormatSpec {
 pub enum Type {
     Named(NamedType),
     Generic(GenericType),
-    /// Namespaced generic type like `ns::Type<T>` or `T::Assoc`
-    NamespacedGeneric(NamespacedGenericType),
+    /// Namespaced generic type like `ns::Type<T>` or `T::Assoc`. Boxed, as
+    /// `Function` is: it carries two names and two spans, and unboxed it makes
+    /// `Type` — and every enum holding one — large enough to be worth splitting.
+    NamespacedGeneric(Box<NamespacedGenericType>),
     Function(Box<FunctionType>),
     Tuple(Vec<Type>),
     Reference(Box<Type>),

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -933,17 +933,23 @@ pub fn walk_trait_bounds<V: AstVisitor>(v: &mut V, bounds: &[TraitBound]) {
             v.visit_id(assoc.id, assoc.span);
             v.visit_type(&assoc.ty);
         }
-        // `T: fn(i32) -> i32 with E` carries its signature's types — and the
-        // effects it names — here, exactly as `Type::Function` does.
+        // `T: fn(i32) -> i32 with E` carries a signature the bound spells out
+        // rather than wrapping in a `Type`, so it is walked as one here.
         if let Some(signature) = &bound.fn_signature {
-            for param in &signature.params {
-                v.visit_type(param);
-            }
-            v.visit_type(&signature.return_type);
-            for (id, span) in &signature.effect_ids {
-                v.visit_id(*id, *span);
-            }
+            walk_function_type(v, signature);
         }
+    }
+}
+
+/// The types and effect names a function signature carries, whether it stands
+/// as a [`Type::Function`] or as a trait bound's `fn_signature`.
+pub fn walk_function_type<V: AstVisitor>(v: &mut V, ft: &FunctionType) {
+    for p in &ft.params {
+        v.visit_type(p);
+    }
+    v.visit_type(&ft.return_type);
+    for (id, span) in &ft.effect_ids {
+        v.visit_id(*id, *span);
     }
 }
 
@@ -962,15 +968,7 @@ pub fn walk_type<V: AstVisitor>(v: &mut V, ty: &Type) {
                 v.visit_type(a);
             }
         }
-        Type::Function(ft) => {
-            for p in &ft.params {
-                v.visit_type(p);
-            }
-            v.visit_type(&ft.return_type);
-            for (id, span) in &ft.effect_ids {
-                v.visit_id(*id, *span);
-            }
-        }
+        Type::Function(ft) => walk_function_type(v, ft),
         Type::Tuple(ts) => {
             for t in ts {
                 v.visit_type(t);
@@ -1772,7 +1770,7 @@ impl ImportAttributes {
     /// Raw lookup for any top-level attribute.
     #[must_use]
     pub fn get(&self, key: &str) -> Option<&AttrValue> {
-        self.entries.get(key).map(|entry| &entry.value)
+        attr_value(&self.entries, key)
     }
 }
 

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -933,8 +933,6 @@ pub fn walk_trait_bounds<V: AstVisitor>(v: &mut V, bounds: &[TraitBound]) {
             v.visit_id(assoc.id, assoc.span);
             v.visit_type(&assoc.ty);
         }
-        // `T: fn(i32) -> i32 with E` carries a signature the bound spells out
-        // rather than wrapping in a `Type`, so it is walked as one here.
         if let Some(signature) = &bound.fn_signature {
             walk_function_type(v, signature);
         }
@@ -1636,18 +1634,14 @@ pub enum AttrValue {
 /// An attribute object's entries, in parse order, each keyed by its name.
 pub type AttrObject = IndexMap<String, AttrEntry>;
 
-/// The value at `key`, for a reader that wants the value and not the key span
-/// stored beside it.
+/// The value at `key`, dropping the key span stored beside it.
 #[must_use]
 pub fn attr_value<'a>(object: &'a AttrObject, key: &str) -> Option<&'a AttrValue> {
     object.get(key).map(|entry| &entry.value)
 }
 
-/// One `key: value` entry of an attribute object.
-///
-/// The key's own span is what lets the highlighter — and, once `options_check`
-/// carries a file, a diagnostic — point at the key rather than at the whole
-/// `with { … }`.
+/// One `key: value` entry of an attribute object. `key_span` is what lets a
+/// reader point at the key rather than at the whole `with { … }`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AttrEntry {
     pub key_span: Span,
@@ -3118,8 +3112,8 @@ pub enum Type {
     Named(NamedType),
     Generic(GenericType),
     /// Namespaced generic type like `ns::Type<T>` or `T::Assoc`. Boxed, as
-    /// `Function` is: it carries two names and two spans, and unboxed it makes
-    /// `Type` — and every enum holding one — large enough to be worth splitting.
+    /// `Function` is: two names and two spans make `Type` large enough that
+    /// every enum holding one draws `large_enum_variant`.
     NamespacedGeneric(Box<NamespacedGenericType>),
     Function(Box<FunctionType>),
     Tuple(Vec<Type>),
@@ -3573,9 +3567,8 @@ pub struct TupleTypeDecl {
     pub id: AstId,
     pub visibility: Visibility,
     pub attrs: Vec<Attribute>,
-    /// The declared head, `[..T]`. The declaration carries no meaning beyond
-    /// anchoring the family, but keeping the type it was written as is what
-    /// lets a walk reach the `T` it binds.
+    /// The declared head, `[..T]`. Kept so a walk reaches the `T` it binds,
+    /// and so the formatter prints the name that was written.
     pub head: Type,
     pub span: Span,
 }

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -941,7 +941,7 @@ pub fn walk_trait_bounds<V: AstVisitor>(v: &mut V, bounds: &[TraitBound]) {
 
 /// The types and effect names a function signature carries, whether it stands
 /// as a [`Type::Function`] or as a trait bound's `fn_signature`.
-pub fn walk_function_type<V: AstVisitor>(v: &mut V, ft: &FunctionType) {
+fn walk_function_type<V: AstVisitor>(v: &mut V, ft: &FunctionType) {
     for p in &ft.params {
         v.visit_type(p);
     }

--- a/wado-compiler/src/ast.rs
+++ b/wado-compiler/src/ast.rs
@@ -580,8 +580,7 @@ pub fn walk_item<V: AstVisitor>(v: &mut V, item: &Item) {
     }
 }
 
-/// A parameter list, wherever one is declared: its bindings, their types, and
-/// the default arguments beside them.
+/// A parameter list wherever one is declared: a function's, a world export's.
 fn walk_params<V: AstVisitor>(v: &mut V, params: &[Param]) {
     for param in params {
         v.visit_id(param.id, param.span);

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -3524,6 +3524,7 @@ impl CmInterfaceRegistry {
                     id: ng.id,
                     namespace: ng.namespace.clone(),
                     name: ng.name.clone(),
+                    name_span: ng.name_span,
                     args: resolved_args,
                     span: ng.span,
                 })

--- a/wado-compiler/src/component_model.rs
+++ b/wado-compiler/src/component_model.rs
@@ -3520,14 +3520,14 @@ impl CmInterfaceRegistry {
                     .iter()
                     .map(|arg| self.resolve_type_impl(arg, preserve_local))
                     .collect();
-                Type::NamespacedGeneric(crate::ast::NamespacedGenericType {
+                Type::NamespacedGeneric(Box::new(crate::ast::NamespacedGenericType {
                     id: ng.id,
                     namespace: ng.namespace.clone(),
                     name: ng.name.clone(),
                     name_span: ng.name_span,
                     args: resolved_args,
                     span: ng.span,
-                })
+                }))
             }
             // TypePackSpread is only valid inside tuple types — pass through
             Type::TypePackSpread(..) | Type::Infer(_) | Type::Error(_) => ty.clone(),

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -6,7 +6,7 @@
 
 use sha2::{Digest, Sha256};
 
-use crate::ast::{AttrValue, Module, UseDecl};
+use crate::ast::{AttrObject, AttrValue, Module, UseDecl, attr_value};
 use crate::compiler_host::{Code, Diagnostic, DiagnosticSpan, Severity};
 use crate::hashmap::IndexMap;
 
@@ -165,7 +165,7 @@ fn use_decls_of(module: &Module) -> impl Iterator<Item = &UseDecl> {
 fn lower_inline(
     module_path: &str,
     use_decl: &UseDecl,
-    cfg: &IndexMap<String, AttrValue>,
+    cfg: &AttrObject,
     descriptors: &IndexMap<String, OptionsDescriptor>,
     manifest_root: &str,
 ) -> Result<Invocation, Vec<Diagnostic>> {
@@ -180,7 +180,7 @@ fn lower_inline(
     // path-relative imports a few characters earlier
     // (`use ... from "./schema.g4"`), so the inline `module` field
     // follows the same rule.
-    let module = match cfg.get("module") {
+    let module = match attr_value(cfg, "module") {
         Some(AttrValue::String(s)) => {
             lower_module_specifier(module_path, use_decl, s, manifest_root, &mut errors)
         }
@@ -247,7 +247,7 @@ fn lower_inline(
         use_decl,
         &mut errors,
     );
-    let inputs = match cfg.get("inputs") {
+    let inputs = match attr_value(cfg, "inputs") {
         None => Vec::new(),
         Some(AttrValue::Array(items)) => items
             .iter()
@@ -292,7 +292,7 @@ fn lower_inline(
     let options = if let Some(module) = module.as_ref() {
         validate_inline_options(
             module,
-            cfg.get("options"),
+            attr_value(cfg, "options"),
             use_decl,
             module_path,
             descriptors,
@@ -302,7 +302,7 @@ fn lower_inline(
         CanonicalOptions::default()
     };
 
-    let output_dir_override = match cfg.get("output_dir") {
+    let output_dir_override = match attr_value(cfg, "output_dir") {
         None => None,
         Some(AttrValue::String(s)) => Some(resolve_or_reject(
             module_path,
@@ -361,7 +361,7 @@ fn lower_inline(
         inputs,
         output_dir,
         options,
-        raw_options: cfg.get("options").cloned(),
+        raw_options: attr_value(cfg, "options").cloned(),
     })
 }
 
@@ -409,12 +409,12 @@ fn resolve_or_reject(
 /// and yields `None`.
 fn optional_source_string(
     field: &str,
-    cfg: &IndexMap<String, AttrValue>,
+    cfg: &AttrObject,
     module_path: &str,
     use_decl: &UseDecl,
     errors: &mut Vec<Diagnostic>,
 ) -> Option<String> {
-    match cfg.get(field) {
+    match attr_value(cfg, field) {
         None => None,
         Some(AttrValue::String(s)) => Some(s.clone()),
         Some(other) => {
@@ -581,7 +581,7 @@ fn attr_kind(v: &AttrValue) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{AstId, ImportAttributes, Item, UseDecl, UseItem};
+    use crate::ast::{AstId, AttrEntry, ImportAttributes, Item, UseDecl, UseItem};
     use crate::token::Span;
     use std::assert_matches;
 
@@ -603,13 +603,22 @@ mod tests {
         Module::new(vec![Item::Use(use_decl)])
     }
 
-    fn attr_with_generator(entries: &[(&str, AttrValue)]) -> ImportAttributes {
-        let mut gen_obj: IndexMap<String, AttrValue> = IndexMap::default();
-        for (k, v) in entries {
-            gen_obj.insert((*k).to_string(), v.clone());
+    /// An attribute entry at a placeholder span: these tests exercise the
+    /// lowering, not where a key sits.
+    fn entry(value: AttrValue) -> AttrEntry {
+        AttrEntry {
+            key_span: span(),
+            value,
         }
-        let mut entries_map: IndexMap<String, AttrValue> = IndexMap::default();
-        entries_map.insert("generator".to_string(), AttrValue::Object(gen_obj));
+    }
+
+    fn attr_with_generator(entries: &[(&str, AttrValue)]) -> ImportAttributes {
+        let mut gen_obj: AttrObject = IndexMap::default();
+        for (k, v) in entries {
+            gen_obj.insert((*k).to_string(), entry(v.clone()));
+        }
+        let mut entries_map: AttrObject = IndexMap::default();
+        entries_map.insert("generator".to_string(), entry(AttrValue::Object(gen_obj)));
         ImportAttributes {
             entries: entries_map,
         }

--- a/wado-compiler/src/kiln/inline.rs
+++ b/wado-compiler/src/kiln/inline.rs
@@ -613,11 +613,11 @@ mod tests {
     }
 
     fn attr_with_generator(entries: &[(&str, AttrValue)]) -> ImportAttributes {
-        let mut gen_obj: AttrObject = IndexMap::default();
+        let mut gen_obj = AttrObject::default();
         for (k, v) in entries {
             gen_obj.insert((*k).to_string(), entry(v.clone()));
         }
-        let mut entries_map: AttrObject = IndexMap::default();
+        let mut entries_map = AttrObject::default();
         entries_map.insert("generator".to_string(), entry(AttrValue::Object(gen_obj)));
         ImportAttributes {
             entries: entries_map,

--- a/wado-compiler/src/kiln/options_check.rs
+++ b/wado-compiler/src/kiln/options_check.rs
@@ -8,7 +8,6 @@
 
 use crate::ast::{AttrObject, AttrValue};
 use crate::compiler_host::{Code, Diagnostic, Severity};
-use crate::hashmap::IndexMap;
 
 use super::options::{CanonicalValue, OptionsDescriptor, OptionsField, OptionsType};
 
@@ -37,7 +36,7 @@ pub fn validate(
     let mut diagnostics = Vec::new();
     let mut output = Vec::with_capacity(descriptor.fields.len());
 
-    let empty: AttrObject = IndexMap::default();
+    let empty = AttrObject::default();
     let (provided, path): (&AttrObject, String) = match value {
         None => (&empty, "options".to_string()),
         Some(AttrValue::Object(obj)) => (obj, "options".to_string()),
@@ -357,7 +356,7 @@ mod tests {
                 Some(CanonicalValue::Bool(false)),
             )],
         };
-        let mut obj: AttrObject = IndexMap::default();
+        let mut obj = AttrObject::default();
         obj.insert("enabled".to_string(), entry(AttrValue::Bool(true)));
         obj.insert("extra".to_string(), entry(AttrValue::Int(1)));
         let err = validate(&desc, Some(&AttrValue::Object(obj))).unwrap_err();
@@ -389,7 +388,7 @@ mod tests {
             vec![("entries".to_string(), CanonicalValue::List(vec![]))]
         );
         // Supplied array → a `List` of the element type.
-        let mut obj: AttrObject = IndexMap::default();
+        let mut obj = AttrObject::default();
         obj.insert(
             "entries".to_string(),
             entry(AttrValue::Array(vec![
@@ -409,7 +408,7 @@ mod tests {
             )]
         );
         // A wrong element type is rejected.
-        let mut obj: AttrObject = IndexMap::default();
+        let mut obj = AttrObject::default();
         obj.insert(
             "entries".to_string(),
             entry(AttrValue::Array(vec![AttrValue::Int(1)])),
@@ -422,7 +421,7 @@ mod tests {
         let desc = OptionsDescriptor {
             fields: vec![field("ratio", OptionsType::F64, None)],
         };
-        let mut obj: AttrObject = IndexMap::default();
+        let mut obj = AttrObject::default();
         obj.insert("ratio".to_string(), entry(AttrValue::Float(f64::INFINITY)));
         let err = validate(&desc, Some(&AttrValue::Object(obj))).unwrap_err();
         assert!(err.iter().any(|d| d.message.contains("must be finite")));
@@ -433,7 +432,7 @@ mod tests {
         let desc = OptionsDescriptor {
             fields: vec![field("enabled", OptionsType::Bool, None)],
         };
-        let mut obj: AttrObject = IndexMap::default();
+        let mut obj = AttrObject::default();
         obj.insert(
             "enabled".to_string(),
             entry(AttrValue::String("yes".to_string())),
@@ -467,7 +466,7 @@ mod tests {
                 None,
             )],
         };
-        let mut obj: AttrObject = IndexMap::default();
+        let mut obj = AttrObject::default();
         obj.insert(
             "rule".to_string(),
             entry(AttrValue::String("expr".to_string())),

--- a/wado-compiler/src/kiln/options_check.rs
+++ b/wado-compiler/src/kiln/options_check.rs
@@ -6,7 +6,7 @@
 //! lock-step. All diagnostics are batched: a single malformed table surfaces
 //! every mismatched / missing / unknown field at once.
 
-use crate::ast::AttrValue;
+use crate::ast::{AttrObject, AttrValue};
 use crate::compiler_host::{Code, Diagnostic, Severity};
 use crate::hashmap::IndexMap;
 
@@ -37,8 +37,8 @@ pub fn validate(
     let mut diagnostics = Vec::new();
     let mut output = Vec::with_capacity(descriptor.fields.len());
 
-    let empty: IndexMap<String, AttrValue> = IndexMap::default();
-    let (provided, path): (&IndexMap<String, AttrValue>, String) = match value {
+    let empty: AttrObject = IndexMap::default();
+    let (provided, path): (&AttrObject, String) = match value {
         None => (&empty, "options".to_string()),
         Some(AttrValue::Object(obj)) => (obj, "options".to_string()),
         Some(other) => {
@@ -58,7 +58,7 @@ pub fn validate(
     for field in &descriptor.fields {
         let field_path = format!("{path}.{}", field.name);
         let canonical = match provided.get(&field.name) {
-            Some(supplied) => check_field(field, supplied, &field_path, &mut diagnostics),
+            Some(supplied) => check_field(field, &supplied.value, &field_path, &mut diagnostics),
             None => apply_default(field, &field_path, &mut diagnostics),
         };
         if let Some(value) = canonical {
@@ -211,7 +211,7 @@ fn check_value(
 
 fn descriptor_validate_object(
     descriptor: &OptionsDescriptor,
-    obj: &IndexMap<String, AttrValue>,
+    obj: &AttrObject,
     path: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<Vec<(String, CanonicalValue)>> {
@@ -220,7 +220,7 @@ fn descriptor_validate_object(
     for field in &descriptor.fields {
         let child_path = format!("{path}.{}", field.name);
         let canonical = match obj.get(&field.name) {
-            Some(v) => check_value(&field.ty, v, &child_path, diagnostics),
+            Some(entry) => check_value(&field.ty, &entry.value, &child_path, diagnostics),
             None => apply_default(field, &child_path, diagnostics),
         };
         match canonical {
@@ -301,7 +301,17 @@ fn attr_value_kind(v: &AttrValue) -> &'static str {
 mod tests {
     use super::*;
     use crate::kiln::options::{CanonicalValue, OptionsDescriptor, OptionsField, OptionsType};
+    use crate::ast::AttrEntry;
     use crate::token::Span;
+
+    /// An attribute entry at a placeholder span: these tests exercise the
+    /// validation, not where a key sits.
+    fn entry(value: AttrValue) -> AttrEntry {
+        AttrEntry {
+            key_span: Span::new(0, 0, 1, 1),
+            value,
+        }
+    }
 
     fn field(name: &str, ty: OptionsType, default: Option<CanonicalValue>) -> OptionsField {
         OptionsField {
@@ -347,9 +357,9 @@ mod tests {
                 Some(CanonicalValue::Bool(false)),
             )],
         };
-        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
-        obj.insert("enabled".to_string(), AttrValue::Bool(true));
-        obj.insert("extra".to_string(), AttrValue::Int(1));
+        let mut obj: AttrObject = IndexMap::default();
+        obj.insert("enabled".to_string(), entry(AttrValue::Bool(true)));
+        obj.insert("extra".to_string(), entry(AttrValue::Int(1)));
         let err = validate(&desc, Some(&AttrValue::Object(obj))).unwrap_err();
         assert!(err.iter().any(|d| d.message.contains("extra")));
     }
@@ -379,13 +389,13 @@ mod tests {
             vec![("entries".to_string(), CanonicalValue::List(vec![]))]
         );
         // Supplied array → a `List` of the element type.
-        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
+        let mut obj: AttrObject = IndexMap::default();
         obj.insert(
             "entries".to_string(),
-            AttrValue::Array(vec![
+            entry(AttrValue::Array(vec![
                 AttrValue::String("a".to_string()),
                 AttrValue::String("b".to_string()),
-            ]),
+            ])),
         );
         let result = validate(&desc, Some(&AttrValue::Object(obj))).unwrap();
         assert_eq!(
@@ -399,10 +409,10 @@ mod tests {
             )]
         );
         // A wrong element type is rejected.
-        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
+        let mut obj: AttrObject = IndexMap::default();
         obj.insert(
             "entries".to_string(),
-            AttrValue::Array(vec![AttrValue::Int(1)]),
+            entry(AttrValue::Array(vec![AttrValue::Int(1)])),
         );
         assert!(validate(&desc, Some(&AttrValue::Object(obj))).is_err());
     }
@@ -412,8 +422,8 @@ mod tests {
         let desc = OptionsDescriptor {
             fields: vec![field("ratio", OptionsType::F64, None)],
         };
-        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
-        obj.insert("ratio".to_string(), AttrValue::Float(f64::INFINITY));
+        let mut obj: AttrObject = IndexMap::default();
+        obj.insert("ratio".to_string(), entry(AttrValue::Float(f64::INFINITY)));
         let err = validate(&desc, Some(&AttrValue::Object(obj))).unwrap_err();
         assert!(err.iter().any(|d| d.message.contains("must be finite")));
     }
@@ -423,8 +433,8 @@ mod tests {
         let desc = OptionsDescriptor {
             fields: vec![field("enabled", OptionsType::Bool, None)],
         };
-        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
-        obj.insert("enabled".to_string(), AttrValue::String("yes".to_string()));
+        let mut obj: AttrObject = IndexMap::default();
+        obj.insert("enabled".to_string(), entry(AttrValue::String("yes".to_string())));
         let err = validate(&desc, Some(&AttrValue::Object(obj))).unwrap_err();
         assert!(err.iter().any(|d| d.message.contains("expected bool")));
     }
@@ -454,8 +464,8 @@ mod tests {
                 None,
             )],
         };
-        let mut obj: IndexMap<String, AttrValue> = IndexMap::default();
-        obj.insert("rule".to_string(), AttrValue::String("expr".to_string()));
+        let mut obj: AttrObject = IndexMap::default();
+        obj.insert("rule".to_string(), entry(AttrValue::String("expr".to_string())));
         let result = validate(&desc, Some(&AttrValue::Object(obj))).unwrap();
         assert_eq!(
             result.values,

--- a/wado-compiler/src/kiln/options_check.rs
+++ b/wado-compiler/src/kiln/options_check.rs
@@ -300,8 +300,8 @@ fn attr_value_kind(v: &AttrValue) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kiln::options::{CanonicalValue, OptionsDescriptor, OptionsField, OptionsType};
     use crate::ast::AttrEntry;
+    use crate::kiln::options::{CanonicalValue, OptionsDescriptor, OptionsField, OptionsType};
     use crate::token::Span;
 
     /// An attribute entry at a placeholder span: these tests exercise the
@@ -434,7 +434,10 @@ mod tests {
             fields: vec![field("enabled", OptionsType::Bool, None)],
         };
         let mut obj: AttrObject = IndexMap::default();
-        obj.insert("enabled".to_string(), entry(AttrValue::String("yes".to_string())));
+        obj.insert(
+            "enabled".to_string(),
+            entry(AttrValue::String("yes".to_string())),
+        );
         let err = validate(&desc, Some(&AttrValue::Object(obj))).unwrap_err();
         assert!(err.iter().any(|d| d.message.contains("expected bool")));
     }
@@ -465,7 +468,10 @@ mod tests {
             )],
         };
         let mut obj: AttrObject = IndexMap::default();
-        obj.insert("rule".to_string(), entry(AttrValue::String("expr".to_string())));
+        obj.insert(
+            "rule".to_string(),
+            entry(AttrValue::String("expr".to_string())),
+        );
         let result = validate(&desc, Some(&AttrValue::Object(obj))).unwrap();
         assert_eq!(
             result.values,

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -3,7 +3,8 @@
 
 use crate::ast::{
     AssertStmt, AssignExpr, AssociatedConst, AssociatedTypeBinding, AssociatedTypeDecl, AstId,
-    AttrArg, Attribute, BinaryExpr, BinaryOp, Block, BreakStmt, BuiltinTypeDecl, CallExpr,
+    AttrArg, AttrEntry, Attribute, BinaryExpr, BinaryOp, Block, BreakStmt, BuiltinTypeDecl,
+    CallExpr,
     CastExpr, ChainedComparison, ClosureExpr, ClosureParam, CmBoundary, CmImport,
     CmResourceBacking, ComparisonChainExpr, CompoundAssignExpr, CompoundAssignOp, Condition,
     ConditionElement, ContinueStmt, EnumCase, EnumDecl, Expr, ExprStmt, FieldAccessExpr, FlagsDecl,
@@ -910,6 +911,7 @@ impl Parser {
                     id: self.alloc_ast_id(),
                     namespace: t.name.clone(),
                     name: second_name,
+                    name_span: second_span,
                     args: second_args,
                     span: start_span,
                 }),
@@ -1558,10 +1560,10 @@ impl Parser {
 
         if !self.check(&TokenKind::RBrace) {
             loop {
-                let key = self.consume_ident()?;
+                let (key, key_span) = self.consume_ident_with_span()?;
                 self.expect(&TokenKind::Colon)?;
                 let value = self.parse_attr_value()?;
-                attrs.entries.insert(key, value);
+                attrs.entries.insert(key, AttrEntry { key_span, value });
 
                 if !self.check(&TokenKind::Comma) {
                     break;
@@ -1654,14 +1656,13 @@ impl Parser {
                     });
                 }
                 self.advance();
-                let mut obj: crate::hashmap::IndexMap<String, crate::ast::AttrValue> =
-                    crate::hashmap::IndexMap::default();
+                let mut obj = crate::ast::AttrObject::default();
                 if !self.check(&TokenKind::RBrace) {
                     loop {
-                        let key = self.consume_ident()?;
+                        let (key, key_span) = self.consume_ident_with_span()?;
                         self.expect(&TokenKind::Colon)?;
-                        let v = self.parse_attr_value()?;
-                        obj.insert(key, v);
+                        let value = self.parse_attr_value()?;
+                        obj.insert(key, AttrEntry { key_span, value });
                         if !self.check(&TokenKind::Comma) {
                             break;
                         }
@@ -4664,8 +4665,10 @@ impl Parser {
     /// Parse a type or a type pack spread (`..T`) inside a tuple type.
     fn parse_type_or_pack(&mut self) -> ParseResult<Type> {
         if self.check_dot_dot_or_ellipsis() {
-            let span = self.consume_dot_dot()?;
-            let name = self.consume_ident()?;
+            self.consume_dot_dot()?;
+            // The name's span, not the `..`, so the span starts at the token
+            // being named — as it does on every other type node.
+            let (name, span) = self.consume_ident_with_span()?;
             return Ok(Type::TypePackSpread(name, span));
         }
         self.parse_type()
@@ -4793,7 +4796,7 @@ impl Parser {
         // Check for namespaced type: namespace::type<T>
         if self.check(&TokenKind::ColonColon) {
             self.advance();
-            let type_name = self.consume_ident()?;
+            let (type_name, type_name_span) = self.consume_ident_with_span()?;
 
             // Namespaced generic type: namespace::type<T>
             if self.check(&TokenKind::Lt) {
@@ -4807,6 +4810,7 @@ impl Parser {
                     id: self.alloc_ast_id(),
                     namespace: name,
                     name: type_name,
+                    name_span: type_name_span,
                     args,
                     span: start_span.merge(&end_span),
                 }));
@@ -4817,6 +4821,7 @@ impl Parser {
                     id: self.alloc_ast_id(),
                     namespace: name,
                     name: type_name,
+                    name_span: type_name_span,
                     args: Vec::new(),
                     span: start_span.merge(&end_span),
                 }));
@@ -5428,10 +5433,11 @@ impl Parser {
             let end_span = self.expect(&TokenKind::Semicolon)?.span;
             let span = start_span.merge(&end_span);
             return match ty {
-                Type::Tuple(_) => Ok(Item::TupleTypeDecl(TupleTypeDecl {
+                head @ Type::Tuple(_) => Ok(Item::TupleTypeDecl(TupleTypeDecl {
                     id,
                     visibility,
                     attrs,
+                    head,
                     span,
                 })),
                 Type::Named(head) => Ok(Item::BuiltinTypeDecl(BuiltinTypeDecl {

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -907,14 +907,14 @@ impl Parser {
             let case_span = self.peek().span;
             let case_name = self.consume_ident()?;
             let qualifier = match first_type {
-                Type::Named(ref t) => Type::NamespacedGeneric(NamespacedGenericType {
+                Type::Named(ref t) => Type::NamespacedGeneric(Box::new(NamespacedGenericType {
                     id: self.alloc_ast_id(),
                     namespace: t.name.clone(),
                     name: second_name,
                     name_span: second_span,
                     args: second_args,
                     span: start_span,
-                }),
+                })),
                 _ => {
                     return Err(ParseError {
                         message: "invalid qualified case pattern".to_string(),
@@ -4806,25 +4806,25 @@ impl Parser {
                 // to the right wins trailing-comment ownership (drops the comment).
                 let end_span = self.tokens[self.pos - 1].span;
 
-                return Ok(Type::NamespacedGeneric(NamespacedGenericType {
+                return Ok(Type::NamespacedGeneric(Box::new(NamespacedGenericType {
                     id: self.alloc_ast_id(),
                     namespace: name,
                     name: type_name,
                     name_span: type_name_span,
                     args,
                     span: start_span.merge(&end_span),
-                }));
+                })));
             } else {
                 // Namespaced type without generics: namespace::type
                 let end_span = self.tokens[self.pos - 1].span;
-                return Ok(Type::NamespacedGeneric(NamespacedGenericType {
+                return Ok(Type::NamespacedGeneric(Box::new(NamespacedGenericType {
                     id: self.alloc_ast_id(),
                     namespace: name,
                     name: type_name,
                     name_span: type_name_span,
                     args: Vec::new(),
                     span: start_span.merge(&end_span),
-                }));
+                })));
             }
         }
 

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -4,8 +4,7 @@
 use crate::ast::{
     AssertStmt, AssignExpr, AssociatedConst, AssociatedTypeBinding, AssociatedTypeDecl, AstId,
     AttrArg, AttrEntry, Attribute, BinaryExpr, BinaryOp, Block, BreakStmt, BuiltinTypeDecl,
-    CallExpr,
-    CastExpr, ChainedComparison, ClosureExpr, ClosureParam, CmBoundary, CmImport,
+    CallExpr, CastExpr, ChainedComparison, ClosureExpr, ClosureParam, CmBoundary, CmImport,
     CmResourceBacking, ComparisonChainExpr, CompoundAssignExpr, CompoundAssignOp, Condition,
     ConditionElement, ContinueStmt, EnumCase, EnumDecl, Expr, ExprStmt, FieldAccessExpr, FlagsDecl,
     FlagsVariant, ForOfStmt, ForStmt, FormatSpec, Function, FunctionType, GenericType, GlobalDecl,
@@ -8486,7 +8485,7 @@ line 2
         assert!(impl_block.methods.is_empty());
     }
 
-    /// `AstSpans::contextual` keys on this span's byte start, so a shift stops
+    /// `AstSpans::overrides` keys on this span's byte start, so a shift stops
     /// the highlighter colouring the word without failing a `kind` assertion.
     #[test]
     fn rest_clause_keyword_span_covers_the_word() {

--- a/wado-compiler/src/parser.rs
+++ b/wado-compiler/src/parser.rs
@@ -4665,8 +4665,7 @@ impl Parser {
     fn parse_type_or_pack(&mut self) -> ParseResult<Type> {
         if self.check_dot_dot_or_ellipsis() {
             self.consume_dot_dot()?;
-            // The name's span, not the `..`, so the span starts at the token
-            // being named — as it does on every other type node.
+            // The span starts at the name, not the `..`, as on every type node.
             let (name, span) = self.consume_ident_with_span()?;
             return Ok(Type::TypePackSpread(name, span));
         }

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -74,7 +74,7 @@ fn attr_value_depth(v: &crate::ast::AttrValue) -> usize {
 }
 
 /// Whether the `with { ... }` attribute object must be expanded multi-line by
-/// the depth rule — i.e. it holds at least one nested container.
+/// the depth rule: it holds at least one nested container.
 fn attrs_force_multiline(u: &UseDecl) -> bool {
     u.attributes.as_ref().is_some_and(|attrs| {
         attrs

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -76,14 +76,12 @@ fn attr_value_depth(v: &crate::ast::AttrValue) -> usize {
 /// Whether the `with { ... }` attribute object must be expanded multi-line by
 /// the depth rule — i.e. it holds at least one nested container.
 fn attrs_force_multiline(u: &UseDecl) -> bool {
-    u.attributes
-        .as_ref()
-        .is_some_and(|attrs| {
-            attrs
-                .entries
-                .values()
-                .any(|entry| attr_value_depth(&entry.value) >= 1)
-        })
+    u.attributes.as_ref().is_some_and(|attrs| {
+        attrs
+            .entries
+            .values()
+            .any(|entry| attr_value_depth(&entry.value) >= 1)
+    })
 }
 
 /// Append each item separated by `", "` via `emit`.
@@ -954,7 +952,9 @@ impl<'a> Unparser<'a> {
     fn unparse_tuple_type_decl(&mut self, d: &TupleTypeDecl) {
         self.emit_outer_attrs(&d.attrs);
         self.emit_visibility(d.visibility);
-        self.output.push_str("type [..T];\n");
+        self.output.push_str("type ");
+        self.unparse_type(&d.head);
+        self.output.push_str(";\n");
     }
 
     fn unparse_builtin_type_decl(&mut self, d: &BuiltinTypeDecl) {

--- a/wado-compiler/src/unparse.rs
+++ b/wado-compiler/src/unparse.rs
@@ -63,7 +63,11 @@ fn attr_value_depth(v: &crate::ast::AttrValue) -> usize {
             1 + items.iter().map(attr_value_depth).max().unwrap_or(0)
         }
         AttrValue::Object(obj) if !obj.is_empty() => {
-            1 + obj.values().map(attr_value_depth).max().unwrap_or(0)
+            1 + obj
+                .values()
+                .map(|entry| attr_value_depth(&entry.value))
+                .max()
+                .unwrap_or(0)
         }
         _ => 0,
     }
@@ -74,7 +78,12 @@ fn attr_value_depth(v: &crate::ast::AttrValue) -> usize {
 fn attrs_force_multiline(u: &UseDecl) -> bool {
     u.attributes
         .as_ref()
-        .is_some_and(|attrs| attrs.entries.values().any(|v| attr_value_depth(v) >= 1))
+        .is_some_and(|attrs| {
+            attrs
+                .entries
+                .values()
+                .any(|entry| attr_value_depth(&entry.value) >= 1)
+        })
 }
 
 /// Append each item separated by `", "` via `emit`.
@@ -559,10 +568,10 @@ impl<'a> Unparser<'a> {
             return;
         }
         self.output.push_str(" with { ");
-        self.comma_sep(&attrs.entries, |s, (k, v)| {
+        self.comma_sep(&attrs.entries, |s, (k, entry)| {
             s.output.push_str(k);
             s.output.push_str(": ");
-            s.unparse_attr_value(v);
+            s.unparse_attr_value(&entry.value);
         });
         self.output.push_str(" }");
     }
@@ -592,10 +601,10 @@ impl<'a> Unparser<'a> {
             }
             crate::ast::AttrValue::Object(obj) => {
                 self.output.push_str("{ ");
-                self.comma_sep(obj, |s, (k, v)| {
+                self.comma_sep(obj, |s, (k, entry)| {
                     s.output.push_str(k);
                     s.output.push_str(": ");
-                    s.unparse_attr_value(v);
+                    s.unparse_attr_value(&entry.value);
                 });
                 self.output.push_str(" }");
             }
@@ -652,17 +661,14 @@ impl<'a> Unparser<'a> {
 
     /// Emit `{` then one `key: value,` per line (recursively wrapping each
     /// value as needed), then a closing `}` on its own indented line.
-    fn unparse_attr_object_multiline(
-        &mut self,
-        obj: &crate::hashmap::IndexMap<String, crate::ast::AttrValue>,
-    ) {
+    fn unparse_attr_object_multiline(&mut self, obj: &crate::ast::AttrObject) {
         self.output.push_str("{\n");
         self.indent_level += 1;
-        for (k, v) in obj {
+        for (k, entry) in obj {
             self.write_indent();
             self.output.push_str(k);
             self.output.push_str(": ");
-            self.unparse_attr_value_wrapped(v);
+            self.unparse_attr_value_wrapped(&entry.value);
             self.output.push_str(",\n");
         }
         self.indent_level -= 1;

--- a/wado-compiler/tests/format.rs
+++ b/wado-compiler/tests/format.rs
@@ -1897,6 +1897,15 @@ fn test_format_deref_method_preserves_parens() {
     );
 }
 
+/// A tuple type declaration names its own pack, so the formatter has to print
+/// the one that was written rather than a fixed `T`.
+#[test]
+fn test_format_tuple_type_decl_keeps_its_pack_name() {
+    let source = "pub type [..Args];\n";
+    let formatted = wado_compiler::format(source).expect("format failed");
+    assert_eq!(formatted, source);
+}
+
 #[test]
 fn test_format_doc_comment_before_attribute_no_extra_blank() {
     // Doc comment immediately before an attribute must not grow a blank line

--- a/wado-compiler/tests/generated/fixtures/blanket_bound_cycle_on_newtype.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/blanket_bound_cycle_on_newtype.wir.wado
@@ -1285,7 +1285,6 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     let ptr_24: i32;
     let i: i32;
     let result: i32;
-    let status: i32;
     let __sroa_data_start: i32;
     let _av_44: i32;
     let _av_45: i32;
@@ -1314,12 +1313,13 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
                 result = "core:rt/cm_await_blocked"(self);
             }
             written_16 = struct.new "core:prelude/types.wado//StreamWrite" { count: result >> 4, result: __inline_cm_copy_result_13: block -> "core:prelude/types.wado//enum:CopyResult" {
-                status = result & 15;
-                if status == 0 {
+                let __match_scrut_0: i32;
+                __match_scrut_0 = result & 15;
+                if __match_scrut_0 == 0 {
                     break __inline_cm_copy_result_13: 0;
-                }
-                if status == 1 {
+                } else if __match_scrut_0 == 1 {
                     break __inline_cm_copy_result_13: 1;
+                } else {
                 }
                 break __inline_cm_copy_result_13: 2;
             } };

--- a/wado-compiler/tests/generated/fixtures/newtype_blanket_beats_base_blanket.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/newtype_blanket_beats_base_blanket.wir.wado
@@ -1425,7 +1425,6 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     let ptr_24: i32;
     let i: i32;
     let result: i32;
-    let status: i32;
     let __sroa_data_start: i32;
     let _av_44: i32;
     let _av_45: i32;
@@ -1454,12 +1453,13 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
                 result = "core:rt/cm_await_blocked"(self);
             }
             written_16 = struct.new "core:prelude/types.wado//StreamWrite" { count: result >> 4, result: __inline_cm_copy_result_13: block -> "core:prelude/types.wado//enum:CopyResult" {
-                status = result & 15;
-                if status == 0 {
+                let __match_scrut_0: i32;
+                __match_scrut_0 = result & 15;
+                if __match_scrut_0 == 0 {
                     break __inline_cm_copy_result_13: 0;
-                }
-                if status == 1 {
+                } else if __match_scrut_0 == 1 {
                     break __inline_cm_copy_result_13: 1;
+                } else {
                 }
                 break __inline_cm_copy_result_13: 2;
             } };

--- a/wado-compiler/tests/generated/fixtures/newtype_blanket_beats_chained_base_blanket.wir.wado
+++ b/wado-compiler/tests/generated/fixtures/newtype_blanket_beats_chained_base_blanket.wir.wado
@@ -1406,7 +1406,6 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
     let ptr_24: i32;
     let i: i32;
     let result: i32;
-    let status: i32;
     let __sroa_data_start: i32;
     let _av_44: i32;
     let _av_45: i32;
@@ -1435,12 +1434,13 @@ fn "core:prelude/types.wado/core:prelude/types.wado/StreamWritable<u8>::write_ra
                 result = "core:rt/cm_await_blocked"(self);
             }
             written_16 = struct.new "core:prelude/types.wado//StreamWrite" { count: result >> 4, result: __inline_cm_copy_result_13: block -> "core:prelude/types.wado//enum:CopyResult" {
-                status = result & 15;
-                if status == 0 {
+                let __match_scrut_0: i32;
+                __match_scrut_0 = result & 15;
+                if __match_scrut_0 == 0 {
                     break __inline_cm_copy_result_13: 0;
-                }
-                if status == 1 {
+                } else if __match_scrut_0 == 1 {
                     break __inline_cm_copy_result_13: 1;
+                } else {
                 }
                 break __inline_cm_copy_result_13: 2;
             } };

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -209,6 +209,19 @@ struct GaleFile {
     pieces: Vec<Piece>,
 }
 
+/// The source of a file both sides accept, or `None` when either rejects it.
+/// Gale's verdict comes first, so a file it rejected is never read.
+fn accepted_source(path: &str, theirs: &GaleFile) -> Option<String> {
+    if theirs.diagnostics != 0 {
+        return None;
+    }
+    let source = fs::read_to_string(path).unwrap_or_else(|e| panic!("reading '{path}': {e}"));
+    wado_compiler::parse(&source)
+        .errors
+        .is_empty()
+        .then_some(source)
+}
+
 pub fn run(mut parser: lexopt::Parser) {
     let mut emit_corpus: Option<String> = None;
     let mut compare: Option<String> = None;
@@ -442,11 +455,10 @@ fn compare_with_gale(gale_tsv: &str, report_path: Option<&str>) {
         let Some(theirs) = gale.get(path) else {
             panic!("the Gale side dumped nothing for '{path}' — the two corpora differ");
         };
-        let source = fs::read_to_string(path).unwrap_or_else(|e| panic!("reading '{path}': {e}"));
-        if theirs.diagnostics != 0 || !wado_compiler::parse(&source).errors.is_empty() {
+        let Some(source) = accepted_source(path, theirs) else {
             skipped += 1;
             continue;
-        }
+        };
         compared += 1;
         let gale_pieces = to_byte_offsets(&source, &theirs.pieces);
         let (found, refined) = diverge(path, &source, &compiler_pieces(&source), &gale_pieces);

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -6,10 +6,14 @@
 //! under `wado run`, `scripts/check-highlight.sh` driving both.
 //!
 //! Both vocabularies project onto [`Class`], and the projection is where the
-//! comparison stays honest about what a context-free grammar can know: every
-//! class but `Ident` is decidable without name resolution and is gated, while
-//! `Ident` covers the dozen resolved kinds Gale cannot tell apart and is only
-//! reported. Files Gale reports diagnostics for are skipped and counted:
+//! comparison stays honest about what a context-free grammar can know. A token
+//! class is decidable from the token stream, so the grammar must carry it and
+//! any disagreement is a defect. An identifier class it may leave plain —
+//! telling a function from a variable takes name resolution — but a span it
+//! does colour has to agree, so the two sides naming one differently is a
+//! defect too. Only silence on an identifier is a capability gap, and that is
+//! reported rather than gated. Files Gale reports diagnostics for are skipped
+//! and counted:
 //! `check-grammar` owns that failure. The two recoveries agree closely — what
 //! comparing them anyway adds is a divergence on the broken token itself.
 
@@ -22,8 +26,10 @@ use wado_lsp::semantic_tokens::{
     ClassifiedToken, TOKEN_TYPES, classify_all, token_modifier, token_type,
 };
 
-/// The vocabulary both sides are projected onto. Everything above `Ident` is
-/// decidable from syntax alone; `Ident` is where semantics starts.
+/// The vocabulary both sides are projected onto: the token classes, then the
+/// identifier classes the grammar can place from its parse alone. The kinds
+/// below those — a function against a variable — take name resolution, so
+/// both sides' leftovers land in `Name`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Class {
     Comment,
@@ -32,14 +38,26 @@ enum Class {
     Keyword,
     Constant,
     Operator,
-    Ident,
+    Type,
+    Property,
+    EnumMember,
+    Name,
 }
 
 impl Class {
-    /// Whether disagreement on this class is a defect rather than a capability
-    /// gap. See the module docs.
-    fn is_gated(self) -> bool {
-        self != Self::Ident
+    /// Whether the grammar has to colour this class at all. See the module
+    /// docs: silence on a token class is a defect, silence on an identifier is
+    /// a capability gap.
+    fn is_required(self) -> bool {
+        match self {
+            Self::Comment
+            | Self::String
+            | Self::Number
+            | Self::Keyword
+            | Self::Constant
+            | Self::Operator => true,
+            Self::Type | Self::Property | Self::EnumMember | Self::Name => false,
+        }
     }
 
     fn name(self) -> &'static str {
@@ -50,14 +68,17 @@ impl Class {
             Self::Keyword => "keyword",
             Self::Constant => "constant",
             Self::Operator => "operator",
-            Self::Ident => "ident",
+            Self::Type => "type",
+            Self::Property => "property",
+            Self::EnumMember => "enumMember",
+            Self::Name => "name",
         }
     }
 }
 
-/// Project one LSP semantic token onto [`Class`]. Every resolved identifier
-/// kind collapses to `Ident`: the distinctions below it are exactly the ones
-/// Gale cannot make.
+/// Project one LSP semantic token onto [`Class`]. Every legend entry is named,
+/// so a token type added to the legend fails here rather than defaulting into
+/// the ungated `Name` and silently leaving the comparison.
 fn class_of_token(token: &ClassifiedToken) -> Class {
     const CONSTANT_MODIFIERS: u32 = token_modifier::READONLY | token_modifier::DEFAULT_LIBRARY;
     match token.token_type {
@@ -69,7 +90,23 @@ fn class_of_token(token: &ClassifiedToken) -> Class {
         token_type::VARIABLE if token.modifiers & CONSTANT_MODIFIERS == CONSTANT_MODIFIERS => {
             Class::Constant
         }
-        _ => Class::Ident,
+        token_type::TYPE
+        | token_type::TYPE_PARAMETER
+        | token_type::STRUCT
+        | token_type::ENUM
+        | token_type::INTERFACE
+        | token_type::CLASS => Class::Type,
+        token_type::PROPERTY => Class::Property,
+        token_type::ENUM_MEMBER => Class::EnumMember,
+        token_type::NAMESPACE
+        | token_type::PARAMETER
+        | token_type::VARIABLE
+        | token_type::FUNCTION
+        | token_type::METHOD => Class::Name,
+        other => panic!(
+            "the classifier emits token type {other} ('{}'), which this comparison has no class for",
+            TOKEN_TYPES[other as usize]
+        ),
     }
 }
 
@@ -83,7 +120,9 @@ fn class_of_capture(capture: &str) -> Class {
         "keyword" => Class::Keyword,
         "constant.builtin" => Class::Constant,
         "operator" => Class::Operator,
-        "variable" | "type" | "property" => Class::Ident,
+        "type" => Class::Type,
+        "property" => Class::Property,
+        "variable" => Class::Name,
         other => panic!(
             "the highlight query emits capture '{other}', which this comparison has no class for"
         ),
@@ -142,13 +181,21 @@ struct Divergence {
 impl Divergence {
     /// The pattern this divergence is an instance of. Thousands of
     /// divergences collapse onto a handful of these, which is what makes the
-    /// report triageable.
-    fn pattern(&self) -> (Relation, Option<Class>, Option<Class>) {
-        (self.relation, self.compiler, self.gale)
+    /// report triageable. [`Self::kind`] is part of it: `name` against
+    /// `property` is a method call or a struct field depending on it, and
+    /// which side is wrong differs between the two.
+    fn pattern(&self) -> (Relation, Option<Class>, Option<Class>, &'static str) {
+        (self.relation, self.compiler, self.gale, self.kind)
     }
 
+    /// Whether this divergence is a defect rather than a capability gap. A
+    /// required class on either side is one the grammar must carry, so any
+    /// relation on it fails; below those, only a span both sides classified —
+    /// and classified differently — does.
     fn is_gated(&self) -> bool {
-        self.compiler.is_some_and(Class::is_gated) || self.gale.is_some_and(Class::is_gated)
+        self.compiler.is_some_and(Class::is_required)
+            || self.gale.is_some_and(Class::is_required)
+            || (self.compiler.is_some() && self.gale.is_some())
     }
 }
 
@@ -421,8 +468,8 @@ fn compare_with_gale(gale_tsv: &str, report_path: Option<&str>) {
         return;
     }
     eprintln!(
-        "\nerror: the grammar and the compiler colour {} pattern(s) differently on a class \
-         neither needs semantics for:\n",
+        "\nerror: the grammar and the compiler disagree on {} pattern(s) neither needs \
+         semantics to settle:\n",
         gated.len()
     );
     for (count, example) in &gated {
@@ -438,11 +485,14 @@ fn compare_with_gale(gale_tsv: &str, report_path: Option<&str>) {
 /// A `type` or `typeParameter` sits in a syntactic position the query could
 /// name (`(typeRef (IDENTIFIER) @type)`). A `function` or `parameter` does
 /// not: telling one from a plain variable takes name resolution, which is
-/// exactly what a context-free grammar cannot do. Reported, never gated.
+/// exactly what a context-free grammar cannot do. Leaving either uncoloured is
+/// reported, never gated — what is gated is colouring one as the wrong class.
 fn render_capability_gap(divergences: &[Divergence]) -> String {
     let mut counts: IndexMap<&'static str, usize> = IndexMap::default();
     for divergence in divergences {
-        if divergence.relation == Relation::Uncovered && divergence.compiler == Some(Class::Ident) {
+        if divergence.relation == Relation::Uncovered
+            && divergence.compiler.is_some_and(|class| !class.is_required())
+        {
             *counts.entry(divergence.kind).or_insert(0) += 1;
         }
     }
@@ -462,8 +512,10 @@ fn render_capability_gap(divergences: &[Divergence]) -> String {
 /// Collapse divergences onto their patterns, most frequent first, keeping one
 /// example each.
 fn group(divergences: &[Divergence]) -> Vec<(usize, Divergence)> {
-    let mut grouped: IndexMap<(Relation, Option<Class>, Option<Class>), (usize, Divergence)> =
-        IndexMap::default();
+    let mut grouped: IndexMap<
+        (Relation, Option<Class>, Option<Class>, &'static str),
+        (usize, Divergence),
+    > = IndexMap::default();
     for divergence in divergences {
         grouped
             .entry(divergence.pattern())
@@ -484,10 +536,11 @@ fn class_name(class: Option<Class>) -> &'static str {
 
 fn render_pattern(count: usize, example: &Divergence) -> String {
     format!(
-        "{count}x {}: compiler={} gale={} e.g. {}:{} {:?}",
+        "{count}x {}: compiler={} gale={} ({}) e.g. {}:{} {:?}",
         example.relation.name(),
         class_name(example.compiler),
         class_name(example.gale),
+        example.kind,
         example.path,
         example.line,
         example.text,
@@ -498,17 +551,19 @@ fn render_report(patterns: &[(usize, Divergence)]) -> String {
     let mut out = String::from(
         "# Where the two Wado highlighters disagree. Generated, not committed.\n#\n\
          # Grouped by pattern, most frequent first, one example each. A pattern\n\
-         # naming `ident` on either side is a capability gap, not a defect: Gale\n\
-         # is context-free and cannot resolve a name.\n#\n\
-         # count<TAB>relation<TAB>compiler<TAB>gale<TAB>path<TAB>line<TAB>text\n",
+         # with a `-` for the Gale side on an identifier class is a capability\n\
+         # gap, not a defect: Gale is context-free and cannot resolve a name.\n\
+         # Every other pattern is a defect.\n#\n\
+         # count<TAB>relation<TAB>compiler<TAB>gale<TAB>kind<TAB>path<TAB>line<TAB>text\n",
     );
     for (count, example) in patterns {
         writeln!(
             out,
-            "{count}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "{count}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             example.relation.name(),
             class_name(example.compiler),
             class_name(example.gale),
+            example.kind,
             example.path,
             example.line,
             example.text,
@@ -561,6 +616,40 @@ mod tests {
         assert_eq!(found[0].relation, Relation::ClassDiffers);
         assert_eq!(found[0].compiler, Some(Class::Comment));
         assert_eq!(found[0].gale, Some(Class::Operator));
+    }
+
+    /// An identifier the grammar colours has to carry the class the compiler
+    /// gave it: `Color::Red` is an `enumMember`, and capturing it `@property`
+    /// is a defect the old flat `Ident` swallowed.
+    #[test]
+    fn two_identifier_classes_on_one_span_is_a_defect() {
+        let mine = [piece(0, 3, Class::EnumMember)];
+        let theirs = [piece(0, 3, Class::Property)];
+        let (found, _) = diverge("t.wado", "Red", &mine, &theirs);
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].relation, Relation::ClassDiffers);
+        assert!(found[0].is_gated());
+    }
+
+    /// Leaving an identifier plain stays a capability gap: the grammar cannot
+    /// tell a function from a variable, and is not asked to.
+    #[test]
+    fn an_uncoloured_identifier_is_a_capability_gap() {
+        let mine = [piece(0, 3, Class::Name)];
+        let (found, _) = diverge("t.wado", "foo", &mine, &[]);
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].relation, Relation::Uncovered);
+        assert!(!found[0].is_gated());
+    }
+
+    /// A token class is decidable from the token stream, so leaving one plain
+    /// is a defect rather than a gap.
+    #[test]
+    fn an_uncoloured_token_class_is_a_defect() {
+        let mine = [piece(0, 3, Class::Keyword)];
+        let (found, _) = diverge("t.wado", "let", &mine, &[]);
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert!(found[0].is_gated());
     }
 
     /// Gale's spans are codepoint offsets; the compiler's are bytes. They agree

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -5,20 +5,16 @@
 //! the same corpus and through the same split — the compiler in-process, Gale
 //! under `wado run`, `scripts/check-highlight.sh` driving both.
 //!
-//! Both vocabularies project onto [`Class`], and the projection is where the
-//! comparison stays honest about what a context-free grammar can know. A token
-//! class is decidable from the token stream, so the grammar must carry it and
-//! any disagreement is a defect. An identifier class it may leave plain —
-//! telling a function from a variable takes name resolution — but a span it
-//! does colour has to agree, so the two sides naming one differently is a
-//! defect too. Only silence on an identifier is a capability gap, and that is
-//! reported rather than gated.
+//! Both vocabularies project onto [`Class`], and the projection is what keeps
+//! the comparison honest about a context-free grammar. The grammar must carry
+//! every token class, so any disagreement there is a defect. It may leave an
+//! identifier plain, because telling a function from a variable takes name
+//! resolution; that silence is reported rather than gated. Colouring one is a
+//! claim, so two names for the same span is a defect again.
 //!
-//! A file either side rejects is skipped and counted. Past a syntax error the
-//! two recoveries describe different programs — a `compile_error` fixture's
-//! parameter list stops being a parameter list on the side that broke — so
-//! comparing them measures the recoveries, not the highlighters.
-//! `check-grammar` owns that divergence.
+//! A file either side rejects is skipped and counted: past a syntax error the
+//! two recoveries describe different programs, so comparing them measures the
+//! recoveries. `check-grammar` owns that divergence.
 
 use std::fmt::Write as _;
 use std::fs;
@@ -49,9 +45,7 @@ enum Class {
 }
 
 impl Class {
-    /// Whether the grammar has to colour this class at all. See the module
-    /// docs: silence on a token class is a defect, silence on an identifier is
-    /// a capability gap.
+    /// Whether the grammar has to colour this class at all.
     fn is_required(self) -> bool {
         match self {
             Self::Comment
@@ -450,11 +444,6 @@ fn compare_with_gale(gale_tsv: &str, report_path: Option<&str>) {
             continue;
         }
         let source = fs::read_to_string(path).unwrap_or_else(|e| panic!("reading '{path}': {e}"));
-        // A file only one side parses puts its recovery against the other's
-        // real parse, and the two recover differently past the break — a
-        // `compile_error` fixture's parameter list stops being a parameter
-        // list. `check-grammar` owns that divergence; this one compares only
-        // where both sides read the same program.
         if !wado_compiler::parse(&source).errors.is_empty() {
             skipped += 1;
             continue;

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -439,12 +439,8 @@ fn compare_with_gale(gale_tsv: &str, report_path: Option<&str>) {
         let Some(theirs) = gale.get(path) else {
             panic!("the Gale side dumped nothing for '{path}' — the two corpora differ");
         };
-        if theirs.diagnostics != 0 {
-            skipped += 1;
-            continue;
-        }
         let source = fs::read_to_string(path).unwrap_or_else(|e| panic!("reading '{path}': {e}"));
-        if !wado_compiler::parse(&source).errors.is_empty() {
+        if theirs.diagnostics != 0 || !wado_compiler::parse(&source).errors.is_empty() {
             skipped += 1;
             continue;
         }

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -12,10 +12,13 @@
 //! telling a function from a variable takes name resolution — but a span it
 //! does colour has to agree, so the two sides naming one differently is a
 //! defect too. Only silence on an identifier is a capability gap, and that is
-//! reported rather than gated. Files Gale reports diagnostics for are skipped
-//! and counted:
-//! `check-grammar` owns that failure. The two recoveries agree closely — what
-//! comparing them anyway adds is a divergence on the broken token itself.
+//! reported rather than gated.
+//!
+//! A file either side rejects is skipped and counted. Past a syntax error the
+//! two recoveries describe different programs — a `compile_error` fixture's
+//! parameter list stops being a parameter list on the side that broke — so
+//! comparing them measures the recoveries, not the highlighters.
+//! `check-grammar` owns that divergence.
 
 use std::fmt::Write as _;
 use std::fs;
@@ -40,6 +43,7 @@ enum Class {
     Operator,
     Type,
     Property,
+    Method,
     EnumMember,
     Name,
 }
@@ -56,7 +60,7 @@ impl Class {
             | Self::Keyword
             | Self::Constant
             | Self::Operator => true,
-            Self::Type | Self::Property | Self::EnumMember | Self::Name => false,
+            Self::Type | Self::Property | Self::Method | Self::EnumMember | Self::Name => false,
         }
     }
 
@@ -70,6 +74,7 @@ impl Class {
             Self::Operator => "operator",
             Self::Type => "type",
             Self::Property => "property",
+            Self::Method => "method",
             Self::EnumMember => "enumMember",
             Self::Name => "name",
         }
@@ -97,12 +102,12 @@ fn class_of_token(token: &ClassifiedToken) -> Class {
         | token_type::INTERFACE
         | token_type::CLASS => Class::Type,
         token_type::PROPERTY => Class::Property,
+        token_type::METHOD => Class::Method,
         token_type::ENUM_MEMBER => Class::EnumMember,
         token_type::NAMESPACE
         | token_type::PARAMETER
         | token_type::VARIABLE
-        | token_type::FUNCTION
-        | token_type::METHOD => Class::Name,
+        | token_type::FUNCTION => Class::Name,
         other => panic!(
             "the classifier emits token type {other} ('{}'), which this comparison has no class for",
             TOKEN_TYPES[other as usize]
@@ -122,6 +127,7 @@ fn class_of_capture(capture: &str) -> Class {
         "operator" => Class::Operator,
         "type" => Class::Type,
         "property" => Class::Property,
+        "function.method" => Class::Method,
         "variable" => Class::Name,
         other => panic!(
             "the highlight query emits capture '{other}', which this comparison has no class for"
@@ -442,6 +448,15 @@ fn compare_with_gale(gale_tsv: &str, report_path: Option<&str>) {
             continue;
         }
         let source = fs::read_to_string(path).unwrap_or_else(|e| panic!("reading '{path}': {e}"));
+        // A file only one side parses puts its recovery against the other's
+        // real parse, and the two recover differently past the break — a
+        // `compile_error` fixture's parameter list stops being a parameter
+        // list. `check-grammar` owns that divergence; this one compares only
+        // where both sides read the same program.
+        if !wado_compiler::parse(&source).errors.is_empty() {
+            skipped += 1;
+            continue;
+        }
         compared += 1;
         let gale_pieces = to_byte_offsets(&source, &theirs.pieces);
         let (found, refined) = diverge(path, &source, &compiler_pieces(&source), &gale_pieces);
@@ -455,7 +470,7 @@ fn compare_with_gale(gale_tsv: &str, report_path: Option<&str>) {
             .unwrap_or_else(|e| panic!("writing '{path}': {e}"));
     }
     println!(
-        "corpus: {} files | compared: {compared} | skipped (Gale diagnostics): {skipped} | \
+        "corpus: {} files | compared: {compared} | skipped (either side rejects): {skipped} | \
          divergences: {} in {} patterns | template refinements: {refinements}",
         corpus.len(),
         divergences.len(),

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -12,9 +12,9 @@
 //! resolution; that silence is reported rather than gated. Colouring one is a
 //! claim, so two different classes on one span is a defect.
 //!
-//! A file either side rejects is skipped and counted: past a syntax error the
-//! two recoveries describe different programs, so comparing them measures the
-//! recoveries. `check-grammar` owns that divergence.
+//! A file either side rejects is skipped and counted: past a lexical or syntax
+//! error the two recoveries describe different programs, so comparing them
+//! measures the recoveries. `check-grammar` owns that divergence.
 
 use std::fmt::Write as _;
 use std::fs;
@@ -217,8 +217,8 @@ fn accepted_source(path: &str, theirs: &GaleFile) -> Option<String> {
     }
     let source = fs::read_to_string(path).unwrap_or_else(|e| panic!("reading '{path}': {e}"));
     wado_compiler::parse(&source)
-        .errors
-        .is_empty()
+        .into_fail_fast()
+        .is_ok()
         .then_some(source)
 }
 

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -196,8 +196,8 @@ impl Divergence {
 
     /// Whether this divergence is a defect rather than a capability gap. A
     /// required class on either side is one the grammar must carry, so any
-    /// relation on it fails; below those, only a span both sides classified —
-    /// and classified differently — does.
+    /// relation on it fails; below those, only a span both sides classified
+    /// does — a class or a boundary the two disagree on, never a silence.
     fn is_gated(&self) -> bool {
         self.compiler.is_some_and(Class::is_required)
             || self.gale.is_some_and(Class::is_required)
@@ -295,9 +295,11 @@ fn read_gale_dump(path: &str) -> IndexMap<String, GaleFile> {
 
 /// The compiler's classification of `source`.
 ///
-/// Semantics are deliberately not loaded: every gated class is decidable from
-/// the token stream and the AST alone, so resolving the whole corpus would buy
-/// only the `Ident` sub-kinds — which are never gated.
+/// Semantics are deliberately not loaded: what the grammar is held to is what
+/// a parse can settle, and that is exactly the classification this path
+/// produces. Resolving the corpus would answer a different question — a
+/// `.method()` becomes the function it resolves to — and hold a context-free
+/// grammar to it.
 fn compiler_pieces(source: &str) -> Vec<Piece> {
     classify_all(source, None)
         .iter()
@@ -506,7 +508,9 @@ fn render_capability_gap(divergences: &[Divergence]) -> String {
     let mut counts: IndexMap<&'static str, usize> = IndexMap::default();
     for divergence in divergences {
         if divergence.relation == Relation::Uncovered
-            && divergence.compiler.is_some_and(|class| !class.is_required())
+            && divergence
+                .compiler
+                .is_some_and(|class| !class.is_required())
         {
             *counts.entry(divergence.kind).or_insert(0) += 1;
         }

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -10,7 +10,7 @@
 //! every token class, so any disagreement there is a defect. It may leave an
 //! identifier plain, because telling a function from a variable takes name
 //! resolution; that silence is reported rather than gated. Colouring one is a
-//! claim, so two names for the same span is a defect again.
+//! claim, so two different classes on one span is a defect.
 //!
 //! A file either side rejects is skipped and counted: past a syntax error the
 //! two recoveries describe different programs, so comparing them measures the
@@ -26,9 +26,9 @@ use wado_lsp::semantic_tokens::{
 };
 
 /// The vocabulary both sides are projected onto: the token classes, then the
-/// identifier classes the grammar can place from its parse alone. The kinds
-/// below those — a function against a variable — take name resolution, so
-/// both sides' leftovers land in `Name`.
+/// identifier classes the grammar can place from its parse alone. Below those,
+/// telling a function from a variable takes name resolution, so both sides'
+/// leftovers land in `Name`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Class {
     Comment,
@@ -164,6 +164,10 @@ impl Relation {
     }
 }
 
+/// What a divergence is grouped by: the relation, both sides' classes, and the
+/// kind of the span.
+type Pattern = (Relation, Option<Class>, Option<Class>, &'static str);
+
 /// One disagreement, before grouping.
 #[derive(Debug, Clone)]
 struct Divergence {
@@ -181,17 +185,17 @@ struct Divergence {
 impl Divergence {
     /// The pattern this divergence is an instance of. Thousands of
     /// divergences collapse onto a handful of these, which is what makes the
-    /// report triageable. [`Self::kind`] is part of it: `name` against
-    /// `property` is a method call or a struct field depending on it, and
-    /// which side is wrong differs between the two.
-    fn pattern(&self) -> (Relation, Option<Class>, Option<Class>, &'static str) {
+    /// report triageable. The kind is part of it: `name` against `property` is
+    /// a method call or a struct field depending on it, and which side is
+    /// wrong differs between the two.
+    fn pattern(&self) -> Pattern {
         (self.relation, self.compiler, self.gale, self.kind)
     }
 
     /// Whether this divergence is a defect rather than a capability gap. A
     /// required class on either side is one the grammar must carry, so any
-    /// relation on it fails; below those, only a span both sides classified
-    /// does — a class or a boundary the two disagree on, never a silence.
+    /// relation on it fails. Below those, only a span both sides classified
+    /// counts: a class or a boundary they disagree on, never a silence.
     fn is_gated(&self) -> bool {
         self.compiler.is_some_and(Class::is_required)
             || self.gale.is_some_and(Class::is_required)
@@ -289,11 +293,10 @@ fn read_gale_dump(path: &str) -> IndexMap<String, GaleFile> {
 
 /// The compiler's classification of `source`.
 ///
-/// Semantics are deliberately not loaded: what the grammar is held to is what
-/// a parse can settle, and that is exactly the classification this path
-/// produces. Resolving the corpus would answer a different question — a
-/// `.method()` becomes the function it resolves to — and hold a context-free
-/// grammar to it.
+/// Semantics are deliberately not loaded: the grammar is held to what a parse
+/// can settle, which is exactly what this path produces. Resolving the corpus
+/// would ask a different question (a `.method()` becomes the function behind
+/// it) and hold a context-free grammar to the answer.
 fn compiler_pieces(source: &str) -> Vec<Piece> {
     classify_all(source, None)
         .iter()
@@ -488,7 +491,7 @@ fn compare_with_gale(gale_tsv: &str, report_path: Option<&str>) {
 /// name (`(typeRef (IDENTIFIER) @type)`). A `function` or `parameter` does
 /// not: telling one from a plain variable takes name resolution, which is
 /// exactly what a context-free grammar cannot do. Leaving either uncoloured is
-/// reported, never gated — what is gated is colouring one as the wrong class.
+/// reported, never gated; colouring one as the wrong class is.
 fn render_capability_gap(divergences: &[Divergence]) -> String {
     let mut counts: IndexMap<&'static str, usize> = IndexMap::default();
     for divergence in divergences {
@@ -516,10 +519,7 @@ fn render_capability_gap(divergences: &[Divergence]) -> String {
 /// Collapse divergences onto their patterns, most frequent first, keeping one
 /// example each.
 fn group(divergences: &[Divergence]) -> Vec<(usize, Divergence)> {
-    let mut grouped: IndexMap<
-        (Relation, Option<Class>, Option<Class>, &'static str),
-        (usize, Divergence),
-    > = IndexMap::default();
+    let mut grouped: IndexMap<Pattern, (usize, Divergence)> = IndexMap::default();
     for divergence in divergences {
         grouped
             .entry(divergence.pattern())
@@ -623,8 +623,8 @@ mod tests {
     }
 
     /// An identifier the grammar colours has to carry the class the compiler
-    /// gave it: `Color::Red` is an `enumMember`, and capturing it `@property`
-    /// is a defect the old flat `Ident` swallowed.
+    /// gave it: `Color::Red` is an `enumMember`, so capturing it `@property`
+    /// is a defect.
     #[test]
     fn two_identifier_classes_on_one_span_is_a_defect() {
         let mine = [piece(0, 3, Class::EnumMember)];

--- a/wado-dev-tools/src/highlight_corpus.rs
+++ b/wado-dev-tools/src/highlight_corpus.rs
@@ -570,9 +570,9 @@ fn render_report(patterns: &[(usize, Divergence)]) -> String {
     let mut out = String::from(
         "# Where the two Wado highlighters disagree. Generated, not committed.\n#\n\
          # Grouped by pattern, most frequent first, one example each. A pattern\n\
-         # with a `-` for the Gale side on an identifier class is a capability\n\
-         # gap, not a defect: Gale is context-free and cannot resolve a name.\n\
-         # Every other pattern is a defect.\n#\n\
+         # with a `-` on one side and an identifier class on the other is a\n\
+         # silence, not a defect: Gale is context-free and cannot resolve a\n\
+         # name. Every other pattern is a defect.\n#\n\
          # count<TAB>relation<TAB>compiler<TAB>gale<TAB>kind<TAB>path<TAB>line<TAB>text\n",
     );
     for (count, example) in patterns {

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -48,7 +48,7 @@ span can classify them: `TestDecl::span`, `ResumeExpr::span`,
 `RestClauseDecl::keyword_span`. `AstSpans::overrides` keeps those apart from
 the type spans because they outrank symbol resolution.
 
-A field name is in there for the same reason. The shorthand `{ state }`
+A field name is in `overrides` for the same reason. The shorthand `{ state }`
 resolves to the binding it reads, so deferring to the symbol would colour it
 `variable` wherever a snapshot exists and `property` wherever one does not.
 

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -46,10 +46,11 @@ The contextual keywords lex as identifiers. `test`, `do`, `resume`, `task`,
 span can classify them: `TestDecl::span`, `ResumeExpr::span`,
 `WithHandlerExpr::do_span`, `TaskReturnStmt::span`, and
 `RestClauseDecl::keyword_span`. `AstSpans::overrides` keeps those apart from
-the type spans because they outrank symbol resolution. A field name is in there
-for the same reason: the shorthand `{ state }` resolves to the binding it
-reads, and deferring to that would colour it `variable` wherever a snapshot
-exists and `property` wherever one does not.
+the type spans because they outrank symbol resolution.
+
+A field name is in there for the same reason. The shorthand `{ state }`
+resolves to the binding it reads, so deferring to the symbol would colour it
+`variable` wherever a snapshot exists and `property` wherever one does not.
 
 `self` is the exception: the language reserves it (it is absent from
 `Wado.g4`'s `identifier` rule), so `classify_token` recognises it lexically and

--- a/wado-lsp/AGENTS.md
+++ b/wado-lsp/AGENTS.md
@@ -45,8 +45,11 @@ The contextual keywords lex as identifiers. `test`, `do`, `resume`, `task`,
 `trap`, and `forward` are also usable as names, so only their declaring node's
 span can classify them: `TestDecl::span`, `ResumeExpr::span`,
 `WithHandlerExpr::do_span`, `TaskReturnStmt::span`, and
-`RestClauseDecl::keyword_span`. `AstSpans::contextual` keeps those apart from
-the type spans because they outrank symbol resolution.
+`RestClauseDecl::keyword_span`. `AstSpans::overrides` keeps those apart from
+the type spans because they outrank symbol resolution. A field name is in there
+for the same reason: the shorthand `{ state }` resolves to the binding it
+reads, and deferring to that would colour it `variable` wherever a snapshot
+exists and `property` wherever one does not.
 
 `self` is the exception: the language reserves it (it is absent from
 `Wado.g4`'s `identifier` rule), so `classify_token` recognises it lexically and

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -385,6 +385,27 @@ struct SpanCollector {
     spans: AstSpans,
 }
 
+impl SpanCollector {
+    /// An effect named in a `with` clause. The declaration site already reads
+    /// as a type (`effect E`); its uses are the same name.
+    fn mark_effect_names(&mut self, effects: &[(AstId, Span)]) {
+        for (_, span) in effects {
+            self.spans.insert(span.start, token_type::TYPE);
+        }
+    }
+
+    /// Mark every key of an attribute object, and of the objects nested in it.
+    fn mark_attr_keys(&mut self, object: &ast::AttrObject) {
+        for entry in object.values() {
+            self.spans
+                .insert(entry.key_span.start, token_type::PROPERTY);
+            if let Some(nested) = entry.value.as_object() {
+                self.mark_attr_keys(nested);
+            }
+        }
+    }
+}
+
 impl AstVisitor for SpanCollector {
     fn visit_item(&mut self, item: &Item) {
         // The contextual keywords lex as identifiers, so the declaration's own
@@ -397,6 +418,13 @@ impl AstVisitor for SpanCollector {
         {
             self.spans.mark_contextual(rest.keyword_span.start, KEYWORD);
         }
+        // An import attribute's keys are its object's fields, at every depth.
+        // They are not expressions, so no other walk reaches them.
+        if let Item::Use(decl) = item
+            && let Some(attributes) = &decl.attributes
+        {
+            self.mark_attr_keys(&attributes.entries);
+        }
         ast::walk_item(self, item);
     }
 
@@ -404,6 +432,7 @@ impl AstVisitor for SpanCollector {
         for param in &func.params {
             self.spans.mark_param(param.id);
         }
+        self.mark_effect_names(&func.effect_ids);
         ast::walk_function(self, func);
     }
 
@@ -428,13 +457,35 @@ impl AstVisitor for SpanCollector {
         if let Expr::WithHandler(w) = expr {
             self.spans.mark_contextual(w.do_span.start, KEYWORD);
         }
+        // A field name is the field, not a variable — including the shorthand
+        // `{ state }`, where it is also a read but names the field first.
+        if let Expr::StructLiteral(literal) = expr {
+            for field in &literal.fields {
+                self.spans
+                    .insert(field.name_span.start, token_type::PROPERTY);
+            }
+        }
         ast::walk_expr(self, expr);
+    }
+
+    fn visit_pattern(&mut self, pat: &ast::Pattern) {
+        // The destructuring side of the same rule: `let { x } = p` names the
+        // field first, and binds through it. A field's span starts at its
+        // name, in the `x: inner` form as much as the shorthand.
+        if let ast::Pattern::Struct { fields, .. } = pat {
+            for field in fields {
+                self.spans.insert(field.span.start, token_type::PROPERTY);
+            }
+        }
+        ast::walk_pattern(self, pat);
     }
 
     fn visit_generic_params(&mut self, params: &[ast::GenericParam]) {
         for param in params {
+            // `name_span`, not `span`: a pack parameter's `span` starts at its
+            // `..`, and classification keys on the identifier's own offset.
             self.spans
-                .insert(param.span.start, token_type::TYPE_PARAMETER);
+                .insert(param.name_span.start, token_type::TYPE_PARAMETER);
         }
         ast::walk_generic_params(self, params);
     }
@@ -442,6 +493,14 @@ impl AstVisitor for SpanCollector {
     fn visit_trait_bounds(&mut self, bounds: &[ast::TraitBound]) {
         for bound in bounds {
             self.spans.insert(bound.span.start, token_type::TYPE);
+            // `Output` in `Builder<Output = T>` names an associated type.
+            for assoc in &bound.assoc_types {
+                self.spans.insert(assoc.span.start, token_type::TYPE);
+            }
+            // A closure bound's own `with` clause: `F: fn() with Stdout`.
+            if let Some(signature) = &bound.fn_signature {
+                self.mark_effect_names(&signature.effect_ids);
+            }
         }
         ast::walk_trait_bounds(self, bounds);
     }
@@ -450,14 +509,20 @@ impl AstVisitor for SpanCollector {
         match ty {
             Type::Named(t) => self.spans.insert(t.span.start, token_type::TYPE),
             Type::Generic(t) => self.spans.insert(t.span.start, token_type::TYPE),
-            // `ns::Value` and `Self::Item` parse to the same node, so the head
-            // is not knowably a namespace; leave it to the symbol map.
-            Type::NamespacedGeneric(_)
-            | Type::Function(_)
-            | Type::Tuple(_)
+            // Both segments sit in a type position, so both take the class the
+            // position gives them. The head is not knowably a namespace —
+            // `ns::Value` and `Self::Item` parse to the same node — and the
+            // symbol map refines it where it resolves one; without that, `type`
+            // beats the `enumMember` the `::` heuristic would land on.
+            Type::NamespacedGeneric(t) => {
+                self.spans.insert(t.span.start, token_type::TYPE);
+                self.spans.insert(t.name_span.start, token_type::TYPE);
+            }
+            Type::TypePackSpread(_, span) => self.spans.insert(span.start, token_type::TYPE),
+            Type::Function(f) => self.mark_effect_names(&f.effect_ids),
+            Type::Tuple(_)
             | Type::Reference(_)
             | Type::MutReference(_)
-            | Type::TypePackSpread(_, _)
             | Type::Infer(_)
             | Type::Error(_) => {}
         }
@@ -642,19 +707,28 @@ fn classify_ident(tokens: &[Token], index: usize, ast_spans: &AstSpans) -> (u32,
             | TokenKind::World
             | TokenKind::Effect => return (token_type::TYPE, 0),
             TokenKind::Dot => {
-                // After `.`: method if followed by `(`, else property
-                if next_is(tokens, index, &TokenKind::LParen) {
+                // After `.`: method if the call follows, else property. A
+                // `::<` turbofish is a call's type arguments — `.collect::<T>()`
+                // is as much a method as `.collect()`.
+                if follows(tokens, index, 1, &TokenKind::LParen)
+                    || (follows(tokens, index, 1, &TokenKind::ColonColon)
+                        && follows(tokens, index, 2, &TokenKind::Lt))
+                {
                     return (token_type::METHOD, 0);
                 }
                 return (token_type::PROPERTY, 0);
             }
             TokenKind::ColonColon => {
                 // After `::`: could be enum member or static method
-                if next_is(tokens, index, &TokenKind::LParen) {
+                if follows(tokens, index, 1, &TokenKind::LParen) {
                     return (token_type::FUNCTION, 0);
                 }
-                if next_is(tokens, index, &TokenKind::ColonColon) {
-                    // Middle of a path like `A::B::C` - treat as type
+                if follows(tokens, index, 1, &TokenKind::ColonColon) {
+                    // `::<` is a turbofish, so this is the callee it applies
+                    // to, not the middle of a path like `A::B::C`.
+                    if follows(tokens, index, 2, &TokenKind::Lt) {
+                        return (token_type::FUNCTION, 0);
+                    }
                     return (token_type::TYPE, 0);
                 }
                 return (token_type::ENUM_MEMBER, 0);
@@ -664,7 +738,7 @@ fn classify_ident(tokens: &[Token], index: usize, ast_spans: &AstSpans) -> (u32,
     }
 
     // 3. Check if followed by `(` → function call
-    if next_is(tokens, index, &TokenKind::LParen) {
+    if follows(tokens, index, 1, &TokenKind::LParen) {
         return (token_type::FUNCTION, 0);
     }
 
@@ -680,9 +754,11 @@ fn prev_significant(tokens: &[Token], index: usize) -> Option<&Token> {
     }
 }
 
-fn next_is(tokens: &[Token], index: usize, kind: &TokenKind) -> bool {
+/// Whether the token `ahead` positions past `index` is of `kind`. `ahead` is 1
+/// for the next token; the `::<` turbofish needs 2.
+fn follows(tokens: &[Token], index: usize, ahead: usize, kind: &TokenKind) -> bool {
     tokens
-        .get(index + 1)
+        .get(index + ahead)
         .is_some_and(|t| std::mem::discriminant(&t.kind) == std::mem::discriminant(kind))
 }
 
@@ -933,6 +1009,120 @@ mod tests {
         let tokens = compute(src, None);
         assert_eq!(kind_of(&tokens, src, 1, "Wide"), token_type::TYPE);
         assert_eq!(kind_of(&tokens, src, 1, "Tall"), token_type::TYPE);
+    }
+
+    /// A struct literal's field names are properties, not the variables the
+    /// default arm made of them. Only the AST knows, so no semantics here.
+    #[test]
+    fn struct_literal_field_names_are_properties() {
+        let src = "struct Gen {\n    state: i32,\n}\nfn run() {\n    let g = Gen {\n        state: 1,\n    };\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 5, "state"), token_type::PROPERTY);
+    }
+
+    /// An import attribute's keys are its object's fields, nested ones too.
+    /// They are not expressions, so only the `use` item's own walk reaches
+    /// them.
+    #[test]
+    fn import_attribute_keys_are_properties() {
+        let src = "use { f } from \"./m.wado\"\n    with {\n        generator: {\n            module: \"lib:gale\",\n        },\n    };\nfn run() {}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 2, "generator"), token_type::PROPERTY);
+        assert_eq!(kind_of(&tokens, src, 3, "module"), token_type::PROPERTY);
+    }
+
+    /// A shorthand field is the field, not the variable it reads.
+    #[test]
+    fn a_shorthand_struct_literal_field_is_a_property() {
+        let src = "struct Gen {\n    state: i32,\n}\nfn run() {\n    let state = 1;\n    let g = Gen {\n        state,\n    };\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 6, "state"), token_type::PROPERTY);
+    }
+
+    /// The destructuring side of the same rule.
+    #[test]
+    fn a_struct_pattern_field_is_a_property() {
+        let src = "fn run() {\n    let p = { x: 1, y: 2 };\n    let {\n        x,\n        y: renamed,\n    } = p;\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 3, "x"), token_type::PROPERTY);
+        assert_eq!(kind_of(&tokens, src, 4, "y"), token_type::PROPERTY);
+    }
+
+    /// A closure-type bound's signature is types as much as any other.
+    #[test]
+    fn a_closure_type_bound_signature_is_types() {
+        let src = "effect E {\n    fn e();\n}\nfn apply<\n    T: fn(i32) -> f64 with E,\n>(f: T) {}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 4, "i32"), token_type::TYPE);
+        assert_eq!(kind_of(&tokens, src, 4, "f64"), token_type::TYPE);
+        assert_eq!(kind_of(&tokens, src, 4, "E"), token_type::TYPE);
+    }
+
+    /// An effect named in a `with` clause reads as the type its declaration
+    /// does — on the function's own clause and inside an `fn(…) with E` type.
+    #[test]
+    fn an_effect_named_in_a_with_clause_is_a_type() {
+        let src = "effect E {\n    fn f();\n}\nfn run<\n    T,\n>(\n    body: fn mut() -> T with E,\n) -> T with E {\n    return body();\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 6, "E"), token_type::TYPE);
+        assert_eq!(kind_of(&tokens, src, 7, "E"), token_type::TYPE);
+    }
+
+    /// A path's turbofish is pinned on the identifier, not on a call, when no
+    /// call follows — and its arguments are types there too.
+    #[test]
+    fn a_path_prefix_turbofish_argument_is_a_type() {
+        let src = "variant Opt<V> {\n    None,\n    Some(V),\n}\nfn run() {\n    let b = Opt::<i32>::None;\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 5, "i32"), token_type::TYPE);
+    }
+
+    /// `Output` in `Builder<Output = T>` names an associated type.
+    #[test]
+    fn an_associated_type_binding_is_a_type() {
+        let src = "fn f<\n    B: Builder<Output = i32>,\n>() {}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 1, "Output"), token_type::TYPE);
+    }
+
+    /// A type pack's member sits in a type position and is one — at its
+    /// declaration, where the `..` starts the parameter's span, as much as at
+    /// its use.
+    #[test]
+    fn a_type_pack_spread_member_is_a_type() {
+        let src = "fn f<\n    ..T,\n>(\n    items: [..T],\n) {}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 1, "T"), token_type::TYPE_PARAMETER);
+        assert_eq!(kind_of(&tokens, src, 3, "T"), token_type::TYPE);
+    }
+
+    /// Both segments of `ns::Value` are in a type position. The head is not
+    /// knowably a namespace — `Self::Item` parses the same — so it takes the
+    /// class the position gives it rather than the one resolution would.
+    #[test]
+    fn a_namespaced_type_is_a_type_on_both_segments() {
+        let src = "fn f(\n    v: ns::Value,\n) {}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 1, "ns"), token_type::TYPE);
+        assert_eq!(kind_of(&tokens, src, 1, "Value"), token_type::TYPE);
+    }
+
+    /// `::<` is a turbofish, so the name before it is the callee, not the
+    /// middle of a path like `A::B::C`.
+    #[test]
+    fn a_turbofish_callee_is_a_function_not_a_path_middle() {
+        let src = "fn run() {\n    let x = builtin::array_new::<u8>(1);\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 1, "array_new"), token_type::FUNCTION);
+    }
+
+    /// The same turbofish after a `.`: type arguments do not make a call a
+    /// field read.
+    #[test]
+    fn a_turbofish_method_call_is_a_method() {
+        let src = "fn run() {\n    let d = \"h\".bytes().collect::<List<u8>>();\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 1, "collect"), token_type::METHOD);
     }
 
     #[test]

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -334,11 +334,11 @@ struct AstSpans {
     /// recovered structurally here). Declaration and use sites share the
     /// binding's definition id, so one set covers both.
     param_ids: IndexSet<AstId>,
-    /// byte start -> class for the names the AST settles outright: the
-    /// contextual keywords, and the field names. Apart from `map` because
-    /// these outrank symbol resolution rather than being refined by it — a
-    /// shorthand `{ state }` resolves to the binding it reads, and the symbol
-    /// winning would colour it `variable` wherever a snapshot exists.
+    /// byte start -> class for the names the AST settles outright: contextual
+    /// keywords and field names. These outrank symbol resolution rather than
+    /// being refined by it, so they stay apart from `map`: a shorthand
+    /// `{ state }` resolves to the binding it reads, which would colour it
+    /// `variable` wherever a snapshot exists.
     overrides: IndexMap<usize, (u32, u32)>,
 }
 
@@ -386,16 +386,16 @@ struct SpanCollector {
 }
 
 impl SpanCollector {
-    /// An effect named in a `with` clause. The declaration site already reads
-    /// as a type (`effect E`); its uses are the same name.
+    /// An effect named in a `with` clause reads as its declaration does:
+    /// `effect E` is a type, and every mention of `E` is the same name.
     fn mark_effect_names(&mut self, effects: &[(AstId, Span)]) {
         for (_, span) in effects {
             self.spans.insert(span.start, token_type::TYPE);
         }
     }
 
-    /// Mark every key of an attribute object, and of the objects nested in it —
-    /// under an array element as much as under another key.
+    /// Every key of an attribute object and of the objects nested in it, under
+    /// an array element as much as under another key.
     fn mark_attr_keys(&mut self, object: &ast::AttrObject) {
         for entry in object.values() {
             self.mark_field_name(entry.key_span);
@@ -521,11 +521,10 @@ impl AstVisitor for SpanCollector {
         match ty {
             Type::Named(t) => self.spans.insert(t.span.start, token_type::TYPE),
             Type::Generic(t) => self.spans.insert(t.span.start, token_type::TYPE),
-            // Both segments sit in a type position, so both take the class the
-            // position gives them. The head is not knowably a namespace —
-            // `ns::Value` and `Self::Item` parse to the same node — and the
-            // symbol map refines it where it resolves one; without that, `type`
-            // beats the `enumMember` the `::` heuristic would land on.
+            // Both segments sit in a type position. The head is not knowably a
+            // namespace (`ns::Value` and `Self::Item` parse to the same node),
+            // so the symbol map refines it where it resolves one, and `type`
+            // beats the `enumMember` the `::` heuristic would otherwise land on.
             Type::NamespacedGeneric(t) => {
                 self.spans.insert(t.span.start, token_type::TYPE);
                 self.spans.insert(t.name_span.start, token_type::TYPE);
@@ -570,11 +569,9 @@ fn classify_token(
             // as the parameter binding it resolves to.
             TokenKind::Ident(name) if name == "self" => CONSTANT,
 
-            // Identifiers. A name the AST settles outright — a contextual
-            // keyword, a field name — outranks whatever else would classify
-            // it; everything else prefers the resolved symbol classification
-            // (precomputed in `sem_classes`, keyed by byte start) and falls
-            // back to the lexer/AST heuristics.
+            // Identifiers, in precedence order: a name the AST settles
+            // outright (a contextual keyword, a field name), then the resolved
+            // symbol class from `sem_classes`, then the lexer/AST heuristics.
             TokenKind::Ident(_) => ast_spans
                 .override_at(token.span.start)
                 .or_else(|| sem_classes.and_then(|classes| classes.get(&token.span.start).copied()))
@@ -720,19 +717,16 @@ fn classify_ident(tokens: &[Token], index: usize, ast_spans: &AstSpans) -> (u32,
             | TokenKind::World
             | TokenKind::Effect => return (token_type::TYPE, 0),
             TokenKind::Dot => {
-                // After `.`: method if the call follows, else property. A
-                // `::<` turbofish is a call's type arguments — `.collect::<T>()`
-                // is as much a method as `.collect()`.
                 if calls(tokens, index) {
                     return (token_type::METHOD, 0);
                 }
                 return (token_type::PROPERTY, 0);
             }
             TokenKind::ColonColon => {
-                // After `::`: could be enum member or static method
                 if calls(tokens, index) {
                     return (token_type::FUNCTION, 0);
                 }
+                // More path after it: a middle segment like `B` in `A::B::C`.
                 if follows(tokens, index, 1, &TokenKind::ColonColon) {
                     return (token_type::TYPE, 0);
                 }
@@ -742,8 +736,7 @@ fn classify_ident(tokens: &[Token], index: usize, ast_spans: &AstSpans) -> (u32,
         }
     }
 
-    // 3. A call follows, directly or past its turbofish: `f(`, `f::<T>(`. A
-    // `::` onto a name instead is a path, and step 2 classifies its segments.
+    // 3. A call. A `::` onto a name is a path instead, classified in step 2.
     if calls(tokens, index) {
         return (token_type::FUNCTION, 0);
     }
@@ -760,8 +753,8 @@ fn prev_significant(tokens: &[Token], index: usize) -> Option<&Token> {
     }
 }
 
-/// Whether the token `ahead` positions past `index` is of `kind`. `ahead` is 1
-/// for the next token; the `::<` turbofish needs 2.
+/// Whether the token `ahead` positions past `index` is of `kind`, counting
+/// from 1 for the next one.
 fn follows(tokens: &[Token], index: usize, ahead: usize, kind: &TokenKind) -> bool {
     tokens
         .get(index + ahead)
@@ -769,10 +762,7 @@ fn follows(tokens: &[Token], index: usize, ahead: usize, kind: &TokenKind) -> bo
 }
 
 /// Whether the name at `index` is called: `f(`, or `f::<T>(` past a turbofish.
-///
-/// The turbofish has to be followed to its close, not merely opened. `::<`
-/// alone also starts `Opt::<i32>::None`, where the type arguments qualify a
-/// path and the name is no callee.
+/// `::<` opens `Opt::<i32>::None` too, so the `(` must follow the close.
 fn calls(tokens: &[Token], index: usize) -> bool {
     if follows(tokens, index, 1, &TokenKind::LParen) {
         return true;
@@ -1049,7 +1039,7 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 1, "Tall"), token_type::TYPE);
     }
 
-    /// Only the AST knows, so this asserts the no-semantics path.
+    /// No symbol resolves a literal's field name, so the AST alone settles it.
     #[test]
     fn struct_literal_field_names_are_properties() {
         let src = "struct Gen {\n    state: i32,\n}\nfn run() {\n    let g = Gen {\n        state: 1,\n    };\n}\n";
@@ -1109,10 +1099,8 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 7, "E"), token_type::TYPE);
     }
 
-    /// A path's turbofish is pinned on the identifier, not on a call, when no
-    /// call follows — and its arguments are types there too. The head is no
-    /// callee either: `::<` opens as much a path as a call, and only the `(`
-    /// the turbofish closes onto tells them apart.
+    /// `Opt::<i32>::None` is a path, not a call. Its arguments are types, and
+    /// its head is no callee: only the `(` a turbofish closes onto says which.
     #[test]
     fn a_path_prefix_turbofish_argument_is_a_type() {
         let src = "variant Opt<V> {\n    None,\n    Some(V),\n}\nfn run() {\n    let b = Opt::<i32>::None;\n}\n";
@@ -1121,8 +1109,8 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 5, "Opt"), token_type::VARIABLE);
     }
 
-    /// The same path one segment in, where a `::` precedes the turbofish's
-    /// name: a path middle, classified as one.
+    /// The same path one segment in: a `::` before the name makes it a path
+    /// middle, and the turbofish after it still does not make it a callee.
     #[test]
     fn a_path_middle_before_a_turbofish_is_not_a_function() {
         let src = "fn run() {\n    let b = ns::Opt::<i32>::None;\n}\n";

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -401,13 +401,28 @@ impl SpanCollector {
         }
     }
 
-    /// Mark every key of an attribute object, and of the objects nested in it.
+    /// Mark every key of an attribute object, and of the objects nested in it —
+    /// under an array element as much as under another key.
     fn mark_attr_keys(&mut self, object: &ast::AttrObject) {
         for entry in object.values() {
             self.mark_field_name(entry.key_span);
-            if let Some(nested) = entry.value.as_object() {
-                self.mark_attr_keys(nested);
+            self.mark_attr_value(&entry.value);
+        }
+    }
+
+    /// Descend an attribute value to the objects it holds. A scalar holds none.
+    fn mark_attr_value(&mut self, value: &ast::AttrValue) {
+        match value {
+            ast::AttrValue::Object(nested) => self.mark_attr_keys(nested),
+            ast::AttrValue::Array(items) => {
+                for item in items {
+                    self.mark_attr_value(item);
+                }
             }
+            ast::AttrValue::String(_)
+            | ast::AttrValue::Int(_)
+            | ast::AttrValue::Float(_)
+            | ast::AttrValue::Bool(_) => {}
         }
     }
 
@@ -1043,6 +1058,15 @@ mod tests {
         let tokens = compute(src, None);
         assert_eq!(kind_of(&tokens, src, 2, "generator"), token_type::PROPERTY);
         assert_eq!(kind_of(&tokens, src, 3, "module"), token_type::PROPERTY);
+    }
+
+    /// An array element is an attribute value like any other, so the object
+    /// inside one carries field names too.
+    #[test]
+    fn import_attribute_keys_under_an_array_are_properties() {
+        let src = "use { f } from \"./m.wado\"\n    with {\n        options: {\n            rules: [\n                { name: \"expr\" },\n            ],\n        },\n    };\nfn run() {}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 4, "name"), token_type::PROPERTY);
     }
 
     /// A shorthand field is the field, not the variable it reads.

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -334,12 +334,19 @@ struct AstSpans {
     /// recovered structurally here). Declaration and use sites share the
     /// binding's definition id, so one set covers both.
     param_ids: IndexSet<AstId>,
-    /// byte start -> class for the contextual keywords that double as names,
-    /// which lex as plain identifiers and are only keywords where they sit:
-    /// `test`, `do`, `resume`, `task`, `trap`, and `forward`. Kept apart from
-    /// `map` because it outranks symbol resolution. `self` is not here — the
-    /// language reserves it, so [`classify_token`] recognises it lexically.
-    contextual: IndexMap<usize, (u32, u32)>,
+    /// byte start -> class for the names the AST settles outright, kept apart
+    /// from `map` because these outrank symbol resolution rather than being
+    /// refined by it:
+    /// - the contextual keywords that double as names — `test`, `do`,
+    ///   `resume`, `task`, `trap`, and `forward` — which lex as plain
+    ///   identifiers and are only keywords where they sit. (`self` is not
+    ///   here: the language reserves it, so [`classify_token`] recognises it
+    ///   lexically.)
+    /// - a field name, which names the field even where it also reads a
+    ///   binding: the shorthand `{ state }` resolves to that binding, and
+    ///   letting the symbol win would colour it `variable` on the path that
+    ///   has a snapshot and `property` on the one that does not.
+    overrides: IndexMap<usize, (u32, u32)>,
 }
 
 impl AstSpans {
@@ -359,12 +366,12 @@ impl AstSpans {
         self.param_ids.contains(&id)
     }
 
-    fn mark_contextual(&mut self, start: usize, class: (u32, u32)) {
-        self.contextual.insert(start, class);
+    fn mark_override(&mut self, start: usize, class: (u32, u32)) {
+        self.overrides.insert(start, class);
     }
 
-    fn contextual_at(&self, start: usize) -> Option<(u32, u32)> {
-        self.contextual.get(&start).copied()
+    fn override_at(&self, start: usize) -> Option<(u32, u32)> {
+        self.overrides.get(&start).copied()
     }
 }
 
@@ -397,12 +404,19 @@ impl SpanCollector {
     /// Mark every key of an attribute object, and of the objects nested in it.
     fn mark_attr_keys(&mut self, object: &ast::AttrObject) {
         for entry in object.values() {
-            self.spans
-                .insert(entry.key_span.start, token_type::PROPERTY);
+            self.mark_field_name(entry.key_span);
             if let Some(nested) = entry.value.as_object() {
                 self.mark_attr_keys(nested);
             }
         }
+    }
+
+    /// A name that is the field it writes. It outranks symbol resolution: a
+    /// shorthand `{ state }` resolves to the binding it reads, and deferring to
+    /// that would colour it `variable` wherever a snapshot exists.
+    fn mark_field_name(&mut self, span: Span) {
+        self.spans
+            .mark_override(span.start, (token_type::PROPERTY, 0));
     }
 }
 
@@ -411,12 +425,12 @@ impl AstVisitor for SpanCollector {
         // The contextual keywords lex as identifiers, so the declaration's own
         // span is the only place each can be recognised.
         if let Item::Test(t) = item {
-            self.spans.mark_contextual(t.span.start, KEYWORD);
+            self.spans.mark_override(t.span.start, KEYWORD);
         }
         if let Item::Impl(b) = item
             && let Some(rest) = b.rest
         {
-            self.spans.mark_contextual(rest.keyword_span.start, KEYWORD);
+            self.spans.mark_override(rest.keyword_span.start, KEYWORD);
         }
         // An import attribute's keys are its object's fields, at every depth.
         // They are not expressions, so no other walk reaches them.
@@ -439,7 +453,7 @@ impl AstVisitor for SpanCollector {
     fn visit_stmt(&mut self, stmt: &ast::Stmt) {
         // `task` in `task return expr;` — the statement span opens on it.
         if let ast::Stmt::TaskReturn(t) = stmt {
-            self.spans.mark_contextual(t.span.start, KEYWORD);
+            self.spans.mark_override(t.span.start, KEYWORD);
         }
         ast::walk_stmt(self, stmt);
     }
@@ -452,17 +466,16 @@ impl AstVisitor for SpanCollector {
         }
         // `resume` and `do`, two more contextual keywords.
         if let Expr::Resume(r) = expr {
-            self.spans.mark_contextual(r.span.start, KEYWORD);
+            self.spans.mark_override(r.span.start, KEYWORD);
         }
         if let Expr::WithHandler(w) = expr {
-            self.spans.mark_contextual(w.do_span.start, KEYWORD);
+            self.spans.mark_override(w.do_span.start, KEYWORD);
         }
         // A field name is the field, not a variable — including the shorthand
         // `{ state }`, where it is also a read but names the field first.
         if let Expr::StructLiteral(literal) = expr {
             for field in &literal.fields {
-                self.spans
-                    .insert(field.name_span.start, token_type::PROPERTY);
+                self.mark_field_name(field.name_span);
             }
         }
         ast::walk_expr(self, expr);
@@ -474,7 +487,7 @@ impl AstVisitor for SpanCollector {
         // name, in the `x: inner` form as much as the shorthand.
         if let ast::Pattern::Struct { fields, .. } = pat {
             for field in fields {
-                self.spans.insert(field.span.start, token_type::PROPERTY);
+                self.mark_field_name(field.span);
             }
         }
         ast::walk_pattern(self, pat);
@@ -558,12 +571,13 @@ fn classify_token(
             // as the parameter binding it resolves to.
             TokenKind::Ident(name) if name == "self" => CONSTANT,
 
-            // Identifiers. A contextual keyword outranks whatever else would
-            // classify the name; everything else prefers the resolved symbol
-            // classification (precomputed in `sem_classes`, keyed by byte
-            // start) and falls back to the lexer/AST heuristics.
+            // Identifiers. A name the AST settles outright — a contextual
+            // keyword, a field name — outranks whatever else would classify
+            // it; everything else prefers the resolved symbol classification
+            // (precomputed in `sem_classes`, keyed by byte start) and falls
+            // back to the lexer/AST heuristics.
             TokenKind::Ident(_) => ast_spans
-                .contextual_at(token.span.start)
+                .override_at(token.span.start)
                 .or_else(|| sem_classes.and_then(|classes| classes.get(&token.span.start).copied()))
                 .unwrap_or_else(|| classify_ident(tokens, index, ast_spans)),
 
@@ -1051,7 +1065,8 @@ mod tests {
     /// A closure-type bound's signature is types as much as any other.
     #[test]
     fn a_closure_type_bound_signature_is_types() {
-        let src = "effect E {\n    fn e();\n}\nfn apply<\n    T: fn(i32) -> f64 with E,\n>(f: T) {}\n";
+        let src =
+            "effect E {\n    fn e();\n}\nfn apply<\n    T: fn(i32) -> f64 with E,\n>(f: T) {}\n";
         let tokens = compute(src, None);
         assert_eq!(kind_of(&tokens, src, 4, "i32"), token_type::TYPE);
         assert_eq!(kind_of(&tokens, src, 4, "f64"), token_type::TYPE);

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -750,8 +750,12 @@ fn classify_ident(tokens: &[Token], index: usize, ast_spans: &AstSpans) -> (u32,
         }
     }
 
-    // 3. Check if followed by `(` → function call
-    if follows(tokens, index, 1, &TokenKind::LParen) {
+    // 3. A call follows, directly or past its turbofish: `f(`, `f::<T>(`. A
+    // `::` onto a name instead is a path, and step 2 classifies its segments.
+    if follows(tokens, index, 1, &TokenKind::LParen)
+        || (follows(tokens, index, 1, &TokenKind::ColonColon)
+            && follows(tokens, index, 2, &TokenKind::Lt))
+    {
         return (token_type::FUNCTION, 0);
     }
 
@@ -1130,6 +1134,23 @@ mod tests {
         let src = "fn run() {\n    let x = builtin::array_new::<u8>(1);\n}\n";
         let tokens = compute(src, None);
         assert_eq!(kind_of(&tokens, src, 1, "array_new"), token_type::FUNCTION);
+    }
+
+    /// An unqualified callee carries its turbofish the same way, with no `.`
+    /// or `::` ahead of it to classify it first.
+    #[test]
+    fn a_turbofish_call_on_a_bare_name_is_a_function() {
+        let src = "fn identity<T>(x: T) -> T {\n    return x;\n}\nfn run() {\n    let n = identity::<i32>(1);\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 4, "identity"), token_type::FUNCTION);
+    }
+
+    /// A `::` onto a name is a path, not a call: the head stays a plain name.
+    #[test]
+    fn a_path_head_is_not_a_function() {
+        let src = "fn run() {\n    let x = builtin::array_new::<u8>(1);\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 1, "builtin"), token_type::VARIABLE);
     }
 
     /// The same turbofish after a `.`: type arguments do not make a call a

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -723,25 +723,17 @@ fn classify_ident(tokens: &[Token], index: usize, ast_spans: &AstSpans) -> (u32,
                 // After `.`: method if the call follows, else property. A
                 // `::<` turbofish is a call's type arguments — `.collect::<T>()`
                 // is as much a method as `.collect()`.
-                if follows(tokens, index, 1, &TokenKind::LParen)
-                    || (follows(tokens, index, 1, &TokenKind::ColonColon)
-                        && follows(tokens, index, 2, &TokenKind::Lt))
-                {
+                if calls(tokens, index) {
                     return (token_type::METHOD, 0);
                 }
                 return (token_type::PROPERTY, 0);
             }
             TokenKind::ColonColon => {
                 // After `::`: could be enum member or static method
-                if follows(tokens, index, 1, &TokenKind::LParen) {
+                if calls(tokens, index) {
                     return (token_type::FUNCTION, 0);
                 }
                 if follows(tokens, index, 1, &TokenKind::ColonColon) {
-                    // `::<` is a turbofish, so this is the callee it applies
-                    // to, not the middle of a path like `A::B::C`.
-                    if follows(tokens, index, 2, &TokenKind::Lt) {
-                        return (token_type::FUNCTION, 0);
-                    }
                     return (token_type::TYPE, 0);
                 }
                 return (token_type::ENUM_MEMBER, 0);
@@ -752,10 +744,7 @@ fn classify_ident(tokens: &[Token], index: usize, ast_spans: &AstSpans) -> (u32,
 
     // 3. A call follows, directly or past its turbofish: `f(`, `f::<T>(`. A
     // `::` onto a name instead is a path, and step 2 classifies its segments.
-    if follows(tokens, index, 1, &TokenKind::LParen)
-        || (follows(tokens, index, 1, &TokenKind::ColonColon)
-            && follows(tokens, index, 2, &TokenKind::Lt))
-    {
+    if calls(tokens, index) {
         return (token_type::FUNCTION, 0);
     }
 
@@ -777,6 +766,38 @@ fn follows(tokens: &[Token], index: usize, ahead: usize, kind: &TokenKind) -> bo
     tokens
         .get(index + ahead)
         .is_some_and(|t| std::mem::discriminant(&t.kind) == std::mem::discriminant(kind))
+}
+
+/// Whether the name at `index` is called: `f(`, or `f::<T>(` past a turbofish.
+///
+/// The turbofish has to be followed to its close, not merely opened. `::<`
+/// alone also starts `Opt::<i32>::None`, where the type arguments qualify a
+/// path and the name is no callee.
+fn calls(tokens: &[Token], index: usize) -> bool {
+    if follows(tokens, index, 1, &TokenKind::LParen) {
+        return true;
+    }
+    if !follows(tokens, index, 1, &TokenKind::ColonColon)
+        || !follows(tokens, index, 2, &TokenKind::Lt)
+    {
+        return false;
+    }
+    // `<` never opens a comparison in type-argument position, so nesting is
+    // decidable by counting. A `>>` closes two levels: the lexer emits one
+    // token for the pair that `List<List<i32>>` ends on.
+    let mut depth = 0usize;
+    for (at, token) in tokens.iter().enumerate().skip(index + 2) {
+        depth = match token.kind {
+            TokenKind::Lt => depth + 1,
+            TokenKind::Gt => depth.saturating_sub(1),
+            TokenKind::GtGt => depth.saturating_sub(2),
+            _ => continue,
+        };
+        if depth == 0 {
+            return follows(tokens, at, 1, &TokenKind::LParen);
+        }
+    }
+    false
 }
 
 #[cfg(test)]
@@ -1089,12 +1110,24 @@ mod tests {
     }
 
     /// A path's turbofish is pinned on the identifier, not on a call, when no
-    /// call follows — and its arguments are types there too.
+    /// call follows — and its arguments are types there too. The head is no
+    /// callee either: `::<` opens as much a path as a call, and only the `(`
+    /// the turbofish closes onto tells them apart.
     #[test]
     fn a_path_prefix_turbofish_argument_is_a_type() {
         let src = "variant Opt<V> {\n    None,\n    Some(V),\n}\nfn run() {\n    let b = Opt::<i32>::None;\n}\n";
         let tokens = compute(src, None);
         assert_eq!(kind_of(&tokens, src, 5, "i32"), token_type::TYPE);
+        assert_eq!(kind_of(&tokens, src, 5, "Opt"), token_type::VARIABLE);
+    }
+
+    /// The same path one segment in, where a `::` precedes the turbofish's
+    /// name: a path middle, classified as one.
+    #[test]
+    fn a_path_middle_before_a_turbofish_is_not_a_function() {
+        let src = "fn run() {\n    let b = ns::Opt::<i32>::None;\n}\n";
+        let tokens = compute(src, None);
+        assert_eq!(kind_of(&tokens, src, 1, "Opt"), token_type::TYPE);
     }
 
     /// `Output` in `Builder<Output = T>` names an associated type.

--- a/wado-lsp/src/semantic_tokens.rs
+++ b/wado-lsp/src/semantic_tokens.rs
@@ -334,18 +334,11 @@ struct AstSpans {
     /// recovered structurally here). Declaration and use sites share the
     /// binding's definition id, so one set covers both.
     param_ids: IndexSet<AstId>,
-    /// byte start -> class for the names the AST settles outright, kept apart
-    /// from `map` because these outrank symbol resolution rather than being
-    /// refined by it:
-    /// - the contextual keywords that double as names — `test`, `do`,
-    ///   `resume`, `task`, `trap`, and `forward` — which lex as plain
-    ///   identifiers and are only keywords where they sit. (`self` is not
-    ///   here: the language reserves it, so [`classify_token`] recognises it
-    ///   lexically.)
-    /// - a field name, which names the field even where it also reads a
-    ///   binding: the shorthand `{ state }` resolves to that binding, and
-    ///   letting the symbol win would colour it `variable` on the path that
-    ///   has a snapshot and `property` on the one that does not.
+    /// byte start -> class for the names the AST settles outright: the
+    /// contextual keywords, and the field names. Apart from `map` because
+    /// these outrank symbol resolution rather than being refined by it — a
+    /// shorthand `{ state }` resolves to the binding it reads, and the symbol
+    /// winning would colour it `variable` wherever a snapshot exists.
     overrides: IndexMap<usize, (u32, u32)>,
 }
 
@@ -410,7 +403,6 @@ impl SpanCollector {
         }
     }
 
-    /// Descend an attribute value to the objects it holds. A scalar holds none.
     fn mark_attr_value(&mut self, value: &ast::AttrValue) {
         match value {
             ast::AttrValue::Object(nested) => self.mark_attr_keys(nested),
@@ -426,9 +418,6 @@ impl SpanCollector {
         }
     }
 
-    /// A name that is the field it writes. It outranks symbol resolution: a
-    /// shorthand `{ state }` resolves to the binding it reads, and deferring to
-    /// that would colour it `variable` wherever a snapshot exists.
     fn mark_field_name(&mut self, span: Span) {
         self.spans
             .mark_override(span.start, (token_type::PROPERTY, 0));
@@ -447,8 +436,7 @@ impl AstVisitor for SpanCollector {
         {
             self.spans.mark_override(rest.keyword_span.start, KEYWORD);
         }
-        // An import attribute's keys are its object's fields, at every depth.
-        // They are not expressions, so no other walk reaches them.
+        // Attribute keys are not expressions, so no other walk reaches them.
         if let Item::Use(decl) = item
             && let Some(attributes) = &decl.attributes
         {
@@ -486,8 +474,6 @@ impl AstVisitor for SpanCollector {
         if let Expr::WithHandler(w) = expr {
             self.spans.mark_override(w.do_span.start, KEYWORD);
         }
-        // A field name is the field, not a variable — including the shorthand
-        // `{ state }`, where it is also a read but names the field first.
         if let Expr::StructLiteral(literal) = expr {
             for field in &literal.fields {
                 self.mark_field_name(field.name_span);
@@ -497,9 +483,7 @@ impl AstVisitor for SpanCollector {
     }
 
     fn visit_pattern(&mut self, pat: &ast::Pattern) {
-        // The destructuring side of the same rule: `let { x } = p` names the
-        // field first, and binds through it. A field's span starts at its
-        // name, in the `x: inner` form as much as the shorthand.
+        // A field's span starts at its name, in `x: inner` as much as `x`.
         if let ast::Pattern::Struct { fields, .. } = pat {
             for field in fields {
                 self.mark_field_name(field.span);
@@ -1040,8 +1024,7 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 1, "Tall"), token_type::TYPE);
     }
 
-    /// A struct literal's field names are properties, not the variables the
-    /// default arm made of them. Only the AST knows, so no semantics here.
+    /// Only the AST knows, so this asserts the no-semantics path.
     #[test]
     fn struct_literal_field_names_are_properties() {
         let src = "struct Gen {\n    state: i32,\n}\nfn run() {\n    let g = Gen {\n        state: 1,\n    };\n}\n";
@@ -1049,9 +1032,8 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 5, "state"), token_type::PROPERTY);
     }
 
-    /// An import attribute's keys are its object's fields, nested ones too.
-    /// They are not expressions, so only the `use` item's own walk reaches
-    /// them.
+    /// Attribute keys are not expressions, so only the `use` item's own walk
+    /// reaches them — the nested ones included.
     #[test]
     fn import_attribute_keys_are_properties() {
         let src = "use { f } from \"./m.wado\"\n    with {\n        generator: {\n            module: \"lib:gale\",\n        },\n    };\nfn run() {}\n";
@@ -1060,8 +1042,6 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 3, "module"), token_type::PROPERTY);
     }
 
-    /// An array element is an attribute value like any other, so the object
-    /// inside one carries field names too.
     #[test]
     fn import_attribute_keys_under_an_array_are_properties() {
         let src = "use { f } from \"./m.wado\"\n    with {\n        options: {\n            rules: [\n                { name: \"expr\" },\n            ],\n        },\n    };\nfn run() {}\n";
@@ -1069,7 +1049,6 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 4, "name"), token_type::PROPERTY);
     }
 
-    /// A shorthand field is the field, not the variable it reads.
     #[test]
     fn a_shorthand_struct_literal_field_is_a_property() {
         let src = "struct Gen {\n    state: i32,\n}\nfn run() {\n    let state = 1;\n    let g = Gen {\n        state,\n    };\n}\n";
@@ -1077,7 +1056,6 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 6, "state"), token_type::PROPERTY);
     }
 
-    /// The destructuring side of the same rule.
     #[test]
     fn a_struct_pattern_field_is_a_property() {
         let src = "fn run() {\n    let p = { x: 1, y: 2 };\n    let {\n        x,\n        y: renamed,\n    } = p;\n}\n";
@@ -1086,7 +1064,6 @@ mod tests {
         assert_eq!(kind_of(&tokens, src, 4, "y"), token_type::PROPERTY);
     }
 
-    /// A closure-type bound's signature is types as much as any other.
     #[test]
     fn a_closure_type_bound_signature_is_types() {
         let src =

--- a/wado-lsp/tests/semantic_tokens.rs
+++ b/wado-lsp/tests/semantic_tokens.rs
@@ -126,10 +126,8 @@ fn f() {
     assert_ne!(c.modifiers & token_modifier::READONLY, 0);
 }
 
-/// A shorthand field also reads a binding, and the snapshot resolves it. The
-/// field name wins anyway, so the class does not depend on whether a snapshot
-/// was available — which is what the unit tests, running without one, cannot
-/// say.
+/// A snapshot resolves a shorthand field to the binding it reads, and the
+/// field name wins anyway. The unit tests run without one and cannot say that.
 #[test]
 fn a_shorthand_field_is_a_property_with_a_snapshot_too() {
     let src = "\

--- a/wado-lsp/tests/semantic_tokens.rs
+++ b/wado-lsp/tests/semantic_tokens.rs
@@ -125,3 +125,29 @@ fn f() {
     assert_eq!(c.token_type, token_type::VARIABLE);
     assert_ne!(c.modifiers & token_modifier::READONLY, 0);
 }
+
+/// A shorthand field also reads a binding, and the snapshot resolves it. The
+/// field name wins anyway, so the class does not depend on whether a snapshot
+/// was available — which is what the unit tests, running without one, cannot
+/// say.
+#[test]
+fn a_shorthand_field_is_a_property_with_a_snapshot_too() {
+    let src = "\
+struct Gen { state: i32 }
+fn make(state: i32) -> Gen {
+    return Gen { state };
+}
+fn take(g: Gen) -> i32 {
+    let { state } = g;
+    return state;
+}
+";
+    let tokens = tokens_for(src);
+
+    // `state` in the literal `Gen { state }`.
+    assert_eq!(at(&tokens, 2, 17).token_type, token_type::PROPERTY);
+    // `state` in the pattern `let { state } = g`.
+    assert_eq!(at(&tokens, 5, 10).token_type, token_type::PROPERTY);
+    // The binding it reads is still a variable at its other use site.
+    assert_eq!(at(&tokens, 6, 11).token_type, token_type::VARIABLE);
+}


### PR DESCRIPTION
`check-highlight` compares every class both highlighters emit, identifiers included.

## The gate

`Class` splits the identifier kinds into `Type`, `Property`, `Method`, `EnumMember` and `Name`, and a divergence is a defect whenever both sides classified the span. The grammar may still leave an identifier plain — telling a function from a variable takes name resolution — and that silence is reported as a capability gap rather than gated.

`class_of_token` names every legend entry, so a token type added to `TOKEN_TYPES` fails there instead of defaulting into the ungated `Name`. The report groups by the compiler's unflattened kind alongside the class, because `name` against `property` is a method call or a struct field depending on it.

A file either side rejects is skipped and counted. Past a syntax error the two recoveries describe different programs, so comparing them measures the recoveries; `check-grammar` owns that divergence.

## Grammar and query

`memberName` is the token set, and each use site wraps it in a one-token rule that carries the capture: `methodName` for `.name(...)`, `fieldName` for `.name` and a literal's or pattern's `name:`, `pathSegment` for a `::` segment. The wrapper is what lets the call form take `@function.method` without repainting its arguments.

A `::` segment stays uncoloured. `Option::None` and `Foo::new` are one shape to the grammar, and the call's `(` sits outside the path rule, so only name resolution splits them. `stores[b]` names a parameter and takes `@variable`.

`postfixOp` requires the call after `.name::<T>`, matching `parse_postfix`.

## Classification

The compiler's syntax-only path reaches the type positions its AST walks drop. Types: a type pack's member at its declaration and its uses, both segments of `ns::Value`, an associated-type binding in `Builder<Output = T>`, a path-prefix turbofish's arguments in `Opt::<i32>::None`, a closure bound's signature and its `with` clause, a world export's signature, and every effect named in a `with` clause. Properties: struct-literal and struct-pattern field names, and an import attribute's keys at every depth, under an array element as much as under another key. `.collect::<T>()` is a method and `builtin::f::<T>()` a function.

A field name sits in `AstSpans::overrides`, ahead of symbol resolution: the shorthand `{ state }` resolves to the binding it reads, and the symbol winning would colour it `variable` wherever a snapshot exists.

## AST

`ImportAttributes` and `AttrValue::Object` hold `AttrEntry`, so every attribute key carries its own span — the prerequisite for #1942, which this branch does not close.

`walk_expr` visits a path-prefix turbofish's type arguments, `walk_trait_bounds` visits a bound's `fn_signature` through the walk `Type::Function` shares, and `walk_item` visits a world's export signatures. `TupleTypeDecl` keeps the head it was declared with, so `wado format` prints the pack name that was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZ6RkYbQ828izPs92pthvo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZ6RkYbQ828izPs92pthvo)_