### PR TITLE
fix(optimizer): unify the per-call verdicts the value graph's loop summary and straight-line walk read

### DIFF
--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -49,16 +49,16 @@ The design, its soundness invariants, the standing "do not reintroduce" rules, a
 
 ## NIR passes
 
-`peephole` is not one of them but the session the position-flexible ones share:
-every local rewrite rule interleaved over one engine worklist per function
-rather than a walk apiece. It hosts `aggregate_forward`, `const_branch_prune`,
-the env-free half of `const_folding`, `drop_value`, `elide_box_local`,
-`elide_local`, `if_chain_to_match`, `labeled_block_fusion`, `match_to_switch`,
-`ref_elim`, `slot_temp_sroa`, `string_push`, and `tuple_projection`. It runs
-twice per fixed-point iteration, pre- and post-`inline`, so each rule sees the
-instruction window the other exposes; `match_to_switch` and `if_chain_to_match`
-are pre-inline only, `ref_elim` / `elide_box_local` / `slot_temp_sroa` /
-`drop_value` post-inline only.
+`peephole` is not a pass. It is the one engine session per function that the
+position-flexible rules share, each on the same worklist instead of a walk of
+its own. It hosts `aggregate_forward`, `const_branch_prune`, the env-free half
+of `const_folding`, `drop_value`, `elide_box_local`, `elide_local`,
+`if_chain_to_match`, `labeled_block_fusion`, `match_to_switch`, `ref_elim`,
+`slot_temp_sroa`, `string_push`, and `tuple_projection`. It runs twice per
+fixed-point iteration, before and after `inline`, so each rule sees the
+instruction window the other exposes. `match_to_switch` and `if_chain_to_match`
+run only before; `ref_elim`, `elide_box_local`, `slot_temp_sroa`, and
+`drop_value` run only after.
 
 Allocation and aggregate:
 
@@ -81,7 +81,7 @@ Variant and reference:
 - `labeled_block_fusion` — delete the intermediate an inlined `?` helper leaves at its consumer, threading each producer directly to the value it yields. Recognises the `Option`/`Result` and the `[tag, slots…]` `sroa_variant_return` leaves in its place.
 - `slot_temp_sroa` — decompose the aggregate temp an inlined helper leaves where fusion cannot relocate the consumer into the block, as in the value-producing `let x = f()?` or a two-armed `get_pow10`. Each projected slot gets a local declared ahead of the block, so its definition dominates every read, and the exits assign it instead of building the aggregate. Takes the `[tag, slots…]` tuple `sroa_variant_return` leaves, a struct literal whose reads cover every field, and an exit handing over the aggregate rather than its fields, which it binds and projects.
 - `ref_elim` — drop reference bindings read only via field access, rewriting each read to the source; a shared borrow of a pure aggregate substitutes the aggregate so its projections fold.
-- `aggregate_forward` — deliver a freshly built aggregate to its consumer directly, so the binding `sroa` sees is the literal. `?` leaves two hops in the way: `sroa_variant_return` puts a `Result`-returning call into slots, so an always-succeeding inlined callee builds the `Ok` only for the caller to open it again and re-bind the payload. Neither hop is elidable alone — `elide_local` wants a local nobody reads, `copy_prop` will not propagate into one later written.
+- `aggregate_forward` — deliver a freshly built aggregate to its consumer directly, so the binding `sroa` sees is the literal. `?` leaves two hops in the way. `sroa_variant_return` puts a `Result`-returning call into slots, so an always-succeeding inlined callee builds the `Ok` only for the caller to open it again and re-bind the payload. Neither hop is elidable alone: `elide_local` wants a local nobody reads, and `copy_prop` will not propagate into one later written.
 - `tuple_projection` — `[a, b, c].1` → `b`. A tuple literal has no identity, so a field read of one built in place is that element; the unselected elements are dropped, so each must be deletable.
 
 Scalar and dataflow:

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -49,6 +49,17 @@ The design, its soundness invariants, the standing "do not reintroduce" rules, a
 
 ## NIR passes
 
+`peephole` is not one of them but the session the position-flexible ones share:
+every local rewrite rule interleaved over one engine worklist per function
+rather than a walk apiece. It hosts `aggregate_forward`, `const_branch_prune`,
+the env-free half of `const_folding`, `drop_value`, `elide_box_local`,
+`elide_local`, `if_chain_to_match`, `labeled_block_fusion`, `match_to_switch`,
+`ref_elim`, `slot_temp_sroa`, `string_push`, and `tuple_projection`. It runs
+twice per fixed-point iteration, pre- and post-`inline`, so each rule sees the
+instruction window the other exposes; `match_to_switch` and `if_chain_to_match`
+are pre-inline only, `ref_elim` / `elide_box_local` / `slot_temp_sroa` /
+`drop_value` post-inline only.
+
 Allocation and aggregate:
 
 - `inline` — replace calls to small, non-recursive functions with their body; reference parameters and receivers inline too. `#[inline]` raises the budget 5x, `#[inline(always)]` forces it, `#[inline(never)]` and cold call sites opt out. A callee over budget as written is re-read under the constants its callers pass. `--optimize-inline-growth` additionally caps what the pass adds to the whole unit; no level sets it.
@@ -70,6 +81,8 @@ Variant and reference:
 - `labeled_block_fusion` — delete the intermediate an inlined `?` helper leaves at its consumer, threading each producer directly to the value it yields. Recognises the `Option`/`Result` and the `[tag, slots…]` `sroa_variant_return` leaves in its place.
 - `slot_temp_sroa` — decompose the aggregate temp an inlined helper leaves where fusion cannot relocate the consumer into the block, as in the value-producing `let x = f()?` or a two-armed `get_pow10`. Each projected slot gets a local declared ahead of the block, so its definition dominates every read, and the exits assign it instead of building the aggregate. Takes the `[tag, slots…]` tuple `sroa_variant_return` leaves, a struct literal whose reads cover every field, and an exit handing over the aggregate rather than its fields, which it binds and projects.
 - `ref_elim` — drop reference bindings read only via field access, rewriting each read to the source; a shared borrow of a pure aggregate substitutes the aggregate so its projections fold.
+- `aggregate_forward` — deliver a freshly built aggregate to its consumer directly, so the binding `sroa` sees is the literal. `?` leaves two hops in the way: `sroa_variant_return` puts a `Result`-returning call into slots, so an always-succeeding inlined callee builds the `Ok` only for the caller to open it again and re-bind the payload. Neither hop is elidable alone — `elide_local` wants a local nobody reads, `copy_prop` will not propagate into one later written.
+- `tuple_projection` — `[a, b, c].1` → `b`. A tuple literal has no identity, so a field read of one built in place is that element; the unselected elements are dropped, so each must be deletable.
 
 Scalar and dataflow:
 
@@ -135,6 +148,8 @@ Branch hints are transparent annotations on `if`/`br_if` conditions: a pass look
 ## Shared facilities
 
 - `mod_ref.rs` — a conservative mod/ref summary backing the move-safety predicates (`may_clobber`, `can_move_past`).
+- `alias.rs` — per-function alias analysis feeding the value-graph builder. One body walk serves both the alias analysis and the mutable-escape scan; `builder_alias_sets` finishes the syntactic mutation set into `mut_escaped`, which is what bounds each pass's heap-write invalidation.
+- `gate.rs` — the per-function dirty-set gate. Its design is the WEP's.
 - `arena_query.rs` — shared arena queries (purity and trap classification, mutation and place-root checks, break-target search, the promoted-read queries). The census walk itself is on `Body`, memoized per session by the engine.
 - `nir_visitor.rs` — the shared pre/post-order visitor traits.
 

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -1,244 +1,236 @@
 # WEP: NIR Optimizer Architecture
 
-The NIR optimizer is a **two-tier IR** — a structured effect skeleton plus a
-hash-consed graph of pure values — rewritten by a **worklist engine** over
-per-function sessions, scheduled by a **per-function dirty-set gate**, and
-**extracted once** into WIR.
+The NIR optimizer is a two-tier IR: a structured effect skeleton plus a
+hash-consed graph of pure values. A worklist engine rewrites it one function at
+a time, a per-function dirty-set gate schedules the passes, and the result is
+extracted once into WIR.
 
-This WEP is the design. The pass inventory lives in
-[`docs/optimizer.md`](./optimizer.md); every implementation detail — node kinds,
-rule predicates, pass ordering, which function holds what — is owned by the code
-(`nir_arena.rs`, `nir_value_graph.rs`, `nir_engine.rs`, `optimize/`).
-
-That division is what keeps this document true. A decision and the measurement
-that settled it are dated facts: they do not go stale. A description of how the
-code is arranged today goes stale the moment the code moves, and every such
-sentence here is one more thing to keep in sync with a refactor that has no
-reason to look. So this WEP states what was decided, why, what it obliges, and
-what is still open — and names an identifier only where the decision is about
-that identifier. A detail a reader needs in order to act correctly belongs in a
-doc comment beside the code it describes, where it cannot drift.
+This WEP records decisions, the measurements that settled them, the obligations
+they impose, and what is still open. It names an identifier only when the
+decision is about that identifier. Everything else is the code's to say: node
+kinds, rule predicates, pass order, and which function holds what live in
+`nir_arena.rs`, `nir_value_graph.rs`, `nir_engine.rs`, and `optimize/`, and the
+pass inventory in [`docs/optimizer.md`](./optimizer.md). A decision does not go
+stale. A description of the code does, the moment the code moves, so a detail a
+reader needs in order to act belongs in a doc comment beside the code.
 
 ## Terms
 
-- Skeleton — the tier that carries execution order: statements, control flow,
+- Skeleton: the tier that carries execution order. Statements, control flow,
   calls, assignments, allocation. Document order is effect order. Pure values
-  have no place in an order, so they are not stored here; what is left is the
-  bare frame of the computation.
-- Hash-consing — interning a value by its structure, so two structurally
-  identical values are handed the same `ValueId` at construction. Equality
-  becomes `==` on a `u32`, and a common subexpression is common before any pass
-  looks at it.
-- Promoted — a skeleton operand slot that holds a `ValueId` instead of pointing
-  at a sub-expression node. The value moved out of the skeleton and into the
-  pool; nothing in the arena spells it any more.
+  have no place in an order, so they are not stored here.
+- Hash-consing: interning a value by its structure, so two structurally
+  identical values get the same `ValueId` when built. Equality is `==` on a
+  `u32`, and a common subexpression is common before any pass looks at it.
+- Promoted: a skeleton operand slot that holds a `ValueId` instead of a
+  sub-expression node. The value has moved out of the skeleton into the pool.
 
 ## Context
 
-The optimizer was ~31 independent passes, each a full mutating walk over an
-owned tree body, run inside a global fixed-point loop. Two costs followed from
-that shape:
+The optimizer was about 31 independent passes. Each was a full mutating walk over
+an owned tree body, inside a global fixed-point loop. That shape had two costs.
 
