### PR TITLE
perf(optimizer): skip drained pass rounds, stamp session buffers, hold the allocator's pages

### DIFF
--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -22,9 +22,7 @@ All levels run DCE on functions, types, and globals.
 
 The inline budget counts emitted Wasm instructions on the callee's hot path, not NIR nodes — see [`inline`](#nir-passes) for the weights. `--optimize-inline-growth <pct>` additionally bounds how far inlining may grow the whole unit; no level sets it by default.
 
-The fixed-point loop exits early on convergence, so a pass must report a change only when it made one, never when it merely found work to look at. A `gate_only!` pass reports to the dirty-set gate alone and never extends the loop.
-
-The schedule skips a pass whose gate has drained before entering it, not inside it: a pass builds its whole-program state — method catalogs, callee maps, effect summaries, alias tables, call-site censuses — before it reaches its first function, and that setup is what a late round would otherwise spend all its time on. So `gated!` and `gate_only!` name the gate column beside the pass, and an empty column skips the round whole.
+The fixed-point loop exits early on convergence, so a pass must report a change only when it made one, never when it merely found work to look at. A `gate_only!` pass reports to the dirty-set gate alone and never extends the loop. Both macros name the pass's gate column beside it, and a drained column skips the round before the pass builds any whole-program state.
 
 A run that reaches the cap logs it at debug level, naming the passes still reporting changes. At `-O2`/`-Os` and `-O3` that is also a `debug_assert`: their caps are sized so the loop converges under them. `-O1`'s smaller number of rounds and an explicit `--optimize-iterations` are budgets, and say nothing about convergence.
 

--- a/docs/optimizer.md
+++ b/docs/optimizer.md
@@ -24,6 +24,8 @@ The inline budget counts emitted Wasm instructions on the callee's hot path, not
 
 The fixed-point loop exits early on convergence, so a pass must report a change only when it made one, never when it merely found work to look at. A `gate_only!` pass reports to the dirty-set gate alone and never extends the loop.
 
+The schedule skips a pass whose gate has drained before entering it, not inside it: a pass builds its whole-program state — method catalogs, callee maps, effect summaries, alias tables, call-site censuses — before it reaches its first function, and that setup is what a late round would otherwise spend all its time on. So `gated!` and `gate_only!` name the gate column beside the pass, and an empty column skips the round whole.
+
 A run that reaches the cap logs it at debug level, naming the passes still reporting changes. At `-O2`/`-Os` and `-O3` that is also a `debug_assert`: their caps are sized so the loop converges under them. `-O1`'s smaller number of rounds and an explicit `--optimize-iterations` are budgets, and say nothing about convergence.
 
 The backend-required rewrites (`select_lowering`, `multi_value_return`, `freeze_pure_arith`) and `match_to_switch` run at every level, including `-O0`.

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -163,6 +163,11 @@ every function, and re-marks the callers of a callee it shrinks. The loop's
 iteration cap is the quiescence bound. A pass whose summary a call-graph change
 invalidates cannot be gated on the callee's revision alone, and stays explicit.
 
+An empty column skips the pass before its whole-program setup, not after: a pass
+builds catalogs, callee maps, effect summaries and call-site censuses before it
+reaches its first function, and a late round that visits nothing would otherwise
+spend all its time there.
+
 Gating changes only which functions a pass visits, never the result of a visit.
 Every loop pass is an optimization, so an imprecise gate costs optimization
 quality, never correctness. The same one-sided argument covers the

--- a/docs/wep-2026-06-05-nir-optimizer-architecture.md
+++ b/docs/wep-2026-06-05-nir-optimizer-architecture.md
@@ -163,10 +163,10 @@ every function, and re-marks the callers of a callee it shrinks. The loop's
 iteration cap is the quiescence bound. A pass whose summary a call-graph change
 invalidates cannot be gated on the callee's revision alone, and stays explicit.
 
-An empty column skips the pass before its whole-program setup, not after: a pass
-builds catalogs, callee maps, effect summaries and call-site censuses before it
-reaches its first function, and a late round that visits nothing would otherwise
-spend all its time there.
+An empty column skips the pass before its whole-program setup rather than after.
+A pass builds its catalogs, callee maps, effect summaries and call-site censuses
+before it reaches its first function, so a late round that visits nothing would
+otherwise spend all its time there.
 
 Gating changes only which functions a pass visits, never the result of a visit.
 Every loop pass is an optimization, so an imprecise gate costs optimization

--- a/mise.toml
+++ b/mise.toml
@@ -202,19 +202,16 @@ run = """
 set -xe -o pipefail
 # A compile builds a working set of several hundred MiB and frees it whole when
 # the file is done, so the heap empties once per file. mimalloc's 10ms purge
-# timer then hands those pages back to the OS just before the next file asks for
-# them again — 7.0 GiB purged over 24.8K calls to compile four fixtures — and
-# taking them back is a page fault plus free-list construction per page. Holding
-# them costs 828s of wall against 931s over this suite (-11%, compile CPU 3081s
-# against 3442s), for a peak RSS of 5941 MiB against 4798: comfortable on a
-# 16 GiB runner, and the first thing to revisit on a smaller one. It is the
-# breathing that costs, not the threads — serializing the compiles (`-p 1`)
-# leaves the page traffic where it was. Batch compilation only: `wado serve` is
-# long-running, and reclaiming after a spike is what the purge is for.
-#
-# The allocation volume behind it is the standing fix: ~31% of a compile's CPU
-# is in the allocator, and a compile that allocated less would have less to hand
-# back.
+# timer then returns those pages to the OS just before the next file asks for
+# them again, and taking them back costs a fault and a free-list rebuild each:
+# 7.0 GiB purged over 24.8K calls to compile four fixtures. Holding them runs
+# this suite in 828s against 931s (-11%, compile CPU 3081s against 3442s) for a
+# peak RSS of 5941 MiB against 4798, which is comfortable on a 16 GiB runner and
+# the first thing to revisit on a smaller one. Serializing the compiles (`-p 1`)
+# leaves the page traffic where it was, so it is the per-file heap that costs,
+# not the threads. Batch compilation only: `wado serve` is long-running, and
+# reclaiming after a spike is what the purge is for. The standing fix is the
+# allocation volume itself — ~31% of a compile's CPU is in the allocator.
 export MIMALLOC_PURGE_DELAY=-1
 extra_args=()
 if [ -n "${CI:-}" ]; then

--- a/mise.toml
+++ b/mise.toml
@@ -181,6 +181,9 @@ set -xe -o pipefail
 # package-gale is excluded in CI only, where test-gale-o3 covers it; locally
 # one run walks every nested package. benchmark/* test blocks need no `--dir`:
 # their file reads sit in `export fn run()`, which the test world never calls.
+# Same batch-compilation shape as `test-gale-o3`, whose comment explains the
+# purge and what holding the pages costs in RSS.
+export MIMALLOC_PURGE_DELAY=-1
 extra_args=()
 if [ -n "${CI:-}" ]; then
     extra_args+=(--exclude 'package-gale/**' --format tap)
@@ -197,6 +200,17 @@ description = "Run package-gale tests with -O3"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
+# One compile's allocations and frees land on different threads (tokio worker,
+# then `spawn_blocking`), so mimalloc abandons the pages and its 10ms purge
+# timer hands them back to the OS just before the next compile asks for them
+# again: 1.0 GiB purged over 2.6K calls in a single file's run, and the
+# re-commit shows up as free-list construction in fresh pages. Holding them
+# costs 828s of wall against 931s over this suite (-11%, compile CPU 3081s
+# against 3442s), for a peak RSS of 5941 MiB against 4798 — comfortable on a
+# 16 GiB runner, and the first thing to revisit on a smaller one. Batch
+# compilation only: `wado serve` is long-running and wants the purge, so this
+# stays out of the binary.
+export MIMALLOC_PURGE_DELAY=-1
 extra_args=()
 if [ -n "${CI:-}" ]; then
     extra_args+=(--format tap)

--- a/mise.toml
+++ b/mise.toml
@@ -200,16 +200,21 @@ description = "Run package-gale tests with -O3"
 run = """
 #!/usr/bin/env bash
 set -xe -o pipefail
