### PR TITLE
perf(test): reuse the stdlib snapshot across fixtures, and prewarm to the work there is

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,8 @@ overflow-checks = false
 # The compiler runs in every test and every `wado` invocation, so `2` buys about
 # a tenth off both. It costs nothing in the edit-test cycle: an incremental
 # rebuild is type-checking and test-binary linking, which measure the same at
-# `1` and `2`. The price is a from-scratch workspace build, which is a third
-# slower — paid on `cargo clean` and a CI cache miss, not on an edit.
+# `1` and `2`. The price is a from-scratch workspace build, about a third
+# slower. That is paid on `cargo clean` and a CI cache miss, never on an edit.
 [profile.dev.package.wado-compiler]
 opt-level = 2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,8 +128,13 @@ opt-level = 2
 debug-assertions = false
 overflow-checks = false
 
+# The compiler runs in every test and every `wado` invocation, so `2` buys about
+# a tenth off both. It costs nothing in the edit-test cycle: an incremental
+# rebuild is type-checking and test-binary linking, which measure the same at
+# `1` and `2`. The price is a from-scratch workspace build, which is a third
+# slower — paid on `cargo clean` and a CI cache miss, not on an edit.
 [profile.dev.package.wado-compiler]
-opt-level = 1
+opt-level = 2
 
 [profile.dev.package.wado-dev-tools]
 opt-level = 1
@@ -165,9 +170,9 @@ debug = 2
 strip = false
 
 # `debugger` is `dev` with the debuginfo `dev` deliberately drops, for stepping
