### PR TITLE
docs: record clamp and the rule builtin::select follows

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1120,6 +1120,7 @@ i32::from_str_radix(&"1010", 2)         // Result<i32, ParseIntError> (radix 2..
 i32::from_str_range(&"xyz42abc", 3, 5)  // parse a byte range without substring alloc
 
 i32::min(a, b)  i32::max(a, b)
+i32::clamp(v, lo, hi)                 // traps when lo > hi
 
 // char classification and conversion
 let code = 'A' as i32;                // 65

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -30,6 +30,11 @@ release build embeds them with `include_str!`, as does any `wasm32` build, which
 has no filesystem. `lib/wasi/` and `lib/core/kiln/` are generated from WIT: read
 `wado-from-idl/AGENTS.md` first.
 
+`builtin::select` returns one of its operands rather than a copy of it, so it is
+correct only for a type that needs no value copy. Write the `if` for `i128`,
+`u128` and any composite: `optimize/select_lowering.rs` rewrites the ones that
+qualify and refuses the rest on the same ground.
+
 ## E2E Tests
 
 `.wado` files in `tests/fixtures/`, expectations in a trailing `__DATA__` JSON

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -5,8 +5,10 @@ The Wado compiler crate. The NIR optimizer has its own guide:
 
 ## Rules
 
-- `codegen.rs` emits the `Package` as is; it knows nothing of the earlier phases.
-- Only `name.rs` knows a name format. Mangling and monomorphization go through it.
+- `src/codegen.rs` emits the `Package` as is; it knows nothing of the earlier
+  phases.
+- Only `src/name.rs` knows a name format. Mangling and monomorphization go
+  through it.
 - A declaration is identified by its `DefId`, never by its name — see
   [WEP: Declaration Identity](../docs/wep-2026-08-12-declaration-identity.md).
 - Walk IR through the visitor utilities, and answer a question with one resolver
@@ -27,7 +29,7 @@ release build embeds them, as does any `wasm32` build, which has no filesystem.
 `wado-from-idl/AGENTS.md` first.
 
 `builtin::select` returns one of its operands rather than a copy, so write the
-`if` for `i128`, `u128` and any composite: `optimize/select_lowering.rs`
+`if` for `i128`, `u128` and any composite: `src/optimize/select_lowering.rs`
 rewrites what qualifies and refuses the rest on that ground.
 
 ## E2E Tests

--- a/wado-compiler/AGENTS.md
+++ b/wado-compiler/AGENTS.md
@@ -1,22 +1,18 @@
 # wado-compiler
 
-The Wado compiler crate: frontend, IR pipeline, optimizer, and codegen. The NIR
-optimizer has its own guide: [`docs/optimizer.md`](../docs/optimizer.md).
+The Wado compiler crate. The NIR optimizer has its own guide:
+[`docs/optimizer.md`](../docs/optimizer.md).
 
 ## Rules
 
 - `codegen.rs` emits the `Package` as is; it knows nothing of the earlier phases.
-- Name mangling and monomorphization go through `name.rs`. No other component knows a name format.
+- Only `name.rs` knows a name format. Mangling and monomorphization go through it.
 - A declaration is identified by its `DefId`, never by its name — see
   [WEP: Declaration Identity](../docs/wep-2026-08-12-declaration-identity.md).
-- Walk IR through the visitor utilities, not by hand, and answer a question
-  once: one resolver total over the IR, rather than partial walkers, which
-  multiply until each misses a different shape.
-- Take a finding one altitude up: it names a line, so ask whether that shape
-  occurs elsewhere in the IR before fixing there.
+- Walk IR through the visitor utilities, and answer a question with one resolver
+  over the IR rather than partial walkers, which each miss a different shape.
 - Optimize as far as correctness allows. A conservatism is a claim about
-  precision: measure what it buys before keeping it, and drop the ones that buy
-  nothing.
+  precision: measure what it buys, and drop the ones that buy nothing.
 - Escalate the test scope as the work matures: `cargo check` while iterating,
   `mise run test` during development, `mise run test-wado` when wrapping up.
 - This crate must compile for `wasm32-unknown-unknown` (checked in CI). Keep
@@ -26,14 +22,13 @@ optimizer has its own guide: [`docs/optimizer.md`](../docs/optimizer.md).
 
 `src/stdlib.rs` lists `lib/core/` and `lib/wasi/`. A dev build reads them from
 disk, so editing one takes effect on the next `wado` run with no rebuild. A
-release build embeds them with `include_str!`, as does any `wasm32` build, which
-has no filesystem. `lib/wasi/` and `lib/core/kiln/` are generated from WIT: read
+release build embeds them, as does any `wasm32` build, which has no filesystem.
+`lib/wasi/` and `lib/core/kiln/` are generated from WIT: read
 `wado-from-idl/AGENTS.md` first.
 
-`builtin::select` returns one of its operands rather than a copy of it, so it is
-correct only for a type that needs no value copy. Write the `if` for `i128`,
-`u128` and any composite: `optimize/select_lowering.rs` rewrites the ones that
-qualify and refuses the rest on the same ground.
+`builtin::select` returns one of its operands rather than a copy, so write the
+`if` for `i128`, `u128` and any composite: `optimize/select_lowering.rs`
+rewrites what qualifies and refuses the rest on that ground.
 
 ## E2E Tests
 


### PR DESCRIPTION
Two things this session's work on `core:prelude` and `core:url` turned up, written where the next person will read them.

## The cheatsheet lists `clamp`

`i32::clamp(v, lo, hi)` sits beside `min` and `max` in the primitive-method block, with the one part of its contract a signature cannot show: an empty range traps.

## `wado-compiler/AGENTS.md` states the rule `builtin::select` follows

`builtin::select` returns one of its operands rather than a copy, so it is for a type that needs no value copy. `optimize/select_lowering.rs` already refuses the rest on that ground; the guide names both the rule and the pass, so someone writing a prelude method reads it before reaching for `select` by hand on `i128`, `u128` or a composite, and can check the claim against the pass when it drifts.

## The guide says each thing once

"Fix the class" lives in the root guide, so the crate guide does not restate it as "take a finding one altitude up". The intro names the crate rather than listing its own directories, and the standard-library note leaves the macro name to `src/stdlib.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkXjZLtdn5AXASiehcNczY

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkXjZLtdn5AXASiehcNczY)_