### PR TITLE
fix(optimizer): use the receiver verdict alone for a call's receiver slot

### DIFF
--- a/wado-compiler/src/nir_value_graph/builder.rs
+++ b/wado-compiler/src/nir_value_graph/builder.rs
@@ -2084,9 +2084,15 @@ fn record_loop_heap_write(
             ..
         } => {
             // A receiver is borrowed unless the callee cannot write through it.
+            // The verdict already accounts for a declared `&mut self`, so it
+            // replaces `arg.is_mut` for that slot rather than joining it.
             let receiver_borrowed = *has_receiver && !facts.receiver_immutable.contains(&e);
             for (i, arg) in args.iter().enumerate() {
-                let borrowed = arg.is_mut || (receiver_borrowed && i == 0);
+                let borrowed = if *has_receiver && i == 0 {
+                    receiver_borrowed
+                } else {
+                    arg.is_mut
+                };
                 if borrowed
                     && let Some(ExprKind::Local { index, .. }) =
                         arg.expr.as_expr().map(|ae| &body.exprs[ae].kind)
@@ -2356,6 +2362,12 @@ mod tests {
 
     /// `self.m()` as the sole statement of a block, `self` being local 0.
     fn receiver_call_block(body: &mut Body) -> (BlockId, ExprId) {
+        receiver_call_block_with(body, false)
+    }
+
+    /// Like [`receiver_call_block`], with the receiver argument's declared
+    /// `is_mut` (a `&mut self` method's own parameter type) as given.
+    fn receiver_call_block_with(body: &mut Body, receiver_is_mut: bool) -> (BlockId, ExprId) {
         use crate::nir::{FuncId, NirLocal};
         use crate::nir_arena::{ArenaCallArg, BlockNode, ExprNode, StmtNode};
         use crate::token::Span;
@@ -2379,7 +2391,7 @@ mod tests {
                 type_args: vec![],
                 args: vec![ArenaCallArg {
                     expr: Operand::Expr(recv),
-                    is_mut: false,
+                    is_mut: receiver_is_mut,
                 }],
                 has_receiver: true,
             },
@@ -2415,6 +2427,22 @@ mod tests {
         let none = TestFacts::default();
         let eff = collect_loop_heap_effects(&body, &none.facts(), block);
         assert!(eff.mut_borrowed.contains(&0));
+    }
+
+    /// A method declared `&mut self` still does not borrow its receiver once
+    /// the verdict proves the body never writes through it: the declared
+    /// mutability alone must not override a proven-safe verdict.
+    #[test]
+    fn receiver_immutable_call_does_not_borrow_a_declared_mut_receiver() {
+        let mut body = Body::empty();
+        let (block, call) = receiver_call_block_with(&mut body, true);
+        let facts = TestFacts::immutable(&[call]);
+
+        let eff = collect_loop_heap_effects(&body, &facts.facts(), block);
+        assert!(
+            !eff.mut_borrowed.contains(&0),
+            "a proven-immutable receiver is not borrowed even when declared `&mut self`"
+        );
     }
 
     /// Receiver immutability says nothing about the other arguments, so it does


### PR DESCRIPTION
## Summary

Follow-up to #1955. The loop heap-effect summary's per-argument borrow check computed `arg.is_mut || (receiver_borrowed && i == 0)` for a call's receiver argument. `arg.is_mut` reflects only the receiver's declared signature (`&mut self` vs `&self`), while `receiver_borrowed` is derived from `method_mutates_receiver`, which already folds the declared signature in as one of its two conditions and additionally proves the case where a `&mut self` method's body never actually writes through the receiver. The `||` meant a `&mut self` method proven not to write was still treated as borrowing its receiver, since `arg.is_mut` alone forced `borrowed = true` regardless of the verdict.

The receiver slot now reads the verdict alone; every other argument still reads its own `is_mut`, unaffected.

Verified against 1,921 golden WIR fixtures and the full test suite: no output changes, consistent with `docs/wep-2026-06-05-nir-optimizer-architecture.md`'s existing record that this precision layer has no consumer yet.

## Changes

- `nir_value_graph/builder.rs`: the receiver argument's borrow decision in the loop heap-effect summary now uses `receiver_borrowed` alone instead of `arg.is_mut || receiver_borrowed`.
- A test pins a `&mut self`-declared, verdict-proven-immutable receiver, which failed under the prior `||` logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLsGU9MnAazy7oRSce8neC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLsGU9MnAazy7oRSce8neC)_