-- No stable handles and no parent / use edges. `&mut NirExpr` recursion owns the
-  path to a node, so nothing could hold a node across an edit — a worklist was
-  not expressible, and CSE hand-rolled a structural `CseKey` because NIR offered
-  nothing better.
-- Every pass re-derived its own analysis. Pure-value identity was per-pass keys;
-  reaching definitions were rebuilt per pass (`KnownValues`, `DefMap`,
+- No stable handles and no parent or use edges. `&mut NirExpr` recursion owned
+  the path to a node, so nothing could hold a node across an edit. A worklist
+  could not be expressed, and CSE hand-rolled a structural `CseKey` because NIR
+  offered nothing better.
+- Every pass re-derived its own analysis. Pure-value identity was a per-pass
+  key. Reaching definitions were rebuilt per pass (`KnownValues`, `DefMap`,
   `env` / `field_env`). A native profile of `wado compile -O2` on `package-gale`
-  put `optimize` at 52 – 65 % of the whole compile, with the per-function value
-  graph rebuilt 2.67× per function and ~27 % of CPU in the allocation churn those
-  rebuilds generate.
+  put `optimize` at 52–65 % of the compile, with the per-function value graph
+  rebuilt 2.67 times per function and about 27 % of CPU in the allocation churn
+  those rebuilds generate.
 
-The second cost is structural, not a tuning problem: an analysis derived from a
-mutable tree must be re-derived after every mutation. The fix is to stop deriving
-it.
+The second cost is structural. An analysis derived from a mutable tree must be
+re-derived after every mutation. The fix is to stop deriving it.
 
 ## Decision
 
-### Layer 1 — the skeleton arena (`nir_arena.rs`)
+### Layer 1: the skeleton arena (`nir_arena.rs`)
 
-A function body is a per-function arena, `Body`, and is the canonical post-lower
-form: `lower::translate` builds it directly and `wir_build` reads it directly.
-A closure's call method and a non-trivial global initializer are bodies too, so
-every pass reaches them without a special case.
+A function body is a per-function arena, `Body`. It is the canonical post-lower
+form: `lower::translate` builds it and `wir_build` reads it. A closure's call
+method and a non-trivial global initializer are bodies too, so every pass reaches
+them without a special case.
 
 - A node is addressed by a stable id, so a worklist entry survives an edit to
-  the node it names — the handle the tree form could not offer. The id spaces
-  are typed per node category rather than uniform, so a rule signature rejects a
-  statement where an expression belongs.
-- Only a node a rewrite can target independently bears an id. The records that
-  are always rewritten through their parent live inline in it, and are
+  the node it names. The tree form could not offer that handle. The id spaces
+  are typed per node category, so a rule signature rejects a statement where an
+  expression belongs.
+- Only a node a rewrite can target on its own bears an id. A record that is
+  always rewritten through its parent lives inline in that parent and is
   transparent to the parent map.
-- Spans are skeleton identity: they feed diagnostics, optimizer remarks, and
-  DWARF. Layer 2 is the span-free layer, not this one.
-- Parent edges and a per-local use index are derived once when a session opens
-  and maintained incrementally by the edit API from there — never re-derived
-  under a running session.
+- Spans are skeleton identity. They feed diagnostics, optimizer remarks, and
+  DWARF. Layer 2 is the span-free layer.
+- Parent edges and a per-local use index are derived once when a session opens.
+  The edit API maintains them from then on. They are never re-derived under a
+  running session.
 - Nodes are not freed mid-run. Liveness is reachability from the root, and the
   use index ignores orphans.
 
-Document order is effect order. The skeleton carries statements, control flow,
-and the expressions that are effectful or allocate; pure values have no place in
-an order and live in Layer 2.
-
-### Layer 2 — the live ValueGraph (`nir_value_graph.rs`)
+### Layer 2: the live ValueGraph (`nir_value_graph.rs`)
 
 Pure values are hash-consed into a per-function `ValuePool`, indexed by
-`ValueId`: two structurally equivalent pure expressions share one id, and
-equality is `==` on a `u32`. The graph is where pure values **live**, not a
-side-table derived from the skeleton.
+`ValueId`. Two structurally equivalent pure expressions share one id. The graph
+is where pure values live. It is not a side-table derived from the skeleton.
 
-- The kinds cover what a pure value can be: constants, an opaque unknown,
+- The kinds cover what a pure value can be: a constant, an opaque unknown,
   arithmetic, a structural merge, a loop recurrence, and a field read carried at
   a heap version.
-- There is no kind naming a local. Flow is resolved into the graph **once, at
-  build**: the builder threads a per-local current value, merges at joins,
-  opens a recurrence at a loop, and bumps heap versions where the skeleton may
-  write. A read's `ValueId` is fixed to the value dominant at that point, so
-  reading a local is not an operation the graph can express — it is already
-  resolved.
-- Identity is structural, and a `ValueId` is stable once allocated: interning is
+- There is no kind naming a local. Flow is resolved into the graph once, at
+  build. The builder threads a per-local current value, merges at joins, opens a
+  recurrence at a loop, and bumps heap versions where the skeleton may write. A
+  read's `ValueId` is fixed to the value dominant at that point, so the graph
+  cannot express "read a local"; that is already resolved.
+- Identity is structural, and a `ValueId` is stable once allocated. Interning is
   pure hash-consing, with no e-class merges and so no representative lookup. A
-  rewrite that proves `a ≡ b` points the operand slot at `b`; it never merges
+  rewrite that proves `a ≡ b` points the operand slot at `b`. It never merges
   two ids. Rules apply eagerly and once per match, never searched to a fixed
   point.
 
-Build once, rewrite eagerly, extract once — the shape Cranelift's aegraph
-mid-end takes, minus its union-find.
+Build once, rewrite eagerly, extract once. This is the shape of Cranelift's
+aegraph mid-end, minus its union-find.
 
-A constant aggregate is one value however deep it is; materialising one is an
-allocation, which is `const_object_globalization`'s decision, so an aggregate
-constant is never frozen into an operand slot.
+A constant aggregate is one value however deep it is. Materialising it is an
+allocation, and where an allocation goes is `const_object_globalization`'s
+decision, so an aggregate constant is never frozen into an operand slot.
 
 ### The operand bridge
 
-A skeleton child slot is `Operand = Expr(ExprId) | Value(ValueId)`. Pure operand
-positions carry `Operand::Value`; effectful and control-flow operands stay
-`Operand::Expr`.
+A skeleton child slot is `Operand = Expr(ExprId) | Value(ValueId)`. A pure
+operand position carries `Operand::Value`. An effectful or control-flow operand
+stays `Operand::Expr`.
 
-Values are **born as operands**: lowering and the promotion passes freeze a pure
+Values are born as operands. Lowering and the promotion passes freeze a pure
 position into its `ValueId` directly, so a pass reads the value off the operand
 rather than looking an expression up.
 
 No expression-keyed value map is persisted. A scoped scratch walk may build one
-to answer a query, but it dies with the query. An unpromoted skeleton leaf
-therefore resolves to no value, which is sound because that is the finest
-partition — a consumer skips the expression rather than over-merging.
+to answer a query, and it dies with the query. An unpromoted skeleton leaf
+therefore resolves to no value. That is sound because "no value" is the finest
+partition: a consumer skips the expression rather than over-merging.
 
-Promotion is staged against what the passes need to see, and the staging is the
-design: a freeze is only sound where nothing later re-contextualizes the operand
-it plants. Arithmetic freezes before the loop, on a clean graph; field reads
-freeze once the structural passes have settled the shape they read; the last
-arithmetic freeze runs after every pass that walks arithmetic.
+Promotion is staged, and the staging is the design. A freeze is sound only where
+nothing later re-contextualizes the operand it plants. Arithmetic freezes before
+the loop, on a clean graph. Field reads freeze once the structural passes have
+settled the shape they read. The last arithmetic freeze runs after every pass
+that walks arithmetic.
 
 ### Extraction
 
 One pass materialises each promoted operand back into concrete form, at WIR
-build, reading each value's type from the pool and recursing on composites. The
-optimizer can extract a constant on its own, which is what lets a pass read a
-frozen value without waiting for the backend.
+build. It reads each value's type from the pool and recurses on composites. The
+optimizer can extract a constant on its own, so a pass can read a frozen value
+without waiting for the backend.
 
-Extraction currently re-materialises a value at each use — always correct, and
-for constants always cheaper than sharing. The share-vs-duplicate cost model for
-multi-use non-constant values is open (see Remaining work).
+A scalar value is re-materialised at each use. That is always correct, and for a
+constant always cheaper than sharing. A multi-use field read may be shared. The
+cost model for sharing a multi-use non-constant scalar is open; see Remaining
+work.
 
 ### The engine (`nir_engine.rs`)
 
-Genuinely-local rewrites run as `Rule`s on a worklist over one function's `Body`,
-to a local fixed point: a node is revisited only when an edit may have made it
+Local rewrites run as `Rule`s on a worklist over one function's `Body`, to a
+local fixed point. A node is revisited only when an edit may have made it
 reducible, never by a whole-tree sweep.
 
 - A session derives its indices and seeds its worklist in one linear pass, then
   maintains them.
-- Rules never touch the arena directly; every mutation goes through the edit
-  API, which is what keeps the indices and the promoted-read census coherent and
+- Rules never touch the arena directly. Every mutation goes through the edit
+  API. That is what keeps the indices and the promoted-read census coherent, and
   re-enqueues exactly the affected neighbourhood. Replacement is in place, so an
-  id — and the worklist entry naming it — survives the edit.
-- At a popped node the engine tries the registered rules in order; the first that
-  reports a change retries at the same node. Rules must be idempotent, and either
-  confluent or priority-ordered — priority is rule order in the session.
+  id survives the edit, and with it the worklist entry naming it.
+- At a popped node the engine tries the registered rules in order. The first
+  that reports a change retries at the same node. Rules must be idempotent, and
+  either confluent or priority-ordered. Priority is rule order in the session.
 
-The position-flexible local rules share **one session per function**, run
-pre-inline and post-inline so each rule sees the instruction window the other
+The position-flexible local rules share one session per function. It runs
+pre-inline and post-inline, so each rule sees the instruction window the other
 exposes. Which rules those are is the inventory's.
 
-What stays outside the engine: flow-sensitive passes that need per-block dataflow
-keep their own walkers over the arena, and the interprocedural stages run as
+Two things stay outside the engine. A flow-sensitive pass that needs per-block
+dataflow keeps its own walker over the arena. The interprocedural stages run as
 distinct steps.
 
 ### Per-function gating
 
 Each function carries a monotonic revision and each pass a per-function
-watermark; a gated pass visits a function only when the revision has passed the
+watermark. A gated pass visits a function only when its revision has passed the
 watermark. A pass that changes a function bumps its revision and, conservatively,
-that of its immediate call-graph neighbours in both directions. Interprocedural
-passes pull their candidate set from the dirty set rather than scanning every
-function, and re-mark affected callers when a callee shrinks; the loop's
+that of its immediate call-graph neighbours in both directions. An
+interprocedural pass pulls its candidates from the dirty set rather than scanning
+every function, and re-marks the callers of a callee it shrinks. The loop's
 iteration cap is the quiescence bound. A pass whose summary a call-graph change
 invalidates cannot be gated on the callee's revision alone, and stays explicit.
 
-Gating changes only **which** functions a pass visits, never the result of a
-visit. Every loop pass is an optimization, so an imprecise gate costs
-optimization quality, never correctness — the same one-sided argument covers the
+Gating changes only which functions a pass visits, never the result of a visit.
+Every loop pass is an optimization, so an imprecise gate costs optimization
+quality, never correctness. The same one-sided argument covers the
 interprocedural over-approximation.
 
 ## Soundness invariants
 
 - Substitution soundness. An operand is repointed from `a` to `b` only when the
-  two denote the same value in every execution reaching that point — the
-  obligation CSE, copy propagation, and forwarding each discharged separately,
-  now expressed once. Sharing an id is stronger than that and needs no
-  justification at all: hash-consing only ever gives one id to structurally
-  identical values.
+  two denote the same value in every execution reaching that point. CSE, copy
+  propagation, and forwarding each discharged that obligation separately. It is
+  now expressed once. Sharing an id is stronger and needs no justification:
+  hash-consing gives one id only to structurally identical values.
 - Flow-freeze validity. A control-flow rewrite that changes which value is
-  dominant must repoint the affected operands; a read must never be left holding
+  dominant must repoint the affected operands. A read must never be left holding
   a value that no longer reaches it.
 - Heap-version monotonicity. A field read's heap version is the version before
-  the read; a later write bumps to a fresh version, so any read after it gets a
+  the read. A later write bumps to a fresh version, so any read after it gets a
   fresh `ValueId`.
 - Single-version proof for a query-time leaf. The build is the primary source of
-  a local's value, but a leaf the build did not reach may be resolved at query
-  time instead, to a version-free value standing for that local. Version-free is
-  the whole hazard: it is one value for every assignment of the local, so it is
-  sound only under a proof that the local has exactly one. Absent the proof the
-  query answers with no value, never with a guess. The anchor rule below is the
-  same obligation seen from the freeze side.
+  a local's value. A leaf the build did not reach may be resolved at query time
+  instead, to a version-free value standing for that local. Version-free is the
+  hazard: it is one value for every assignment of the local, so it is sound only
+  under a proof that the local has exactly one. Without the proof the query
+  answers with no value, never with a guess. The anchor rule below is the same
+  obligation seen from the freeze side.
 - Pointwise maintenance. A structural edit keeps the graph coherent at the point
-  of the edit — pruning a branch repoints the surviving operands past the dead
-  merge arm; splicing an inlined body or an SROA split interns value nodes for
-  the new skeleton subtree. Monotone growth, never a re-derivation of existing
-  flow. This is the load-bearing claim of the design.
-- Extraction equivalence. The extracted form computes, for every effectful
-  position, the same values in the same effect order as graph + skeleton.
+  of the edit. Pruning a branch repoints the surviving operands past the dead
+  merge arm. Splicing an inlined body or an SROA split interns value nodes for
+  the new skeleton subtree. Growth is monotone. Existing flow is never
+  re-derived. This is the load-bearing claim of the design.
+- Extraction equivalence. For every effectful position, the extracted form
+  computes the same values in the same effect order as graph plus skeleton.
 - The edit API is the only mutation path during a run. A pass that pokes the
   arena maps directly desynchronises the parent and use indices.
+- One verdict per call. The straight-line walk and the loop summary classify a
+  call from the same per-call verdicts. Two paths answering the same question
+  with different predicates was the shape of every precision defect found in
+  this layer.
 
-### Standing invariants — do not reintroduce
+### Standing invariants: do not reintroduce
 
 These are settled by measurement and re-derived at a cost.
 
 - No mid-pipeline rebuild of the value graph. Build-once is structural, not a
-  cache policy: nothing clears the graph. Maintain in place; never
-  clear-and-rebuild.
+  cache policy. Nothing clears the graph. Maintain in place.
 - No expression-keyed value cache or side-table that outlives a query. A pass
   needing a value uses born-as-operands or a scoped scratch walk.
 - A promoted read lives in the pool, not the skeleton. A pass that decides a
   local is unused, or rewrites every read of one, must count the pool's reads as
-  well — scoped to the operands the skeleton still carries, since the pool is
-  append-only and also holds reads that folded away.
-- That census is session-scoped, never per-application: it walks the whole body,
-  so recomputing it per rule application is quadratic. It is memoized, and the
-  memo is held across edits while it is empty — the case that decides the cost,
-  since inside the loop nothing reachable names a local. Only a local-naming
-  operand becoming reachable drops it, which the edit API is what reports; a
-  rule therefore never writes such an operand into the body behind the API's
-  back. A debug-only audit at session end is a backstop, not a proof.
+  well. The count is scoped to the operands the skeleton still carries, since the
+  pool is append-only and also holds reads that folded away.
+- That census is session-scoped, never per-application. It walks the whole
+  body, so recomputing it per rule application is quadratic. It is memoized, and
+  the memo is held across edits while it is empty. That is the case that decides
+  the cost, since inside the loop nothing reachable names a local. Only a
+  local-naming operand becoming reachable drops it, and the edit API is what
+  reports that. A rule therefore never writes such an operand into the body
+  behind the API's back. A debug-only audit at session end is a backstop, not a
+  proof.
 - No whole-body walk per rule application, in an assertion either. A rewrite
-  that deletes a binding records the local and the session audits the batch
-  once; checking it at each rewrite cost more than half the loop. The audit
-  reads the arena fresh rather than the indices the rewrite decided on —
-  substituting those would make it agree with itself and catch nothing.
+  that deletes a binding records the local, and the session audits the batch
+  once. Checking at each rewrite cost more than half the loop. The audit reads
+  the arena fresh rather than the indices the rewrite decided on. Reading those
+  would make it agree with itself and catch nothing.
+- Per-loop heap summarization is a union over the whole body. It is sound and
+  necessary, not a conservatism: the body runs many times, so every write in it
+  must be assumed to precede every read. Its granularity is the ceiling on what
+  a loop can know about its heap.
 
 ## Rejected and deferred
 
@@ -248,88 +240,107 @@ Sea-of-nodes, and dropping the skeleton, stay rejected.
 
 ### Not equality saturation
 
-Saturation over the value graph would unlock **algebraic exploration** —
-re-association, distributive law, strength-reduction-per-use, cost-based
-share-vs-duplicate. Wado's output is Wasm, which the host runtime JITs again, and
-the host redoes most of that algebra. Cranelift's aegraph reports 5 – 10 % on
-native AOT; the JIT-target number is much smaller. Meanwhile the optimizations
-Wado actually carries — allocation elimination, structural cleanup, dense-`Match`
-lowering, bounds-check elimination, inlining — are single-direction structural
-rewrites that saturation does not help.
+Saturation over the value graph would unlock algebraic exploration:
+re-association, the distributive law, strength reduction per use, cost-based
+share-versus-duplicate. Wado's output is Wasm, which the host runtime JITs
+again, and the host redoes most of that algebra. Cranelift's aegraph reports
+5–10 % on native AOT, and the JIT-target number is much smaller. The
+optimizations Wado carries are single-direction structural rewrites that
+saturation does not help: allocation elimination, structural cleanup, dense
+`Match` lowering, bounds-check elimination, inlining.
 
 So saturation stays the terminal ideal, activated only if measurement justifies
-it (a native-AOT backend, or Wasm output measurably benefiting from algebra the
-JIT cannot do). Two things would have to exist first: tooling that makes a value
-graph and a rule firing visible, since a saturating rule set is not debuggable by
-reading output; and budget-bounded rule sets, where a budget hit degrades
-gracefully to the partially saturated graph, never panicking and never producing
-worse output than the input.
+it, through a native-AOT backend or Wasm output that measurably benefits from
+algebra the JIT cannot do. Two things would have to exist first. One is tooling
+that makes a value graph and a rule firing visible, since a saturating rule set
+cannot be debugged from its output. The other is budget-bounded rule sets, where
+a budget hit degrades to the partially saturated graph, never panics, and never
+produces worse output than the input.
 
 ### Not a session index carried across passes
 
-Opening a session rebuilds the parent map and use index — 1.03 s of a
-~5.8 s loop over 36 000 sessions. Carrying it across passes was built and
-measured: 91 % of sessions reuse it and the derivation drops 68 %, but the loop
-total does not move, and three things argue against it.
+Opening a session rebuilds the parent map and use index: 1.03 s of a 5.8 s loop
+over 36 000 sessions. Carrying the index across passes was built and measured.
+91 % of sessions reuse it and the derivation drops 68 %, but the loop total does
+not move. Three things argue against it.
 
-- It optimizes the structure the terminal ideal retires (see the pure-node-kind
+- It optimizes the structure the terminal ideal retires (the pure-node-kind
   item), and does nothing for the census the precision items load.
-- Reuse changes the output (+3.3 KB), so the carried state is not equivalent.
+- Reuse changes the output by 3.3 KB, so the carried state is not equivalent.
 - Soundness would rest on 36 `invalidate_engine_index` calls staying correct by
   hand, each omission a silent miscompile.
 
-Closing the arena's mutation surface — so that the type system, rather than a
-reviewer, carries the invariant that every edit goes through the API — is the
-prerequisite that would change this verdict. Until then the surface is whatever
-the current passes leave open, which is a thing to measure at the time, not a
-number to record here.
+The prerequisite that would change this verdict is closing the arena's mutation
+surface, so that the type system rather than a reviewer carries the invariant
+that every edit goes through the API. Until then the surface is whatever the
+current passes leave open. Measure it at the time; it is not a number to record
+here.
 
 ### Not incremental rebuild, and not a richer cache
 
-Both were prototyped and measured, and both are the wrong shape: they make
-re-deriving a derived analysis cheaper, when the analysis only needs re-deriving
-because it is derived. See "Measured dead ends".
+Both were prototyped and measured, and both are the wrong shape. They make
+re-deriving a derived analysis cheaper, when the analysis needs re-deriving only
+because it is derived. See Measured dead ends.
 
 ## Remaining work
 
-Compile speed here means the debug build — the compiler-developer inner loop —
-so every timing in this WEP includes `debug_assert!`s.
+Compile speed here means the debug build, the compiler-developer inner loop, so
+every timing in this WEP includes `debug_assert!`s.
 
-The graph build is ~6 % of the phase (was ~21 % before build-once); what is left
-to cut is the passes and their assertions. At `-O2` the loop costs ~6 s on each
-benchmark, spread over `peephole` (23 %) and `copy_prop` / `const_fold` / `licm`
-(13 % each), with no dominant iteration.
+The graph build is about 6 % of the phase; it was 21 % before build-once. What
+is left to cut is the passes and their assertions. At `-O2` the loop costs about
+6 s on each benchmark, spread over `peephole` at 23 % and `copy_prop`,
+`const_fold`, and `licm` at 13 % each, with no dominant iteration.
 
-- [ ] Fold the graph build into `lower` (born-at-`lower`). Buys one body walk
-      per function, not earlier availability: the early freeze already walks
-      every body before the loop, so the lazy first-query path is eager in
-      practice.
+- [ ] Fold the graph build into `lower`. This buys one body walk per function,
+      not earlier availability: the early freeze already walks every body
+      before the loop, so the lazy first-query path is eager in practice.
 
 - [ ] Retire the pure node kinds still left in the skeleton, so every pure
-      position is an operand. A compile-speed item as much as a saturation
-      prerequisite: pure kinds were 52 % of the arena when last measured, and
-      the local reads the use index is made of 34 %, so retiring them roughly
-      halves what every session walk covers — and the other compile-speed items
-      are sized against a skeleton this shrinks. Almost none of it is
-      independently reachable, because a value query recurses through operands:
+      position is an operand. This is a compile-speed item as much as a
+      saturation prerequisite. When last measured, pure kinds were 52 % of the
+      arena and the local reads the use index is made of were 34 %, so retiring
+      them roughly halves what every session walk covers. The other
+      compile-speed items are sized against a skeleton this shrinks. Almost none
+      of it is reachable on its own. A value query recurses through operands, so
       arithmetic left in the skeleton bottoms out on a field load or a call
-      result and yields no value at all, rather than being gated on something a
-      flag could flip. It waits on Precision below.
+      result and yields no value at all. It waits on a consumer; see Precision.
 
 - [ ] Arena compaction. In-place rewrites orphan nodes that are never freed
-      mid-run (~1.66× bloat measured at end-of-optimize on `package-gale`).
+      mid-run. Measured at 1.66× bloat at end-of-optimize on `package-gale`.
 
-- [ ] Price the switch lowering on something other than how wide the table is.
-      The threshold is a count of the values the table covers, set where the
-      `br_table` starts paying on the benchmarks, but the count is a proxy: a
+- [ ] Price the switch lowering on something other than table width. The
+      threshold is a count of the values the table covers, set where the
+      `br_table` starts paying on the benchmarks. The count is a proxy. A
       40-arm synthetic of plain `i32` fields prefers the `else if` chain by
-      11 % where `cbor-twitter`'s 40-arm `User` prefers the table by 2 %.
-      Whatever separates those two — arm body size, how well the scrutinee
-      sequence predicts — is what the threshold should be reading. Arm body size
-      is already summed, but as a blow-up guard on the emitted table, never as
-      the pay-off predicate.
+      11 %, and `cbor-twitter`'s 40-arm `User` prefers the table by 2 %. What
+      separates those two is what the threshold should read: arm body size, or
+      how well the scrutinee sequence predicts. Arm body size is already summed,
+      but only as a blow-up guard on the emitted table, never as the pay-off
+      predicate.
 
-Precision. All of it waits on one rule.
+### Precision
+
+Every precision item below waits on a consumer, not the other way round. That
+is the measured finding of this section.
+
+The value graph's heap precision is not on the critical path of any consumer
+that exists. The escaped-set generation invalidates 66 % of local-rooted field
+reads on `sqlite_parse` and 43 % on `json_twitter`. Five conservatisms feeding
+that generation were removed, each measured to fire widely, and every one left
+the corpus WIR-identical over 1 921 goldens and every benchmark.
+
+The reason is visible on the shape they targeted: a mutable receiver whose
+fields are read repeatedly in a loop around calls on it. The emitted loop
+already carries the invariant reads hoisted and the mutable field shadowed in a
+local. LICM's structural path and `field_scalarize` do that, and neither asks
+the value graph. What the escaped generation invalidates is either a read the
+structural passes have already retired, or a read between calls that genuinely
+mutate. No further precision at the call boundary changes that until a consumer
+wants what the structural passes do not already take; field-granular mod/ref
+was designed on the way and is priced out by the same fact. Each removed
+conservatism stands on the principle that an unjustified conservatism is dropped
+for being unjustified. None is a performance change.
 
 ### The anchor rule
 
@@ -337,141 +348,87 @@ A frozen operand may name a local only when that local's defining statement
 travels with the operand.
 
 A source local fails that. A parameter is defined by the function entry, which
-is not a statement that can travel, so inlining splices the operand into a
-caller where the same slot is assigned once per call — and since a query-time
-local value is version-free, two reads that now denote different values share an
-id. That is the over-merge behind `String::substr_bytes` under "Measured dead
-ends". The guard used to be "every leaf is a parameter", a proxy for "this local
-has one version" that inlining invalidates, parameter-ness not surviving being
-inlined; it is now that predicate itself, plus a dominance check at the
-placement.
+is not a statement that can travel. Inlining splices the operand into a caller
+where the same slot is assigned once per call, and since a query-time local
+value is version-free, two reads that now denote different values share an id.
+That is the over-merge behind `String::substr_bytes` under Measured dead ends.
+The guard is the single-version predicate itself plus a dominance check at the
+placement. "Every leaf is a parameter" was an earlier proxy for it, and
+parameter-ness does not survive inlining.
 
-A freeze-minted temp satisfies the rule by construction: a fresh immutable
-binding, in the same body, assigned once, so any pass that copies the operand
-copies the definition with it and the one-value-per-binding property holds in
-every context it lands in. So: never freeze a value naming a source local —
-materialise it into such a temp and name that. The freeze already mints one for
-the multi-use case; the rule makes it the only way a local may be named, and
-replaces the parameter restriction.
+A freeze-minted temp satisfies the rule by construction. It is a fresh immutable
+binding in the same body, assigned once, so any pass that copies the operand
+copies the definition with it, and one value per binding holds in every context
+it lands in. So a value naming a source local is never frozen. It is
+materialised into such a temp, and the temp is named. That is the only way a
+local may be named.
 
-The rule is necessary and not sufficient. There is no in-loop freeze: one was
-built under it and promoted nothing on either benchmark, at 11.3 % of the loop,
-so it was removed, phase and all — reviving it means adding the phase back under
-the rule, not flipping a flag. Two things have to hold and neither did.
+The rule is necessary and not sufficient. There is no in-loop freeze. One was
+built under the rule and promoted nothing on either benchmark, at 11.3 % of the
+loop, so it was removed with its phase. Reviving it means adding the phase back
+under the rule, not flipping a flag. Two things have to hold and neither did.
 
 The material has to exist. Resolving every provably single-version local, not
 just parameters, changes no output on its own, because the leaves that matter
-are field loads and call results — and a field read is keyed on the heap version
-at its point, which no query-time re-derivation supplies. The builder is the
+are field loads and call results. A field read is keyed on the heap version at
+its point, and no query-time re-derivation supplies that. The builder is the
 only source, through the graph build or a scratch re-walk.
 
 A consumer has to want it. The candidate was hoisting a loop-invariant field
-load, and no value-graph consumer does it: LICM's value path excludes field
-reads, and its structural path, which does hoist them, is deliberately
-value-graph-free — so the one pass that wants the fact derives it without
-asking. Surveyed, in-loop field reads that are provably invariant are 2.7 % and
-7.1 % on the two benchmarks — too few to pay for maintaining promoted operands
-across inlining and SROA, which an in-loop freeze would need.
-
-One note for whoever revives this. The invariance test is free: every slot a
-loop may write is bumped before the body walk and versions are monotonic, so a
-read below the loop-entry watermark is invariant.
-
-One conservatism that held that 2.7 % down is gone: the loop heap-effect
-collection marked a call's receiver mutably borrowed whether or not the callee
-could mutate it, while the alias analysis beside it asks that very question
-before aliasing the same receiver. Both now read one verdict. It fires widely —
-77 % of in-loop receiver calls on `sqlite_parse`, 64 % on `json_twitter` — and
-buys nothing: the fixture corpus is WIR-identical over 1 921 goldens, and so is
-every benchmark.
-
-It buys nothing because the set-wide bump subsumes it. Measured at the read: on
-`sqlite_parse` the escaped-set generation is what invalidates 66 % of field
-reads rooted at a local, on `json_twitter` 43 %; the per-local mark the receiver
-verdict suppresses decides 0.4 % and 0 %, and even those roots are escaped, so
-the read falls to the set-wide generation instead of surviving. There was no
-read for the verdict to save.
-
-The second conservatism of the same shape is gone too: the loop summary decided
-"external write" by a builtin-only test where the straight-line walk asks the
-purity verdict, so the loop asked a strictly weaker question of the same call.
-Both now read one verdict. Pure calls are common in loop bodies — 22 % on
-`sqlite_parse` — and it still buys nothing, because the summary is a union over
-the whole body and an impure call sits beside them in nearly every loop. That
-union is not a conservatism to remove: the body runs many times, so every write
-in it must be assumed to precede every read. Per-loop summarization is sound
-and necessary, and the ceiling is its granularity.
-
-So the escaped-set bump is where the remaining precision is, and it is
-overwhelmingly a _correct_ invalidation at the wrong granularity: a `&mut self`
-method calling `self.advance()` really does mutate `self`, and the bump kills
-every field of `self` where `advance` writes one. The prize is field-granular.
-
-- [ ] Field-granular call effects — a per-parameter, per-field mod/ref
-      summary. The receiver-only version was designed and then priced out by
-      measurement: of the impure calls in loop bodies, a bare-local receiver is
-      18 % on `sqlite_parse` and 22 % on `json_twitter`, while 65 % and 57 %
-      have no receiver at all, and the loop summary is a union, so one
-      receiver-less impure call beside a receiver call re-bumps the escaped set
-      the receiver was exempted from. Precision at a call boundary is only as
-      good as the least precise call in the loop. So the summary a callee needs
-      is what it writes through _each_ parameter, by direct field, with Top for
-      a deeper projection, a `&mut` hand-out or a store through a global; the
-      existing param-0 fixpoint in `compute_receiver_mutating` is the shape of
-      it, widened to every parameter and from a bool to a field set. At a call
-      site each argument's storage root then takes slot bumps for its
-      parameter's set instead of the set-wide one, and the set-wide bump is
-      owed only by a call with a Top parameter or an argument the callee could
-      reach some other way (`untrackable`, or aliased with another argument).
-      This is a new analysis, not a rewiring of an existing verdict, and it is
-      the one thing that reaches the 66 % — nothing downstream of the call
-      boundary can.
+load, and no value-graph consumer does it. LICM's value path excludes field
+reads. Its structural path, which does hoist them, is deliberately
+value-graph-free, so the one pass that wants the fact derives it without asking.
+Surveyed, provably invariant in-loop field reads are 2.7 % and 7.1 % on the two
+benchmarks, too few to pay for maintaining promoted operands across inlining and
+SROA, which an in-loop freeze would need. Whoever revives this should know the
+invariance test is free: every slot a loop may write is bumped before the body
+walk and versions are monotonic, so a read below the loop-entry watermark is
+invariant.
 
 - [ ] Reach the in-loop consumers. Every freeze that may plant a local-naming
       value runs after the fixed-point loop, so the passes inside it still see
-      none: LICM reads the loop-entry values and its value hoist collected zero
-      loop-entry locals in 10,900 queries, which is why keeping that map across
-      the loop costs nothing either way. An in-loop freeze cannot simply be
-      added — one was, and is recorded under "The anchor rule"; the early freeze
-      is separately bound by the context-free rule under "Measured dead ends".
-      Moving the build to lowering does not lift that bound: it is the
-      extraction that is point-dependent, not the build. This and the widening
-      above share one prerequisite, the anchor rule opening this section, which
-      also gates nearly all of retiring the pure node kinds — not only the local
-      reads, since the arithmetic above a local read resolves to no value
+      none: LICM's value hoist collected zero loop-entry locals in 10 900
+      queries. An in-loop freeze cannot simply be added; see The anchor rule. The early freeze is separately bound by the
+      context-free rule under Measured dead ends. Moving the build to lowering
+      does not lift that bound: the extraction is point-dependent, not the
+      build. This and resolving every single-version local share the anchor
+      rule as prerequisite. It also gates nearly all of retiring the pure node
+      kinds, not only the
+      local reads, since the arithmetic above a local read resolves to no value
       either.
 
-- [ ] Copy propagation on value identity rather than on locals. Source-stability
-      is not subsumed by value equality — a write-once `x` whose source `y` is
-      later reassigned can read equal ids yet be unsafe to fold. Revisit with
-      provenance on the merge and opaque kinds.
+- [ ] Copy propagation on value identity rather than on locals.
+      Source-stability is not subsumed by value equality. A write-once `x` whose
+      source `y` is later reassigned can read equal ids yet be unsafe to fold.
+      Revisit with provenance on the merge and opaque kinds.
 - [ ] Induction-variable recognition, as a tagged opaque carrying base and step.
-      Not needed yet — a post-increment read already appears as the addition it
-      is — so it lands when a rule first wants it.
+      Not needed yet. A post-increment read already appears as the addition it
+      is, so this lands when a rule first wants it.
 - [ ] Stop a borrow of a local that flows only into callees which cannot retain
       it from marking the local aliased. Plumbing the callee's escape summary
-      into the ref-argument check is not the way: the aliased set is seeded from
+      into the ref-argument check is not the way. The aliased set is seeded from
       the address-taken locals the elaborator records for every borrow of a
       local, so the `(&self).field` shape this was written for is already
       aliased before the call site is looked at. Measured, 3.7 % of ref-arg
-      marks are the sole reason their local is aliased — borrows of a
-      projection, which the elaborator does not record. Narrowing the rest means
-      narrowing the seed, which is a whole-function question (do _all_ uses of
-      the borrow flow into callees that cannot retain it?) over an annotation
-      several other passes also read. Note too that the mutable-escape set is
-      built by filtering the aliased set, so dropping a local from one silently
-      drops it from the other — and a callee that cannot retain a reference can
-      still mutate through it during the call, so the two have to be decoupled
-      first.
-- [ ] Directed gate propagation, callee-shrink to callers only. Deferred: it
+      marks are the sole reason their local is aliased: borrows of a projection,
+      which the elaborator does not record. Narrowing the rest means narrowing
+      the seed. That is a whole-function question, whether all uses of the
+      borrow flow into callees that cannot retain it, over an annotation several
+      other passes also read. The mutable-escape set is built by filtering the
+      aliased set, so dropping a local from one silently drops it from the
+      other, and a callee that cannot retain a reference can still mutate
+      through it during the call. The two have to be decoupled first.
+- [ ] Directed gate propagation, callee-shrink to callers only. Deferred. It
       drops the edges inlining adds to the build-once call graph, and a
-      per-iteration rebuild does not recover them — the staleness is
+      per-iteration rebuild does not recover them because the staleness is
       intra-iteration. It would need incremental edge maintenance, for a
       measured net-neutral gain.
 
-Terminal ideal, gated behind measurement (see "Not equality saturation").
+### Terminal ideal
 
-- [ ] Saturation driver plus cost-based extraction: run rules to a bounded
+Gated behind measurement; see Not equality saturation.
+
+- [ ] Saturation driver plus cost-based extraction. Run rules to a bounded
       saturation, then extract a cost-minimal form per operand, materialising a
       multi-use value only when sharing beats duplication. This subsumes the
       extraction cost model, the global fixed-point loop, the per-rule
@@ -481,63 +438,65 @@ Terminal ideal, gated behind measurement (see "Not equality saturation").
 
 Each was built, verified, and reverted. Do not retry as-is.
 
-- **Incremental ValueGraph rebuild.** Reuse a parked graph's unchanged prefix and
-  re-walk only the disturbed region. Correct (verified by a build-both-ways
-  oracle) but it fired on ~0.15 % of builds on the large workload and 0 % on the
-  small ones: the only clean pass adjacency was spoiled by non-journaling passes
-  between handoffs, and `inline` restructures bodies wholesale every iteration.
-  Raising the fire rate needs the single-worklist architecture, which subsumes
-  the whole mechanism.
-- **A richer graph cache.** Caps low for the same reason: it rebuilds whenever a
+- Incremental ValueGraph rebuild. Reuse a parked graph's unchanged prefix and
+  re-walk only the disturbed region. It was correct, verified by a
+  build-both-ways oracle, and fired on 0.15 % of builds on the large workload
+  and none on the small ones. The only clean pass adjacency was spoiled by
+  non-journaling passes between handoffs, and `inline` restructures bodies
+  wholesale every iteration. Raising the fire rate needs the single-worklist
+  architecture, which subsumes the whole mechanism.
+- A richer graph cache. Caps low for the same reason: it rebuilds whenever a
   pass changes a function, which is the common case. Deleted.
-- **Pooling the graph builder's output maps.** The build is compute-bound (walk +
-  hash-cons + flow joins), not allocation-bound; measured no improvement.
-- **Promoting induction-variable local reads to source-bearing opaques.** That
+- Pooling the graph builder's output maps. The build is compute-bound, in the
+  walk, the hash-consing, and the flow joins, not allocation-bound. No
+  improvement measured.
+- Promoting induction-variable local reads to source-bearing opaques. That
   resolver keyed one `ValueId` per local, where the builder mints one per
-  assignment, so the id spanned every version of the local — and an induction
+  assignment, so the id spanned every version of the local, and an induction
   variable has one per iteration. Traps `closure_for_loop_mutation`.
-- **Freezing a local-naming value before the structural passes.** The early
-  freeze is sound because a frozen value survives inlining and SROA copying the
-  operand around — true of a constant, which means the same thing wherever it
-  lands, false of a value naming a local, because those passes renumber locals
-  and splice a callee body into a caller, re-contextualizing the slot underneath
-  the value. `String::substr_bytes`'s parameters, frozen early and inlined into
-  `trim_start`'s loop, read back as an iteration's worth of values and trap with
-  "allocation size too large". The invariant is now explicit at the freeze
-  decision: early plants only context-free values.
-- **A query-time materialiser for a field read at function entry.** Miscompiled
-  ~165 fixtures: reference and aggregate fields change copy / alias semantics.
-- **Keeping caller values across a loop-free-but-impure inline.** Over-merges two
+- Freezing a local-naming value before the structural passes. The early freeze
+  is sound because a frozen value survives inlining and SROA copying the operand
+  around. That is true of a constant, which means the same thing wherever it
+  lands. It is false of a value naming a local, because those passes renumber
+  locals and splice a callee body into a caller, re-contextualizing the slot
+  underneath the value. `String::substr_bytes`'s parameters, frozen early and
+  inlined into `trim_start`'s loop, read back as an iteration's worth of values
+  and trap with "allocation size too large". The invariant is explicit at the
+  freeze decision: early plants only context-free values.
+- A query-time materialiser for a field read at function entry. Miscompiled
+  about 165 fixtures. Reference and aggregate fields change copy and alias
+  semantics.
+- Keeping caller values across a loop-free but impure inline. Over-merges two
   reads of a mutable reference parameter.
-- **Dropping the promoted-read census memo on every edit.** The obvious
-  invalidation rule, and measurably worse than no memo: a whole-body walk per
-  rewrite where the per-block recomputation it replaced at least amortised over
-  a block. Only holding an empty memo across edits pays.
+- Dropping the promoted-read census memo on every edit. The obvious invalidation
+  rule, and measurably worse than no memo: a whole-body walk per rewrite, where
+  the per-block recomputation it replaced at least amortised over a block. Only
+  holding an empty memo across edits pays.
 
-The throughline: a value's identity is sound only when carried by an operand the
-edits maintain, or by a leaf whose single version the query itself proves — never
+A value's identity is sound only when an operand the edits maintain carries it,
+or when the query itself proves the leaf has a single version. It is never
 re-derived from a side-table at query time.
 
 ## Consequences
 
-- A cluster of former passes became graph structure and stopped existing: CSE and
-  GVN fall out of hash-consing, pure copy propagation out of shared ids,
+- A cluster of former passes became graph structure and stopped existing. CSE
+  and GVN fall out of hash-consing, pure copy propagation out of shared ids,
   store-load forwarding out of receiver-field-version identity. Their walks and
   bespoke analysis caches went with them.
-- The optimizer gained a hash-cons pool, a builder, and an extractor; it lost
-  the persisted value side-table, the cache machinery, the per-pass value
-  rebuild, and every per-pass structural key.
-- The arena costs one mutation discipline: the edit API is mandatory, and dead
+- The optimizer gained a hash-cons pool, a builder, and an extractor. It lost the
+  persisted value side-table, the cache machinery, the per-pass value rebuild,
+  and every per-pass structural key.
+- The arena costs one mutation discipline. The edit API is mandatory, and dead
   nodes accumulate until compaction lands.
 - Measured wins along the way: the arena-direct engine cut a heavy module's
-  optimize phase ~40 % against the bridge baseline; dirty-set gating cut it a
-  further ~50 % on the Gale-generated SQLite parser at `-O2`.
+  optimize phase by about 40 % against the bridge baseline, and dirty-set gating
+  cut it a further 50 % on the Gale-generated SQLite parser at `-O2`.
 
 ## See also
 
-- [`docs/optimizer.md`](./optimizer.md) — the pass inventory this architecture runs.
-- [Normalized IR (NIR) Layer](./wep-2026-05-11-nir.md) — the type boundary at `lower` that NIR is.
-- [Wasm IR (WIR) Layer](./wep-2026-02-14-wir-layer.md) — the separately-typed backend IR NIR extracts into.
-- [Optimizer Remarks for Missed Optimizations](./wep-2026-06-03-optimizer-remarks.md) — how a missed rewrite is reported.
-- Cranelift's aegraph mid-end and `egg` (https://egraphs-good.github.io/) — the build-once, eager-rewrite, single-extraction model this adapts (without their union-find over e-classes).
-- `.claude/skills/profiling-wado-compiler` — the workflow behind the cost numbers.
+- [`docs/optimizer.md`](./optimizer.md), the pass inventory this architecture runs.
+- [Normalized IR (NIR) Layer](./wep-2026-05-11-nir.md), the type boundary at `lower` that NIR is.
+- [Wasm IR (WIR) Layer](./wep-2026-02-14-wir-layer.md), the separately-typed backend IR NIR extracts into.
+- [Optimizer Remarks for Missed Optimizations](./wep-2026-06-03-optimizer-remarks.md), how a missed rewrite is reported.
+- Cranelift's aegraph mid-end and `egg` (https://egraphs-good.github.io/), the build-once, eager-rewrite, single-extraction model this adapts, without their union-find over e-classes.
+- `.claude/skills/profiling-wado-compiler`, the workflow behind the cost numbers.

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -407,20 +407,25 @@ overwhelmingly a _correct_ invalidation at the wrong granularity: a `&mut self`
 method calling `self.advance()` really does mutate `self`, and the bump kills
 every field of `self` where `advance` writes one. The prize is field-granular.
 
-- [ ] Field-granular receiver write sets. `compute_receiver_mutating` already
-      fixpoints "writes through param 0" as a bool; widen it to the set of
-      direct fields written (`self.f = …` contributes `f`; a deeper projection,
-      `*self = …`, a `&mut` hand-out or a `mut` argument contributes Top), and
-      at a call with a bare-local receiver bump those slots instead of the
-      local. The set-wide bump must then exempt that receiver, which is sound
-      exactly when the receiver is the callee's only path to it — not
-      `untrackable`, and no other argument in its alias class — since only then
-      is the param-0 write set complete. An O(1) exemption per local suffices:
-      record the escaped generation before and after the call, and let a read
-      of that local use the before-value while the after-value is still the
-      current one; the next unrelated impure call advances past it and the
-      exemption expires on its own. Unmeasured: what share of in-loop impure
-      calls carry a bare-local receiver, which is what this reaches.
+- [ ] Field-granular call effects — a per-parameter, per-field mod/ref
+      summary. The receiver-only version was designed and then priced out by
+      measurement: of the impure calls in loop bodies, a bare-local receiver is
+      18 % on `sqlite_parse` and 22 % on `json_twitter`, while 65 % and 57 %
+      have no receiver at all, and the loop summary is a union, so one
+      receiver-less impure call beside a receiver call re-bumps the escaped set
+      the receiver was exempted from. Precision at a call boundary is only as
+      good as the least precise call in the loop. So the summary a callee needs
+      is what it writes through _each_ parameter, by direct field, with Top for
+      a deeper projection, a `&mut` hand-out or a store through a global; the
+      existing param-0 fixpoint in `compute_receiver_mutating` is the shape of
+      it, widened to every parameter and from a bool to a field set. At a call
+      site each argument's storage root then takes slot bumps for its
+      parameter's set instead of the set-wide one, and the set-wide bump is
+      owed only by a call with a Top parameter or an argument the callee could
+      reach some other way (`untrackable`, or aliased with another argument).
+      This is a new analysis, not a rewiring of an existing verdict, and it is
+      the one thing that reaches the 66 % — nothing downstream of the call
+      boundary can.
 
 - [ ] Reach the in-loop consumers. Every freeze that may plant a local-naming
       value runs after the fixed-point loop, so the passes inside it still see

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -365,30 +365,30 @@ are field loads and call results — and a field read is keyed on the heap versi
 at its point, which no query-time re-derivation supplies. The builder is the
 only source, through the graph build or a scratch re-walk.
 
-A consumer has to want it. The candidate is hoisting a loop-invariant field
-load, which no pass does: LICM's structural path is deliberately
-value-graph-free and its value path excludes field reads. Surveyed, in-loop
-field reads that are provably invariant are 2.7 % and 7.1 % on the two
-benchmarks — too few to pay for maintaining promoted operands across inlining
-and SROA, which an in-loop freeze would need.
+A consumer has to want it. The candidate was hoisting a loop-invariant field
+load, and no value-graph consumer does it: LICM's value path excludes field
+reads, and its structural path, which does hoist them, is deliberately
+value-graph-free — so the one pass that wants the fact derives it without
+asking. Surveyed, in-loop field reads that are provably invariant are 2.7 % and
+7.1 % on the two benchmarks — too few to pay for maintaining promoted operands
+across inlining and SROA, which an in-loop freeze would need.
 
-Two notes for whoever revives this. The invariance test is free: every slot a
+One note for whoever revives this. The invariance test is free: every slot a
 loop may write is bumped before the body walk and versions are monotonic, so a
-read below the loop-entry watermark is invariant. And what holds that 2.7 % down
-is upstream — a call's receiver is marked mutably borrowed whether or not the
-callee can mutate it, so one `self.helper()` kills every `self.field` invariance
-in a loop.
+read below the loop-entry watermark is invariant.
 
-- [ ] Give the loop heap-effect collection the callee immutability the optimizer
-      already computes elsewhere. It marks a call's receiver mutably borrowed
-      whether or not the callee can mutate it, while the alias and mod/ref
-      analyses know the answer and the builder is handed only the pure builtins.
-      Raises the precision of store-load forwarding, field promotion, and
-      condition implication at once, and touches no part of the anchor rule —
-      measure it before anything else here. One caveat the code carries: the
-      unconditional mark is precise only for a bare local argument, every other
-      shape being covered by the blanket external-writes fallback. That fallback
-      has to stay.
+What used to hold that 2.7 % down was upstream, and is fixed: the loop
+heap-effect collection marked a call's receiver mutably borrowed whether or not
+the callee could mutate it, disagreeing with the alias analysis beside it, which
+asks that very question before aliasing the same receiver. Both now read one
+verdict. It bought no output: the fixture corpus is WIR-identical over 1 921
+goldens, and so is every benchmark. The reason is this section's other half —
+still no consumer. A field read of a reference parameter across an immutable
+call in a loop is already hoisted by LICM's structural path, which never asks
+the value graph, and the value-side consumers do not reach the shape at all,
+because a local struct is scalarized by SROA and a small callee is gone to the
+inliner before either matters. So the precision is real and unclaimed, and the
+consumer, not the precision, is what to build next.
 
 - [ ] Reach the in-loop consumers. Every freeze that may plant a local-naming
       value runs after the fixed-point loop, so the passes inside it still see

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -60,13 +60,17 @@ Closure `__call` methods and non-trivial global initializers are bodies too.
 - Records that are never independent rewrite targets — match arms, struct
   fields, call args — are not id-bearing. They live inline in their parent and
   are transparent to the parent map.
-- `type_id` and `span` stay per node: `span` feeds diagnostics, optimizer
-  remarks, and DWARF, and is part of skeleton identity. Layer 2 is the span-free
-  layer, not this one.
+- `span` stays per node — it feeds diagnostics, optimizer remarks, and DWARF,
+  and is part of skeleton identity. Layer 2 is the span-free layer, not this
+  one. `type_id` is per expression, there being nothing to type on a statement,
+  a block, or a pattern.
 - Parent edges (nearest id-bearing ancestor) and a per-local use index
-  (`def` / `reads` / `writes`) are maintained incrementally by the edit API,
-  never recomputed. Function-level alias facts (`address_taken_locals`,
-  `stores_aliased_locals`) and the local table travel on `Body` beside the arena.
+  (`def` / `reads` / `writes`) are derived once per session, at `Engine::new`,
+  and maintained incrementally by the edit API from there — never re-derived
+  under a running session. Function-level alias facts (`address_taken_locals`,
+  `stores_aliased_locals`) and the local table travel on `Body` beside the
+  arena, and are mirrored on `NirFunction` for the passes that run outside a
+  session; `sroa` merges its deltas back into the function's copy.
 - Nodes are not freed mid-run. Liveness is reachability from `root`, and the use
   index ignores orphans.
 
@@ -88,6 +92,14 @@ side-table derived from the skeleton.
   the builder threads a per-local current value, constructs `Select` at merge
   points and `LoopPhi` at loops, and bumps heap versions where the skeleton may
   write. A read's `ValueId` is fixed to the value dominant at that point.
+- A skeleton `Local` read the build did not reach resolves at query time
+  instead, to the memoized `Opaque` `ValuePool::canonical_local` mints — one
+  `ValueId` per local index, version-free. That is sound only where the local
+  has a single version, so `Engine::value` gates it on
+  `local_has_one_version`; a multi-version local resolves to `None`. The
+  builder's threaded value and this memo are the pool's two sources of a
+  local-valued leaf, and the anchor rule below is what keeps the second from
+  over-merging.
 - Identity is structural, and a `ValueId` is stable once allocated: interning is
   pure hash-consing, with no e-class merges and so no representative lookup. A
   rewrite that proves `a ≡ b` points the operand slot at `b`; it never merges
@@ -109,10 +121,17 @@ positions carry `Operand::Value`; effectful and control-flow operands stay
 
 Values are **born as operands**: `lower::translate` and the promotion passes
 (`optimize/extract.rs`) freeze a pure position into its `ValueId` directly, so a
-pass reads the value off the operand rather than looking an `ExprId` up. There is
-no `ExprId → ValueId` side-table; an unpromoted skeleton leaf resolves to `None`,
-which is sound because `None` is the finest partition — a consumer skips the
-expression rather than over-merging.
+pass reads the value off the operand rather than looking an `ExprId` up. Lower's
+share is the scalar constants, interned as it translates each literal; a string
+or bytes literal deliberately stays an expression, being an allocation whose site
+`const_object_globalization` decides. Everything non-constant is promoted later,
+by a freeze.
+
+No `ExprId → ValueId` map is persisted. A scoped scratch walk still returns one,
+which is what `FieldAccess` promotion reads, but it dies with the query that
+asked. An unpromoted skeleton leaf therefore resolves to `None`, which is sound
+because `None` is the finest partition — a consumer skips the expression rather
+than over-merging.
 
 Promotion is staged against what the passes need to see: arithmetic freezes
 before the loop (on each function's clean, un-restructured graph, which is what
@@ -163,10 +182,12 @@ keep their own walkers over the arena, and the interprocedural stages (`inline`,
 Each function carries a monotonic revision and each pass a per-function
 watermark; a gated pass visits a function only when `revision > watermark`. A
 pass that changes a function bumps its revision and, conservatively, that of its
-1-hop call-graph neighbours. Interprocedural passes pull their candidate set from
-the dirty set rather than scanning every function, and re-mark affected callers
-when a callee shrinks; `OptConfig::iterations` is the quiescence bound. Terminal
-stages stay explicit.
+1-hop call-graph neighbours in both directions. Interprocedural passes pull their
+candidate set from the dirty set rather than scanning every function, and re-mark
+affected callers when a callee shrinks; `OptConfig::iterations` is the quiescence
+bound. Terminal stages stay explicit, and so does `param_spec`, which scans every
+function because a summary it took before a callee gained a caller does not
+describe the callee it now has.
 
 Gating changes only **which** functions a pass visits, never the result of a
 visit. Every loop pass is an optimization, so an imprecise gate costs
@@ -257,7 +278,7 @@ panic and never produce worse output than the input.
 `Engine::new` rebuilds the parent maps and use index per function — 1.03 s of a
 ~5.8 s loop over 36 000 sessions. Carrying it across passes was built and
 measured: 91 % of sessions reuse it and the derivation drops 68 %, but the loop
-total does not move, and four things argue against it.
+total does not move, and three things argue against it.
 
 - It optimizes the structure the terminal ideal retires (see the `ExprKind`
   item), and does nothing for the census the precision items load.
@@ -265,8 +286,11 @@ total does not move, and four things argue against it.
 - Soundness would rest on 36 `invalidate_engine_index` calls staying correct by
   hand, each omission a silent miscompile.
 
-Closing the arena's mutation surface (226 sites over 57 files) so the type
-system carries the invariant is the prerequisite that would change this verdict.
+Closing the arena's mutation surface so the type system carries the invariant is
+the prerequisite that would change this verdict. That surface is 124 direct
+writes to an arena map over nine `optimize/` files, outside the edit API and
+outside tests — `sroa_variant_return`, `const_object_globalization`, and
+`field_scalarize` are two thirds of it.
 
 ### Not incremental rebuild, and not a richer cache
 
@@ -284,8 +308,6 @@ to cut is the passes and their assertions. At `-O2` the loop costs ~6 s on each
 benchmark, spread over `peephole` (23 %) and `copy_prop` / `const_fold` / `licm`
 (13 % each), with no dominant iteration.
 
-- [ ] Function-level parallelism. The per-function build and walk are
-      independent.
 - [ ] Fold the graph build into `lower` (born-at-`lower`). Buys one body walk
       per function, not earlier availability: the early freeze already walks
       every body before the loop, so the lazy first-query path is eager in
@@ -306,12 +328,15 @@ benchmark, spread over `peephole` (23 %) and `copy_prop` / `const_fold` / `licm`
 - [ ] Arena compaction. In-place rewrites orphan nodes that are never freed
       mid-run (~1.66× bloat measured at end-of-optimize on `package-gale`).
 
-- [ ] Price `match_to_switch` on something other than the arm count. Twelve is
-      where the `br_table` starts paying on the benchmarks, but the count is a
-      proxy: a 40-arm synthetic of plain `i32` fields prefers the `else if`
-      chain by 11 % where `cbor-twitter`'s 40-arm `User` prefers the table by
-      2 %. Whatever separates those two — arm body size, how well the scrutinee
-      sequence predicts — is what the threshold should be reading.
+- [ ] Price `match_to_switch` on something other than how wide the table is.
+      `SWITCH_MIN_CASES` is twelve values covered — one range arm can reach it
+      alone — which is where the `br_table` starts paying on the benchmarks, but
+      the count is a proxy: a 40-arm synthetic of plain `i32` fields prefers the
+      `else if` chain by 11 % where `cbor-twitter`'s 40-arm `User` prefers the
+      table by 2 %. Whatever separates those two — arm body size, how well the
+      scrutinee sequence predicts — is what the threshold should be reading. Arm
+      body size is already summed, as `SWITCH_MAX_CLONE_COST`, but only as a
+      blow-up guard on the emitted table, never as the pay-off predicate.
 
 Precision. All of it waits on one rule.
 
@@ -354,7 +379,9 @@ field load, which nothing does: its structural path is deliberately
 value-graph-free and its value path excludes `FieldAccess`. Surveyed, in-loop
 field reads that are provably invariant are 2.7 % and 7.1 % on the two
 benchmarks — too few to pay for maintaining promoted operands across `inline`
-and `sroa`, which dropping `must_anchor` would need.
+and `sroa`, which an in-loop freeze would need. `FreezePhase` carries no in-loop
+variant, so there is nothing to enable: reviving this means adding the phase
+back under the rule, not flipping a flag.
 
 Two notes for whoever revives this. The invariance test is free:
 `apply_loop_heap_effects` bumps every slot the loop may write before the body
@@ -377,17 +404,20 @@ invariance in a loop.
 
 - [ ] Reach the in-loop consumers. Every freeze that may plant a local-naming
       value runs after the fixed-point loop, so the passes inside it still see
-      none: LICM's value hoist collected zero loop-entry locals in 10,900
-      queries, and `loop_entry_values` still has no working consumer, which is
-      why `inline` discarding a non-empty map 1,469 times costs nothing. An
-      in-loop freeze cannot simply be added — one was, and is recorded under
-      "The anchor rule"; the early freeze is separately bound by the
-      context-free rule under "Measured dead ends". Moving the build to `lower`
-      does not lift that bound: it is the extraction that is point-dependent,
-      not the build. This and the widening above share one prerequisite, the
-      anchor rule below, which also gates nearly all of retiring the pure
-      `ExprKind`s — not only its `Local` half, since the arithmetic above a
-      local read resolves to no value either.
+      none: `licm` reads `loop_entry_values` twice — the CSE availability test
+      and the entry-live leaf gate — and its value hoist collected zero
+      loop-entry locals in 10,900 queries. Which is why the map's upkeep is
+      free: `inline` keeps it only across a splice that preserves the graph
+      (every inlined call pure and loop-free) and clears it otherwise, and
+      nothing notices either way. An in-loop freeze cannot simply be added —
+      one was, and is recorded under "The anchor rule"; the early freeze is
+      separately bound by the context-free rule under "Measured dead ends".
+      Moving the build to `lower` does not lift that bound: it is the
+      extraction that is point-dependent, not the build. This and the widening
+      above share one prerequisite, the anchor rule opening this section, which
+      also gates nearly all of retiring the pure `ExprKind`s — not only its
+      `Local` half, since the arithmetic above a local read resolves to no
+      value either.
 
 - [ ] Copy propagation on `ValueId`. Source-stability is not subsumed by value
       equality — a write-once `x` whose source `y` is later reassigned can read
@@ -464,7 +494,8 @@ Each was built, verified, and reverted. Do not retry as-is.
   a block. Only holding an empty memo across edits pays.
 
 The throughline: a value's identity is sound only when carried by an operand the
-edits maintain, never re-derived from a side-table at query time.
+edits maintain, or by a leaf whose single version the query itself proves — never
+re-derived from a side-table at query time.
 
 ## Consequences
 
@@ -473,8 +504,8 @@ edits maintain, never re-derived from a side-table at query time.
   store-load forwarding out of `(receiver, field, heap_ver)` identity. Their
   walks and bespoke analysis caches went with them.
 - The optimizer gained a hash-cons pool, a builder, and an extractor; it lost
-  the `value_of` side-table, the cache machinery, the engine's per-pass value
-  rebuild, and every per-pass structural key.
+  the persisted `value_of` side-table, the cache machinery, the engine's
+  per-pass value rebuild, and every per-pass structural key.
 - The arena costs one mutation discipline: the edit API is mandatory, and dead
   nodes accumulate until compaction lands.
 - Measured wins along the way: the arena-direct engine cut a heavy module's

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -7,8 +7,17 @@ per-function sessions, scheduled by a **per-function dirty-set gate**, and
 
 This WEP is the design. The pass inventory lives in
 [`docs/optimizer.md`](./optimizer.md); every implementation detail — node kinds,
-rule predicates, pass ordering — is owned by the code
+rule predicates, pass ordering, which function holds what — is owned by the code
 (`nir_arena.rs`, `nir_value_graph.rs`, `nir_engine.rs`, `optimize/`).
+
+That division is what keeps this document true. A decision and the measurement
+that settled it are dated facts: they do not go stale. A description of how the
+code is arranged today goes stale the moment the code moves, and every such
+sentence here is one more thing to keep in sync with a refactor that has no
+reason to look. So this WEP states what was decided, why, what it obliges, and
+what is still open — and names an identifier only where the decision is about
+that identifier. A detail a reader needs in order to act correctly belongs in a
+doc comment beside the code it describes, where it cannot drift.
 
 ## Terms
 
@@ -51,32 +60,27 @@ it.
 
 A function body is a per-function arena, `Body`, and is the canonical post-lower
 form: `lower::translate` builds it directly and `wir_build` reads it directly.
-Closure `__call` methods and non-trivial global initializers are bodies too.
+A closure's call method and a non-trivial global initializer are bodies too, so
+every pass reaches them without a special case.
 
-- Typed id spaces (`ExprId` / `StmtId` / `BlockId` / `PatId`) over
-  `cranelift_entity` maps, with `NodeRef` as the uniform handle the worklist and
-  parent map speak. Typed rather than uniform so a rule signature rejects a
+- A node is addressed by a stable id, so a worklist entry survives an edit to
+  the node it names — the handle the tree form could not offer. The id spaces
+  are typed per node category rather than uniform, so a rule signature rejects a
   statement where an expression belongs.
-- Records that are never independent rewrite targets — match arms, struct
-  fields, call args — are not id-bearing. They live inline in their parent and
-  are transparent to the parent map.
-- `span` stays per node — it feeds diagnostics, optimizer remarks, and DWARF,
-  and is part of skeleton identity. Layer 2 is the span-free layer, not this
-  one. `type_id` is per expression, there being nothing to type on a statement,
-  a block, or a pattern.
-- Parent edges (nearest id-bearing ancestor) and a per-local use index
-  (`def` / `reads` / `writes`) are derived once per session, at `Engine::new`,
+- Only a node a rewrite can target independently bears an id. The records that
+  are always rewritten through their parent live inline in it, and are
+  transparent to the parent map.
+- Spans are skeleton identity: they feed diagnostics, optimizer remarks, and
+  DWARF. Layer 2 is the span-free layer, not this one.
+- Parent edges and a per-local use index are derived once when a session opens
   and maintained incrementally by the edit API from there — never re-derived
-  under a running session. Function-level alias facts (`address_taken_locals`,
-  `stores_aliased_locals`) and the local table travel on `Body` beside the
-  arena, and are mirrored on `NirFunction` for the passes that run outside a
-  session; `sroa` merges its deltas back into the function's copy.
-- Nodes are not freed mid-run. Liveness is reachability from `root`, and the use
-  index ignores orphans.
+  under a running session.
+- Nodes are not freed mid-run. Liveness is reachability from the root, and the
+  use index ignores orphans.
 
 Document order is effect order. The skeleton carries statements, control flow,
-effectful and allocation-bearing expressions (`Call`, heap `Assign`,
-`StructLiteral` / `TupleLiteral` / `ArrayLiteral`), and patterns.
+and the expressions that are effectful or allocate; pure values have no place in
+an order and live in Layer 2.
 
 ### Layer 2 — the live ValueGraph (`nir_value_graph.rs`)
 
@@ -85,21 +89,15 @@ Pure values are hash-consed into a per-function `ValuePool`, indexed by
 equality is `==` on a `u32`. The graph is where pure values **live**, not a
 side-table derived from the skeleton.
 
-- Kinds cover literals, `Opaque` (parameters and unknowns), `Binary` / `Unary` /
-  `Cast`, `Select` (structural merge), `LoopPhi` (loop recurrence), and
-  `FieldAccess` carrying a per-field `HeapVersion`.
-- There is no `Local` kind. Flow is resolved into the graph **once, at build**:
-  the builder threads a per-local current value, constructs `Select` at merge
-  points and `LoopPhi` at loops, and bumps heap versions where the skeleton may
-  write. A read's `ValueId` is fixed to the value dominant at that point.
-- A skeleton `Local` read the build did not reach resolves at query time
-  instead, to the memoized `Opaque` `ValuePool::canonical_local` mints — one
-  `ValueId` per local index, version-free. That is sound only where the local
-  has a single version, so `Engine::value` gates it on
-  `local_has_one_version`; a multi-version local resolves to `None`. The
-  builder's threaded value and this memo are the pool's two sources of a
-  local-valued leaf, and the anchor rule below is what keeps the second from
-  over-merging.
+- The kinds cover what a pure value can be: constants, an opaque unknown,
+  arithmetic, a structural merge, a loop recurrence, and a field read carried at
+  a heap version.
+- There is no kind naming a local. Flow is resolved into the graph **once, at
+  build**: the builder threads a per-local current value, merges at joins,
+  opens a recurrence at a loop, and bumps heap versions where the skeleton may
+  write. A read's `ValueId` is fixed to the value dominant at that point, so
+  reading a local is not an operation the graph can express — it is already
+  resolved.
 - Identity is structural, and a `ValueId` is stable once allocated: interning is
   pure hash-consing, with no e-class merges and so no representative lookup. A
   rewrite that proves `a ≡ b` points the operand slot at `b`; it never merges
@@ -109,7 +107,7 @@ side-table derived from the skeleton.
 Build once, rewrite eagerly, extract once — the shape Cranelift's aegraph
 mid-end takes, minus its union-find.
 
-Constant aggregates are named by a single `Const` kind; materialising one is an
+A constant aggregate is one value however deep it is; materialising one is an
 allocation, which is `const_object_globalization`'s decision, so an aggregate
 constant is never frozen into an operand slot.
 
@@ -119,33 +117,27 @@ A skeleton child slot is `Operand = Expr(ExprId) | Value(ValueId)`. Pure operand
 positions carry `Operand::Value`; effectful and control-flow operands stay
 `Operand::Expr`.
 
-Values are **born as operands**: `lower::translate` and the promotion passes
-(`optimize/extract.rs`) freeze a pure position into its `ValueId` directly, so a
-pass reads the value off the operand rather than looking an `ExprId` up. Lower's
-share is the scalar constants, interned as it translates each literal; a string
-or bytes literal deliberately stays an expression, being an allocation whose site
-`const_object_globalization` decides. Everything non-constant is promoted later,
-by a freeze.
+Values are **born as operands**: lowering and the promotion passes freeze a pure
+position into its `ValueId` directly, so a pass reads the value off the operand
+rather than looking an expression up.
 
-No `ExprId → ValueId` map is persisted. A scoped scratch walk still returns one,
-which is what `FieldAccess` promotion reads, but it dies with the query that
-asked. An unpromoted skeleton leaf therefore resolves to `None`, which is sound
-because `None` is the finest partition — a consumer skips the expression rather
-than over-merging.
+No expression-keyed value map is persisted. A scoped scratch walk may build one
+to answer a query, but it dies with the query. An unpromoted skeleton leaf
+therefore resolves to no value, which is sound because that is the finest
+partition — a consumer skips the expression rather than over-merging.
 
-Promotion is staged against what the passes need to see: arithmetic freezes
-before the loop (on each function's clean, un-restructured graph, which is what
-makes freezing a constant leaf read sound), `FieldAccess` freezes after the SROA
-passes have settled the struct shape, and the final arithmetic freeze runs last,
-after every binary-walking pass.
+Promotion is staged against what the passes need to see, and the staging is the
+design: a freeze is only sound where nothing later re-contextualizes the operand
+it plants. Arithmetic freezes before the loop, on a clean graph; field reads
+freeze once the structural passes have settled the shape they read; the last
+arithmetic freeze runs after every pass that walks arithmetic.
 
 ### Extraction
 
-One pass materialises each promoted operand back into concrete form. Constant
-extraction is available to the optimizer itself (`extract::extract_const`); the
-full extraction happens at WIR build (`wir_build::translate::extract_value`),
-which lowers each kind from the pool using the type the builder recorded and
-recurses on composite operands.
+One pass materialises each promoted operand back into concrete form, at WIR
+build, reading each value's type from the pool and recursing on composites. The
+optimizer can extract a constant on its own, which is what lets a pass read a
+frozen value without waiting for the backend.
 
 Extraction currently re-materialises a value at each use — always correct, and
 for constants always cheaper than sharing. The share-vs-duplicate cost model for
@@ -157,37 +149,34 @@ Genuinely-local rewrites run as `Rule`s on a worklist over one function's `Body`
 to a local fixed point: a node is revisited only when an edit may have made it
 reducible, never by a whole-tree sweep.
 
-- A session builds the parent maps, the use index, and a post-order-seeded
-  worklist in one O(n) pass.
-- Rules never touch the arena maps; every mutation goes through the edit API
-  (`replace_expr_kind`, `become_expr`, `set_block_stmts`, `alloc_*`,
-  `clone_expr`), which keeps the parent map, the use index, and the
-  promoted-read census coherent and re-enqueues exactly the affected
-  neighbourhood. In-place replacement keeps the id stable, so a worklist entry
-  survives the edit.
+- A session derives its indices and seeds its worklist in one linear pass, then
+  maintains them.
+- Rules never touch the arena directly; every mutation goes through the edit
+  API, which is what keeps the indices and the promoted-read census coherent and
+  re-enqueues exactly the affected neighbourhood. Replacement is in place, so an
+  id — and the worklist entry naming it — survives the edit.
 - At a popped node the engine tries the registered rules in order; the first that
   reports a change retries at the same node. Rules must be idempotent, and either
   confluent or priority-ordered — priority is rule order in the session.
 
-The position-flexible local rules share **one session per function** (the unified
-peephole, `optimize/peephole.rs`), run pre-inline and post-inline so each rule
-sees the instruction window the other exposes.
+The position-flexible local rules share **one session per function**, run
+pre-inline and post-inline so each rule sees the instruction window the other
+exposes. Which rules those are is the inventory's.
 
 What stays outside the engine: flow-sensitive passes that need per-block dataflow
-keep their own walkers over the arena, and the interprocedural stages (`inline`,
-`dce`, `dae`, `drve`, globalization) run as distinct steps.
+keep their own walkers over the arena, and the interprocedural stages run as
+distinct steps.
 
-### Per-function gating (`optimize/gate.rs`)
+### Per-function gating
 
 Each function carries a monotonic revision and each pass a per-function
-watermark; a gated pass visits a function only when `revision > watermark`. A
-pass that changes a function bumps its revision and, conservatively, that of its
-1-hop call-graph neighbours in both directions. Interprocedural passes pull their
-candidate set from the dirty set rather than scanning every function, and re-mark
-affected callers when a callee shrinks; `OptConfig::iterations` is the quiescence
-bound. Terminal stages stay explicit, and so does `param_spec`, which scans every
-function because a summary it took before a callee gained a caller does not
-describe the callee it now has.
+watermark; a gated pass visits a function only when the revision has passed the
+watermark. A pass that changes a function bumps its revision and, conservatively,
+that of its immediate call-graph neighbours in both directions. Interprocedural
+passes pull their candidate set from the dirty set rather than scanning every
+function, and re-mark affected callers when a callee shrinks; the loop's
+iteration cap is the quiescence bound. A pass whose summary a call-graph change
+invalidates cannot be gated on the callee's revision alone, and stays explicit.
 
 Gating changes only **which** functions a pass visits, never the result of a
 visit. Every loop pass is an optimization, so an imprecise gate costs
@@ -205,12 +194,19 @@ interprocedural over-approximation.
 - Flow-freeze validity. A control-flow rewrite that changes which value is
   dominant must repoint the affected operands; a read must never be left holding
   a value that no longer reaches it.
-- Heap-version monotonicity. A `FieldAccess` value's `heap_ver` is the version
-  before the read; a later write bumps to a fresh version, so any read after it
-  gets a fresh `ValueId`.
+- Heap-version monotonicity. A field read's heap version is the version before
+  the read; a later write bumps to a fresh version, so any read after it gets a
+  fresh `ValueId`.
+- Single-version proof for a query-time leaf. The build is the primary source of
+  a local's value, but a leaf the build did not reach may be resolved at query
+  time instead, to a version-free value standing for that local. Version-free is
+  the whole hazard: it is one value for every assignment of the local, so it is
+  sound only under a proof that the local has exactly one. Absent the proof the
+  query answers with no value, never with a guess. The anchor rule below is the
+  same obligation seen from the freeze side.
 - Pointwise maintenance. A structural edit keeps the graph coherent at the point
   of the edit — pruning a branch repoints the surviving operands past the dead
-  `Select` arm; splicing an inlined body or an SROA split interns value nodes for
+  merge arm; splicing an inlined body or an SROA split interns value nodes for
   the new skeleton subtree. Monotone growth, never a re-derivation of existing
   flow. This is the load-bearing claim of the design.
 - Extraction equivalence. The extracted form computes, for every effectful
@@ -222,32 +218,27 @@ interprocedural over-approximation.
 
 These are settled by measurement and re-derived at a cost.
 
-- No mid-pipeline rebuild of the value graph. Build-once is structural: nothing
-  clears `Body::value_graph`. Maintain in place; never clear-and-rebuild.
-- No `ExprId`-keyed value cache or side-table. A pass needing a value uses
-  born-as-operands or a scoped scratch walk.
+- No mid-pipeline rebuild of the value graph. Build-once is structural, not a
+  cache policy: nothing clears the graph. Maintain in place; never
+  clear-and-rebuild.
+- No expression-keyed value cache or side-table that outlives a query. A pass
+  needing a value uses born-as-operands or a scoped scratch walk.
 - A promoted read lives in the pool, not the skeleton. A pass that decides a
-  local is unused, or rewrites every read of one, must count the pool's reads
-  (`arena_query`'s `promoted_*` queries) — scoped to the operands the skeleton
-  still carries, since the pool is append-only and also holds reads that folded
-  away.
+  local is unused, or rewrites every read of one, must count the pool's reads as
+  well — scoped to the operands the skeleton still carries, since the pool is
+  append-only and also holds reads that folded away.
 - That census is session-scoped, never per-application: it walks the whole body,
-  so recomputing it per rule application is quadratic. `Engine` memoizes it and
-  holds an _empty_ memo across edits — the case that decides the cost, since
-  inside the loop the early freeze plants context-free values only and no
-  reachable operand names a local. Only a local-naming operand becoming
-  reachable drops it, which the edit API reports; a rule therefore never writes
-  an operand past it into `Body`, and an operand-slot sweep goes through
-  `Engine::map_operands`. `Engine::run` audits the memo against a fresh walk
-  under debug assertions — a backstop covering a session that asked, at its end
-  only, not a proof.
+  so recomputing it per rule application is quadratic. It is memoized, and the
+  memo is held across edits while it is empty — the case that decides the cost,
+  since inside the loop nothing reachable names a local. Only a local-naming
+  operand becoming reachable drops it, which the edit API is what reports; a
+  rule therefore never writes such an operand into the body behind the API's
+  back. A debug-only audit at session end is a backstop, not a proof.
 - No whole-body walk per rule application, in an assertion either. A rewrite
-  that deletes a binding reports the local through `Engine::note_elided_local`
-  and `Engine::run` audits the batch once; checking it at the rewrite put
-  `peephole` at 5.1 s of a 9.5 s loop, against 1.4 s of 6.2 s once
-  session-scoped. The audit reads the arena fresh rather than the use index and
-  census memo the rewrite decided on — substituting those would make it agree
-  with itself and catch nothing.
+  that deletes a binding records the local and the session audits the batch
+  once; checking it at each rewrite cost more than half the loop. The audit
+  reads the arena fresh rather than the indices the rewrite decided on —
+  substituting those would make it agree with itself and catch nothing.
 
 ## Rejected and deferred
 
@@ -268,29 +259,30 @@ rewrites that saturation does not help.
 
 So saturation stays the terminal ideal, activated only if measurement justifies
 it (a native-AOT backend, or Wasm output measurably benefiting from algebra the
-JIT cannot do). Its prerequisites are visualisation tooling
-(`WADO_DUMP_VALUE_GRAPH`, `WADO_DUMP_AFTER_RULE`) and budget-bounded rule sets —
-a budget hit must degrade gracefully to the partially saturated graph, never
-panic and never produce worse output than the input.
+JIT cannot do). Two things would have to exist first: tooling that makes a value
+graph and a rule firing visible, since a saturating rule set is not debuggable by
+reading output; and budget-bounded rule sets, where a budget hit degrades
+gracefully to the partially saturated graph, never panicking and never producing
+worse output than the input.
 
 ### Not a session index carried across passes
 
-`Engine::new` rebuilds the parent maps and use index per function — 1.03 s of a
+Opening a session rebuilds the parent map and use index — 1.03 s of a
 ~5.8 s loop over 36 000 sessions. Carrying it across passes was built and
 measured: 91 % of sessions reuse it and the derivation drops 68 %, but the loop
 total does not move, and three things argue against it.
 
-- It optimizes the structure the terminal ideal retires (see the `ExprKind`
+- It optimizes the structure the terminal ideal retires (see the pure-node-kind
   item), and does nothing for the census the precision items load.
 - Reuse changes the output (+3.3 KB), so the carried state is not equivalent.
 - Soundness would rest on 36 `invalidate_engine_index` calls staying correct by
   hand, each omission a silent miscompile.
 
-Closing the arena's mutation surface so the type system carries the invariant is
-the prerequisite that would change this verdict. That surface is 124 direct
-writes to an arena map over nine `optimize/` files, outside the edit API and
-outside tests — `sroa_variant_return`, `const_object_globalization`, and
-`field_scalarize` are two thirds of it.
+Closing the arena's mutation surface — so that the type system, rather than a
+reviewer, carries the invariant that every edit goes through the API — is the
+prerequisite that would change this verdict. Until then the surface is whatever
+the current passes leave open, which is a thing to measure at the time, not a
+number to record here.
 
 ### Not incremental rebuild, and not a richer cache
 
@@ -313,30 +305,29 @@ benchmark, spread over `peephole` (23 %) and `copy_prop` / `const_fold` / `licm`
       every body before the loop, so the lazy first-query path is eager in
       practice.
 
-- [ ] Retire the remaining pure `ExprKind` variants, so every pure position is
-      an `Operand::Value`. A compile-speed item as much as a saturation
-      prerequisite: pure kinds are 52 % of the arena on the two benchmarks and
-      the `Local` nodes the use index is made of are 34 %, so retiring them
-      halves what every session walk covers. Re-measure `Engine::new` (1.03 s,
-      ~17 % of the loop) afterwards — the other compile-speed items are sized
-      against a skeleton this shrinks.
-      Almost none of it is independently reachable. `Engine::value` recurses
-      through operands, so arithmetic left in the skeleton has no value at all,
-      bottoming out on a field load or a call result rather than being gated.
-      It waits on Precision below.
+- [ ] Retire the pure node kinds still left in the skeleton, so every pure
+      position is an operand. A compile-speed item as much as a saturation
+      prerequisite: pure kinds were 52 % of the arena when last measured, and
+      the local reads the use index is made of 34 %, so retiring them roughly
+      halves what every session walk covers — and the other compile-speed items
+      are sized against a skeleton this shrinks. Almost none of it is
+      independently reachable, because a value query recurses through operands:
+      arithmetic left in the skeleton bottoms out on a field load or a call
+      result and yields no value at all, rather than being gated on something a
+      flag could flip. It waits on Precision below.
 
 - [ ] Arena compaction. In-place rewrites orphan nodes that are never freed
       mid-run (~1.66× bloat measured at end-of-optimize on `package-gale`).
 
-- [ ] Price `match_to_switch` on something other than how wide the table is.
-      `SWITCH_MIN_CASES` is twelve values covered — one range arm can reach it
-      alone — which is where the `br_table` starts paying on the benchmarks, but
-      the count is a proxy: a 40-arm synthetic of plain `i32` fields prefers the
-      `else if` chain by 11 % where `cbor-twitter`'s 40-arm `User` prefers the
-      table by 2 %. Whatever separates those two — arm body size, how well the
-      scrutinee sequence predicts — is what the threshold should be reading. Arm
-      body size is already summed, as `SWITCH_MAX_CLONE_COST`, but only as a
-      blow-up guard on the emitted table, never as the pay-off predicate.
+- [ ] Price the switch lowering on something other than how wide the table is.
+      The threshold is a count of the values the table covers, set where the
+      `br_table` starts paying on the benchmarks, but the count is a proxy: a
+      40-arm synthetic of plain `i32` fields prefers the `else if` chain by
+      11 % where `cbor-twitter`'s 40-arm `User` prefers the table by 2 %.
+      Whatever separates those two — arm body size, how well the scrutinee
+      sequence predicts — is what the threshold should be reading. Arm body size
+      is already summed, but as a blow-up guard on the emitted table, never as
+      the pay-off predicate.
 
 Precision. All of it waits on one rule.
 
@@ -345,104 +336,98 @@ Precision. All of it waits on one rule.
 A frozen operand may name a local only when that local's defining statement
 travels with the operand.
 
-A source local fails that. A parameter's def is the function entry, which is not
-a statement, so `inline` splices the operand into a caller where the same index
-is assigned once per call — and because `ValuePool::canonical_local` hands out
-one `ValueId` per local index, two reads that now denote different values share
-an id. That is the over-merge behind `String::substr_bytes` under
-"Measured dead ends". The guard used to be "every leaf is a parameter", a proxy
-for "this local has one version" that inlining invalidates, since
-parameter-ness does not survive being inlined; it is now the predicate itself
-(`Engine::local_has_one_version`) plus a dominance check at the placement.
+A source local fails that. A parameter is defined by the function entry, which
+is not a statement that can travel, so inlining splices the operand into a
+caller where the same slot is assigned once per call — and since a query-time
+local value is version-free, two reads that now denote different values share an
+id. That is the over-merge behind `String::substr_bytes` under "Measured dead
+ends". The guard used to be "every leaf is a parameter", a proxy for "this local
+has one version" that inlining invalidates, parameter-ness not surviving being
+inlined; it is now that predicate itself, plus a dominance check at the
+placement.
 
-A freeze-minted temp satisfies it by construction. `let _av = <value>` is a
-statement in the same body, non-`mut`, and assigned once, so any pass that
-copies the operand copies the def with it, and one `ValueId` per `_av` stays
-true in every context it lands in. So: never freeze a value naming a source
-local — materialise it into an `_av` and name that.
-`apply_value_freeze` already mints `_av` this way for the multi-use case; the
-rule makes it the only way a local may be named, and drops the parameter
-restriction, which the anchor replaces.
+A freeze-minted temp satisfies the rule by construction: a fresh immutable
+binding, in the same body, assigned once, so any pass that copies the operand
+copies the definition with it and the one-value-per-binding property holds in
+every context it lands in. So: never freeze a value naming a source local —
+materialise it into such a temp and name that. The freeze already mints one for
+the multi-use case; the rule makes it the only way a local may be named, and
+replaces the parameter restriction.
 
 The rule is necessary and not sufficient. There is no in-loop freeze: one was
 built under it and promoted nothing on either benchmark, at 11.3 % of the loop,
-so it was removed. Two things have to hold and neither did.
+so it was removed, phase and all — reviving it means adding the phase back under
+the rule, not flipping a flag. Two things have to hold and neither did.
 
 The material has to exist. Resolving every provably single-version local, not
 just parameters, changes no output on its own, because the leaves that matter
-are field loads and call results — and a `FieldAccess` is keyed on the
-`heap_ver` at its point, which no query-time re-derivation supplies. The builder
-is the only source, through the graph build or a scratch re-walk.
+are field loads and call results — and a field read is keyed on the heap version
+at its point, which no query-time re-derivation supplies. The builder is the
+only source, through the graph build or a scratch re-walk.
 
-A consumer has to want it. The candidate is `licm` hoisting a loop-invariant
-field load, which nothing does: its structural path is deliberately
-value-graph-free and its value path excludes `FieldAccess`. Surveyed, in-loop
+A consumer has to want it. The candidate is hoisting a loop-invariant field
+load, which no pass does: LICM's structural path is deliberately
+value-graph-free and its value path excludes field reads. Surveyed, in-loop
 field reads that are provably invariant are 2.7 % and 7.1 % on the two
-benchmarks — too few to pay for maintaining promoted operands across `inline`
-and `sroa`, which an in-loop freeze would need. `FreezePhase` carries no in-loop
-variant, so there is nothing to enable: reviving this means adding the phase
-back under the rule, not flipping a flag.
+benchmarks — too few to pay for maintaining promoted operands across inlining
+and SROA, which an in-loop freeze would need.
 
-Two notes for whoever revives this. The invariance test is free:
-`apply_loop_heap_effects` bumps every slot the loop may write before the body
-walk and versions are monotonic, so a read below the loop-entry watermark is
-invariant. And what holds that 2.7 % down is upstream —
-`collect_loop_heap_effects` marks a call's receiver `mut_borrowed` whether or
-not the callee can mutate it, so one `self.helper()` kills every `self.field`
-invariance in a loop.
+Two notes for whoever revives this. The invariance test is free: every slot a
+loop may write is bumped before the body walk and versions are monotonic, so a
+read below the loop-entry watermark is invariant. And what holds that 2.7 % down
+is upstream — a call's receiver is marked mutably borrowed whether or not the
+callee can mutate it, so one `self.helper()` kills every `self.field` invariance
+in a loop.
 
-- [ ] Give `collect_loop_heap_effects` the callee immutability the optimizer
-      already computes. It marks a call's receiver `mut_borrowed` whether or not
-      the callee can mutate it, while `alias.rs`'s `CallImmutability` and
-      `mod_ref::FnEffect` know the answer and the builder is handed only
-      `pure_builtin_callees`. Raises the precision of `store_load_forward`,
-      `promote_fields`, and `condition_implication` at once, and touches no part
-      of the anchor rule — measure it before anything else here.
-      One caveat: the `Call` arm records `mut_borrowed` only for a bare `Local`
-      argument, other shapes being covered only because every non-builtin call
-      sets `has_external_writes`. That fallback has to stay.
+- [ ] Give the loop heap-effect collection the callee immutability the optimizer
+      already computes elsewhere. It marks a call's receiver mutably borrowed
+      whether or not the callee can mutate it, while the alias and mod/ref
+      analyses know the answer and the builder is handed only the pure builtins.
+      Raises the precision of store-load forwarding, field promotion, and
+      condition implication at once, and touches no part of the anchor rule —
+      measure it before anything else here. One caveat the code carries: the
+      unconditional mark is precise only for a bare local argument, every other
+      shape being covered by the blanket external-writes fallback. That fallback
+      has to stay.
 
 - [ ] Reach the in-loop consumers. Every freeze that may plant a local-naming
       value runs after the fixed-point loop, so the passes inside it still see
-      none: `licm` reads `loop_entry_values` twice — the CSE availability test
-      and the entry-live leaf gate — and its value hoist collected zero
-      loop-entry locals in 10,900 queries. Which is why the map's upkeep is
-      free: `inline` keeps it only across a splice that preserves the graph
-      (every inlined call pure and loop-free) and clears it otherwise, and
-      nothing notices either way. An in-loop freeze cannot simply be added —
-      one was, and is recorded under "The anchor rule"; the early freeze is
-      separately bound by the context-free rule under "Measured dead ends".
-      Moving the build to `lower` does not lift that bound: it is the
+      none: LICM reads the loop-entry values and its value hoist collected zero
+      loop-entry locals in 10,900 queries, which is why keeping that map across
+      the loop costs nothing either way. An in-loop freeze cannot simply be
+      added — one was, and is recorded under "The anchor rule"; the early freeze
+      is separately bound by the context-free rule under "Measured dead ends".
+      Moving the build to lowering does not lift that bound: it is the
       extraction that is point-dependent, not the build. This and the widening
       above share one prerequisite, the anchor rule opening this section, which
-      also gates nearly all of retiring the pure `ExprKind`s — not only its
-      `Local` half, since the arithmetic above a local read resolves to no
-      value either.
+      also gates nearly all of retiring the pure node kinds — not only the local
+      reads, since the arithmetic above a local read resolves to no value
+      either.
 
-- [ ] Copy propagation on `ValueId`. Source-stability is not subsumed by value
-      equality — a write-once `x` whose source `y` is later reassigned can read
-      equal ids yet be unsafe to fold. Revisit with `Select` / `Opaque`
-      provenance.
-- [ ] Induction-variable recognition (`Opaque` tagged `{ base, step }`). Not
-      needed yet — post-increment reads already appear as `Add(opaque_i, step)` —
-      so it lands when a rule first wants it.
-- [ ] Stop a `&` / `&mut` on a local that flows only into `stores`-free callees
-      from marking the local aliased. Plumbing the callee's `stores` into
-      `alias::escape_ref_arg` is not the way: `build_alias_info` seeds `aliased`
-      from `address_taken_locals`, and the elaborator marks that for every
-      `&x` / `&mut x` on a local, so the `(&self).field` shape this was written
-      for is already aliased before the call site is looked at. Measured, 3.7 %
-      of ref-arg marks (2 099 of 56 269 on `benchmark/sqlite_parse`) are the
-      sole reason their local is aliased — refs to a projection (`f(&x.field)`),
-      which the elaborator does not record. Narrowing the rest means narrowing
-      the seed, which is a whole-function question (do _all_ uses of `&x` flow
-      into `stores`-free callees?) over an annotation `boxing`, `sroa`, and
-      `elide_local` also read. Also note `mut_escaped` is built by filtering
-      `aliased`, so dropping a local from `aliased` silently drops it from
-      `mut_escaped` too — a callee that cannot retain a reference can still
-      mutate through it during the call, so the two have to be decoupled first.
-- [ ] Directed gate propagation (callee-shrink → callers only). Deferred: it
-      drops the edges `inline` adds to the build-once call graph, and a
+- [ ] Copy propagation on value identity rather than on locals. Source-stability
+      is not subsumed by value equality — a write-once `x` whose source `y` is
+      later reassigned can read equal ids yet be unsafe to fold. Revisit with
+      provenance on the merge and opaque kinds.
+- [ ] Induction-variable recognition, as a tagged opaque carrying base and step.
+      Not needed yet — a post-increment read already appears as the addition it
+      is — so it lands when a rule first wants it.
+- [ ] Stop a borrow of a local that flows only into callees which cannot retain
+      it from marking the local aliased. Plumbing the callee's escape summary
+      into the ref-argument check is not the way: the aliased set is seeded from
+      the address-taken locals the elaborator records for every borrow of a
+      local, so the `(&self).field` shape this was written for is already
+      aliased before the call site is looked at. Measured, 3.7 % of ref-arg
+      marks are the sole reason their local is aliased — borrows of a
+      projection, which the elaborator does not record. Narrowing the rest means
+      narrowing the seed, which is a whole-function question (do _all_ uses of
+      the borrow flow into callees that cannot retain it?) over an annotation
+      several other passes also read. Note too that the mutable-escape set is
+      built by filtering the aliased set, so dropping a local from one silently
+      drops it from the other — and a callee that cannot retain a reference can
+      still mutate through it during the call, so the two have to be decoupled
+      first.
+- [ ] Directed gate propagation, callee-shrink to callers only. Deferred: it
+      drops the edges inlining adds to the build-once call graph, and a
       per-iteration rebuild does not recover them — the staleness is
       intra-iteration. It would need incremental edge maintenance, for a
       measured net-neutral gain.
@@ -452,8 +437,8 @@ Terminal ideal, gated behind measurement (see "Not equality saturation").
 - [ ] Saturation driver plus cost-based extraction: run rules to a bounded
       saturation, then extract a cost-minimal form per operand, materialising a
       multi-use value only when sharing beats duplication. This subsumes the
-      extraction cost model, the global fixed-point loop, per-rule `applied`
-      guards, and the dirty-set gate.
+      extraction cost model, the global fixed-point loop, the per-rule
+      did-anything-change guards, and the dirty-set gate.
 
 ## Measured dead ends
 
@@ -466,17 +451,16 @@ Each was built, verified, and reverted. Do not retry as-is.
   between handoffs, and `inline` restructures bodies wholesale every iteration.
   Raising the fire rate needs the single-worklist architecture, which subsumes
   the whole mechanism.
-- **A richer graph cache** (`vg_cache` / `carry_vg_cache`). Caps low for the same
-  reason: it rebuilds whenever a pass changes a function, which is the common
-  case. Deleted.
+- **A richer graph cache.** Caps low for the same reason: it rebuilds whenever a
+  pass changes a function, which is the common case. Deleted.
 - **Pooling the graph builder's output maps.** The build is compute-bound (walk +
   hash-cons + flow joins), not allocation-bound; measured no improvement.
-- **Promoting induction-variable `Local` reads to source-bearing opaques.** That
-  resolver keyed one `ValueId` per local index (the builder instead mints one
-  per assignment), so the id spanned every version of the local, and an
-  induction variable has one per iteration. Traps `closure_for_loop_mutation`.
+- **Promoting induction-variable local reads to source-bearing opaques.** That
+  resolver keyed one `ValueId` per local, where the builder mints one per
+  assignment, so the id spanned every version of the local — and an induction
+  variable has one per iteration. Traps `closure_for_loop_mutation`.
 - **Freezing a local-naming value before the structural passes.** The early
-  freeze is sound because a frozen value survives `inline` and `sroa` copying the
+  freeze is sound because a frozen value survives inlining and SROA copying the
   operand around — true of a constant, which means the same thing wherever it
   lands, false of a value naming a local, because those passes renumber locals
   and splice a callee body into a caller, re-contextualizing the slot underneath
@@ -484,10 +468,10 @@ Each was built, verified, and reverted. Do not retry as-is.
   `trim_start`'s loop, read back as an iteration's worth of values and trap with
   "allocation size too large". The invariant is now explicit at the freeze
   decision: early plants only context-free values.
-- **A query-time entry-`FieldAccess` materialiser.** Miscompiled ~165 fixtures:
-  reference and aggregate fields change copy / alias semantics.
+- **A query-time materialiser for a field read at function entry.** Miscompiled
+  ~165 fixtures: reference and aggregate fields change copy / alias semantics.
 - **Keeping caller values across a loop-free-but-impure inline.** Over-merges two
-  reads of a `&mut` parameter.
+  reads of a mutable reference parameter.
 - **Dropping the promoted-read census memo on every edit.** The obvious
   invalidation rule, and measurably worse than no memo: a whole-body walk per
   rewrite where the per-block recomputation it replaced at least amortised over
@@ -501,11 +485,11 @@ re-derived from a side-table at query time.
 
 - A cluster of former passes became graph structure and stopped existing: CSE and
   GVN fall out of hash-consing, pure copy propagation out of shared ids,
-  store-load forwarding out of `(receiver, field, heap_ver)` identity. Their
-  walks and bespoke analysis caches went with them.
+  store-load forwarding out of receiver-field-version identity. Their walks and
+  bespoke analysis caches went with them.
 - The optimizer gained a hash-cons pool, a builder, and an extractor; it lost
-  the persisted `value_of` side-table, the cache machinery, the engine's
-  per-pass value rebuild, and every per-pass structural key.
+  the persisted value side-table, the cache machinery, the per-pass value
+  rebuild, and every per-pass structural key.
 - The arena costs one mutation discipline: the edit API is mandatory, and dead
   nodes accumulate until compaction lands.
 - Measured wins along the way: the arena-direct engine cut a heavy module's

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -385,23 +385,42 @@ before aliasing the same receiver. Both now read one verdict. It fires widely �
 buys nothing: the fixture corpus is WIR-identical over 1 921 goldens, and so is
 every benchmark.
 
-It buys nothing because a sibling conservatism in the same match arm subsumes
-it. Every non-builtin call sets the blanket external-writes flag, a receiver
-call included, so any loop holding one bumps the whole `mut_escaped` set's
-generation — and a read rooted at an escaped local takes the max of that. The
-per-local mark and the set-wide flag invalidate the same reads, so suppressing
-the first pays only for a receiver outside `mut_escaped`. What remains
-unmeasured is how many of the suppressed receivers are in it; that count decides
-whether the flag explains the null entirely or only mostly.
+It buys nothing because the set-wide bump subsumes it. Measured at the read: on
+`sqlite_parse` the escaped-set generation is what invalidates 66 % of field
+reads rooted at a local, on `json_twitter` 43 %; the per-local mark the receiver
+verdict suppresses decides 0.4 % and 0 %, and even those roots are escaped, so
+the read falls to the set-wide generation instead of surviving. There was no
+read for the verdict to save.
 
-- [ ] Give the blanket external-writes flag the callee's mod/ref summary. It is
-      the same unjustified conservatism one line below the one just removed, and
-      the binding one: `mod_ref::FnEffect` knows what a callee writes, while the
-      flag bumps every escaped local's generation for every non-builtin call.
-      Narrowing it is what would let the receiver verdict above reach an output,
-      and it is a precondition for the in-loop consumer work below, not an
-      alternative to it. Measure the escaped-receiver count first — it sizes the
-      prize.
+The second conservatism of the same shape is gone too: the loop summary decided
+"external write" by a builtin-only test where the straight-line walk asks the
+purity verdict, so the loop asked a strictly weaker question of the same call.
+Both now read one verdict. Pure calls are common in loop bodies — 22 % on
+`sqlite_parse` — and it still buys nothing, because the summary is a union over
+the whole body and an impure call sits beside them in nearly every loop. That
+union is not a conservatism to remove: the body runs many times, so every write
+in it must be assumed to precede every read. Per-loop summarization is sound
+and necessary, and the ceiling is its granularity.
+
+So the escaped-set bump is where the remaining precision is, and it is
+overwhelmingly a _correct_ invalidation at the wrong granularity: a `&mut self`
+method calling `self.advance()` really does mutate `self`, and the bump kills
+every field of `self` where `advance` writes one. The prize is field-granular.
+
+- [ ] Field-granular receiver write sets. `compute_receiver_mutating` already
+      fixpoints "writes through param 0" as a bool; widen it to the set of
+      direct fields written (`self.f = …` contributes `f`; a deeper projection,
+      `*self = …`, a `&mut` hand-out or a `mut` argument contributes Top), and
+      at a call with a bare-local receiver bump those slots instead of the
+      local. The set-wide bump must then exempt that receiver, which is sound
+      exactly when the receiver is the callee's only path to it — not
+      `untrackable`, and no other argument in its alias class — since only then
+      is the param-0 write set complete. An O(1) exemption per local suffices:
+      record the escaped generation before and after the call, and let a read
+      of that local use the before-value while the after-value is still the
+      current one; the next unrelated impure call advances past it and the
+      exemption expires on its own. Unmeasured: what share of in-loop impure
+      calls carry a bare-local receiver, which is what this reaches.
 
 - [ ] Reach the in-loop consumers. Every freeze that may plant a local-naming
       value runs after the fixed-point loop, so the passes inside it still see

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -377,18 +377,31 @@ One note for whoever revives this. The invariance test is free: every slot a
 loop may write is bumped before the body walk and versions are monotonic, so a
 read below the loop-entry watermark is invariant.
 
-What used to hold that 2.7 % down was upstream, and is fixed: the loop
-heap-effect collection marked a call's receiver mutably borrowed whether or not
-the callee could mutate it, disagreeing with the alias analysis beside it, which
-asks that very question before aliasing the same receiver. Both now read one
-verdict. It bought no output: the fixture corpus is WIR-identical over 1 921
-goldens, and so is every benchmark. The reason is this section's other half —
-still no consumer. A field read of a reference parameter across an immutable
-call in a loop is already hoisted by LICM's structural path, which never asks
-the value graph, and the value-side consumers do not reach the shape at all,
-because a local struct is scalarized by SROA and a small callee is gone to the
-inliner before either matters. So the precision is real and unclaimed, and the
-consumer, not the precision, is what to build next.
+One conservatism that held that 2.7 % down is gone: the loop heap-effect
+collection marked a call's receiver mutably borrowed whether or not the callee
+could mutate it, while the alias analysis beside it asks that very question
+before aliasing the same receiver. Both now read one verdict. It fires widely —
+77 % of in-loop receiver calls on `sqlite_parse`, 64 % on `json_twitter` — and
+buys nothing: the fixture corpus is WIR-identical over 1 921 goldens, and so is
+every benchmark.
+
+It buys nothing because a sibling conservatism in the same match arm subsumes
+it. Every non-builtin call sets the blanket external-writes flag, a receiver
+call included, so any loop holding one bumps the whole `mut_escaped` set's
+generation — and a read rooted at an escaped local takes the max of that. The
+per-local mark and the set-wide flag invalidate the same reads, so suppressing
+the first pays only for a receiver outside `mut_escaped`. What remains
+unmeasured is how many of the suppressed receivers are in it; that count decides
+whether the flag explains the null entirely or only mostly.
+
+- [ ] Give the blanket external-writes flag the callee's mod/ref summary. It is
+      the same unjustified conservatism one line below the one just removed, and
+      the binding one: `mod_ref::FnEffect` knows what a callee writes, while the
+      flag bumps every escaped local's generation for every non-builtin call.
+      Narrowing it is what would let the receiver verdict above reach an output,
+      and it is a precondition for the in-loop consumer work below, not an
+      alternative to it. Measure the escaped-receiver count first — it sizes the
+      prize.
 
 - [ ] Reach the in-loop consumers. Every freeze that may plant a local-naming
       value runs after the fixed-point loop, so the passes inside it still see

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -478,16 +478,15 @@ pub struct Body {
     pub locals: Vec<NirLocal>,
     pub address_taken_locals: IndexSet<u32>,
     pub stores_aliased_locals: IndexSet<u32>,
-    /// The function's pure-value graph — the source of truth for every
-    /// [`Operand::Value`] in the skeleton. Built once
-    /// by `lower::translate` and maintained in place by the optimizer's edits;
-    /// never re-derived from the skeleton. Empty on a body built before operand
-    /// promotion populates it.
+    /// The function's pure-value pool — the source of truth for every
+    /// [`Operand::Value`] in the skeleton. Seeded by `lower::translate` with the
+    /// constants it promotes, filled by the graph build, and maintained in place
+    /// by the optimizer's edits; never re-derived from the skeleton.
     pub values: ValuePool,
-    /// The per-function value graph (`value_of` + `loop_entry_values`), persisted
-    /// here so it survives across optimizer passes instead of living as a
-    /// per-`Engine`-session cache (build-once). `None`
-    /// until the first value query builds it.
+    /// The per-function build product, `loop_entry_values`, persisted here so it
+    /// survives across optimizer passes instead of living as a
+    /// per-`Engine`-session cache (build-once). `None` until the first value
+    /// query builds it.
     pub value_graph: Option<crate::nir_value_graph::builder::ValueGraphBuild>,
 }
 

--- a/wado-compiler/src/nir_arena.rs
+++ b/wado-compiler/src/nir_arena.rs
@@ -478,15 +478,11 @@ pub struct Body {
     pub locals: Vec<NirLocal>,
     pub address_taken_locals: IndexSet<u32>,
     pub stores_aliased_locals: IndexSet<u32>,
-    /// The function's pure-value pool — the source of truth for every
-    /// [`Operand::Value`] in the skeleton. Seeded by `lower::translate` with the
-    /// constants it promotes, filled by the graph build, and maintained in place
-    /// by the optimizer's edits; never re-derived from the skeleton.
+    /// The pure-value pool every [`Operand::Value`] indexes. Maintained in
+    /// place; never re-derived from the skeleton.
     pub values: ValuePool,
-    /// The per-function build product, `loop_entry_values`, persisted here so it
-    /// survives across optimizer passes instead of living as a
-    /// per-`Engine`-session cache (build-once). `None` until the first value
-    /// query builds it.
+    /// The graph build's persisted product. `None` until the first value query
+    /// builds it; never cleared after.
     pub value_graph: Option<crate::nir_value_graph::builder::ValueGraphBuild>,
 }
 

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -249,15 +249,11 @@ pub struct Engine<'a> {
     /// passes consuming [`Engine::loop_entry_value`] must call
     /// [`Engine::set_param_locals`] first.
     param_locals: Vec<u32>,
-    /// `ExprId` indices of calls that mutate no caller local
-    /// ([`crate::optimize::alias::call_verdicts`]); the build skips their
-    /// per-call `mut_escaped` bump. Empty (conservative — every call bumps)
-    /// unless a pass supplies it via [`Engine::set_call_verdicts`] before the
-    /// first value query.
+    /// Calls that mutate no caller local; the build skips their per-call
+    /// `mut_escaped` bump. Empty is conservative.
     pure_calls: IndexSet<crate::nir_arena::ExprId>,
-    /// `ExprId` indices of calls whose callee cannot write through the receiver,
-    /// from the same walk as `pure_calls`. A loop containing one does not treat
-    /// the receiver as borrowed for its whole body. Empty is conservative.
+    /// Calls whose callee cannot write through the receiver. Empty is
+    /// conservative.
     receiver_immutable_calls: IndexSet<crate::nir_arena::ExprId>,
     /// Type table for the `ValueGraph` builder's constant folding of pure
     /// arithmetic. `None` (the default) disables folding. Set via
@@ -615,13 +611,8 @@ impl<'a> Engine<'a> {
         self.param_locals = locals;
     }
 
-    /// Record the per-call verdicts the build reads: the calls that mutate no
-    /// caller local (whose per-call `mut_escaped` bump is skipped) and those
-    /// whose callee cannot write through the receiver (which a loop does not
-    /// treat as borrowing it). Taken together because one walk decides both, and
-    /// answering either alone lets the two drift. Supply before the first value
-    /// query (the build is lazy); the persisted config carries them so the
-    /// verify oracle rebuilds consistently.
+    /// Record the per-call verdicts the build reads. Supply before the first
+    /// value query; the build is lazy.
     pub fn set_call_verdicts(
         &mut self,
         pure_calls: IndexSet<crate::nir_arena::ExprId>,

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -250,10 +250,15 @@ pub struct Engine<'a> {
     /// [`Engine::set_param_locals`] first.
     param_locals: Vec<u32>,
     /// `ExprId` indices of calls that mutate no caller local
-    /// ([`crate::optimize::alias::pure_calls`]); the build skips their per-call
-    /// `mut_escaped` bump. Empty (conservative — every call bumps) unless a pass
-    /// supplies it via [`Engine::set_pure_calls`] before the first value query.
+    /// ([`crate::optimize::alias::call_verdicts`]); the build skips their
+    /// per-call `mut_escaped` bump. Empty (conservative — every call bumps)
+    /// unless a pass supplies it via [`Engine::set_call_verdicts`] before the
+    /// first value query.
     pure_calls: IndexSet<crate::nir_arena::ExprId>,
+    /// `ExprId` indices of calls whose callee cannot write through the receiver,
+    /// from the same walk as `pure_calls`. A loop containing one does not treat
+    /// the receiver as borrowed for its whole body. Empty is conservative.
+    receiver_immutable_calls: IndexSet<crate::nir_arena::ExprId>,
     /// Type table for the `ValueGraph` builder's constant folding of pure
     /// arithmetic. `None` (the default) disables folding. Set via
     /// [`Engine::set_value_graph_type_table`] before the first value query.
@@ -302,6 +307,7 @@ impl<'a> Engine<'a> {
             mut_escaped_locals: IndexSet::default(),
             param_locals: Vec::new(),
             pure_calls: IndexSet::default(),
+            receiver_immutable_calls: IndexSet::default(),
             vg_type_table: None,
             panic_callee_ids: None,
             pure_builtin_callees: None,
@@ -609,12 +615,20 @@ impl<'a> Engine<'a> {
         self.param_locals = locals;
     }
 
-    /// Record the `ExprId` indices of calls that mutate no caller local, so the
-    /// one build-once construction skips their per-call `mut_escaped` bump. Supply
-    /// before the first value query (the build is lazy); the persisted config
-    /// carries it so the verify oracle rebuilds consistently.
-    pub fn set_pure_calls(&mut self, pure_calls: IndexSet<crate::nir_arena::ExprId>) {
+    /// Record the per-call verdicts the build reads: the calls that mutate no
+    /// caller local (whose per-call `mut_escaped` bump is skipped) and those
+    /// whose callee cannot write through the receiver (which a loop does not
+    /// treat as borrowing it). Taken together because one walk decides both, and
+    /// answering either alone lets the two drift. Supply before the first value
+    /// query (the build is lazy); the persisted config carries them so the
+    /// verify oracle rebuilds consistently.
+    pub fn set_call_verdicts(
+        &mut self,
+        pure_calls: IndexSet<crate::nir_arena::ExprId>,
+        receiver_immutable_calls: IndexSet<crate::nir_arena::ExprId>,
+    ) {
         self.pure_calls = pure_calls;
+        self.receiver_immutable_calls = receiver_immutable_calls;
     }
 
     /// Record the function's reference-aliased and `stores`-aliased locals so
@@ -690,6 +704,7 @@ impl<'a> Engine<'a> {
             &self.mut_escaped_locals,
             &self.pure_calls,
             self.pure_builtin_callees.unwrap_or(&empty_builtins),
+            &self.receiver_immutable_calls,
             self.vg_type_table,
         );
         self.body.value_graph = Some(build);

--- a/wado-compiler/src/nir_package.rs
+++ b/wado-compiler/src/nir_package.rs
@@ -174,14 +174,20 @@ impl NirPackage {
     /// the call node carries no `FunctionRef`. O(functions); a pass computes it
     /// once before its per-function loop.
     pub fn pure_builtin_callee_ids(&self) -> IndexSet<FuncId> {
+        let type_table = self.type_table.borrow();
         self.functions
             .iter()
             .filter_map(|f| {
                 let f = f.borrow();
                 let descriptor = FunctionRef::from_resolved(&f, f.module_source.clone());
-                let is_pure_builtin = descriptor.builtin_name().is_some()
-                    || descriptor.monomorphized_builtin_name().is_some();
-                is_pure_builtin.then(|| f.id.expect("func_id assigned at lower"))
+                // An intrinsic below the field layer, a value-copy helper, or a
+                // bodied function that never returns. Bodied only: an extern
+                // stub's `return_type` is not an id this table resolves.
+                let writes_no_slot = descriptor.builtin_name().is_some()
+                    || descriptor.monomorphized_builtin_name().is_some()
+                    || f.is_value_copy()
+                    || (f.body.is_some() && type_table.is_never(f.return_type));
+                writes_no_slot.then(|| f.id.expect("func_id assigned at lower"))
             })
             .collect()
     }

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -658,9 +658,15 @@ impl ValuePool {
     }
 
     /// A stable `Opaque(Local idx)` for `idx`, the same value on every call.
-    /// Models "the value of `idx`" where the local holds one value across the
-    /// reads being re-seeded (a loop-stable local); two reads of the same local
-    /// — or two field copies of the same source — then share an identity.
+    /// Models "the value of `idx`", so two reads of the same local — or two
+    /// field copies of the same source — share an identity.
+    ///
+    /// The id is version-free: it stands for every assignment of the local at
+    /// once. So the caller owes a proof that there is only one, and the two that
+    /// discharge it are [`crate::nir_engine::Engine::local_has_one_version`] at
+    /// a value query and `extract`'s equivalent at a freeze. Calling this
+    /// without one merges reads that denote different values, which is the
+    /// miscompile recorded under "Measured dead ends" in WEP 2026-06-05.
     pub fn canonical_local(&mut self, idx: u32, ty: TypeId) -> ValueId {
         if let Some(&v) = self.canonical_locals.get(&idx) {
             return v;

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -657,16 +657,10 @@ impl ValuePool {
         self.opaque_sources.get(&opaque).copied()
     }
 
-    /// A stable `Opaque(Local idx)` for `idx`, the same value on every call.
-    /// Models "the value of `idx`", so two reads of the same local — or two
-    /// field copies of the same source — share an identity.
-    ///
-    /// The id is version-free: it stands for every assignment of the local at
-    /// once. So the caller owes a proof that there is only one, and the two that
-    /// discharge it are [`crate::nir_engine::Engine::local_has_one_version`] at
-    /// a value query and `extract`'s equivalent at a freeze. Calling this
-    /// without one merges reads that denote different values, which is the
-    /// miscompile recorded under "Measured dead ends" in WEP 2026-06-05.
+    /// A stable `Opaque(Local idx)`, the same value on every call. It is
+    /// version-free, so the caller owes a single-version proof
+    /// ([`crate::nir_engine::Engine::local_has_one_version`]); without one, two
+    /// reads that denote different values share an id.
     pub fn canonical_local(&mut self, idx: u32, ty: TypeId) -> ValueId {
         if let Some(&v) = self.canonical_locals.get(&idx) {
             return v;

--- a/wado-compiler/src/nir_value_graph.rs
+++ b/wado-compiler/src/nir_value_graph.rs
@@ -1,7 +1,7 @@
 //! NIR Value Graph (Layer 2): a hash-consed DAG where structurally-equivalent
 //! values share one [`ValueId`]. CSE is pure hash-consing, with no e-class
-//! merges, so an id is stable once allocated; the `SkelTree` references pure
-//! operands by id and holds none itself. Built lazily per function by
+//! merges, so an id is stable once allocated; the skeleton arena references
+//! pure operands by id and holds none itself. Built lazily per function by
 //! [`crate::nir_engine::Engine::value`]. See WEP 2026-06-05.
 
 pub mod builder;
@@ -261,8 +261,8 @@ impl OpaqueId {
     }
 }
 
-/// Heap-version tag carried by [`ValueKind::FieldAccess`]. The Stage-2
-/// builder bumps the version on every `SkelTree` node that may write the heap;
+/// Heap-version tag carried by [`ValueKind::FieldAccess`]. The builder bumps
+/// the version on every skeleton node that may write the heap;
 /// reads at the same `(receiver, field, heap_ver)` triple share a
 /// `ValueId`, automatically forwarding stored values. Granularity is
 /// per-`(receiver-root, field)`; `version_of` maxes the per-slot,
@@ -289,12 +289,10 @@ impl HeapVersion {
 
 /// A pure-value expression. Hash-consed by structural equality.
 ///
-/// Side-effecting nodes (`Call`, `Assign`-to-heap, …) stay
-/// in the `SkelTree`. Pure operand positions connect to their `ValueId`s
-/// through the per-function side-table `value_of: IndexMap<ExprId,
-/// ValueId>` populated by [`crate::nir_value_graph::builder`]. Stage 7
-/// of the WEP would replace that table with `Operand::Value(ValueId)` on
-/// Skel slots, but is deferred.
+/// Side-effecting nodes (`Call`, `Assign`-to-heap, …) stay in the skeleton
+/// arena, which names a pure operand by
+/// [`crate::nir_arena::Operand::Value`] — there is no `ExprId` → `ValueId`
+/// side-table.
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum ValueKind {
     // ---- Literals ----
@@ -325,8 +323,8 @@ pub enum ValueKind {
     Const(ConstKey, TypeId),
 
     // ---- Opaque ----
-    /// Anonymous unknown. Used for parameters and loop locals; Stage 6
-    /// may promote recognised inductions to a tagged form.
+    /// Anonymous unknown. Used for parameters and loop locals; a recognised
+    /// induction would be a tagged form of this, which nothing wants yet.
     Opaque(OpaqueId),
 
     // ---- Pure arithmetic ----
@@ -353,17 +351,16 @@ pub enum ValueKind {
 
     // ---- Structural merge / loop recurrence ----
     /// Result of a structural If / Match / Switch endpoint:
-    /// `if cond then then_v else else_v`. The Stage-2 builder constructs
-    /// these at merge points where a local's value differs across arms.
+    /// `if cond then then_v else else_v`. The builder constructs these at
+    /// merge points where a local's value differs across arms.
     Select {
         cond: ValueId,
         then: ValueId,
         else_: ValueId,
     },
     /// Loop-recurrence placeholder. `entry` is the value at loop entry;
-    /// `body_iter` is the value after one iteration of the loop body. MVP
-    /// keeps `body_iter` set to an `Opaque` (no induction recognition); the
-    /// kind exists so Stage 6 can fill it in without an enum change.
+    /// `body_iter` is the value after one iteration of the loop body, kept an
+    /// `Opaque` until a rule wants induction recognition.
     LoopPhi {
         entry: ValueId,
         body_iter: ValueId,

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -693,6 +693,15 @@ impl<'a> Builder<'a> {
         }
     }
 
+    /// The per-call verdicts, as the loop summary reads them.
+    fn call_facts(&self) -> CallFacts<'_> {
+        CallFacts {
+            pure_builtin: &self.pure_builtin_callees,
+            pure: &self.pure_calls,
+            receiver_immutable: &self.receiver_immutable_calls,
+        }
+    }
+
     fn heap_version_of(&self, root: Option<u32>, field: u32) -> HeapVersion {
         let escaped = root.is_some_and(|r| self.mut_escaped.contains(&r));
         self.heap_state.version_of(root, field, escaped)
@@ -892,12 +901,8 @@ impl<'a> Builder<'a> {
                     // Invalidate only what the rhs writes, not a blanket
                     // `bump_all`: a pure rhs leaves unrelated fields intact.
                     if let Some(re) = right.as_expr() {
-                        let eff = collect_node_heap_effects(
-                            self.body,
-                            &self.pure_builtin_callees,
-                            &self.receiver_immutable_calls,
-                            NodeRef::Expr(re),
-                        );
+                        let eff =
+                            collect_node_heap_effects(self.body, &self.call_facts(), NodeRef::Expr(re));
                         self.apply_loop_heap_effects(&eff);
                     }
                     rhs
@@ -1805,12 +1810,7 @@ impl<'a> Builder<'a> {
     fn walk_loop(&mut self, body_block: crate::nir_arena::BlockId) {
         let writes = writes_of_block(self.body, body_block, &mut self.block_writes);
         let heap_effects =
-            collect_loop_heap_effects(
-                self.body,
-                &self.pure_builtin_callees,
-                &self.receiver_immutable_calls,
-                body_block,
-            );
+            collect_loop_heap_effects(self.body, &self.call_facts(), body_block);
         // Snapshot before the reassigned-local opaques below overwrite the
         // written locals' pre-loop values.
         self.fresh_invalidations.clear();
@@ -1878,6 +1878,17 @@ impl<'a> Builder<'a> {
         }
         if eff.has_external_writes {
             self.heap_state.bump_escaped();
+        } else if eff.has_pure_calls {
+            // No set-wide bump: a pure call mutates no caller local. It still
+            // reaches the `untrackable` ones, which are too few to justify the
+            // shared version — [`Self::bump_call_effects`] splits it the same
+            // way for a single call.
+            for i in 0..self.mut_escaped_sorted.len() {
+                let l = self.mut_escaped_sorted[i];
+                if self.untrackable.contains(&l) {
+                    self.heap_state.bump_local(l);
+                }
+            }
         }
     }
 
@@ -1935,6 +1946,21 @@ fn block_breaks_to_node(body: &Body, node: NodeRef, label: &str) -> bool {
         .any(|c| block_breaks_to_node(body, c, label))
 }
 
+/// The per-call verdicts the loop summary reads. Bundled because they are one
+/// walk's output ([`crate::optimize::alias::call_verdicts`], plus the builtin
+/// set) and because the summary must ask the same questions
+/// [`Builder::bump_call_effects`] asks of a single call — a loop is that call
+/// repeated, so a weaker predicate here silently costs precision the
+/// straight-line path already has.
+struct CallFacts<'a> {
+    /// Builtin intrinsics operating below the struct-field layer.
+    pure_builtin: &'a crate::hashmap::IndexSet<FuncId>,
+    /// Calls that mutate no caller local.
+    pure: &'a crate::hashmap::IndexSet<ExprId>,
+    /// Calls whose callee cannot write through the receiver.
+    receiver_immutable: &'a crate::hashmap::IndexSet<ExprId>,
+}
+
 /// A loop body's heap-write effects, used to invalidate exactly the fields a
 /// loop may mutate (mirrors `const_folding`'s `LoopWriteEffects`). Reassigned
 /// locals are handled separately by `walk_loop`'s `Opaque` reassignment.
@@ -1945,10 +1971,16 @@ struct LoopHeapEffects {
     /// `&mut local`, `&mut local.field`, a `&mut` call arg, or a method
     /// receiver — the callee may store through the reference.
     mut_borrowed: crate::hashmap::IndexSet<u32>,
-    /// A non-builtin call, indirect / CM call, or opaque-target store
-    /// (`(*p).f`, `arr[i]`, deep field) that may mutate aliased state from
-    /// outside the straight-line walk.
+    /// An impure call, indirect / CM call, or opaque-target store (`(*p).f`,
+    /// `arr[i]`, deep field) that may mutate aliased state from outside the
+    /// straight-line walk.
     has_external_writes: bool,
+    /// A call that mutates no caller local still reaches an `untrackable` one —
+    /// a local stashed across a `stores` callee, which no argument list names.
+    /// Kept apart from [`Self::has_external_writes`] so a loop of pure calls
+    /// invalidates those locals without the set-wide bump, exactly as
+    /// [`Builder::bump_call_effects`] does for one call.
+    has_pure_calls: bool,
 }
 
 /// True when `func_id` is a builtin / monomorphized-builtin intrinsic that
@@ -1976,16 +2008,10 @@ fn root_local_of(body: &Body, op: Operand) -> Option<u32> {
 
 fn collect_loop_heap_effects(
     body: &Body,
-    pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
-    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
+    facts: &CallFacts<'_>,
     block: BlockId,
 ) -> LoopHeapEffects {
-    collect_node_heap_effects(
-        body,
-        pure_builtin_callees,
-        receiver_immutable_calls,
-        NodeRef::Block(block),
-    )
+    collect_node_heap_effects(body, facts, NodeRef::Block(block))
 }
 
 /// The heap-write effects of a node's subtree, so a caller can invalidate
@@ -1993,42 +2019,33 @@ fn collect_loop_heap_effects(
 /// block) and the short-circuit arm (conditional rhs).
 fn collect_node_heap_effects(
     body: &Body,
-    pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
-    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
+    facts: &CallFacts<'_>,
     node: NodeRef,
 ) -> LoopHeapEffects {
     let mut eff = LoopHeapEffects::default();
-    collect_loop_heap_node(
-        body,
-        pure_builtin_callees,
-        receiver_immutable_calls,
-        node,
-        &mut eff,
-    );
+    collect_loop_heap_node(body, facts, node, &mut eff);
     eff
 }
 
 fn collect_loop_heap_node(
     body: &Body,
-    pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
-    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
+    facts: &CallFacts<'_>,
     node: NodeRef,
     eff: &mut LoopHeapEffects,
 ) {
     if let NodeRef::Expr(e) = node {
-        record_loop_heap_write(body, pure_builtin_callees, receiver_immutable_calls, e, eff);
+        record_loop_heap_write(body, facts, e, eff);
     }
     let mut kids = Vec::new();
     body.for_each_child(node, |c| kids.push(c));
     for c in kids {
-        collect_loop_heap_node(body, pure_builtin_callees, receiver_immutable_calls, c, eff);
+        collect_loop_heap_node(body, facts, c, eff);
     }
 }
 
 fn record_loop_heap_write(
     body: &Body,
-    pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
-    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
+    facts: &CallFacts<'_>,
     e: ExprId,
     eff: &mut LoopHeapEffects,
 ) {
@@ -2085,7 +2102,7 @@ fn record_loop_heap_write(
             // provably cannot write through it — the same verdict that decides
             // whether `build_alias_info` aliases the receiver, so a call the
             // alias analysis leaves unaliased does not get borrowed here.
-            let receiver_borrowed = *has_receiver && !receiver_immutable_calls.contains(&e);
+            let receiver_borrowed = *has_receiver && !facts.receiver_immutable.contains(&e);
             for (i, arg) in args.iter().enumerate() {
                 let borrowed = arg.is_mut || (receiver_borrowed && i == 0);
                 if borrowed
@@ -2095,8 +2112,16 @@ fn record_loop_heap_write(
                     eff.mut_borrowed.insert(*index);
                 }
             }
-            if !is_builtin_pure_call(pure_builtin_callees, *func_id) {
-                eff.has_external_writes = true;
+            // A builtin below the field layer writes no tracked slot at all. A
+            // call proven to mutate no caller local writes no *escaped* slot,
+            // but still reaches the `untrackable` ones — the same split
+            // `bump_call_effects` makes for one call. Anything else is opaque.
+            if !is_builtin_pure_call(facts.pure_builtin, *func_id) {
+                if facts.pure.contains(&e) {
+                    eff.has_pure_calls = true;
+                } else {
+                    eff.has_external_writes = true;
+                }
             }
         }
         ExprKind::IndirectCall { .. } | ExprKind::CmRawCall { .. } => {
@@ -2316,6 +2341,39 @@ mod tests {
         b
     }
 
+    /// Owns the sets a [`CallFacts`] borrows, so a test can name just the
+    /// verdict it is about and leave the rest at their conservative empty.
+    #[derive(Default)]
+    struct TestFacts {
+        builtin: crate::hashmap::IndexSet<FuncId>,
+        pure: crate::hashmap::IndexSet<ExprId>,
+        immutable: crate::hashmap::IndexSet<ExprId>,
+    }
+
+    impl TestFacts {
+        fn pure(calls: &[ExprId]) -> Self {
+            Self {
+                pure: calls.iter().copied().collect(),
+                ..Self::default()
+            }
+        }
+
+        fn immutable(calls: &[ExprId]) -> Self {
+            Self {
+                immutable: calls.iter().copied().collect(),
+                ..Self::default()
+            }
+        }
+
+        fn facts(&self) -> CallFacts<'_> {
+            CallFacts {
+                pure_builtin: &self.builtin,
+                pure: &self.pure,
+                receiver_immutable: &self.immutable,
+            }
+        }
+    }
+
     /// `self.m()` as the sole statement of a block, `self` being local 0.
     fn receiver_call_block(body: &mut Body) -> (BlockId, ExprId) {
         use crate::nir::{FuncId, NirLocal};
@@ -2366,36 +2424,55 @@ mod tests {
     /// declined to alias that same receiver. The two have to agree.
     #[test]
     fn receiver_immutable_call_does_not_borrow_its_receiver() {
-        use crate::hashmap::IndexSet;
-        let no_callees = IndexSet::default();
         let mut body = Body::empty();
         let (block, call) = receiver_call_block(&mut body);
+        let facts = TestFacts::immutable(&[call]);
 
-        let immutable: IndexSet<ExprId> = [call].into_iter().collect();
-        let eff = collect_loop_heap_effects(&body, &no_callees, &immutable, block);
+        let eff = collect_loop_heap_effects(&body, &facts.facts(), block);
         assert!(
             !eff.mut_borrowed.contains(&0),
             "a callee that cannot write through the receiver does not borrow it"
         );
 
         // Unknown callee: the conservative mark stays.
-        let none: IndexSet<ExprId> = IndexSet::default();
-        let eff = collect_loop_heap_effects(&body, &no_callees, &none, block);
+        let none = TestFacts::default();
+        let eff = collect_loop_heap_effects(&body, &none.facts(), block);
         assert!(eff.mut_borrowed.contains(&0));
     }
 
-    /// The blanket fallback is what covers every argument shape the bare-`Local`
-    /// mark misses, so proving the receiver immutable must not touch it.
+    /// Receiver-immutability says nothing about the other arguments, so it must
+    /// not clear the blanket fallback that covers the shapes the bare-`Local`
+    /// mark misses. Only a purity verdict over every argument may.
     #[test]
     fn receiver_immutable_call_still_reports_external_writes() {
-        use crate::hashmap::IndexSet;
-        let no_callees = IndexSet::default();
         let mut body = Body::empty();
         let (block, call) = receiver_call_block(&mut body);
-        let immutable: IndexSet<ExprId> = [call].into_iter().collect();
+        let facts = TestFacts::immutable(&[call]);
 
-        let eff = collect_loop_heap_effects(&body, &no_callees, &immutable, block);
+        let eff = collect_loop_heap_effects(&body, &facts.facts(), block);
         assert!(eff.has_external_writes);
+    }
+
+    /// A loop asks the same question of a call that the straight-line walk
+    /// does. `bump_call_effects` skips the set-wide bump for a call that mutates
+    /// no caller local; the loop summary used a strictly weaker builtin-only
+    /// test, so one ordinary pure call in a loop invalidated every escaped
+    /// local's fields.
+    #[test]
+    fn pure_call_in_a_loop_writes_no_escaped_state() {
+        let mut body = Body::empty();
+        let (block, call) = receiver_call_block(&mut body);
+        let facts = TestFacts::pure(&[call]);
+
+        let eff = collect_loop_heap_effects(&body, &facts.facts(), block);
+        assert!(
+            !eff.has_external_writes,
+            "a call that mutates no caller local writes no escaped state"
+        );
+        assert!(
+            eff.has_pure_calls,
+            "it still reaches the untrackable locals no argument list names"
+        );
     }
 
     #[test]

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -210,6 +210,7 @@ pub fn build(
     mut_escaped: &crate::hashmap::IndexSet<u32>,
     pure_calls: &crate::hashmap::IndexSet<ExprId>,
     pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
+    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
     type_table: Option<&crate::tir::TypeTable>,
 ) -> ValueGraphBuild {
     // Build into the body's own pool: take it out as the seed (so a promoted
@@ -221,6 +222,7 @@ pub fn build(
         let mut b = Builder::new(&*body, aliased, untrackable, mut_escaped, type_table, seed);
         b.pure_calls.clone_from(pure_calls);
         b.pure_builtin_callees.clone_from(pure_builtin_callees);
+        b.receiver_immutable_calls.clone_from(receiver_immutable_calls);
         b.seed_params(param_locals);
         b.walk_block(body.root);
         (b.pool, b.loop_entry_values)
@@ -472,6 +474,12 @@ struct Builder<'a> {
     /// intrinsics does not invalidate forwarded field versions. Empty is
     /// conservative (every call is a heap write). See [`is_builtin_pure_call`].
     pure_builtin_callees: crate::hashmap::IndexSet<FuncId>,
+    /// `ExprId` indices of `recv.m(…)` calls whose callee provably cannot write
+    /// through the receiver, so the call does not borrow it for the loop's
+    /// heap-effect summary. Same verdict `build_alias_info` uses to decide
+    /// whether to alias that receiver, so the two analyses agree by
+    /// construction. Empty is conservative (every receiver is borrowed).
+    receiver_immutable_calls: crate::hashmap::IndexSet<ExprId>,
 }
 
 impl<'a> Builder<'a> {
@@ -506,6 +514,7 @@ impl<'a> Builder<'a> {
             stmt_entry_version: IndexMap::default(),
             pure_calls: crate::hashmap::IndexSet::default(),
             pure_builtin_callees: crate::hashmap::IndexSet::default(),
+            receiver_immutable_calls: crate::hashmap::IndexSet::default(),
         }
     }
 
@@ -886,6 +895,7 @@ impl<'a> Builder<'a> {
                         let eff = collect_node_heap_effects(
                             self.body,
                             &self.pure_builtin_callees,
+                            &self.receiver_immutable_calls,
                             NodeRef::Expr(re),
                         );
                         self.apply_loop_heap_effects(&eff);
@@ -1795,7 +1805,12 @@ impl<'a> Builder<'a> {
     fn walk_loop(&mut self, body_block: crate::nir_arena::BlockId) {
         let writes = writes_of_block(self.body, body_block, &mut self.block_writes);
         let heap_effects =
-            collect_loop_heap_effects(self.body, &self.pure_builtin_callees, body_block);
+            collect_loop_heap_effects(
+                self.body,
+                &self.pure_builtin_callees,
+                &self.receiver_immutable_calls,
+                body_block,
+            );
         // Snapshot before the reassigned-local opaques below overwrite the
         // written locals' pre-loop values.
         self.fresh_invalidations.clear();
@@ -1962,9 +1977,15 @@ fn root_local_of(body: &Body, op: Operand) -> Option<u32> {
 fn collect_loop_heap_effects(
     body: &Body,
     pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
+    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
     block: BlockId,
 ) -> LoopHeapEffects {
-    collect_node_heap_effects(body, pure_builtin_callees, NodeRef::Block(block))
+    collect_node_heap_effects(
+        body,
+        pure_builtin_callees,
+        receiver_immutable_calls,
+        NodeRef::Block(block),
+    )
 }
 
 /// The heap-write effects of a node's subtree, so a caller can invalidate
@@ -1973,32 +1994,41 @@ fn collect_loop_heap_effects(
 fn collect_node_heap_effects(
     body: &Body,
     pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
+    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
     node: NodeRef,
 ) -> LoopHeapEffects {
     let mut eff = LoopHeapEffects::default();
-    collect_loop_heap_node(body, pure_builtin_callees, node, &mut eff);
+    collect_loop_heap_node(
+        body,
+        pure_builtin_callees,
+        receiver_immutable_calls,
+        node,
+        &mut eff,
+    );
     eff
 }
 
 fn collect_loop_heap_node(
     body: &Body,
     pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
+    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
     node: NodeRef,
     eff: &mut LoopHeapEffects,
 ) {
     if let NodeRef::Expr(e) = node {
-        record_loop_heap_write(body, pure_builtin_callees, e, eff);
+        record_loop_heap_write(body, pure_builtin_callees, receiver_immutable_calls, e, eff);
     }
     let mut kids = Vec::new();
     body.for_each_child(node, |c| kids.push(c));
     for c in kids {
-        collect_loop_heap_node(body, pure_builtin_callees, c, eff);
+        collect_loop_heap_node(body, pure_builtin_callees, receiver_immutable_calls, c, eff);
     }
 }
 
 fn record_loop_heap_write(
     body: &Body,
     pure_builtin_callees: &crate::hashmap::IndexSet<FuncId>,
+    receiver_immutable_calls: &crate::hashmap::IndexSet<ExprId>,
     e: ExprId,
     eff: &mut LoopHeapEffects,
 ) {
@@ -2051,10 +2081,13 @@ fn record_loop_heap_write(
             has_receiver,
             ..
         } => {
+            // A receiver is borrowed for the whole call unless the callee
+            // provably cannot write through it — the same verdict that decides
+            // whether `build_alias_info` aliases the receiver, so a call the
+            // alias analysis leaves unaliased does not get borrowed here.
+            let receiver_borrowed = *has_receiver && !receiver_immutable_calls.contains(&e);
             for (i, arg) in args.iter().enumerate() {
-                // A receiver is borrowed for the whole call whether or not the
-                // method declares `&mut self` — the callee reaches its storage.
-                let borrowed = arg.is_mut || (*has_receiver && i == 0);
+                let borrowed = arg.is_mut || (receiver_borrowed && i == 0);
                 if borrowed
                     && let Some(ExprKind::Local { index, .. }) =
                         arg.expr.as_expr().map(|ae| &body.exprs[ae].kind)
@@ -2283,6 +2316,88 @@ mod tests {
         b
     }
 
+    /// `self.m()` as the sole statement of a block, `self` being local 0.
+    fn receiver_call_block(body: &mut Body) -> (BlockId, ExprId) {
+        use crate::nir::{FuncId, NirLocal};
+        use crate::nir_arena::{ArenaCallArg, BlockNode, ExprNode, StmtNode};
+        use crate::token::Span;
+        let span = Span::new(0, 0, 0, 0);
+        body.locals = vec![NirLocal {
+            name: "self".to_string(),
+            type_id: TypeTable::I32,
+            is_mut: false,
+        }];
+        let recv = body.exprs.push(ExprNode {
+            kind: ExprKind::Local {
+                index: 0,
+                name: "self".to_string(),
+            },
+            type_id: TypeTable::I32,
+            span,
+        });
+        let call = body.exprs.push(ExprNode {
+            kind: ExprKind::Call {
+                func_id: FuncId::from_u32(0),
+                type_args: vec![],
+                args: vec![ArenaCallArg {
+                    expr: Operand::Expr(recv),
+                    is_mut: false,
+                }],
+                has_receiver: true,
+            },
+            type_id: TypeTable::I32,
+            span,
+        });
+        let stmt = body.stmts.push(StmtNode {
+            kind: StmtKind::Expr(Operand::Expr(call)),
+            span,
+        });
+        let block = body.blocks.push(BlockNode {
+            stmts: vec![stmt],
+            span,
+        });
+        (block, call)
+    }
+
+    /// A receiver is borrowed for the whole call only when the callee can write
+    /// through it. Marking it unconditionally bumps the receiver's `per_local`
+    /// generation, which kills every `self.field` invariance in a loop that
+    /// calls any method on `self` — while `build_alias_info` has already
+    /// declined to alias that same receiver. The two have to agree.
+    #[test]
+    fn receiver_immutable_call_does_not_borrow_its_receiver() {
+        use crate::hashmap::IndexSet;
+        let no_callees = IndexSet::default();
+        let mut body = Body::empty();
+        let (block, call) = receiver_call_block(&mut body);
+
+        let immutable: IndexSet<ExprId> = [call].into_iter().collect();
+        let eff = collect_loop_heap_effects(&body, &no_callees, &immutable, block);
+        assert!(
+            !eff.mut_borrowed.contains(&0),
+            "a callee that cannot write through the receiver does not borrow it"
+        );
+
+        // Unknown callee: the conservative mark stays.
+        let none: IndexSet<ExprId> = IndexSet::default();
+        let eff = collect_loop_heap_effects(&body, &no_callees, &none, block);
+        assert!(eff.mut_borrowed.contains(&0));
+    }
+
+    /// The blanket fallback is what covers every argument shape the bare-`Local`
+    /// mark misses, so proving the receiver immutable must not touch it.
+    #[test]
+    fn receiver_immutable_call_still_reports_external_writes() {
+        use crate::hashmap::IndexSet;
+        let no_callees = IndexSet::default();
+        let mut body = Body::empty();
+        let (block, call) = receiver_call_block(&mut body);
+        let immutable: IndexSet<ExprId> = [call].into_iter().collect();
+
+        let eff = collect_loop_heap_effects(&body, &no_callees, &immutable, block);
+        assert!(eff.has_external_writes);
+    }
+
     #[test]
     fn cse_independent_of_mut_escaped_iteration_order() {
         use crate::hashmap::IndexSet;
@@ -2301,6 +2416,7 @@ mod tests {
                 mut_escaped,
                 &no_calls,
                 &no_callees,
+                &no_calls,
                 None,
             );
             body.values.values

--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -222,7 +222,8 @@ pub fn build(
         let mut b = Builder::new(&*body, aliased, untrackable, mut_escaped, type_table, seed);
         b.pure_calls.clone_from(pure_calls);
         b.pure_builtin_callees.clone_from(pure_builtin_callees);
-        b.receiver_immutable_calls.clone_from(receiver_immutable_calls);
+        b.receiver_immutable_calls
+            .clone_from(receiver_immutable_calls);
         b.seed_params(param_locals);
         b.walk_block(body.root);
         (b.pool, b.loop_entry_values)
@@ -469,16 +470,12 @@ struct Builder<'a> {
     /// `ExprId` indices of calls that mutate no caller local. See
     /// [`BuildConfig::pure_calls`].
     pure_calls: crate::hashmap::IndexSet<ExprId>,
-    /// [`FuncId`]s of pure builtin intrinsics (`array_get_value`, `array_len`, …): a
-    /// call to one writes no heap, so a loop body that only calls such
-    /// intrinsics does not invalidate forwarded field versions. Empty is
-    /// conservative (every call is a heap write). See [`is_builtin_pure_call`].
+    /// Callees that write no tracked `(root, field)` slot: an intrinsic below
+    /// the field layer, a value-copy helper, or a bodied function that never
+    /// returns. Empty is conservative.
     pure_builtin_callees: crate::hashmap::IndexSet<FuncId>,
-    /// `ExprId` indices of `recv.m(…)` calls whose callee provably cannot write
-    /// through the receiver, so the call does not borrow it for the loop's
-    /// heap-effect summary. Same verdict `build_alias_info` uses to decide
-    /// whether to alias that receiver, so the two analyses agree by
-    /// construction. Empty is conservative (every receiver is borrowed).
+    /// Calls whose callee cannot write through the receiver, so a loop does not
+    /// borrow it. Empty is conservative.
     receiver_immutable_calls: crate::hashmap::IndexSet<ExprId>,
 }
 
@@ -901,8 +898,11 @@ impl<'a> Builder<'a> {
                     // Invalidate only what the rhs writes, not a blanket
                     // `bump_all`: a pure rhs leaves unrelated fields intact.
                     if let Some(re) = right.as_expr() {
-                        let eff =
-                            collect_node_heap_effects(self.body, &self.call_facts(), NodeRef::Expr(re));
+                        let eff = collect_node_heap_effects(
+                            self.body,
+                            &self.call_facts(),
+                            NodeRef::Expr(re),
+                        );
                         self.apply_loop_heap_effects(&eff);
                     }
                     rhs
@@ -1809,8 +1809,7 @@ impl<'a> Builder<'a> {
     /// pre-loop version, so a store before a builtin-only loop still forwards.
     fn walk_loop(&mut self, body_block: crate::nir_arena::BlockId) {
         let writes = writes_of_block(self.body, body_block, &mut self.block_writes);
-        let heap_effects =
-            collect_loop_heap_effects(self.body, &self.call_facts(), body_block);
+        let heap_effects = collect_loop_heap_effects(self.body, &self.call_facts(), body_block);
         // Snapshot before the reassigned-local opaques below overwrite the
         // written locals' pre-loop values.
         self.fresh_invalidations.clear();
@@ -1879,10 +1878,8 @@ impl<'a> Builder<'a> {
         if eff.has_external_writes {
             self.heap_state.bump_escaped();
         } else if eff.has_pure_calls {
-            // No set-wide bump: a pure call mutates no caller local. It still
-            // reaches the `untrackable` ones, which are too few to justify the
-            // shared version — [`Self::bump_call_effects`] splits it the same
-            // way for a single call.
+            // A pure call still reaches the `untrackable` locals; bump those
+            // alone, as `bump_call_effects` does for one call.
             for i in 0..self.mut_escaped_sorted.len() {
                 let l = self.mut_escaped_sorted[i];
                 if self.untrackable.contains(&l) {
@@ -1946,12 +1943,8 @@ fn block_breaks_to_node(body: &Body, node: NodeRef, label: &str) -> bool {
         .any(|c| block_breaks_to_node(body, c, label))
 }
 
-/// The per-call verdicts the loop summary reads. Bundled because they are one
-/// walk's output ([`crate::optimize::alias::call_verdicts`], plus the builtin
-/// set) and because the summary must ask the same questions
-/// [`Builder::bump_call_effects`] asks of a single call — a loop is that call
-/// repeated, so a weaker predicate here silently costs precision the
-/// straight-line path already has.
+/// The per-call verdicts the loop summary reads, bundled so it asks the same
+/// questions [`Builder::bump_call_effects`] asks of one call.
 struct CallFacts<'a> {
     /// Builtin intrinsics operating below the struct-field layer.
     pure_builtin: &'a crate::hashmap::IndexSet<FuncId>,
@@ -1971,15 +1964,11 @@ struct LoopHeapEffects {
     /// `&mut local`, `&mut local.field`, a `&mut` call arg, or a method
     /// receiver — the callee may store through the reference.
     mut_borrowed: crate::hashmap::IndexSet<u32>,
-    /// An impure call, indirect / CM call, or opaque-target store (`(*p).f`,
-    /// `arr[i]`, deep field) that may mutate aliased state from outside the
-    /// straight-line walk.
+    /// An impure call, indirect or CM call, or opaque-target store that may
+    /// mutate aliased state.
     has_external_writes: bool,
-    /// A call that mutates no caller local still reaches an `untrackable` one —
-    /// a local stashed across a `stores` callee, which no argument list names.
-    /// Kept apart from [`Self::has_external_writes`] so a loop of pure calls
-    /// invalidates those locals without the set-wide bump, exactly as
-    /// [`Builder::bump_call_effects`] does for one call.
+    /// A pure call, which still reaches the `untrackable` locals. Kept apart so
+    /// a loop of pure calls skips the set-wide bump.
     has_pure_calls: bool,
 }
 
@@ -2017,11 +2006,7 @@ fn collect_loop_heap_effects(
 /// The heap-write effects of a node's subtree, so a caller can invalidate
 /// exactly what it writes rather than `bump_all`. Used by `walk_loop` (body
 /// block) and the short-circuit arm (conditional rhs).
-fn collect_node_heap_effects(
-    body: &Body,
-    facts: &CallFacts<'_>,
-    node: NodeRef,
-) -> LoopHeapEffects {
+fn collect_node_heap_effects(body: &Body, facts: &CallFacts<'_>, node: NodeRef) -> LoopHeapEffects {
     let mut eff = LoopHeapEffects::default();
     collect_loop_heap_node(body, facts, node, &mut eff);
     eff
@@ -2098,10 +2083,7 @@ fn record_loop_heap_write(
             has_receiver,
             ..
         } => {
-            // A receiver is borrowed for the whole call unless the callee
-            // provably cannot write through it — the same verdict that decides
-            // whether `build_alias_info` aliases the receiver, so a call the
-            // alias analysis leaves unaliased does not get borrowed here.
+            // A receiver is borrowed unless the callee cannot write through it.
             let receiver_borrowed = *has_receiver && !facts.receiver_immutable.contains(&e);
             for (i, arg) in args.iter().enumerate() {
                 let borrowed = arg.is_mut || (receiver_borrowed && i == 0);
@@ -2112,10 +2094,8 @@ fn record_loop_heap_write(
                     eff.mut_borrowed.insert(*index);
                 }
             }
-            // A builtin below the field layer writes no tracked slot at all. A
-            // call proven to mutate no caller local writes no *escaped* slot,
-            // but still reaches the `untrackable` ones — the same split
-            // `bump_call_effects` makes for one call. Anything else is opaque.
+            // A builtin writes no tracked slot; a pure call writes no escaped
+            // slot but reaches the `untrackable` ones; anything else is opaque.
             if !is_builtin_pure_call(facts.pure_builtin, *func_id) {
                 if facts.pure.contains(&e) {
                     eff.has_pure_calls = true;
@@ -2417,11 +2397,8 @@ mod tests {
         (block, call)
     }
 
-    /// A receiver is borrowed for the whole call only when the callee can write
-    /// through it. Marking it unconditionally bumps the receiver's `per_local`
-    /// generation, which kills every `self.field` invariance in a loop that
-    /// calls any method on `self` — while `build_alias_info` has already
-    /// declined to alias that same receiver. The two have to agree.
+    /// A callee that cannot write through the receiver does not borrow it for
+    /// the loop; an unknown callee still does.
     #[test]
     fn receiver_immutable_call_does_not_borrow_its_receiver() {
         let mut body = Body::empty();
@@ -2440,9 +2417,8 @@ mod tests {
         assert!(eff.mut_borrowed.contains(&0));
     }
 
-    /// Receiver-immutability says nothing about the other arguments, so it must
-    /// not clear the blanket fallback that covers the shapes the bare-`Local`
-    /// mark misses. Only a purity verdict over every argument may.
+    /// Receiver immutability says nothing about the other arguments, so it does
+    /// not clear the external-writes fallback; only the purity verdict may.
     #[test]
     fn receiver_immutable_call_still_reports_external_writes() {
         let mut body = Body::empty();
@@ -2453,11 +2429,8 @@ mod tests {
         assert!(eff.has_external_writes);
     }
 
-    /// A loop asks the same question of a call that the straight-line walk
-    /// does. `bump_call_effects` skips the set-wide bump for a call that mutates
-    /// no caller local; the loop summary used a strictly weaker builtin-only
-    /// test, so one ordinary pure call in a loop invalidated every escaped
-    /// local's fields.
+    /// A pure call sets no external write, and still reaches the `untrackable`
+    /// locals.
     #[test]
     fn pure_call_in_a_loop_writes_no_escaped_state() {
         let mut body = Body::empty();

--- a/wado-compiler/src/optimize/alias.rs
+++ b/wado-compiler/src/optimize/alias.rs
@@ -462,17 +462,31 @@ impl<'a> CallImmutability<'a> {
 
 use super::arena_query::storage_root;
 
-/// Call exprs that mutate no caller local: a free call, or one with a `&self`
-/// receiver, whose every argument is safe — not `mut`, an immutable borrow, or a
-/// call-immutable value the callee cannot reach back through. The value graph
-/// skips the per-call bump for these, so `arr.len()` does not split `arr.used`'s
-/// version. An unknown callee stays impure for a receiver.
-pub(super) fn pure_calls(
+/// The per-call verdicts the value-graph builder needs, both read off one walk.
+/// They nest — `pure` implies `receiver_immutable` — so computing them apart
+/// would ask [`method_mutates_receiver`] the same question twice and let the two
+/// answers drift.
+pub(super) struct CallVerdicts {
+    /// Calls that mutate no caller local: a free call, or one with a `&self`
+    /// receiver, whose every argument is safe — not `mut`, an immutable borrow,
+    /// or a call-immutable value the callee cannot reach back through. The value
+    /// graph skips the per-call bump for these, so `arr.len()` does not split
+    /// `arr.used`'s version. An unknown callee stays impure for a receiver.
+    pub pure: IndexSet<crate::nir_arena::ExprId>,
+    /// Calls whose callee provably cannot write through the receiver, whatever
+    /// the other arguments do. A loop containing one does not have to treat the
+    /// receiver as borrowed for the whole body, which is what keeps a
+    /// `self.field` read invariant across a `self.helper()`.
+    pub receiver_immutable: IndexSet<crate::nir_arena::ExprId>,
+}
+
+/// Classify every call in `body`. See [`CallVerdicts`].
+pub(super) fn call_verdicts(
     body: &Body,
     type_table: &TypeTable,
     first_param_types: &FirstParamTypes,
     call_immutability: &CallImmutability,
-) -> IndexSet<crate::nir_arena::ExprId> {
+) -> CallVerdicts {
     let arg_safe = |arg: &crate::nir_arena::ArenaCallArg| -> bool {
         if arg.is_mut {
             return false;
@@ -494,42 +508,46 @@ pub(super) fn pure_calls(
     };
     // Walk reachable nodes only: `body.exprs` also holds orphaned nodes left by
     // earlier promotion, whose stale `type_id`s are no longer in the table.
-    let mut out = IndexSet::default();
+    let mut out = CallVerdicts {
+        pure: IndexSet::default(),
+        receiver_immutable: IndexSet::default(),
+    };
     walk_all(body, NodeRef::Block(body.root), &mut |body, node| {
         let NodeRef::Expr(e) = node else {
             return;
         };
-        let pure = match &body.exprs[e].kind {
-            ExprKind::Call {
-                func_id,
-                args,
-                has_receiver,
-                ..
-            } => {
-                // A receiver is judged by the callee's declared `self` mode, which
-                // stays conservative for a callee absent from `first_param_types`;
-                // `arg_safe` alone would clear an unknown one.
-                let receiver_safe = !*has_receiver
-                    || args
-                        .first()
-                        .and_then(|a| a.expr.as_expr())
-                        .is_some_and(|re| {
-                            !method_mutates_receiver(
-                                body,
-                                re,
-                                *func_id,
-                                first_param_types,
-                                type_table,
-                                true,
-                                Some(call_immutability),
-                            )
-                        });
-                receiver_safe && args.iter().skip(usize::from(*has_receiver)).all(&arg_safe)
-            }
-            _ => false,
+        let ExprKind::Call {
+            func_id,
+            args,
+            has_receiver,
+            ..
+        } = &body.exprs[e].kind
+        else {
+            return;
         };
-        if pure {
-            out.insert(e);
+        // A receiver is judged by the callee's declared `self` mode, which
+        // stays conservative for a callee absent from `first_param_types`;
+        // `arg_safe` alone would clear an unknown one.
+        let receiver_safe = !*has_receiver
+            || args
+                .first()
+                .and_then(|a| a.expr.as_expr())
+                .is_some_and(|re| {
+                    !method_mutates_receiver(
+                        body,
+                        re,
+                        *func_id,
+                        first_param_types,
+                        type_table,
+                        true,
+                        Some(call_immutability),
+                    )
+                });
+        if receiver_safe {
+            out.receiver_immutable.insert(e);
+            if args.iter().skip(usize::from(*has_receiver)).all(&arg_safe) {
+                out.pure.insert(e);
+            }
         }
     });
     out

--- a/wado-compiler/src/optimize/alias.rs
+++ b/wado-compiler/src/optimize/alias.rs
@@ -357,6 +357,9 @@ pub(super) struct CallImmutability<'a> {
     /// *proven*, not unknown). A callee that does not resolve here (extern /
     /// builtin / unstamped) stays conservatively mutating.
     has_body: SecondaryMap<FuncId, bool>,
+    /// Callees that write no tracked slot whatever their arguments; the set
+    /// [`NirPackage::pure_builtin_callee_ids`] defines.
+    effect_free: IndexSet<FuncId>,
 }
 
 impl<'a> CallImmutability<'a> {
@@ -389,6 +392,7 @@ impl<'a> CallImmutability<'a> {
             memo: std::cell::RefCell::default(),
             receiver_mutating,
             has_body,
+            effect_free: project.pure_builtin_callee_ids(),
         }
     }
 
@@ -462,21 +466,14 @@ impl<'a> CallImmutability<'a> {
 
 use super::arena_query::storage_root;
 
-/// The per-call verdicts the value-graph builder needs, both read off one walk.
-/// They nest — `pure` implies `receiver_immutable` — so computing them apart
-/// would ask [`method_mutates_receiver`] the same question twice and let the two
-/// answers drift.
+/// The per-call verdicts the value-graph builder reads, from one walk. `pure`
+/// implies `receiver_immutable`.
 pub(super) struct CallVerdicts {
-    /// Calls that mutate no caller local: a free call, or one with a `&self`
-    /// receiver, whose every argument is safe — not `mut`, an immutable borrow,
-    /// or a call-immutable value the callee cannot reach back through. The value
-    /// graph skips the per-call bump for these, so `arr.len()` does not split
-    /// `arr.used`'s version. An unknown callee stays impure for a receiver.
+    /// Calls that mutate no caller local: no `mut` argument, every by-value
+    /// argument call-immutable. An unknown callee stays impure for a receiver.
     pub pure: IndexSet<crate::nir_arena::ExprId>,
-    /// Calls whose callee provably cannot write through the receiver, whatever
-    /// the other arguments do. A loop containing one does not have to treat the
-    /// receiver as borrowed for the whole body, which is what keeps a
-    /// `self.field` read invariant across a `self.helper()`.
+    /// Calls whose callee cannot write through the receiver, whatever the other
+    /// arguments do.
     pub receiver_immutable: IndexSet<crate::nir_arena::ExprId>,
 }
 
@@ -525,6 +522,13 @@ pub(super) fn call_verdicts(
         else {
             return;
         };
+        // An effect-free callee is pure whatever it is handed: it writes no slot
+        // the caller can read afterwards, by construction or by never returning.
+        if call_immutability.effect_free.contains(func_id) {
+            out.receiver_immutable.insert(e);
+            out.pure.insert(e);
+            return;
+        }
         // A receiver is judged by the callee's declared `self` mode, which
         // stays conservative for a callee absent from `first_param_types`;
         // `arg_safe` alone would clear an unknown one.

--- a/wado-compiler/src/optimize/extract.rs
+++ b/wado-compiler/src/optimize/extract.rs
@@ -1,5 +1,5 @@
 //! Extraction: materialize pure values from the live `ValueGraph` back into the
-//! `SkelTree`, walking the skeleton and lowering each pure operand to its
+//! skeleton arena, walking it and lowering each pure operand to its
 //! hash-consed [`ValueId`]'s concrete form. Constants are always cheaper to
 //! rematerialize than to share, so they need no cost decision.
 //! [`extract_const`] is the shared primitive, used by `store_load_forward`.
@@ -405,7 +405,7 @@ pub(super) fn freeze_pure_arith(
                 changed |=
                     apply_field_materialise(&mut engine, rep, &ids, id_ty, &param_set, &found);
             } else {
-                changed |= apply_value_freeze(&mut engine, rep, &ids, id_ty, &param_set, phase);
+                changed |= apply_value_freeze(&mut engine, rep, &ids, id_ty, &param_set);
             }
         }
     }
@@ -435,14 +435,14 @@ struct FreezeCtx<'a> {
     include_fields: bool,
 }
 
-/// Where a freeze sits relative to the passes that relocate operands, which is
-/// what the anchor rule turns on (WEP: NIR Optimizer Architecture).
+/// Where a freeze sits relative to the passes that relocate operands. There is
+/// no in-loop phase: a freeze between them would have to anchor every
+/// local-naming value in a `let _av` to survive the relocation, which bought
+/// nothing when measured (WEP: NIR Optimizer Architecture).
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum FreezePhase {
     /// Before the loop. Plants context-free values only.
     Early,
-    /// Inside the loop, so `inline` and `sroa` still follow.
-    InLoop,
     /// After the loop. Nothing relocates an operand from here on.
     Terminal,
 }
@@ -655,7 +655,6 @@ fn apply_value_freeze(
     ids: &[ExprId],
     id_ty: crate::tir::TypeId,
     param_set: &crate::hashmap::IndexSet<u32>,
-    phase: FreezePhase,
 ) -> bool {
     let mut leaves = crate::hashmap::IndexSet::default();
     engine.body.values.collect_opaque_locals(rep, &mut leaves);
@@ -669,13 +668,7 @@ fn apply_value_freeze(
                 .iter()
                 .all(|&l| leaf_available_at(engine, l, s, param_set))
         });
-    // The anchor rule: with relocation still to come, a value naming a source
-    // local is only sound anchored in an `_av`.
-    let must_anchor = phase == FreezePhase::InLoop && !leaves.is_empty();
     let materialize = shareable && anchorable;
-    if must_anchor && !materialize {
-        return false;
-    }
     let mut changed = false;
     if materialize {
         let (anchor, block) = point.expect("`anchorable` holds only with a point");

--- a/wado-compiler/src/optimize/extract.rs
+++ b/wado-compiler/src/optimize/extract.rs
@@ -436,9 +436,7 @@ struct FreezeCtx<'a> {
 }
 
 /// Where a freeze sits relative to the passes that relocate operands. There is
-/// no in-loop phase: a freeze between them would have to anchor every
-/// local-naming value in a `let _av` to survive the relocation, which bought
-/// nothing when measured (WEP: NIR Optimizer Architecture).
+/// no in-loop phase; the WEP records why.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) enum FreezePhase {
     /// Before the loop. Plants context-free values only.

--- a/wado-compiler/src/optimize/extract.rs
+++ b/wado-compiler/src/optimize/extract.rs
@@ -334,13 +334,13 @@ pub(super) fn freeze_pure_arith(
         // *immutable*-`&`-escaped local (licm's `&config`) is stable and its field
         // constant freezes soundly. Keep a copy before `set_alias_sets` moves it.
         let mut_escaped_leaf = mut_escaped.clone();
-        let pure_calls =
-            super::alias::pure_calls(body, &type_table, &first_param_types, &call_immutability);
+        let verdicts =
+            super::alias::call_verdicts(body, &type_table, &first_param_types, &call_immutability);
         let mut engine = Engine::new(body, &mut buffers, locals);
         engine.set_alias_sets(aliased, untrackable, mut_escaped);
         engine.set_value_graph_type_table(&type_table);
         engine.set_param_locals(param_locals);
-        engine.set_pure_calls(pure_calls);
+        engine.set_call_verdicts(verdicts.pure, verdicts.receiver_immutable);
         engine.set_pure_builtin_callees(&pure_builtin_callees);
 
         // Locals a frozen value may not name, from the same predicate that

--- a/wado-compiler/src/optimize/inline.rs
+++ b/wado-compiler/src/optimize/inline.rs
@@ -1525,12 +1525,13 @@ pub fn inline_functions(
             // keys). Drives the graph-preserving gate below.
             let pure_set = {
                 let body = func.body.as_ref().unwrap();
-                super::alias::pure_calls(
+                super::alias::call_verdicts(
                     body,
                     &inline_type_table,
                     &inline_first_param_types,
                     &inline_call_immutability,
                 )
+                .pure
             };
             {
                 let body = func.body.as_mut().unwrap();

--- a/wado-compiler/src/tir.rs
+++ b/wado-compiler/src/tir.rs
@@ -4737,7 +4737,7 @@ pub enum TirExprKind {
     },
     /// `Array<T>` of exactly `elements.len()` slots, the value a `[e0, e1, …]`
     /// literal denotes. Emitted by literal coercion, which then hands it to the
-    /// target type's `From<Array<T>>` impl. Lowers to `NirExprKind::ArrayLiteral`.
+    /// target type's `From<Array<T>>` impl. Lowers to `ExprKind::ArrayLiteral`.
     ArrayLiteral {
         elements: Vec<TirExpr>,
     },


### PR DESCRIPTION
## Summary

The NIR optimizer's loop heap-effect summary and its straight-line walk classified the same call two different ways: one treated a method receiver as always borrowed and used a builtin-only purity test, the other consulted the alias analysis's receiver-mutation verdict and a fuller purity check. Both now read from one `CallVerdicts` computed per function, so a call is pure, receiver-immutable, or effect-free to both paths at once. The effect-free set also gains two cases neither path recognized before: a value-copy helper (which only reads its argument) and a bodied function that never returns (the cold-outlined bounds-check panic every array index emits), the latter closing a real gap where the straight-line walk over-invalidated on every indexed loop.

Measured against 1,921 golden WIR fixtures and four benchmarks (`sqlite_parse`, `json_twitter`, `json_catalog`, `fts`): output is byte-identical before and after. The escaped-set generation these calls used to bump unconditionally is not on the critical path of any consumer today — LICM's structural path and `field_scalarize` already retire the loop-invariant reads at the WIR level without consulting the value graph. `docs/wep-2026-06-05-nir-optimizer-architecture.md` records this as the current state of the optimizer's precision work: every remaining item in that section now waits on a consumer, not the other way round.

`docs/wep-2026-06-05-nir-optimizer-architecture.md` is also rewritten end to end to hold decisions, their soundness obligations, and dated measurements rather than a description of the code's current shape — implementation detail belongs in the doc comments beside the code it describes, where it can't drift out of sync with a refactor.

## Changes

- `nir_value_graph/builder.rs`, `optimize/alias.rs`, `nir_engine.rs`, `nir_package.rs`: one `CallVerdicts` per function (pure / receiver-immutable / effect-free), read identically by the loop heap-effect summary and the straight-line value-graph walk.
- `nir_package.rs`: `pure_builtin_callee_ids` also classifies a value-copy helper and a bodied never-returning function as effect-free.
- `docs/wep-2026-06-05-nir-optimizer-architecture.md`: rewritten to record decisions and measurements at design altitude; the precision section now states that every open item waits on a consumer.
- `docs/optimizer.md`: documents the `peephole` engine session and two previously-undocumented rules (`aggregate_forward`, `tuple_projection`) plus `alias.rs` and `gate.rs` as shared facilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLsGU9MnAazy7oRSce8neC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLsGU9MnAazy7oRSce8neC)_