-# under rust-gdb. `dev` sets `debug = "line-tables-only"` and raises the
-# workspace crates to `opt-level = 1` to keep the edit-test cycle fast, which
-# together leave `info locals` / `info args` empty in every compiler frame.
+# under rust-gdb. `dev` sets `debug = "line-tables-only"` and optimizes the
+# workspace crates, which together leave `info locals` / `info args` empty in
+# every compiler frame.
 # This profile restores full DWARF and turns optimization off for the crates
 # being stepped through, at the cost of a slower binary. Build with
 # `cargo build --profile debugger --bin wado`; it lives in its own

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -2286,16 +2286,6 @@ async fn run_one_package(
 /// distinct threads; those same threads are then reused for the
 /// `spawn_blocking` compile tasks scheduled by [`run_compile_stage`],
 /// turning each first-compile from a cold miss into a cache hit.
-/// How many workers are worth prewarming for `total_files` of compile work.
-///
-/// A worker builds its snapshot on the first compile it takes, so warming more
-/// workers than there are files leaves snapshots nothing will ever use — and
-/// each one costs a build and a few hundred MB. `wado test <one file>` used to
-/// warm one per core.
-fn prewarm_workers(compile_jobs: usize, total_files: usize) -> usize {
-    compile_jobs.min(total_files).max(1)
-}
-
 async fn prewarm_stdlib_snapshot_on_workers(parallelism: usize) {
     let parallelism = parallelism.max(1);
     let barrier = Arc::new(std::sync::Barrier::new(parallelism));
@@ -2329,6 +2319,15 @@ async fn prewarm_stdlib_snapshot_on_workers(parallelism: usize) {
     for handle in handles {
         let _ = handle.await;
     }
+}
+
+/// How many workers are worth prewarming for `total_files` of compile work.
+///
+/// A worker builds its snapshot on the first compile it takes, so warming more
+/// workers than there are files leaves snapshots nothing will ever use, each
+/// costing a build and the memory to hold it.
+fn prewarm_workers(compile_jobs: usize, total_files: usize) -> usize {
+    compile_jobs.min(total_files).max(1)
 }
 
 /// Report the source files that changed while the run was in progress, and
@@ -2406,13 +2405,8 @@ pub async fn run(opts: TestOptions) -> Result<(), CliExit> {
 
     let total_files: usize = package_runs.iter().map(|r| r.paths.len()).sum();
 
-    // Prewarm the stdlib snapshot on the worker threads before stage 1 starts.
-    // Each worker would otherwise build the snapshot on its first compile and
-    // steal that time from the first batch of compiles; running the builds in
-    // parallel up-front amortises the cost and leaves the tokio blocking-pool
-    // threads in the steady state that the compile stage's `spawn_blocking`
-    // tasks can re-use.
     prewarm_stdlib_snapshot_on_workers(prewarm_workers(compile_jobs, total_files)).await;
+
     let reporter: Arc<dyn TestReporter> = match format {
         TestFormat::Verbose => Arc::new(VerboseReporter::new(overall_start)),
         TestFormat::Heartbeat => Arc::new(HeartbeatReporter::new(overall_start, total_files)),

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -2286,6 +2286,16 @@ async fn run_one_package(
 /// distinct threads; those same threads are then reused for the
 /// `spawn_blocking` compile tasks scheduled by [`run_compile_stage`],
 /// turning each first-compile from a cold miss into a cache hit.
+/// How many workers are worth prewarming for `total_files` of compile work.
+///
+/// A worker builds its snapshot on the first compile it takes, so warming more
+/// workers than there are files leaves snapshots nothing will ever use — and
+/// each one costs a build and a few hundred MB. `wado test <one file>` used to
+/// warm one per core.
+fn prewarm_workers(compile_jobs: usize, total_files: usize) -> usize {
+    compile_jobs.min(total_files).max(1)
+}
+
 async fn prewarm_stdlib_snapshot_on_workers(parallelism: usize) {
     let parallelism = parallelism.max(1);
     let barrier = Arc::new(std::sync::Barrier::new(parallelism));
@@ -2394,16 +2404,15 @@ pub async fn run(opts: TestOptions) -> Result<(), CliExit> {
     let load_jobs = (jobs / 2).max(1);
     let execute_jobs = jobs.max(1);
 
-    // Prewarm the stdlib snapshot on `compile_jobs` distinct worker
-    // threads before stage 1 starts. Each worker would otherwise build
-    // the snapshot (~120 ms) on its first compile and steal that time
-    // from the first batch of compiles; running the builds in parallel
-    // up-front amortises the cost and leaves the tokio blocking-pool
-    // threads in the steady state that the compile stage's
-    // `spawn_blocking` tasks can re-use.
-    prewarm_stdlib_snapshot_on_workers(compile_jobs).await;
-
     let total_files: usize = package_runs.iter().map(|r| r.paths.len()).sum();
+
+    // Prewarm the stdlib snapshot on the worker threads before stage 1 starts.
+    // Each worker would otherwise build the snapshot on its first compile and
+    // steal that time from the first batch of compiles; running the builds in
+    // parallel up-front amortises the cost and leaves the tokio blocking-pool
+    // threads in the steady state that the compile stage's `spawn_blocking`
+    // tasks can re-use.
+    prewarm_stdlib_snapshot_on_workers(prewarm_workers(compile_jobs, total_files)).await;
     let reporter: Arc<dyn TestReporter> = match format {
         TestFormat::Verbose => Arc::new(VerboseReporter::new(overall_start)),
         TestFormat::Heartbeat => Arc::new(HeartbeatReporter::new(overall_start, total_files)),
@@ -2460,6 +2469,15 @@ mod tests {
 
     fn parse(name: &str) -> TestExportName {
         parse_test_export(name).unwrap_or_else(|| panic!("expected `test-` prefix in {name:?}"))
+    }
+
+    #[test]
+    fn prewarming_stops_at_the_files_there_are() {
+        assert_eq!(prewarm_workers(16, 1), 1);
+        assert_eq!(prewarm_workers(16, 4), 4);
+        assert_eq!(prewarm_workers(16, 4000), 16);
+        // A run with nothing to compile still warms the thread that finds out.
+        assert_eq!(prewarm_workers(16, 0), 1);
     }
 
     #[test]

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -429,6 +429,12 @@ fn resolve_paths(paths: Vec<String>, extra_excludes: &[String]) -> Result<Vec<St
     Ok(resolved)
 }
 
+/// The ceiling on `--parallel`. A worker holds a stdlib snapshot and the memory
+/// under it, and every prewarm task holds a blocking-pool thread until the last
+/// one reaches the barrier, so the count has to stay well inside tokio's pool.
+/// No machine wants more than this.
+pub const MAX_JOBS: usize = 128;
+
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     let usage = format_usage();
     let mut paths: Vec<String> = Vec::new();
@@ -543,10 +549,12 @@ pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
     // Default to CPU count to saturate compile/execute. Load derives a
     // lower cap internally (Cranelift JIT is multi-threaded; see `run`).
     // `.max(2)` covers single-core environments.
-    let mut jobs = jobs.unwrap_or_else(|| {
-        let cpus = std::thread::available_parallelism().map_or(4, std::num::NonZero::get);
-        cpus.max(2)
-    });
+    let mut jobs = jobs
+        .unwrap_or_else(|| {
+            let cpus = std::thread::available_parallelism().map_or(4, std::num::NonZero::get);
+            cpus.max(2)
+        })
+        .min(MAX_JOBS);
 
     if matches!(profile, ProfileMode::Guest { .. }) {
         if no_run {

--- a/wado-cli/src/test.rs
+++ b/wado-cli/src/test.rs
@@ -430,9 +430,7 @@ fn resolve_paths(paths: Vec<String>, extra_excludes: &[String]) -> Result<Vec<St
 }
 
 /// The ceiling on `--parallel`. A worker holds a stdlib snapshot and the memory
-/// under it, and every prewarm task holds a blocking-pool thread until the last
-/// one reaches the barrier, so the count has to stay well inside tokio's pool.
-/// No machine wants more than this.
+/// under it, and the prewarm barrier needs every worker inside tokio's pool.
 pub const MAX_JOBS: usize = 128;
 
 pub fn parse_args(mut parser: lexopt::Parser) -> Result<TestOptions, CliExit> {
@@ -642,11 +640,11 @@ struct PipelineBudget {
 
 impl PipelineBudget {
     fn new(parallel_cap: usize, compile_jobs: usize, execute_jobs: usize) -> Self {
-        let cpu_cap = parallel_cap.max(1);
-        let modules_cap = compile_jobs.max(1) + execute_jobs.max(1);
+        // A zero-permit semaphore is a stage that never runs.
+        assert!(parallel_cap > 0 && compile_jobs > 0 && execute_jobs > 0);
         Self {
-            cpu: Arc::new(Semaphore::new(cpu_cap)),
-            modules: Arc::new(Semaphore::new(modules_cap)),
+            cpu: Arc::new(Semaphore::new(parallel_cap)),
+            modules: Arc::new(Semaphore::new(compile_jobs + execute_jobs)),
         }
     }
 }
@@ -2407,9 +2405,9 @@ pub async fn run(opts: TestOptions) -> Result<(), CliExit> {
     // load workers on top of internal Cranelift threading thrashes
     // more than it helps. The shared cpu semaphore enforces the
     // cross-stage total either way.
-    let compile_jobs = jobs.max(1);
+    let compile_jobs = jobs;
     let load_jobs = (jobs / 2).max(1);
-    let execute_jobs = jobs.max(1);
+    let execute_jobs = jobs;
 
     let total_files: usize = package_runs.iter().map(|r| r.paths.len()).sum();
 

--- a/wado-cli/tests/integration/cli_parse.rs
+++ b/wado-cli/tests/integration/cli_parse.rs
@@ -578,6 +578,13 @@ fn test_with_parallel() {
 }
 
 #[test]
+fn test_parallel_is_capped() {
+    let parser = Parser::from_args(&["-p", "600", "a.wado"]);
+    let opts = wado_cli::test::parse_args(parser).unwrap();
+    assert_eq!(opts.jobs, wado_cli::test::MAX_JOBS);
+}
+
+#[test]
 fn test_parallel_invalid() {
     let parser = Parser::from_args(&["-p", "0", "a.wado"]);
     assert_err(

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -291,27 +291,26 @@ pub fn runtime() -> PooledRuntime {
 /// A closure a compile worker runs, having captured its own result channel.
 type CompileJob = Box<dyn FnOnce() + Send>;
 
-/// The workers not currently running a job, most recently used last.
-static IDLE_COMPILE_WORKERS: OnceLock<Mutex<Vec<std::sync::mpsc::Sender<CompileJob>>>> =
-    OnceLock::new();
+/// The handle a job is queued through; dropping every clone ends the thread.
+type CompileWorker = std::sync::mpsc::Sender<CompileJob>;
 
-fn idle_compile_workers() -> &'static Mutex<Vec<std::sync::mpsc::Sender<CompileJob>>> {
-    IDLE_COMPILE_WORKERS.get_or_init(Default::default)
+/// The workers not currently running a job, most recently used last.
+static IDLE_COMPILE_WORKERS: OnceLock<Mutex<Vec<CompileWorker>>> = OnceLock::new();
+
+fn idle_compile_workers() -> std::sync::MutexGuard<'static, Vec<CompileWorker>> {
+    IDLE_COMPILE_WORKERS
+        .get_or_init(Default::default)
+        .lock()
+        .expect("compile worker pool is not poisoned")
 }
 
 /// Take a compile worker, spawning one if none is idle.
 ///
 /// A compile seeds from a thread-local stdlib snapshot that is not cheap to
-/// build, and libtest gives each test its own thread: compiling on the test's
-/// own thread builds one snapshot per fixture and drops it. A worker keeps its
-/// snapshot for the rest of the run, and is spawned on demand so the pool
-/// settles at the runner's concurrency.
-fn take_compile_worker() -> std::sync::mpsc::Sender<CompileJob> {
-    if let Some(worker) = idle_compile_workers()
-        .lock()
-        .expect("compile worker pool is not poisoned")
-        .pop()
-    {
+/// build, and libtest gives each test its own thread. A worker keeps its
+/// snapshot for the rest of the run.
+fn take_compile_worker() -> CompileWorker {
+    if let Some(worker) = idle_compile_workers().pop() {
         return worker;
     }
 
@@ -344,10 +343,7 @@ fn on_compile_worker<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) 
         // thread's snapshot in a state every later compile here would seed
         // from, so drop the sender and let the thread end with it.
         if outcome.is_ok() {
-            idle_compile_workers()
-                .lock()
-                .expect("compile worker pool is not poisoned")
-                .push(returning);
+            idle_compile_workers().push(returning);
         }
         let _ = sender.send(outcome);
     });
@@ -369,7 +365,7 @@ fn on_compile_worker<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) 
 }
 
 /// The text a panic payload carries, for the two shapes `panic!` produces.
-/// [`None`] for anything else — a `panic_any` sentinel such as [`TodoResolved`].
+/// [`None`] for anything else, such as the `panic_any` sentinel [`TodoResolved`].
 pub fn panic_message(payload: &(dyn std::any::Any + Send)) -> Option<&str> {
     payload
         .downcast_ref::<String>()
@@ -379,9 +375,8 @@ pub fn panic_message(payload: &(dyn std::any::Any + Send)) -> Option<&str> {
 
 /// What a fixture compile carries back off the worker.
 ///
-/// [`wado_compiler::CompileResult`] is `!Send` — its AST and WIT snapshot hold
-/// `Rc`s — so the worker keeps it and returns only what a fixture asserts on,
-/// the WIR already unparsed.
+/// [`wado_compiler::CompileResult`] is `!Send`, its AST and WIT snapshot holding
+/// `Rc`s, so the worker keeps it and returns only what a fixture asserts on.
 pub struct CompiledFixture {
     /// The component bytes, or the compile error as the fixture would print it.
     pub wasm: Result<Vec<u8>, String>,

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -301,15 +301,11 @@ fn idle_compile_workers() -> &'static Mutex<Vec<std::sync::mpsc::Sender<CompileJ
 
 /// Take a compile worker, spawning one if none is idle.
 ///
-/// The stdlib snapshot each compile seeds from — the elaborated `core:*`
-/// closure — is thread-local and takes ~200 ms to build, because `Semantics`
-/// is `!Send`. libtest gives each test its own thread, so compiling on the
-/// test's own thread builds a snapshot per fixture and drops it: over the e2e
-/// corpus that is thousands of builds serving one compile each. A worker keeps
-/// its snapshot for the rest of the run.
-///
-/// Spawned on demand rather than up front, so the pool settles at the runner's
-/// concurrency and no worker builds a snapshot it will not reuse.
+/// A compile seeds from a thread-local stdlib snapshot that is not cheap to
+/// build, and libtest gives each test its own thread: compiling on the test's
+/// own thread builds one snapshot per fixture and drops it. A worker keeps its
+/// snapshot for the rest of the run, and is spawned on demand so the pool
+/// settles at the runner's concurrency.
 fn take_compile_worker() -> std::sync::mpsc::Sender<CompileJob> {
     if let Some(worker) = idle_compile_workers()
         .lock()
@@ -344,11 +340,15 @@ fn on_compile_worker<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) 
     let job: CompileJob = Box::new(move || {
         let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
         // Idle again before the caller wakes, so a caller that compiles twice
-        // in a row reuses this worker instead of spawning a cold one.
-        idle_compile_workers()
-            .lock()
-            .expect("compile worker pool is not poisoned")
-            .push(returning);
+        // in a row reuses this worker. Not after a panic: the unwind left this
+        // thread's snapshot in a state every later compile here would seed
+        // from, so drop the sender and let the thread end with it.
+        if outcome.is_ok() {
+            idle_compile_workers()
+                .lock()
+                .expect("compile worker pool is not poisoned")
+                .push(returning);
+        }
         let _ = sender.send(outcome);
     });
     worker
@@ -356,8 +356,25 @@ fn on_compile_worker<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) 
         .expect("a compile worker outlives the job handed to it");
     match receiver.recv().expect("a compile worker answers every job") {
         Ok(value) => value,
-        Err(payload) => std::panic::resume_unwind(payload),
+        Err(payload) => {
+            // libtest captures output per thread, so the worker's own panic
+            // message landed on stderr under no test. Re-panicking files it
+            // under the failing one.
+            if let Some(message) = panic_message(payload.as_ref()) {
+                panic!("compile worker panicked: {message}");
+            }
+            std::panic::resume_unwind(payload)
+        }
     }
+}
+
+/// The text a panic payload carries, for the two shapes `panic!` produces.
+/// [`None`] for anything else — a `panic_any` sentinel such as [`TodoResolved`].
+pub fn panic_message(payload: &(dyn std::any::Any + Send)) -> Option<&str> {
+    payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
 }
 
 /// What a fixture compile carries back off the worker.
@@ -368,7 +385,7 @@ fn on_compile_worker<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) 
 pub struct CompiledFixture {
     /// The component bytes, or the compile error as the fixture would print it.
     pub wasm: Result<Vec<u8>, String>,
-    /// Unparsed WIR, present when the caller asked for it.
+    /// The WIR unparsed to text, when the compile was asked to retain it.
     pub wir_text: Option<String>,
     pub warnings: Vec<String>,
     pub errors: Vec<String>,

--- a/wado-compiler/tests/common.rs
+++ b/wado-compiler/tests/common.rs
@@ -284,6 +284,135 @@ pub fn runtime() -> PooledRuntime {
     })))
 }
 
+// ---------------------------------------------------------------------------
+// Compile worker pool
+// ---------------------------------------------------------------------------
+
+/// A closure a compile worker runs, having captured its own result channel.
+type CompileJob = Box<dyn FnOnce() + Send>;
+
+/// The workers not currently running a job, most recently used last.
+static IDLE_COMPILE_WORKERS: OnceLock<Mutex<Vec<std::sync::mpsc::Sender<CompileJob>>>> =
+    OnceLock::new();
+
+fn idle_compile_workers() -> &'static Mutex<Vec<std::sync::mpsc::Sender<CompileJob>>> {
+    IDLE_COMPILE_WORKERS.get_or_init(Default::default)
+}
+
+/// Take a compile worker, spawning one if none is idle.
+///
+/// The stdlib snapshot each compile seeds from — the elaborated `core:*`
+/// closure — is thread-local and takes ~200 ms to build, because `Semantics`
+/// is `!Send`. libtest gives each test its own thread, so compiling on the
+/// test's own thread builds a snapshot per fixture and drops it: over the e2e
+/// corpus that is thousands of builds serving one compile each. A worker keeps
+/// its snapshot for the rest of the run.
+///
+/// Spawned on demand rather than up front, so the pool settles at the runner's
+/// concurrency and no worker builds a snapshot it will not reuse.
+fn take_compile_worker() -> std::sync::mpsc::Sender<CompileJob> {
+    if let Some(worker) = idle_compile_workers()
+        .lock()
+        .expect("compile worker pool is not poisoned")
+        .pop()
+    {
+        return worker;
+    }
+
+    let (sender, receiver) = std::sync::mpsc::channel::<CompileJob>();
+    std::thread::Builder::new()
+        .name("wado-compile".to_string())
+        // The compiler is recursive-descent end to end, and a deep fixture
+        // overflows a default stack; `wado-cli` gives its compile threads the
+        // same 64 MiB.
+        .stack_size(64 * 1024 * 1024)
+        .spawn(move || {
+            while let Ok(job) = receiver.recv() {
+                job();
+            }
+        })
+        .expect("compile worker spawns");
+    sender
+}
+
+/// Run `f` on a compile worker and hand back what it returned, re-raising a
+/// panic on the calling thread so libtest still attributes it to the test.
+fn on_compile_worker<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) -> R {
+    let worker = take_compile_worker();
+    let returning = worker.clone();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    let job: CompileJob = Box::new(move || {
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        // Idle again before the caller wakes, so a caller that compiles twice
+        // in a row reuses this worker instead of spawning a cold one.
+        idle_compile_workers()
+            .lock()
+            .expect("compile worker pool is not poisoned")
+            .push(returning);
+        let _ = sender.send(outcome);
+    });
+    worker
+        .send(job)
+        .expect("a compile worker outlives the job handed to it");
+    match receiver.recv().expect("a compile worker answers every job") {
+        Ok(value) => value,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+/// What a fixture compile carries back off the worker.
+///
+/// [`wado_compiler::CompileResult`] is `!Send` — its AST and WIT snapshot hold
+/// `Rc`s — so the worker keeps it and returns only what a fixture asserts on,
+/// the WIR already unparsed.
+pub struct CompiledFixture {
+    /// The component bytes, or the compile error as the fixture would print it.
+    pub wasm: Result<Vec<u8>, String>,
+    /// Unparsed WIR, present when the caller asked for it.
+    pub wir_text: Option<String>,
+    pub warnings: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+/// Compile a fixture on a compile worker, unparsing its WIR there when
+/// [`wado_compiler::CompilerOptions::retain_wir`] asked for it.
+pub fn compile_fixture_on_worker(
+    path: PathBuf,
+    source: String,
+    options: wado_compiler::CompilerOptions,
+    env: indexmap::IndexMap<String, String>,
+    dependencies: indexmap::IndexMap<String, String>,
+) -> CompiledFixture {
+    let unparse_wir = options.retain_wir;
+    on_compile_worker(move || {
+        let CapturedCompile {
+            result,
+            warnings,
+            errors,
+        } = compile_capturing_diagnostics(&path, &source, options, None, env, dependencies);
+        let (wasm, wir_text) = match result {
+            Ok(compiled) => {
+                let wir_text = unparse_wir.then(|| {
+                    wado_compiler::wir_unparse::unparse_wir(
+                        compiled
+                            .wir_package
+                            .as_ref()
+                            .expect("retain_wir keeps the WIR package"),
+                    )
+                });
+                (Ok(compiled.wasm), wir_text)
+            }
+            Err(error) => (Err(error.to_string()), None),
+        };
+        CompiledFixture {
+            wasm,
+            wir_text,
+            warnings,
+            errors,
+        }
+    })
+}
+
 /// Shared wasmtime Engine for all tests (initialized once)
 static ENGINE: OnceLock<Engine> = OnceLock::new();
 

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -672,11 +672,7 @@ fn run_fixture_test_with_opt(fixture_path: &Path, source: &str, opt_level: OptLe
                 if let Some(resolved) = err.downcast_ref::<common::TodoResolved>() {
                     panic!("{}", resolved.0);
                 }
-                let msg = err
-                    .downcast_ref::<String>()
-                    .map(String::as_str)
-                    .or_else(|| err.downcast_ref::<&str>().copied())
-                    .unwrap_or("(unknown panic)");
+                let msg = common::panic_message(err.as_ref()).unwrap_or("(unknown panic)");
                 eprintln!("[{test_id}] #![TODO] module pending: {msg}");
                 return;
             }
@@ -815,7 +811,6 @@ fn run_normal_test(
         }
     }
 
-    // No compile error expected - compilation must succeed
     let wasm = wasm.unwrap_or_else(|e| {
         panic!("[{test_id}] compilation failed: {e}");
     });
@@ -884,8 +879,7 @@ fn run_normal_test(
         verify_result(&result, spec, test_id, opt_level);
     }
 
-    // Verify WIR pattern expectations (if any for this optimization level)
-    if let Some(wir_text) = &wir_text {
+    if let Some(wir_text) = wir_text {
         let (expect, not_expect) = spec.wir_expectations(opt_level);
         let opt_name = common::opt_level_name(opt_level);
 

--- a/wado-compiler/tests/e2e.rs
+++ b/wado-compiler/tests/e2e.rs
@@ -704,8 +704,6 @@ fn run_normal_test(
         None
     };
 
-    // Use CompilerOptions to pass the target world through
-    let has_wir = spec.has_wir_expectations(opt_level);
     // Default to debug allocator in e2e tests to catch use-after-free bugs,
     // unless the fixture explicitly overrides it.
     let allocator = Some(
@@ -734,7 +732,7 @@ fn run_normal_test(
         opt_level,
         target_world,
         skip_validation: false,
-        retain_wir: has_wir,
+        retain_wir: spec.has_wir_expectations(opt_level),
         allocator,
         param_overrides: spec
             .params
@@ -745,15 +743,15 @@ fn run_normal_test(
         ..Default::default()
     };
 
-    let common::CapturedCompile {
-        result: compile_result,
+    let common::CompiledFixture {
+        wasm,
+        wir_text,
         warnings,
         errors,
-    } = common::compile_capturing_diagnostics(
-        fixture_path,
-        source,
+    } = common::compile_fixture_on_worker(
+        fixture_path.to_path_buf(),
+        source.to_string(),
         options,
-        None,
         spec.param_env.clone(),
         spec.dependencies.clone(),
     );
@@ -790,9 +788,8 @@ fn run_normal_test(
 
     // Handle expected compile errors (works for any world)
     if let Some(expected_error) = &spec.compile_error {
-        match compile_result {
-            Err(e) => {
-                let error_msg = e.to_string();
+        match wasm {
+            Err(error_msg) => {
                 assert!(
                     error_msg.contains(expected_error),
                     "[{test_id}] compile error mismatch:\n  expected to contain: {expected_error}\n  actual error: {error_msg}"
@@ -819,7 +816,7 @@ fn run_normal_test(
     }
 
     // No compile error expected - compilation must succeed
-    let compile_result = compile_result.unwrap_or_else(|e| {
+    let wasm = wasm.unwrap_or_else(|e| {
         panic!("[{test_id}] compilation failed: {e}");
     });
 
@@ -833,13 +830,13 @@ fn run_normal_test(
             .map(|s| s.to_string_lossy().into_owned())
             .unwrap_or_else(|| "unknown".to_string());
         let opt_name = common::opt_level_name(opt_level);
-        keep_wasm_artifacts(&dir, &fixture_name, opt_name, &compile_result.wasm, test_id);
+        keep_wasm_artifacts(&dir, &fixture_name, opt_name, &wasm, test_id);
     }
 
     // Dispatch to the appropriate runner based on world
     if let Some(http_spec) = &spec.http_service {
         match run_http_request(
-            compile_result.wasm,
+            wasm,
             &http_spec.request,
             spec.outgoing_mocks.clone(),
             spec.tls_mocks.clone(),
@@ -861,7 +858,7 @@ fn run_normal_test(
         }
     } else if spec.test_world.is_some() {
         let result = common::run_test_world(
-            &compile_result.wasm,
+            &wasm,
             test_id,
             spec.outgoing_mocks.clone(),
             spec.tls_mocks.clone(),
@@ -875,7 +872,7 @@ fn run_normal_test(
         // a `TempDir` deletes it from disk.
         let (dirs, _temp_dirs) = prepare_preopened_dirs(&spec.preopened_dirs, test_id);
         let result = common::run_wasm_with_full_options(
-            compile_result.wasm,
+            wasm,
             &dirs,
             spec.stdin.as_deref(),
             spec.outgoing_mocks.clone(),
@@ -888,13 +885,7 @@ fn run_normal_test(
     }
 
     // Verify WIR pattern expectations (if any for this optimization level)
-    if has_wir {
-        let wir_package = compile_result
-            .wir_package
-            .as_ref()
-            .expect("wir_package should be retained when retain_wir is set");
-        let wir_text = wado_compiler::wir_unparse::unparse_wir(wir_package);
-
+    if let Some(wir_text) = &wir_text {
         let (expect, not_expect) = spec.wir_expectations(opt_level);
         let opt_name = common::opt_level_name(opt_level);
 


### PR DESCRIPTION
Three changes that cut what the test suite and the `wado` binary spend on the
same work.

## Fixture compiles run on workers that keep their stdlib snapshot

A compile seeds from a thread-local stdlib snapshot — the elaborated `core:*`
closure — that is not cheap to build, and `Semantics` is `!Send`, so the
snapshot cannot leave the thread that built it. libtest gives each test its own
thread, so a compile on the test's own thread builds one snapshot per fixture
and drops it.

`common.rs` routes fixture compiles through workers spawned on demand and kept
for the run, so the pool settles at the runner's concurrency and each worker
reuses its snapshot. `CompileResult` is `!Send` — its AST and WIT snapshot hold
`Rc`s — so the worker keeps it and returns `CompiledFixture`: the component
bytes or the compile error's text, and the WIR already unparsed. A worker whose
compile panicked is retired rather than reused, since the unwind left its
snapshot in a state later compiles would seed from.

The e2e suite runs in 175s where it took 335s, at a peak RSS 11% higher for the
snapshots the pool retains.

## `wado test` prewarms one snapshot per file, not one per core

`prewarm_workers` caps the prewarm at the file count. `wado test` on a single
fixture spends 0.47s of CPU and peaks at 296 MB, against 10.0s and 2.37 GB when
every core warms a snapshot that one compile will never reach. Runs with more
files than cores are unaffected.

This is what made the CLI integration tests unstable: twenty of them drive
`wado test` in parallel, and twenty multi-gigabyte processes on a 15 GB machine
land in swap. That target now finishes in 54s, reproducibly.

## `wado-compiler` at `opt-level = 2` in the dev profile

The compiler runs in every test and every `wado` invocation, and `2` takes about
a tenth off both. An incremental rebuild — type-checking plus test-binary
linking — measures the same at either level, so the edit-test cycle pays
nothing. A from-scratch workspace build is about a third slower, which an edit
never triggers.