-# One compile's allocations and frees land on different threads (tokio worker,
-# then `spawn_blocking`), so mimalloc abandons the pages and its 10ms purge
-# timer hands them back to the OS just before the next compile asks for them
-# again: 1.0 GiB purged over 2.6K calls in a single file's run, and the
-# re-commit shows up as free-list construction in fresh pages. Holding them
-# costs 828s of wall against 931s over this suite (-11%, compile CPU 3081s
-# against 3442s), for a peak RSS of 5941 MiB against 4798 — comfortable on a
-# 16 GiB runner, and the first thing to revisit on a smaller one. Batch
-# compilation only: `wado serve` is long-running and wants the purge, so this
-# stays out of the binary.
+# A compile builds a working set of several hundred MiB and frees it whole when
+# the file is done, so the heap empties once per file. mimalloc's 10ms purge
+# timer then hands those pages back to the OS just before the next file asks for
+# them again — 7.0 GiB purged over 24.8K calls to compile four fixtures — and
+# taking them back is a page fault plus free-list construction per page. Holding
+# them costs 828s of wall against 931s over this suite (-11%, compile CPU 3081s
+# against 3442s), for a peak RSS of 5941 MiB against 4798: comfortable on a
+# 16 GiB runner, and the first thing to revisit on a smaller one. It is the
+# breathing that costs, not the threads — serializing the compiles (`-p 1`)
+# leaves the page traffic where it was. Batch compilation only: `wado serve` is
+# long-running, and reclaiming after a spike is what the purge is for.
+#
+# The allocation volume behind it is the standing fix: ~31% of a compile's CPU
+# is in the allocator, and a compile that allocated less would have less to hand
+# back.
 export MIMALLOC_PURGE_DELAY=-1
 extra_args=()
 if [ -n "${CI:-}" ]; then

--- a/wado-compiler/src/elaborator.rs
+++ b/wado-compiler/src/elaborator.rs
@@ -680,7 +680,7 @@ impl<'a, H: CompilerHost> Elaborator<'a, H> {
         let statics = self
             .static_method_entries(receiver, method_name)
             .map(|e| e.method_id);
-        let mut seen = std::collections::HashSet::new();
+        let mut seen = crate::hashmap::IndexSet::default();
         statics
             .chain(self.impl_method_decl_ids(receiver, method_name))
             .filter(move |def| seen.insert(*def))

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -260,24 +260,25 @@ impl EngineBuffers {
 
     /// Cover a node the session just allocated. The maps are grown and never
     /// truncated, so a body smaller than an earlier one leaves entries behind
-    /// and a push would land at the wrong index.
-    fn note_alloc(&mut self, node: NodeRef, arena_len: usize) {
+    /// and a push would land at the wrong index. The reach is read off the id
+    /// rather than passed in, so no caller can name the wrong arena's length.
+    fn note_alloc(&mut self, node: NodeRef) {
         match node {
-            NodeRef::Expr(_) => {
-                grow(&mut self.expr_parent, arena_len);
-                grow(&mut self.expr_queued, arena_len);
+            NodeRef::Expr(id) => {
+                grow(&mut self.expr_parent, id.index() + 1);
+                grow(&mut self.expr_queued, id.index() + 1);
             }
-            NodeRef::Stmt(_) => {
-                grow(&mut self.stmt_parent, arena_len);
-                grow(&mut self.stmt_queued, arena_len);
+            NodeRef::Stmt(id) => {
+                grow(&mut self.stmt_parent, id.index() + 1);
+                grow(&mut self.stmt_queued, id.index() + 1);
             }
-            NodeRef::Block(_) => {
-                grow(&mut self.block_parent, arena_len);
-                grow(&mut self.block_queued, arena_len);
+            NodeRef::Block(id) => {
+                grow(&mut self.block_parent, id.index() + 1);
+                grow(&mut self.block_queued, id.index() + 1);
             }
-            NodeRef::Pat(_) => {
-                grow(&mut self.pat_parent, arena_len);
-                grow(&mut self.pat_queued, arena_len);
+            NodeRef::Pat(id) => {
+                grow(&mut self.pat_parent, id.index() + 1);
+                grow(&mut self.pat_queued, id.index() + 1);
             }
         }
         self.set_parent(node, None);
@@ -1270,8 +1271,7 @@ impl<'a> Engine<'a> {
             type_id,
             span,
         });
-        let arena_len = self.body.exprs.len();
-        self.buf.note_alloc(NodeRef::Expr(id), arena_len);
+        self.buf.note_alloc(NodeRef::Expr(id));
         self.census_note_node_operands(NodeRef::Expr(id));
         let mut children = Vec::new();
         self.body
@@ -1302,8 +1302,7 @@ impl<'a> Engine<'a> {
     /// Edit API: allocate a fresh statement node.
     pub fn alloc_stmt(&mut self, kind: StmtKind, span: Span) -> StmtId {
         let id = self.body.stmts.push(StmtNode { kind, span });
-        let arena_len = self.body.stmts.len();
-        self.buf.note_alloc(NodeRef::Stmt(id), arena_len);
+        self.buf.note_alloc(NodeRef::Stmt(id));
         self.census_note_node_operands(NodeRef::Stmt(id));
         let mut children = Vec::new();
         self.body
@@ -1324,8 +1323,7 @@ impl<'a> Engine<'a> {
     /// Edit API: allocate a fresh block node from a statement list.
     pub fn alloc_block(&mut self, stmts: Vec<StmtId>, span: Span) -> BlockId {
         let id = self.body.blocks.push(BlockNode { stmts, span });
-        let arena_len = self.body.blocks.len();
-        self.buf.note_alloc(NodeRef::Block(id), arena_len);
+        self.buf.note_alloc(NodeRef::Block(id));
         self.census_note_structure();
         let kids: Vec<StmtId> = self.body.blocks[id].stmts.clone();
         for s in kids {
@@ -1338,8 +1336,7 @@ impl<'a> Engine<'a> {
     /// Edit API: allocate a fresh pattern node.
     pub fn alloc_pat(&mut self, kind: PatKind, span: Span) -> PatId {
         let id = self.body.pats.push(PatNode { kind, span });
-        let arena_len = self.body.pats.len();
-        self.buf.note_alloc(NodeRef::Pat(id), arena_len);
+        self.buf.note_alloc(NodeRef::Pat(id));
         self.census_note_node_operands(NodeRef::Pat(id));
         let mut children = Vec::new();
         self.body
@@ -2176,6 +2173,60 @@ mod tests {
             popped,
             vec![NodeRef::Block(new_block), NodeRef::Pat(new_pat)]
         );
+    }
+
+    /// One `EngineBuffers` is lent to every session of a pass, and the parent /
+    /// in-worklist maps it owns are grown but never cleared or truncated. The
+    /// epoch stamp is what keeps one session out of the next, and every other
+    /// test builds a fresh `EngineBuffers` — so this is the only place the reuse
+    /// the design rests on is exercised: a second, smaller body must not read
+    /// the first body's parent edge at the same arena index, and an `alloc_*`
+    /// must land in its own slot rather than past the entries left behind.
+    #[test]
+    fn a_reused_engine_buffers_keeps_one_sessions_maps_out_of_the_next() {
+        let mut buffers = EngineBuffers::default();
+        let mut locals: Vec<NirLocal> = Vec::new();
+
+        // Session 1 over `{ let x = 1 + 2; return x; }`. Every node is
+        // reachable, so the walk stamps a parent into expr slot 0.
+        let mut big = Body::empty();
+        let one = lit(&mut big, 1);
+        let two = lit(&mut big, 2);
+        let add = bin(&mut big, one, NirBinaryOp::Add, two);
+        let let_stmt = let_x(&mut big, add, false);
+        let ret = ret_x(&mut big);
+        big.root = big.blocks.push(BlockNode {
+            stmts: vec![let_stmt, ret],
+            span: Span::default(),
+        });
+        {
+            let eng = Engine::new(&mut big, &mut buffers, &mut locals);
+            assert_eq!(
+                eng.parent_of(NodeRef::Expr(add)),
+                Some(NodeRef::Stmt(let_stmt))
+            );
+        }
+
+        // Session 2, same buffers, over a smaller body whose only expression is
+        // an orphan the walk never reaches — and it occupies the very slot
+        // session 1 stamped.
+        let mut small = mk_body(|_| Vec::new());
+        let orphan = e(&mut small, ExprKind::Dead);
+        assert_eq!(orphan, add, "the two bodies must collide on expr slot 0");
+        let mut eng = Engine::new(&mut small, &mut buffers, &mut locals);
+        assert_eq!(eng.parent_of(NodeRef::Expr(orphan)), None);
+
+        // Drain the root block seeded at construction, then mint a node while
+        // the maps still run ahead of this body: it must be unparented and
+        // queued exactly once, not inherit slot 1 from session 1's `return x`.
+        while eng.pop().is_some() {}
+        let fresh = eng.alloc_expr(ExprKind::Dead, TypeTable::UNIT, Span::default());
+        assert_eq!(eng.parent_of(NodeRef::Expr(fresh)), None);
+        let mut popped = Vec::new();
+        while let Some(n) = eng.pop() {
+            popped.push(n);
+        }
+        assert_eq!(popped, vec![NodeRef::Expr(fresh)]);
     }
 
     /// `uses_entry` grows `EngineBuffers::uses` on demand for a local

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -80,15 +80,6 @@ fn arena_slot<'a, T>(
     }
 }
 
-/// Extend a per-node buffer to cover `len` nodes, leaving what is already there
-/// alone — the epoch stamp is what makes an older session's entry absent, so a
-/// session never has to clear one.
-fn grow<T: Copy + Default>(v: &mut Vec<T>, len: usize) {
-    if v.len() < len {
-        v.resize(len, T::default());
-    }
-}
-
 /// Mutable counterpart of [`arena_slot`].
 fn arena_slot_mut<'a, T>(
     node: NodeRef,
@@ -105,13 +96,8 @@ fn arena_slot_mut<'a, T>(
     }
 }
 
-/// A parent edge, stamped with the session that wrote it. The parent and
-/// in-worklist maps are indexed by arena position, and the arena never compacts
-/// — after a round of inlining and rewriting it runs far ahead of the live tree
-/// [`Engine::build_indices`] walks — so clearing them per session would cost
-/// more than the walk they serve. A slot left by an older session reads as
-/// absent instead, which is what lets [`EngineBuffers::reset_for`] grow the maps
-/// without touching what is already there.
+/// A parent edge and the session that wrote it. Older stamps read as absent, so
+/// a session starts by bumping the stamp rather than by clearing the map.
 #[derive(Clone, Copy, Default)]
 struct ParentSlot {
     epoch: u64,
@@ -127,9 +113,8 @@ struct ParentSlot {
 /// allocations keeps the optimizer off the global allocator's hot path.
 #[derive(Default)]
 pub struct EngineBuffers {
-    /// This session's stamp. Bumped by [`Self::reset_for`]; a parent or
-    /// in-worklist slot carrying an older one is absent. `0` is no session, so a
-    /// freshly grown slot starts absent. See [`ParentSlot`].
+    /// This session's stamp, bumped by [`Self::reset_for`]. `0` is no session,
+    /// so a freshly grown slot starts absent. See [`ParentSlot`].
     epoch: u64,
     expr_parent: Vec<ParentSlot>,
     stmt_parent: Vec<ParentSlot>,
@@ -153,8 +138,7 @@ pub struct EngineBuffers {
     /// `enqueue`/`pop` run on nearly every rewrite edit, the engine's hottest
     /// path, so a `NodeRef`-keyed `IndexSet` here would pay a hash + probe on
     /// every one of them instead of a plain array index. A node is queued while
-    /// its slot holds the current [`Self::epoch`], so these need no per-session
-    /// clear either.
+    /// its slot holds the current [`Self::epoch`].
     expr_queued: Vec<u64>,
     stmt_queued: Vec<u64>,
     block_queued: Vec<u64>,
@@ -165,11 +149,22 @@ pub struct EngineBuffers {
     elided_locals: Vec<u32>,
 }
 
+/// Extend a per-node map to cover `len` nodes, leaving the entries already there
+/// for the session stamp to rule absent.
+fn grow<T: Copy + Default>(v: &mut Vec<T>, len: usize) {
+    if v.len() < len {
+        v.resize(len, T::default());
+    }
+}
+
 impl EngineBuffers {
-    /// Clear every buffer and size the parent / queued-bit / use-index maps to
-    /// `body`'s current node and local counts, readying them for a fresh
-    /// session. Capacity is retained, so a reused `EngineBuffers` allocates
-    /// only when a body is larger than any seen before.
+    /// Ready the buffers for a fresh session over `body`: bump the stamp, then
+    /// extend the parent, in-worklist and use-index maps to cover its counts.
+    ///
+    /// The maps are indexed by arena position, and the arena never compacts.
+    /// After a round of inlining it runs far ahead of the live tree
+    /// [`Engine::build_indices`] walks, so clearing the maps would cost more
+    /// than the walk they serve. The stamp rules the leftovers absent instead.
     fn reset_for(&mut self, body: &Body, local_count: usize) {
         self.epoch += 1;
         grow(&mut self.expr_parent, body.exprs.len());
@@ -233,8 +228,8 @@ impl EngineBuffers {
         ) = if value { epoch } else { 0 };
     }
 
-    /// The parent edge this session recorded for `node`, or `None` for the body
-    /// root and for a node no session of this stamp reached.
+    /// The parent this session recorded for `node`, or `None` for the body root
+    /// and for a node it never reached.
     fn parent(&self, node: NodeRef) -> Option<NodeRef> {
         let slot = arena_slot(
             node,
@@ -246,7 +241,7 @@ impl EngineBuffers {
         (slot.epoch == self.epoch).then_some(slot.parent).flatten()
     }
 
-    /// Record `node`'s parent edge under this session's stamp.
+    /// Record `node`'s parent for this session.
     fn set_parent(&mut self, node: NodeRef, parent: Option<NodeRef>) {
         let epoch = self.epoch;
         *arena_slot_mut(
@@ -258,10 +253,9 @@ impl EngineBuffers {
         ) = ParentSlot { epoch, parent };
     }
 
-    /// Cover a node the session just allocated. The maps are grown and never
-    /// truncated, so a body smaller than an earlier one leaves entries behind
-    /// and a push would land at the wrong index. The reach is read off the id
-    /// rather than passed in, so no caller can name the wrong arena's length.
+    /// Cover a node the session just allocated. The maps are never truncated, so
+    /// a body smaller than an earlier one leaves entries behind them and a push
+    /// would land past the new node rather than on it.
     fn note_alloc(&mut self, node: NodeRef) {
         match node {
             NodeRef::Expr(id) => {
@@ -2175,13 +2169,9 @@ mod tests {
         );
     }
 
-    /// One `EngineBuffers` is lent to every session of a pass, and the parent /
-    /// in-worklist maps it owns are grown but never cleared or truncated. The
-    /// epoch stamp is what keeps one session out of the next, and every other
-    /// test builds a fresh `EngineBuffers` — so this is the only place the reuse
-    /// the design rests on is exercised: a second, smaller body must not read
-    /// the first body's parent edge at the same arena index, and an `alloc_*`
-    /// must land in its own slot rather than past the entries left behind.
+    /// The stamp is what keeps one session's maps out of the next, and every
+    /// other test builds a fresh `EngineBuffers` — so this is the only place the
+    /// reuse it exists for is exercised.
     #[test]
     fn a_reused_engine_buffers_keeps_one_sessions_maps_out_of_the_next() {
         let mut buffers = EngineBuffers::default();

--- a/wado-compiler/src/nir_engine.rs
+++ b/wado-compiler/src/nir_engine.rs
@@ -80,6 +80,15 @@ fn arena_slot<'a, T>(
     }
 }
 
+/// Extend a per-node buffer to cover `len` nodes, leaving what is already there
+/// alone — the epoch stamp is what makes an older session's entry absent, so a
+/// session never has to clear one.
+fn grow<T: Copy + Default>(v: &mut Vec<T>, len: usize) {
+    if v.len() < len {
+        v.resize(len, T::default());
+    }
+}
+
 /// Mutable counterpart of [`arena_slot`].
 fn arena_slot_mut<'a, T>(
     node: NodeRef,
@@ -96,19 +105,36 @@ fn arena_slot_mut<'a, T>(
     }
 }
 
+/// A parent edge, stamped with the session that wrote it. The parent and
+/// in-worklist maps are indexed by arena position, and the arena never compacts
+/// — after a round of inlining and rewriting it runs far ahead of the live tree
+/// [`Engine::build_indices`] walks — so clearing them per session would cost
+/// more than the walk they serve. A slot left by an older session reads as
+/// absent instead, which is what lets [`EngineBuffers::reset_for`] grow the maps
+/// without touching what is already there.
+#[derive(Clone, Copy, Default)]
+struct ParentSlot {
+    epoch: u64,
+    parent: Option<NodeRef>,
+}
+
 /// The reusable scratch buffers an [`Engine`] session needs: the parent map,
 /// use index, and worklist. Constructing an engine for every dirty function in
 /// every engine-based pass — `peephole` twice per fixed-point iteration,
 /// `match_to_switch`, … — happens tens of thousands of times on a large
 /// program, so these containers are owned by the caller once and lent to each
-/// session via [`Engine::new`], which clears and right-sizes them. Reusing the
+/// session via [`Engine::new`], which stamps and right-sizes them. Reusing the
 /// allocations keeps the optimizer off the global allocator's hot path.
 #[derive(Default)]
 pub struct EngineBuffers {
-    expr_parent: Vec<Option<NodeRef>>,
-    stmt_parent: Vec<Option<NodeRef>>,
-    block_parent: Vec<Option<NodeRef>>,
-    pat_parent: Vec<Option<NodeRef>>,
+    /// This session's stamp. Bumped by [`Self::reset_for`]; a parent or
+    /// in-worklist slot carrying an older one is absent. `0` is no session, so a
+    /// freshly grown slot starts absent. See [`ParentSlot`].
+    epoch: u64,
+    expr_parent: Vec<ParentSlot>,
+    stmt_parent: Vec<ParentSlot>,
+    block_parent: Vec<ParentSlot>,
+    pat_parent: Vec<ParentSlot>,
     /// Indexed directly by local index (dense, `0..locals.len()` — same
     /// invariant `LocalSet` relies on elsewhere), not hashed: a local-keyed
     /// `IndexMap` here would pay a hash + probe for every read/def recorded by
@@ -122,15 +148,17 @@ pub struct EngineBuffers {
     /// function means the walk runs tens of thousands of times per compile.
     walk_stack: Vec<(NodeRef, bool)>,
     walk_children: Vec<NodeRef>,
-    /// Dense in-worklist bit per node, one `Vec` per arena kind (mirrors the
+    /// Dense in-worklist stamp per node, one `Vec` per arena kind (mirrors the
     /// `*_parent` vecs above) — same dense-index rationale as `uses`:
     /// `enqueue`/`pop` run on nearly every rewrite edit, the engine's hottest
     /// path, so a `NodeRef`-keyed `IndexSet` here would pay a hash + probe on
-    /// every one of them instead of a plain array index.
-    expr_queued: Vec<bool>,
-    stmt_queued: Vec<bool>,
-    block_queued: Vec<bool>,
-    pat_queued: Vec<bool>,
+    /// every one of them instead of a plain array index. A node is queued while
+    /// its slot holds the current [`Self::epoch`], so these need no per-session
+    /// clear either.
+    expr_queued: Vec<u64>,
+    stmt_queued: Vec<u64>,
+    block_queued: Vec<u64>,
+    pat_queued: Vec<u64>,
     /// Locals whose defining binding a rule deleted this session, audited once
     /// at [`Engine::run`]'s end. Only written under debug assertions — the
     /// audit is the sole reader. See [`Engine::note_elided_local`].
@@ -143,22 +171,15 @@ impl EngineBuffers {
     /// session. Capacity is retained, so a reused `EngineBuffers` allocates
     /// only when a body is larger than any seen before.
     fn reset_for(&mut self, body: &Body, local_count: usize) {
-        let fill = |v: &mut Vec<Option<NodeRef>>, len: usize| {
-            v.clear();
-            v.resize(len, None);
-        };
-        fill(&mut self.expr_parent, body.exprs.len());
-        fill(&mut self.stmt_parent, body.stmts.len());
-        fill(&mut self.block_parent, body.blocks.len());
-        fill(&mut self.pat_parent, body.pats.len());
-        let fill_bit = |v: &mut Vec<bool>, len: usize| {
-            v.clear();
-            v.resize(len, false);
-        };
-        fill_bit(&mut self.expr_queued, body.exprs.len());
-        fill_bit(&mut self.stmt_queued, body.stmts.len());
-        fill_bit(&mut self.block_queued, body.blocks.len());
-        fill_bit(&mut self.pat_queued, body.pats.len());
+        self.epoch += 1;
+        grow(&mut self.expr_parent, body.exprs.len());
+        grow(&mut self.stmt_parent, body.stmts.len());
+        grow(&mut self.block_parent, body.blocks.len());
+        grow(&mut self.pat_parent, body.pats.len());
+        grow(&mut self.expr_queued, body.exprs.len());
+        grow(&mut self.stmt_queued, body.stmts.len());
+        grow(&mut self.block_queued, body.blocks.len());
+        grow(&mut self.pat_queued, body.pats.len());
         // Not `clear()`: that frees every `reads` Vec `build_indices` then
         // reallocates. Entries past `local_count` stay reset, which every
         // `uses.get` reads as absent.
@@ -189,7 +210,7 @@ impl EngineBuffers {
         &mut self.uses[i]
     }
 
-    /// Whether `node` currently has an in-worklist bit set.
+    /// Whether `node` is currently on the worklist.
     fn is_queued(&self, node: NodeRef) -> bool {
         *arena_slot(
             node,
@@ -197,18 +218,70 @@ impl EngineBuffers {
             &self.stmt_queued,
             &self.block_queued,
             &self.pat_queued,
-        )
+        ) == self.epoch
     }
 
-    /// Set `node`'s in-worklist bit.
+    /// Mark `node` on or off the worklist.
     fn set_queued(&mut self, node: NodeRef, value: bool) {
+        let epoch = self.epoch;
         *arena_slot_mut(
             node,
             &mut self.expr_queued,
             &mut self.stmt_queued,
             &mut self.block_queued,
             &mut self.pat_queued,
-        ) = value;
+        ) = if value { epoch } else { 0 };
+    }
+
+    /// The parent edge this session recorded for `node`, or `None` for the body
+    /// root and for a node no session of this stamp reached.
+    fn parent(&self, node: NodeRef) -> Option<NodeRef> {
+        let slot = arena_slot(
+            node,
+            &self.expr_parent,
+            &self.stmt_parent,
+            &self.block_parent,
+            &self.pat_parent,
+        );
+        (slot.epoch == self.epoch).then_some(slot.parent).flatten()
+    }
+
+    /// Record `node`'s parent edge under this session's stamp.
+    fn set_parent(&mut self, node: NodeRef, parent: Option<NodeRef>) {
+        let epoch = self.epoch;
+        *arena_slot_mut(
+            node,
+            &mut self.expr_parent,
+            &mut self.stmt_parent,
+            &mut self.block_parent,
+            &mut self.pat_parent,
+        ) = ParentSlot { epoch, parent };
+    }
+
+    /// Cover a node the session just allocated. The maps are grown and never
+    /// truncated, so a body smaller than an earlier one leaves entries behind
+    /// and a push would land at the wrong index.
+    fn note_alloc(&mut self, node: NodeRef, arena_len: usize) {
+        match node {
+            NodeRef::Expr(_) => {
+                grow(&mut self.expr_parent, arena_len);
+                grow(&mut self.expr_queued, arena_len);
+            }
+            NodeRef::Stmt(_) => {
+                grow(&mut self.stmt_parent, arena_len);
+                grow(&mut self.stmt_queued, arena_len);
+            }
+            NodeRef::Block(_) => {
+                grow(&mut self.block_parent, arena_len);
+                grow(&mut self.block_queued, arena_len);
+            }
+            NodeRef::Pat(_) => {
+                grow(&mut self.pat_parent, arena_len);
+                grow(&mut self.pat_queued, arena_len);
+            }
+        }
+        self.set_parent(node, None);
+        self.set_queued(node, false);
     }
 }
 
@@ -847,21 +920,14 @@ impl<'a> Engine<'a> {
             children.clear();
             self.body.for_each_child(node, |c| children.push(c));
             for &child in &children {
-                let slot = arena_slot_mut(
-                    child,
-                    &mut self.buf.expr_parent,
-                    &mut self.buf.stmt_parent,
-                    &mut self.buf.block_parent,
-                    &mut self.buf.pat_parent,
-                );
-                if let Some(prev) = *slot {
+                if let Some(prev) = self.buf.parent(child) {
                     panic!(
                         "[NIR engine] {child:?} has two live parents ({prev:?} and {node:?}): \
                          an edit shared a child id between two nodes — move the kind \
                          (`become_expr`), do not share ids"
                     );
                 }
-                *slot = Some(node);
+                self.buf.set_parent(child, Some(node));
             }
             for &child in children.iter().rev() {
                 stack.push((child, false));
@@ -889,13 +955,7 @@ impl<'a> Engine<'a> {
     /// The parent of a node (the nearest id-bearing ancestor), or `None` for
     /// the body root.
     pub fn parent_of(&self, node: NodeRef) -> Option<NodeRef> {
-        *arena_slot(
-            node,
-            &self.buf.expr_parent,
-            &self.buf.stmt_parent,
-            &self.buf.block_parent,
-            &self.buf.pat_parent,
-        )
+        self.buf.parent(node)
     }
 
     /// Every `Local { index }` expression node naming `local`.
@@ -1011,13 +1071,7 @@ impl<'a> Engine<'a> {
     }
 
     fn set_parent(&mut self, child: NodeRef, parent: Option<NodeRef>) {
-        *arena_slot_mut(
-            child,
-            &mut self.buf.expr_parent,
-            &mut self.buf.stmt_parent,
-            &mut self.buf.block_parent,
-            &mut self.buf.pat_parent,
-        ) = parent;
+        self.buf.set_parent(child, parent);
     }
 
     /// Edit API: rewrite every operand slot of `node` through `f`.
@@ -1216,8 +1270,8 @@ impl<'a> Engine<'a> {
             type_id,
             span,
         });
-        self.buf.expr_parent.push(None);
-        self.buf.expr_queued.push(false);
+        let arena_len = self.body.exprs.len();
+        self.buf.note_alloc(NodeRef::Expr(id), arena_len);
         self.census_note_node_operands(NodeRef::Expr(id));
         let mut children = Vec::new();
         self.body
@@ -1248,8 +1302,8 @@ impl<'a> Engine<'a> {
     /// Edit API: allocate a fresh statement node.
     pub fn alloc_stmt(&mut self, kind: StmtKind, span: Span) -> StmtId {
         let id = self.body.stmts.push(StmtNode { kind, span });
-        self.buf.stmt_parent.push(None);
-        self.buf.stmt_queued.push(false);
+        let arena_len = self.body.stmts.len();
+        self.buf.note_alloc(NodeRef::Stmt(id), arena_len);
         self.census_note_node_operands(NodeRef::Stmt(id));
         let mut children = Vec::new();
         self.body
@@ -1270,8 +1324,8 @@ impl<'a> Engine<'a> {
     /// Edit API: allocate a fresh block node from a statement list.
     pub fn alloc_block(&mut self, stmts: Vec<StmtId>, span: Span) -> BlockId {
         let id = self.body.blocks.push(BlockNode { stmts, span });
-        self.buf.block_parent.push(None);
-        self.buf.block_queued.push(false);
+        let arena_len = self.body.blocks.len();
+        self.buf.note_alloc(NodeRef::Block(id), arena_len);
         self.census_note_structure();
         let kids: Vec<StmtId> = self.body.blocks[id].stmts.clone();
         for s in kids {
@@ -1284,8 +1338,8 @@ impl<'a> Engine<'a> {
     /// Edit API: allocate a fresh pattern node.
     pub fn alloc_pat(&mut self, kind: PatKind, span: Span) -> PatId {
         let id = self.body.pats.push(PatNode { kind, span });
-        self.buf.pat_parent.push(None);
-        self.buf.pat_queued.push(false);
+        let arena_len = self.body.pats.len();
+        self.buf.note_alloc(NodeRef::Pat(id), arena_len);
         self.census_note_node_operands(NodeRef::Pat(id));
         let mut children = Vec::new();
         self.body
@@ -1657,7 +1711,7 @@ impl<'a> Engine<'a> {
                 "[NIR engine] a rule reported eliding local {local}, but a reachable \
                  read of it survived this session — the binding it named is gone and \
                  that read now has no definition. The reporting rules are \
-                 `elide_local` and `labeled_block_fusion`."
+                 `elide_local`, `labeled_block_fusion` and `copy_prop`."
             );
         }
         debug_assert!(
@@ -2088,15 +2142,14 @@ mod tests {
         assert_eq!(popped, total);
     }
 
-    /// `alloc_block`/`alloc_pat` push a `false` into `block_queued`/`pat_queued`
-    /// alongside the existing `block_parent`/`pat_parent` push. Neither path is
-    /// exercised by any other test (`clone_expr_deep_copies_into_fresh_nodes`
-    /// only clones a `Binary` over literal operands, never reaching
-    /// `clone_block`/`clone_pat`), so a regression that drops or reorders the
-    /// `_queued` push would panic here (out-of-bounds index in `enqueue`'s
-    /// `is_queued` check) instead of on real optimizer input.
+    /// `alloc_block`/`alloc_pat` extend the block/pat parent and in-worklist
+    /// maps to cover the node they mint. Neither path is exercised by any other
+    /// test (`clone_expr_deep_copies_into_fresh_nodes` only clones a `Binary`
+    /// over literal operands, never reaching `clone_block`/`clone_pat`), so a
+    /// regression that drops the extension would panic here (out-of-bounds index
+    /// in `enqueue`'s `is_queued` check) instead of on real optimizer input.
     #[test]
-    fn alloc_block_and_alloc_pat_extend_the_queued_bitsets() {
+    fn alloc_block_and_alloc_pat_extend_the_queued_maps() {
         let mut body = sample_body();
         let mut __buf_eng = EngineBuffers::default();
         let mut __locals_eng: Vec<NirLocal> = Vec::new();

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -608,19 +608,13 @@ fn run_optimization_passes(
         // `inline` self-reports the callers it modified to the gate (no
         // `bump_all`); it only mutates caller bodies, so the gated passes need
         // re-examine just those (and their neighbours).
-        record!(
-            "nir/inline",
-            run_pass("nir/inline", project, profiler, |p| {
-                gate.any_pending(GatedPass::Inline, p.functions.len())
-                    && inline_functions(
-                        p,
-                        config.inline_threshold,
-                        &mut inline_budget,
-                        &mut gate,
-                        &mut descriptor_cache,
-                    )
-            })
-        );
+        gated!("nir/inline", GatedPass::Inline, |p, g| inline_functions(
+            p,
+            config.inline_threshold,
+            &mut inline_budget,
+            g,
+            &mut descriptor_cache,
+        ));
         // Peephole engine, post-inline run. `elide_local` runs again over
         // inline's freshly dead bindings. No `MatchToSwitchRule` — the
         // pre-inline run lowered every reachable `Match` already.
@@ -649,13 +643,9 @@ fn run_optimization_passes(
         // collapse — where the env-free half runs in `nir/peephole`. It absorbs
         // `field_forward`, which used to alternate one statement per round and
         // left `-O3` non-convergent. No `cse` pass: hash-consing already shares.
-        record!(
-            "nir/const_fold",
-            run_pass("nir/const_fold", project, profiler, |p| {
-                gate.any_pending(GatedPass::ConstFold, p.functions.len())
-                    && fold_constants(p, &mut gate, &mut const_fold_cache)
-            })
-        );
+        gated!("nir/const_fold", GatedPass::ConstFold, |p, g| {
+            fold_constants(p, g, &mut const_fold_cache)
+        });
         // Trivial-block / dead-statement pruning moved into the pre-inline
         // `nir/peephole` run above; the post-loop `branch_prune_final` and the
         // post-globalization `const_fold_post_global` keep their own engine
@@ -670,7 +660,11 @@ fn run_optimization_passes(
             })
         );
         gated!("nir/licm", GatedPass::Licm, apply_licm);
-        gated!("nir/tmpl_hoist", GatedPass::TmplHoist, hoist_template_buffers);
+        gated!(
+            "nir/tmpl_hoist",
+            GatedPass::TmplHoist,
+            hoist_template_buffers
+        );
         profiler.span_end(&format!("nir/iteration {}", i + 1));
         crate::compiler_trace!(
             "opt_loop",

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -73,6 +73,7 @@ use tmpl_hoist::hoist_template_buffers;
 use value_copy_demote::demote_value_copies;
 
 use extract::FreezePhase;
+use gate::GatedPass;
 
 use crate::compiler_host::SpanEmitter;
 use crate::nir_package::NirPackage;
@@ -526,19 +527,32 @@ fn run_optimization_passes(
         // A gate-aware pass: receives `&mut gate`, skips functions it has
         // already processed at their current revision, and reports its own
         // per-function changes.
+        //
+        // The round is skipped here, not inside the pass: a pass builds its
+        // whole-program state — method catalogs, callee maps, effect summaries,
+        // alias tables, call-site censuses — before it reaches its first
+        // function, and that setup outweighs the per-function work once the
+        // gate has drained. Owning the skip at the schedule is what keeps a
+        // pass from forgetting it. An empty gate means no function changed
+        // since this pass last ran, so the round it skips is one that would
+        // rebuild the same state and rewrite nothing.
         macro_rules! gated {
-            ($name:expr, $pass:expr) => {{
+            ($name:expr, $id:expr, $pass:expr) => {{
                 record!(
                     $name,
-                    run_pass($name, project, profiler, |p| $pass(p, &mut gate))
+                    run_pass($name, project, profiler, |p| {
+                        gate.any_pending($id, p.functions.len()) && $pass(p, &mut gate)
+                    })
                 );
             }};
         }
         // Reports changes to the gate but not to `iter_changed` — must never
         // keep the loop alive on its own.
         macro_rules! gate_only {
-            ($name:expr, $pass:expr) => {{
-                run_pass($name, project, profiler, |p| $pass(p, &mut gate));
+            ($name:expr, $id:expr, $pass:expr) => {{
+                run_pass($name, project, profiler, |p| {
+                    gate.any_pending($id, p.functions.len()) && $pass(p, &mut gate)
+                });
             }};
         }
         // Container SROA must run before inline in each iteration: inline
@@ -546,72 +560,90 @@ fn run_optimization_passes(
         // `builtin::array_get_value` + field-access pairs, after which the method-call
         // shape this pass keys on is gone. Running early also catches the `[]`
         // desugaring while its inner `Constructor` is still a plain `Call`.
-        gated!("nir/container_sroa", scalarize_containers);
+        gated!(
+            "nir/container_sroa",
+            GatedPass::ContainerSroa,
+            scalarize_containers
+        );
         // Peephole engine, pre-inline run — several rules over one worklist; see
         // `optimize/peephole.rs`. Before inline so `string_push` still sees the
         // `buf.push_str("0.")` shape, which the inliner's expansion would erase.
         // Hosts `MatchToSwitchRule` (`include_match = true`), so `inline` copies
         // `Switch`-shaped bodies, and `const_branch_prune`.
-        gated!("nir/peephole", |p, g| peephole::run_peephole(p, g, true));
+        gated!("nir/peephole", GatedPass::PeepholePre, |p, g| {
+            peephole::run_peephole(p, g, true)
+        });
         // Demote deep `$value_copy$T` copies of `List<E>` to shallow spine
         // copies when the binding's elements are provably never mutated through
         // it. Runs before `nir/inline`, where the `$value_copy$T(arg)` shape it
         // matches disappears. (Copies are inserted precisely at the lower phase,
         // so there is no elision pass to sequence against.)
-        gate_only!("nir/value_copy_demote", |p, g| demote_value_copies(
-            p,
-            g,
-            &mut descriptor_cache
-        ));
+        gate_only!(
+            "nir/value_copy_demote",
+            GatedPass::ValueCopyDemote,
+            |p, g| demote_value_copies(p, g, &mut descriptor_cache)
+        );
         // Single-field parameter SROA: rewrite functions whose parameter type
         // is `&S` for a single-field struct (`Box<T>` being the canonical
         // case) to take the inner scalar directly. Runs before `nir/inline`
         // so the inliner sees post-SROA signatures and can propagate the
         // scalar through call chains. NIR analog of WIR's `sroa_param`; see
         // `optimize/sroa_param.rs`.
-        gated!("nir/sroa_param", sroa_single_field_parameters);
+        gated!(
+            "nir/sroa_param",
+            GatedPass::SroaParam,
+            sroa_single_field_parameters
+        );
         // Variant returns become tuple returns: `Result<T, E>` -> `[tag, slots]`.
         // Runs beside `sroa_param` and before `nir/inline` for the same reason —
         // the inliner, and every value pass after it, then sees an integer tag
         // and plain locals where a boxed variant used to be opaque. The Wasm ABI
         // is left to `multi_value_return`, which already flattens a destructured
         // tuple return.
-        gated!("nir/sroa_variant_return", scalarize_variant_returns);
+        gated!(
+            "nir/sroa_variant_return",
+            GatedPass::SroaVariantReturn,
+            scalarize_variant_returns
+        );
         // `inline` self-reports the callers it modified to the gate (no
         // `bump_all`); it only mutates caller bodies, so the gated passes need
         // re-examine just those (and their neighbours).
         record!(
             "nir/inline",
             run_pass("nir/inline", project, profiler, |p| {
-                inline_functions(
-                    p,
-                    config.inline_threshold,
-                    &mut inline_budget,
-                    &mut gate,
-                    &mut descriptor_cache,
-                )
+                gate.any_pending(GatedPass::Inline, p.functions.len())
+                    && inline_functions(
+                        p,
+                        config.inline_threshold,
+                        &mut inline_budget,
+                        &mut gate,
+                        &mut descriptor_cache,
+                    )
             })
         );
         // Peephole engine, post-inline run. `elide_local` runs again over
         // inline's freshly dead bindings. No `MatchToSwitchRule` — the
         // pre-inline run lowered every reachable `Match` already.
-        gated!("nir/peephole", |p, g| peephole::run_peephole(p, g, false));
+        gated!("nir/peephole", GatedPass::PeepholePost, |p, g| {
+            peephole::run_peephole(p, g, false)
+        });
         // `labeled_block_fusion` moved into the post-inline `nir/peephole`
         // session as `LabeledBlockFusionRule`; see `optimize/peephole.rs`.
         gated!(
             "nir/let_block_flatten",
+            GatedPass::LetBlockFlatten,
             let_block_flatten::flatten_let_blocks
         );
-        gated!("nir/sroa", scalar_replace_aggregates);
-        gated!("nir/copy_prop", propagate_copies);
+        gated!("nir/sroa", GatedPass::Sroa, scalar_replace_aggregates);
+        gated!("nir/copy_prop", GatedPass::CopyProp, propagate_copies);
         // DAE / DRVE after `copy_prop` shrinks signatures and discards unused
         // let-bindings before `const_fold` revisits the simplified body.
         // Running here (rather than at WIR level) lets `inline` see the slimmer
         // signatures on the next iteration and lets `dce` clean up the freshly
         // dead computation in the same fixed-point loop. (Write-only local
         // elimination moved into the unified `nir/peephole` pass above.)
-        gated!("nir/dae", eliminate_dead_arguments);
-        gated!("nir/drve", eliminate_dead_return_values);
+        gated!("nir/dae", GatedPass::Dae, eliminate_dead_arguments);
+        gated!("nir/drve", GatedPass::Drve, eliminate_dead_return_values);
         // The flow-sensitive half of constant folding — env-bound locals,
         // forwarded struct fields, immutable-global reads, constant-branch
         // collapse — where the env-free half runs in `nir/peephole`. It absorbs
@@ -620,7 +652,8 @@ fn run_optimization_passes(
         record!(
             "nir/const_fold",
             run_pass("nir/const_fold", project, profiler, |p| {
-                fold_constants(p, &mut gate, &mut const_fold_cache)
+                gate.any_pending(GatedPass::ConstFold, p.functions.len())
+                    && fold_constants(p, &mut gate, &mut const_fold_cache)
             })
         );
         // Trivial-block / dead-statement pruning moved into the pre-inline
@@ -636,8 +669,8 @@ fn run_optimization_passes(
                 param_spec::specialize_const_params(p, &mut param_spec_state, &mut gate)
             })
         );
-        gated!("nir/licm", apply_licm);
-        gated!("nir/tmpl_hoist", hoist_template_buffers);
+        gated!("nir/licm", GatedPass::Licm, apply_licm);
+        gated!("nir/tmpl_hoist", GatedPass::TmplHoist, hoist_template_buffers);
         profiler.span_end(&format!("nir/iteration {}", i + 1));
         crate::compiler_trace!(
             "opt_loop",

--- a/wado-compiler/src/optimize.rs
+++ b/wado-compiler/src/optimize.rs
@@ -528,31 +528,26 @@ fn run_optimization_passes(
         // already processed at their current revision, and reports its own
         // per-function changes.
         //
-        // The round is skipped here, not inside the pass: a pass builds its
-        // whole-program state — method catalogs, callee maps, effect summaries,
-        // alias tables, call-site censuses — before it reaches its first
-        // function, and that setup outweighs the per-function work once the
-        // gate has drained. Owning the skip at the schedule is what keeps a
-        // pass from forgetting it. An empty gate means no function changed
-        // since this pass last ran, so the round it skips is one that would
-        // rebuild the same state and rewrite nothing.
+        // A drained column skips the round at the schedule, not inside the
+        // pass. A pass builds its whole-program state before it reaches its
+        // first function, and a drained column means no function changed since
+        // it last ran, so that round would rebuild the state and rewrite
+        // nothing.
         macro_rules! gated {
+            (@run $name:expr, $id:expr, $pass:expr) => {
+                run_pass($name, project, profiler, |p| {
+                    gate.any_pending($id, p.functions.len()) && $pass(p, &mut gate)
+                })
+            };
             ($name:expr, $id:expr, $pass:expr) => {{
-                record!(
-                    $name,
-                    run_pass($name, project, profiler, |p| {
-                        gate.any_pending($id, p.functions.len()) && $pass(p, &mut gate)
-                    })
-                );
+                record!($name, gated!(@run $name, $id, $pass));
             }};
         }
         // Reports changes to the gate but not to `iter_changed` — must never
         // keep the loop alive on its own.
         macro_rules! gate_only {
             ($name:expr, $id:expr, $pass:expr) => {{
-                run_pass($name, project, profiler, |p| {
-                    gate.any_pending($id, p.functions.len()) && $pass(p, &mut gate)
-                });
+                gated!(@run $name, $id, $pass);
             }};
         }
         // Container SROA must run before inline in each iteration: inline
@@ -652,7 +647,9 @@ fn run_optimization_passes(
         // sessions (`prune_template_block_wrappers` / `prune_constant_branches`).
         // After `const_fold`, so a caller's config struct literal already holds
         // folded constants; inside the loop, so the next iteration prunes the
-        // clone's dead branches and reaches one call deeper.
+        // clone's dead branches and reaches one call deeper. Not `gated!`: it
+        // owns no column, since a summary taken before a callee gained a write
+        // would license an unsound substitution (see its module doc).
         record!(
             "nir/param_spec",
             run_pass("nir/param_spec", project, profiler, |p| {

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -886,16 +886,12 @@ fn propagate_at_root(
         substitute_promoted_reads(engine, &substitutions);
         let root = engine.body.root;
         apply_in_block(engine, root, &substitutions, &dead_locals);
-        debug_assert!(
-            {
-                let mut reads = IndexSet::default();
-                super::arena_query::collect_reads(engine.body, &mut reads);
-                super::arena_query::promoted_local_reads(engine.body, &mut reads);
-                dead_locals.iter().all(|l| !reads.contains(l))
-            },
-            "[NIR] copy_prop: a propagated-away local is still read, \
-             in the skeleton or the value pool"
-        );
+        // Report the bindings this round propagated away rather than walking the
+        // body to check them here: the audit is `Body::surviving_read` either
+        // way, and reporting pays one walk per session instead of one per round.
+        for &local in &dead_locals {
+            engine.note_elided_local(local);
+        }
         ever_changed = true;
         if !has_deferred {
             break;

--- a/wado-compiler/src/optimize/copy_prop.rs
+++ b/wado-compiler/src/optimize/copy_prop.rs
@@ -886,9 +886,6 @@ fn propagate_at_root(
         substitute_promoted_reads(engine, &substitutions);
         let root = engine.body.root;
         apply_in_block(engine, root, &substitutions, &dead_locals);
-        // Report the bindings this round propagated away rather than walking the
-        // body to check them here: the audit is `Body::surviving_read` either
-        // way, and reporting pays one walk per session instead of one per round.
         for &local in &dead_locals {
             engine.note_elided_local(local);
         }

--- a/wado-compiler/src/optimize/gate.rs
+++ b/wado-compiler/src/optimize/gate.rs
@@ -170,17 +170,17 @@ impl FunctionGate {
         }
     }
 
-    /// Drive a gate-aware per-function pass: call `f` only for the functions
-    /// `pass` needs to (re)process, marking each seen afterwards and bumping the
-    /// gate when `f` reports a change. Returns whether any function changed.
-    /// `len` is the current function count (read once; these passes do not add
-    /// functions mid-pass).
     /// Whether any function in `0..len` is still dirty for `pass`. Lets a
     /// caller skip whole-program work it would only need inside the loop.
     pub fn any_pending(&mut self, pass: GatedPass, len: usize) -> bool {
         (0..len).any(|i| self.needs(pass, FuncId::new(i)))
     }
 
+    /// Drive a gate-aware per-function pass: call `f` only for the functions
+    /// `pass` needs to (re)process, marking each seen afterwards and bumping the
+    /// gate when `f` reports a change. Returns whether any function changed.
+    /// `len` is the current function count (read once; these passes do not add
+    /// functions mid-pass).
     pub fn run_gated(
         &mut self,
         pass: GatedPass,

--- a/wado-compiler/src/optimize/peephole.rs
+++ b/wado-compiler/src/optimize/peephole.rs
@@ -71,12 +71,10 @@ pub(super) fn run_peephole(
     } else {
         GatedPass::PeepholePost
     };
-    // Once for the run, and only when the gate has a body to visit.
-    let effects = if gate.any_pending(gated_pass, len) {
-        super::mod_ref::compute_fn_effects(&project.functions, &project.builtin_registry)
-    } else {
-        Vec::new()
-    };
+    // Once for the run. The schedule enters this pass only with a non-empty
+    // gate, so there is a body to visit.
+    let effects =
+        super::mod_ref::compute_fn_effects(&project.functions, &project.builtin_registry);
     gate.run_gated(gated_pass, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
         // `stores_aliased_locals` is per-function, so the ref-elimination rule is

--- a/wado-compiler/src/optimize/peephole.rs
+++ b/wado-compiler/src/optimize/peephole.rs
@@ -73,11 +73,10 @@ pub(super) fn run_peephole(
     };
     debug_assert!(
         gate.any_pending(gated_pass, len),
-        "[NIR] run_peephole entered with a drained gate: the whole-program setup \
-         above would be built for a run that visits no function. The schedule \
-         (`gated!` in `optimize.rs`) owns that skip."
+        "[NIR] run_peephole entered on a drained gate: the setup above would be \
+         built for a run that visits no function. `gated!` owns that skip."
     );
-    // Once for the run — the assert above is what says there is a body to visit.
+    // Once for the run.
     let effects = super::mod_ref::compute_fn_effects(&project.functions, &project.builtin_registry);
     gate.run_gated(gated_pass, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();

--- a/wado-compiler/src/optimize/peephole.rs
+++ b/wado-compiler/src/optimize/peephole.rs
@@ -71,10 +71,14 @@ pub(super) fn run_peephole(
     } else {
         GatedPass::PeepholePost
     };
-    // Once for the run. The schedule enters this pass only with a non-empty
-    // gate, so there is a body to visit.
-    let effects =
-        super::mod_ref::compute_fn_effects(&project.functions, &project.builtin_registry);
+    debug_assert!(
+        gate.any_pending(gated_pass, len),
+        "[NIR] run_peephole entered with a drained gate: the whole-program setup \
+         above would be built for a run that visits no function. The schedule \
+         (`gated!` in `optimize.rs`) owns that skip."
+    );
+    // Once for the run — the assert above is what says there is a body to visit.
+    let effects = super::mod_ref::compute_fn_effects(&project.functions, &project.builtin_registry);
     gate.run_gated(gated_pass, len, |fid| {
         let mut func = project.functions[fid.index()].borrow_mut();
         // `stores_aliased_locals` is per-function, so the ref-elimination rule is


### PR DESCRIPTION
Three changes to what a `-O3` compile spends its time on, plus the allocator setting the batch test tasks run under. `test-gale-o3` is the job that motivated it: its cost is almost entirely compilation (`compile: 1082 files [cpu: 3081s]` against `test: [cpu: 4.4s]`), and roughly 55-65% of each compile is `optimize`.

## The schedule owns the gate skip

`gated!` and `gate_only!` name the pass's `GatedPass` column beside the pass, and a drained column skips the round before the pass builds any whole-program state. A pass assembles its method catalogs, callee maps, effect summaries, alias tables and call-site censuses before it reaches its first function, and a drained column means no function changed since it last ran — so that round would rebuild the state and rewrite nothing.

`run_peephole` asserts the gate it relies on. `param_spec` carries a clause saying it owns no column, since a summary taken before a callee gained a write would license an unsound substitution.

## `copy_prop` reports its elided bindings

Each round hands the locals it propagated away to `Engine::note_elided_local`, and the session-end audit checks them with `Body::surviving_read`. The check costs one walk of the body per session, which is the discipline `note_elided_local` exists to enforce.

## Epoch-stamped session buffers

`EngineBuffers` carries a stamp that `reset_for` bumps per session; a parent or in-worklist slot holding an older stamp reads as absent. The maps grow to cover a body and are never cleared or truncated. They are indexed by arena position, the arena never compacts, and after a round of inlining it runs far ahead of the live tree `Engine::build_indices` walks — so clearing them costs more than the walk they serve.

## Batch compilation holds the allocator's pages

`test-gale-o3` and `test-wado` export `MIMALLOC_PURGE_DELAY=-1`. A compile builds a working set of several hundred MiB and frees it whole when the file is done, so the heap empties once per compiled file. mimalloc's 10 ms purge timer returns those pages to the OS just before the next file asks for them again, and taking them back costs a fault and a free-list rebuild each: 7.0 GiB purged over 24.8K calls to compile four fixtures. Serializing the compiles (`-p 1`) leaves the page traffic where it was, so it is the per-file heap that costs rather than the threads.

`wado serve` is left alone. It is long-running, and reclaiming after a spike is what the purge is for.

## Measured

`CI=1 mise run test-gale-o3` on a 4-core box — 1082 compiles, 2900 tests:

| | wall | compile CPU | peak RSS |
| --- | ---: | ---: | ---: |
| `main` | 1077.72s | 3861.63s | 4836 MiB |
| optimizer changes only | 930.75s | 3441.73s | 4798 MiB |
| this branch | 828.55s | 3081.45s | 5941 MiB |

The allocator setting is what buys the last row, and it is paid for in RSS: 5941 MiB is comfortable on a 16 GiB runner, and the first thing to revisit on a smaller one. `MIMALLOC_PURGE_DELAY=500` is the middle ground if that day comes — on a four-fixture subset it took system time from 8.80s to 5.81s where holding the pages outright took it to 4.46s.

The emitted Wasm is unchanged. `test-wado` (194 compiles, 2265 tests) peaks at 3210 MiB.

## Also

`elaborator.rs` builds its seen-set with `crate::hashmap::IndexSet`, which is what the workspace lints allow, so `cargo clippy -p wado-compiler --all-targets -- -D warnings` runs clean on the crate.

## Standing work this does not take

- The `dev` profile's `debug-assertions` and `overflow-checks` cost ~21% of a compile, and CI runs that profile. Most of it is std's inlined `ub_checks` rather than the optimizer's own audits (~2%), and stable Rust offers no way to separate them.
- `Body::nodes_only_clone` is ~3.5% of a compile: the CTFE interpreter rewrites nodes as it executes, so each run clones the callee's whole arena.
- `run_peephole` rebuilds the CTFE callee maps that `const_folding` already caches, ~3%. `is_ctfe_runnable` reads only the declaration, so the existing cache's soundness argument covers sharing them.
- The allocation volume itself is the standing fix behind the purge: ~31% of a compile's CPU is in the allocator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZRXp3YveF4hKdY8f96j7r

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZRXp3YveF4hKdY8f96j7r)_